### PR TITLE
feat:  Implement Contract Initialization and Admin Config

### DIFF
--- a/contract/src/config.rs
+++ b/contract/src/config.rs
@@ -1,0 +1,146 @@
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::errors::InsightArenaError;
+use crate::storage_types::DataKey;
+
+// ── TTL constants ─────────────────────────────────────────────────────────────
+// Assuming ~5 s per ledger:
+//   PERSISTENT_BUMP      ≈ 30 days  (518 400 ledgers)
+//   PERSISTENT_THRESHOLD ≈ 29 days  — only bump when remaining TTL falls below this
+pub const PERSISTENT_BUMP: u32 = 518_400;
+pub const PERSISTENT_THRESHOLD: u32 = 501_120; // PERSISTENT_BUMP − 1 day
+
+// ── Config struct ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// Platform administrator; the only address allowed to call mutators.
+    pub admin: Address,
+    /// Platform cut in basis points (e.g. 200 = 2 %).
+    pub protocol_fee_bps: u32,
+    /// Hard cap on the fee a market creator may charge, in basis points.
+    pub max_creator_fee_bps: u32,
+    /// Minimum XLM stake required to participate in a market, in stroops.
+    pub min_stake_xlm: i128,
+    /// Trusted oracle contract address used for market resolution.
+    pub oracle_address: Address,
+    /// When `true`, all non-admin entry points must revert with `Paused`.
+    pub is_paused: bool,
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+/// Extend the persistent TTL for the Config entry whenever it drops below
+/// `PERSISTENT_THRESHOLD`. Must be called on every read *and* every write.
+fn bump_config(env: &Env) {
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Config, PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
+}
+
+/// Load Config from persistent storage.
+/// Returns `NotInitialized` if the key is absent rather than panicking.
+fn load_config(env: &Env) -> Result<Config, InsightArenaError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Config)
+        .ok_or(InsightArenaError::NotInitialized)
+}
+
+// ── Entry-point logic (called from contractimpl in lib.rs) ────────────────────
+
+/// One-time contract setup.
+///
+/// Stores the initial [`Config`] and returns `AlreadyInitialized` on any
+/// subsequent call, providing an idempotency guard.
+pub fn initialize(
+    env: &Env,
+    admin: Address,
+    oracle: Address,
+    fee_bps: u32,
+) -> Result<(), InsightArenaError> {
+    if env.storage().persistent().has(&DataKey::Config) {
+        return Err(InsightArenaError::AlreadyInitialized);
+    }
+
+    let config = Config {
+        admin,
+        protocol_fee_bps: fee_bps,
+        max_creator_fee_bps: 500,  // 5 % absolute cap for market creators
+        min_stake_xlm: 10_000_000, // 1 XLM expressed in stroops
+        oracle_address: oracle,
+        is_paused: false,
+    };
+
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    Ok(())
+}
+
+/// Return the current global [`Config`] and extend its TTL.
+pub fn get_config(env: &Env) -> Result<Config, InsightArenaError> {
+    let config = load_config(env)?;
+    bump_config(env);
+    Ok(config)
+}
+
+/// Update the protocol fee rate. Caller must be the stored admin.
+pub fn update_protocol_fee(env: &Env, new_fee_bps: u32) -> Result<(), InsightArenaError> {
+    let mut config = load_config(env)?;
+
+    // Authorisation check — reverts the entire transaction if auth is absent.
+    config.admin.require_auth();
+
+    config.protocol_fee_bps = new_fee_bps;
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    Ok(())
+}
+
+/// Pause or resume the contract. Caller must be the stored admin.
+///
+/// When `paused` is `true`, all non-admin entry points should call
+/// [`ensure_not_paused`] and revert with [`InsightArenaError::Paused`].
+pub fn set_paused(env: &Env, paused: bool) -> Result<(), InsightArenaError> {
+    let mut config = load_config(env)?;
+
+    config.admin.require_auth();
+
+    config.is_paused = paused;
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    Ok(())
+}
+
+/// Atomically replace the admin address. Caller must be the current admin.
+///
+/// After this call the old admin address loses all privileges immediately.
+pub fn transfer_admin(env: &Env, new_admin: Address) -> Result<(), InsightArenaError> {
+    let mut config = load_config(env)?;
+
+    // Auth against the *current* admin before overwriting.
+    config.admin.require_auth();
+
+    config.admin = new_admin;
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    Ok(())
+}
+
+/// Guard used at the top of every sensitive non-admin entry point.
+///
+/// Extends the Config TTL on every call (counts as a read).
+/// Returns `Paused` when the platform is in emergency-halt mode.
+pub fn ensure_not_paused(env: &Env) -> Result<(), InsightArenaError> {
+    let config = load_config(env)?;
+    bump_config(env);
+    if config.is_paused {
+        return Err(InsightArenaError::Paused);
+    }
+    Ok(())
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,18 +1,57 @@
 #![no_std]
 
+pub mod config;
 pub mod errors;
 pub mod storage_types;
 
+pub use crate::config::Config;
 pub use crate::errors::InsightArenaError;
 pub use crate::storage_types::{DataKey, InviteCode, Market, Prediction, Season, UserProfile};
 
-use soroban_sdk::{contract, contractimpl};
+use soroban_sdk::{contract, contractimpl, Address, Env};
 
 #[contract]
 pub struct InsightArenaContract;
 
 #[contractimpl]
 impl InsightArenaContract {
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    /// Set up the contract for the first time.
+    /// Reverts with `AlreadyInitialized` on any subsequent call.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        oracle: Address,
+        fee_bps: u32,
+    ) -> Result<(), InsightArenaError> {
+        config::initialize(&env, admin, oracle, fee_bps)
+    }
+
+    // ── Config read ───────────────────────────────────────────────────────────
+
+    /// Return the current global [`Config`]. TTL is extended on each call.
+    pub fn get_config(env: Env) -> Result<Config, InsightArenaError> {
+        config::get_config(&env)
+    }
+
+    // ── Admin mutators ────────────────────────────────────────────────────────
+
+    /// Update the platform fee rate. Caller must be the stored admin.
+    pub fn update_protocol_fee(env: Env, new_fee_bps: u32) -> Result<(), InsightArenaError> {
+        config::update_protocol_fee(&env, new_fee_bps)
+    }
+
+    /// Pause or resume the contract. Caller must be the stored admin.
+    pub fn set_paused(env: Env, paused: bool) -> Result<(), InsightArenaError> {
+        config::set_paused(&env, paused)
+    }
+
+    /// Transfer admin rights to `new_admin`. Caller must be the current admin.
+    pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), InsightArenaError> {
+        config::transfer_admin(&env, new_admin)
+    }
+
     // Contract modules (market, prediction, user, leaderboard, season, invite)
     // will be implemented here using the canonical DataKey enum.
 }


### PR DESCRIPTION


This PR introduces the core configuration module for the InsightArena Soroban contract. It implements contract initialization, persistent configuration storage, and admin-controlled parameter management.

Every Soroban contract requires a secure and idempotent initialization flow. This PR ensures that the contract is properly bootstrapped with essential global parameters while enforcing strict admin authorization for all sensitive operations.

What’s Included
1. Config Module
Created contract/src/config.rs
Defined the Config struct using #[contracttype]:
#[contracttype]
#[derive(Clone, Debug)]
pub struct Config {
    pub admin: Address,
    pub protocol_fee_bps: u32,
    pub max_creator_fee_bps: u32,
    pub min_stake_xlm: i128,
    pub oracle_address: Address,
    pub is_paused: bool,
}
2. Initialization Logic
Implemented initialize(...):
Sets:
Admin address
Oracle address
Protocol fee (basis points)
Stores config in persistent storage (DataKey::Config)
Enforces idempotency:
Returns AlreadyInitialized if called more than once
3. Config Access
Implemented get_config(...):
Reads from persistent storage
Extends TTL on access
4. Admin-Controlled Functions

All mutator functions:

Require admin authorization via require_auth()
Extend TTL on read/write
Return Result<_, InsightArenaError>

Implemented:

update_protocol_fee(...)
set_paused(...)
transfer_admin(...)
5. Pause Control
set_paused(bool) toggles contract state
When paused:
Non-admin functions are blocked via ensure_not_paused()
6. Storage & TTL Management
Uses env.storage().persistent() with DataKey::Config
TTL is extended on:
Every read
Every write
Follows the established TTL module pattern
7. Re-exports
Config is re-exported from lib.rs for external access
Security Considerations
Enforced strict admin-only access for all mutators
Prevented re-initialization via guard
Eliminated unsafe unwrap() usage in production paths
Ensured atomic admin transfer
Introduced pause mechanism for emergency control
Acceptance Criteria Checklist
 initialize returns AlreadyInitialized on second call
 All mutators call require_auth() and revert on failure
 set_paused(true) blocks non-admin execution
 transfer_admin updates admin atomically
 All functions return Result<_, InsightArenaError> (no unwraps)
 TTL extended on every storage read/write    closes #47