### PR TITLE
feat: jwt auth guard

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { APP_GUARD } from '@nestjs/core';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthModule } from './health/health.module';
+import { CommonModule } from './common/common.module';
+import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { validate } from './config/env.validation';
 
 @Module({
@@ -30,9 +33,16 @@ import { validate } from './config/env.validation';
     }),
 
     HealthModule,
+    CommonModule,
   ],
 
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { JwtStrategy } from './strategies/jwt.strategy';
+
+@Module({
+  imports: [
+    PassportModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET')!,
+        signOptions: {
+          expiresIn: configService.get('JWT_EXPIRES_IN') as never,
+        },
+      }),
+    }),
+  ],
+  providers: [JwtStrategy],
+  exports: [JwtModule],
+})
+export class CommonModule {}

--- a/backend/src/common/decorators/public.decorator.ts
+++ b/backend/src/common/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/backend/src/common/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,76 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JsonWebTokenError, TokenExpiredError } from '@nestjs/jwt';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+const mockReflector = (isPublic: boolean) =>
+  ({
+    getAllAndOverride: jest.fn().mockReturnValue(isPublic),
+  }) as unknown as Reflector;
+
+const mockContext = () =>
+  ({
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue({ headers: {} }),
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('JwtAuthGuard', () => {
+  describe('canActivate', () => {
+    it('returns true for @Public() routes without calling super', () => {
+      const guard = new JwtAuthGuard(mockReflector(true));
+      const ctx = mockContext();
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('delegates to AuthGuard for non-public routes', () => {
+      const guard = new JwtAuthGuard(mockReflector(false));
+      const superSpy = jest
+        .spyOn(Object.getPrototypeOf(JwtAuthGuard.prototype), 'canActivate')
+        .mockReturnValue(true);
+      const ctx = mockContext();
+      guard.canActivate(ctx);
+      expect(superSpy).toHaveBeenCalledWith(ctx);
+      superSpy.mockRestore();
+    });
+  });
+
+  describe('handleRequest', () => {
+    let guard: JwtAuthGuard;
+
+    beforeEach(() => {
+      guard = new JwtAuthGuard(mockReflector(false));
+    });
+
+    it('returns the user when token is valid', () => {
+      const user = { userId: '1', email: 'test@example.com' };
+      expect(guard.handleRequest(null, user, null)).toBe(user);
+    });
+
+    it('throws 401 with "Token expired" for expired tokens', () => {
+      expect(() =>
+        guard.handleRequest(null, null, new TokenExpiredError('jwt expired', new Date())),
+      ).toThrow(new UnauthorizedException('Token expired'));
+    });
+
+    it('throws 401 for invalid/malformed tokens', () => {
+      expect(() =>
+        guard.handleRequest(null, null, new JsonWebTokenError('invalid token')),
+      ).toThrow(UnauthorizedException);
+    });
+
+    it('throws 401 when no token is provided (missing user)', () => {
+      expect(() => guard.handleRequest(null, null, null)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws 401 when err is present', () => {
+      expect(() =>
+        guard.handleRequest(new Error('some error'), null, null),
+      ).toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,45 @@
+import {
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthGuard } from '@nestjs/passport';
+import { JsonWebTokenError, TokenExpiredError } from '@nestjs/jwt';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+
+  handleRequest<TUser = unknown>(
+    err: Error | null,
+    user: TUser,
+    info: Error | null,
+  ): TUser {
+    if (info instanceof TokenExpiredError) {
+      throw new UnauthorizedException('Token expired');
+    }
+
+    if (err || info instanceof JsonWebTokenError || !user) {
+      throw new UnauthorizedException();
+    }
+
+    return user;
+  }
+}

--- a/backend/src/common/strategies/jwt.strategy.ts
+++ b/backend/src/common/strategies/jwt.strategy.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+export interface JwtPayload {
+  sub: string;
+  email: string;
+  iat?: number;
+  exp?: number;
+}
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get<string>('JWT_SECRET')!,
+    });
+  }
+
+  validate(payload: JwtPayload) {
+    return { userId: payload.sub, email: payload.email };
+  }
+}


### PR DESCRIPTION
<p><strong>feat: implement global JWT auth guard with <code>@Public()</code> decorator</strong></p>
<p>Closes #105</p>
<h2>What</h2>
<p>Adds a reusable JWT authentication layer that protects all routes by default, with an opt-out mechanism for public endpoints.</p>
<h2>Changes</h2>
<ul>
<li><p><code>src/common/guards/jwt-auth.guard.ts</code> — <code>JwtAuthGuard</code> extending <code>AuthGuard('jwt')</code>. Checks for the <code>@Public()</code> metadata before delegating to Passport, and overrides <code>handleRequest</code> to return a typed 401 with <code>"Token expired"</code> for <code>TokenExpiredError</code> vs a generic 401 for all other failures.</p>
</li>
<li><p><code>src/common/decorators/public.decorator.ts</code> — <code>@Public()</code> decorator using <code>SetMetadata</code> to mark routes/controllers as unauthenticated-accessible.</p>
</li>
<li><p><code>src/common/strategies/jwt.strategy.ts</code> — <code>JwtStrategy</code> using <code>passport-jwt</code> with bearer token extraction, wired to <code>JWT_SECRET</code> and <code>JWT_EXPIRES_IN</code> from config. Validates the payload and returns <code>{ userId, email }</code> onto the request.</p>
</li>
<li><p><code>src/common/common.module.ts</code> — <code>CommonModule</code> registering <code>PassportModule</code>, <code>JwtModule</code> (async, config-driven), and <code>JwtStrategy</code>. Exports <code>JwtModule</code> for use in feature modules.</p>
</li>
<li><p><code>src/app.module.ts</code> — imports <code>CommonModule</code> and registers <code>JwtAuthGuard</code> globally via <code>APP_GUARD</code>, so every route is protected without needing per-controller decorators.</p>
</li>
<li><p><code>src/common/guards/jwt-auth.guard.spec.ts</code> — unit tests covering: valid token, expired token (<code>"Token expired"</code> message), invalid/malformed token, missing token, and <code>@Public()</code> bypass.</p>
</li>
</ul>
<h2>Behavior</h2>

Scenario | Result
-- | --
Valid Bearer token | 200, user attached to request
Expired token | 401 { message: "Token expired" }
Invalid / malformed token | 401
No token | 401
Route decorated with @Public() | passes through, no token needed


<h2>Usage</h2>
<pre><code class="language-ts">// protect by default — no decorator needed

// opt out for a specific route
@Public()
@Get('auth/login')
login() {}

// opt out for an entire controller
@Public()
@Controller('auth')
export class AuthController {}
</code></pre>
</body></html>

<img width="707" height="294" alt="Screenshot 2026-03-24 at 00 35 57" src="https://github.com/user-attachments/assets/607332b3-f9ac-4312-8773-915a79e5f4a7" />
