### PR TITLE
feat: updated footer links and copyright to 2026

### DIFF
--- a/frontend/src/component/Footer.tsx
+++ b/frontend/src/component/Footer.tsx
@@ -5,28 +5,29 @@ export default function Footer() {
     {
       title: "PLATFORM",
       links: [
-        { name: "Play Games", href: "/games" },
-        { name: "Tournaments", href: "/tournaments" },
+        { name: "Market", href: "/markets" },
         { name: "Leaderboard", href: "/leaderboard" },
-        { name: "FAQ", href: "/faq" },
-        { name: "Roadmap", href: "/roadmap" },
+        { name: "Create Market", href: "/create-market" },
+        { name: "Profile", href: "/profile" },
+       
       ],
     },
     {
-      title: "LEGAL",
+      title: "RESOURCES",
       links: [
+        { name: "Documentation", href: "/docs" },
+        { name: "API", href: "/api" },
+        { name: "GitHub", href: "/https://github.com/Arena1X" },
+        { name: "Smart Contracts", href: "/contracts" },
+      ],
+    },
+    {
+      title: "COMPANY",
+      links: [
+        { name: "Telegram", href: "https://t.me/+hR9dZKau8f84YTk0" },
+        { name: "Twitter", href: "https://twitter.com/InsightArena" },
+        { name: "Discord", href: "https://discord.gg/InsightArena" },
         { name: "Terms of Service", href: "/terms" },
-        { name: "Privacy Policy", href: "/privacy" },
-        { name: "Audit Reports", href: "/audits" },
-        { name: "Bug Bounty", href: "/bug-bounty" },
-      ],
-    },
-    {
-      title: "COMMUNITY",
-      links: [
-        { name: "Discord", href: "https://discord.gg/truecall" },
-        { name: "Twitter", href: "https://twitter.com/truecall" },
-        { name: "GitHub", href: "https://github.com/truecall" },
       ],
     },
   ];


### PR DESCRIPTION
I have updated the footer component to match the new InsightArena design specs.
Updated all links in Platform, Resources, and Company columns.
Swapped 'About' for 'Telegram' as requested.
Updated copyright to 2026.
Closes: #80
Verification: See attached screenshot below👇
<img width="1915" height="950" alt="Screenshot 2026-03-23 211847" src="https://github.com/user-attachments/assets/17e4344a-8d5d-4a45-a134-ccdd1d0038b3" />
