### PR TITLE
feat: implement contract storage and errors

### DIFF
--- a/contract/src/errors.rs
+++ b/contract/src/errors.rs
@@ -1,0 +1,114 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub enum InsightArenaError {
+    // ── Initialization ────────────────────────────────────────────────────────
+    /// The contract `initialize` function has already been called.
+    /// Raised to prevent re-initialization from overwriting global config.
+    AlreadyInitialized = 1,
+    /// The contract has not yet been initialized.
+    /// Raised when any state-dependent function is called before `initialize`.
+    NotInitialized = 2,
+
+    // ── Authorization ─────────────────────────────────────────────────────────
+    /// The caller does not have the required role for this operation
+    /// (e.g. a non-creator attempting to resolve a market, or a non-admin
+    /// calling an admin-only function).
+    Unauthorized = 3,
+    /// A cryptographic signature supplied with the call could not be verified
+    /// against the expected public key or message payload.
+    InvalidSignature = 4,
+
+    // ── Market ────────────────────────────────────────────────────────────────
+    /// No market exists for the given `market_id`.
+    /// Raised on any market lookup that returns nothing from storage.
+    MarketNotFound = 10,
+    /// The market has already been resolved and its outcome is finalized.
+    /// Raised when a second resolution or conflicting write is attempted.
+    MarketAlreadyResolved = 11,
+    /// The market has not yet been resolved.
+    /// Raised when a payout claim or post-resolution action is attempted early.
+    MarketNotResolved = 12,
+    /// The current ledger timestamp is past `end_time`.
+    /// Raised when a prediction submission arrives after the market has closed.
+    MarketExpired = 13,
+    /// The current ledger timestamp is before `start_time`.
+    /// Raised when a prediction submission arrives before the market opens.
+    MarketNotStarted = 14,
+    /// The market's `end_time` has not yet been reached.
+    /// Raised when resolution is attempted while the market is still accepting
+    /// predictions.
+    MarketStillOpen = 15,
+    /// The predicted outcome symbol is not present in `outcome_options`.
+    /// Raised when a user submits a prediction with an unrecognised outcome.
+    InvalidOutcome = 16,
+    /// The supplied time range is logically inconsistent
+    /// (e.g. `end_time <= start_time`, or `resolution_time < end_time`).
+    InvalidTimeRange = 17,
+    /// The `creator_fee_bps` value exceeds the platform maximum of 500 bps (5%).
+    /// Raised during market creation when the requested fee is out of bounds.
+    InvalidFee = 18,
+
+    // ── Prediction ────────────────────────────────────────────────────────────
+    /// No prediction exists for the given `(market_id, predictor)` pair.
+    /// Raised on lookup when the user has not yet staked in this market.
+    PredictionNotFound = 20,
+    /// The caller has already submitted a prediction for this market.
+    /// Raised to enforce the one-prediction-per-wallet-per-market rule.
+    AlreadyPredicted = 21,
+    /// The submitted stake is below the market's `min_stake` threshold.
+    /// Raised during prediction submission to enforce the minimum entry amount.
+    StakeTooLow = 22,
+    /// The submitted stake exceeds the market's `max_stake` ceiling.
+    /// Raised during prediction submission to enforce the maximum entry amount.
+    StakeTooHigh = 23,
+    /// The user has already successfully claimed their payout for this market.
+    /// Raised to prevent double-claiming after `payout_claimed` is set to true.
+    PayoutAlreadyClaimed = 24,
+
+    // ── Escrow ────────────────────────────────────────────────────────────────
+    /// The contract's escrow balance is insufficient to complete the transfer.
+    /// Raised when a payout or refund exceeds the available on-chain funds.
+    InsufficientFunds = 30,
+    /// A native XLM token transfer via the Stellar asset contract failed.
+    /// Raised when the underlying `transfer` call returns an error.
+    TransferFailed = 31,
+    /// The escrow pool for this market contains no funds.
+    /// Raised when resolution or refund logic encounters a zero `total_pool`.
+    EscrowEmpty = 32,
+
+    // ── Season ────────────────────────────────────────────────────────────────
+    /// The referenced season is not currently active (`is_active` is false).
+    /// Raised when a points award or participation action targets a closed season.
+    SeasonNotActive = 40,
+    /// The season has already been finalized (`is_finalized` is true).
+    /// Raised when a second finalization or post-finalization write is attempted.
+    SeasonAlreadyFinalized = 41,
+    /// No season exists for the given `season_id`.
+    /// Raised on any season lookup that returns nothing from storage.
+    SeasonNotFound = 42,
+
+    // ── Invite ────────────────────────────────────────────────────────────────
+    /// The supplied invite code symbol does not exist in storage or does not
+    /// match the target market. Raised on redemption of an unrecognised code.
+    InvalidInviteCode = 50,
+    /// The invite code's `expires_at` timestamp is in the past.
+    /// Raised when a redemption attempt arrives after the expiry ledger time.
+    InviteCodeExpired = 51,
+    /// The invite code has reached its `max_uses` limit (`current_uses >= max_uses`).
+    /// Raised when a redemption attempt arrives after the usage cap is exhausted.
+    InviteCodeMaxUsed = 52,
+
+    // ── General ───────────────────────────────────────────────────────────────
+    /// An arithmetic operation produced a value outside the valid i128/u32 range.
+    /// Raised anywhere checked arithmetic (pool accumulation, payout calculation)
+    /// would otherwise silently wrap or saturate.
+    Overflow = 100,
+    /// The contract is in emergency-paused state (`DataKey::Paused` is set).
+    /// Raised at the top of any sensitive function when the pause flag is active.
+    Paused = 101,
+    /// A supplied argument fails basic validation that is not covered by a more
+    /// specific error code (e.g. empty strings, zero-length outcome lists).
+    InvalidInput = 102,
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,7 +1,10 @@
 #![no_std]
 
+pub mod errors;
 pub mod storage_types;
-pub use crate::storage_types::{DataKey, Market, Prediction};
+
+pub use crate::errors::InsightArenaError;
+pub use crate::storage_types::{DataKey, InviteCode, Market, Prediction, Season, UserProfile};
 
 use soroban_sdk::{contract, contractimpl};
 

--- a/contract/src/storage_types.rs
+++ b/contract/src/storage_types.rs
@@ -143,3 +143,148 @@ impl Market {
         }
     }
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserProfile {
+    /// The wallet address uniquely identifying this user on-chain.
+    pub address: Address,
+    /// Total number of predictions this user has ever submitted across all markets.
+    pub total_predictions: u32,
+    /// Number of predictions that resolved in the user's favour.
+    pub correct_predictions: u32,
+    /// Cumulative XLM (in stroops) staked across all predictions.
+    pub total_staked: i128,
+    /// Cumulative XLM (in stroops) won across all resolved markets.
+    pub total_winnings: i128,
+    /// Points accumulated in the current active season.
+    /// Points are awarded on payout: base points scale with stake size,
+    /// with a correctness multiplier applied for winning predictions.
+    pub season_points: u32,
+    /// Derived reputation score, recomputed on every payout.
+    /// Formula: (correct_predictions * 100) / total_predictions,
+    /// clamped to [0, 100]. Represents the user's historical accuracy
+    /// as a percentage and is used for leaderboard tiebreaking.
+    pub reputation_score: u32,
+    /// Ledger timestamp recorded when the user first interacted with the platform.
+    pub joined_at: u64,
+}
+
+impl UserProfile {
+    /// Creates a new `UserProfile` for a wallet joining the platform.
+    /// All counters and accumulators are initialised to zero;
+    /// only `address` and `joined_at` are set from the arguments.
+    pub fn new(address: Address, joined_at: u64) -> Self {
+        Self {
+            address,
+            total_predictions: 0,
+            correct_predictions: 0,
+            total_staked: 0,
+            total_winnings: 0,
+            season_points: 0,
+            reputation_score: 0,
+            joined_at,
+        }
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Season {
+    /// Unique identifier for this season, incrementing from 1.
+    pub season_id: u32,
+    /// Ledger timestamp marking when this season's competition window opens
+    /// and points accumulation begins.
+    pub start_time: u64,
+    /// Ledger timestamp marking when this season's competition window closes
+    /// and no further points are awarded.
+    pub end_time: u64,
+    /// Total XLM prize pool (in stroops) allocated for distribution to
+    /// top-ranked participants at finalization.
+    pub reward_pool: i128,
+    /// Number of unique wallets that have earned at least one point
+    /// during this season.
+    pub participant_count: u32,
+    /// True while the season window is open (start_time <= now < end_time).
+    /// Set to false when the season ends or is administratively closed.
+    pub is_active: bool,
+    /// Set to true only after the leaderboard has been fully settled,
+    /// rewards have been distributed to winners, and season_points have
+    /// been snapshotted. No further mutations to this season are permitted
+    /// once finalized.
+    pub is_finalized: bool,
+    /// The address of the highest-ranked participant after finalization.
+    /// Remains None throughout the active window; populated only when
+    /// `is_finalized` is set to true and the leaderboard is resolved.
+    pub top_winner: Option<Address>,
+}
+
+impl Season {
+    /// Creates a new `Season` for an upcoming competition window.
+    /// The season opens immediately as active with no participants or winner;
+    /// finalization is deferred until rewards are distributed after `end_time`.
+    pub fn new(season_id: u32, start_time: u64, end_time: u64, reward_pool: i128) -> Self {
+        Self {
+            season_id,
+            start_time,
+            end_time,
+            reward_pool,
+            participant_count: 0,
+            is_active: true,
+            is_finalized: false,
+            top_winner: None,
+        }
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InviteCode {
+    /// The unique symbol string representing this invite code,
+    /// used as the `DataKey::InviteCode(code)` storage key.
+    pub code: Symbol,
+    /// The market this invite code grants access to.
+    /// Must reference a valid, non-resolved private market (`is_public: false`).
+    pub market_id: u64,
+    /// The wallet address of the market creator who generated this code.
+    pub creator: Address,
+    /// Maximum number of times this code may be redeemed before it is
+    /// automatically considered exhausted. Once `current_uses >= max_uses`,
+    /// any further redemption attempt must be rejected regardless of
+    /// `is_active` or `expires_at`.
+    pub max_uses: u32,
+    /// Running count of successful redemptions so far.
+    /// Incremented atomically on each valid redemption; never decremented.
+    pub current_uses: u32,
+    /// Ledger timestamp after which this code is no longer redeemable,
+    /// even if `current_uses < max_uses`. Should be set at or before
+    /// the market's `end_time` to prevent late-entry abuse.
+    pub expires_at: u64,
+    /// Allows the creator to manually revoke the code before it expires
+    /// or reaches `max_uses`. When false, redemption must be rejected
+    /// immediately without checking other fields.
+    pub is_active: bool,
+}
+
+impl InviteCode {
+    /// Creates a new `InviteCode` granting access to a private market.
+    /// The code is immediately active with zero recorded uses;
+    /// expiry and usage cap are enforced at redemption time by the contract.
+    pub fn new(
+        code: Symbol,
+        market_id: u64,
+        creator: Address,
+        max_uses: u32,
+        expires_at: u64,
+    ) -> Self {
+        Self {
+            code,
+            market_id,
+            creator,
+            max_uses,
+            current_uses: 0,
+            expires_at,
+            is_active: true,
+        }
+    }
+}


### PR DESCRIPTION
feat(storage): define core contract types and error codes (#43–#46)


Add UserProfile, Season, InviteCode structs and InsightArenaError enum
to complete the foundational storage layer for InsightArena.

- Define UserProfile struct with prediction stats, season points, and
  reputation score; implement new() initializing all counters to zero
- Define Season struct for competition windows with active/finalized
  state flags; implement new() with is_active=true, is_finalized=false
- Define InviteCode struct for private market access control with usage
  cap and expiry enforcement; implement new() with current_uses=0
- Define InsightArenaError enum using #[contracterror] with 28 variants
  grouped across initialization, auth, market, prediction, escrow,
  season, invite, and general failure domains
- Re-export all new types and error enum via lib.rs

Notes:
- Removed manual From<InsightArenaError> for soroban_sdk::Error impl;
  #[contracterror] macro generates this automatically and the manual
  impl produced a conflicting implementation compiler error
- Error code ranges use intentional gaps between groups to allow future
  variants without renumbering existing codes
  
  
closes #43 
closes #44 
closes #45 
closes #46 