### PR TITLE
feat: add Reward Wallet Card to UI

### DIFF
--- a/frontend/src/component/RewardsWalletCard.tsx
+++ b/frontend/src/component/RewardsWalletCard.tsx
@@ -1,0 +1,50 @@
+import { Wallet } from "lucide-react";
+
+export default function RewardsWalletCard() {
+  return (
+    <div className="relative bg-[#0f172a] rounded-2xl p-5 w-full shadow-lg overflow-hidden">
+      {/* TOP GOLD EDGE (same gold as UI) */}
+      <div className="absolute top-0 left-0 right-0 h-[3px] bg-[#F5C451]/70 rounded-t-2xl" />
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-white font-semibold">Rewards Wallet</h2>
+        <Wallet className="h-5 w-5 text-[#F5C451]" />
+      </div>
+
+      {/* Total Earned */}
+      <div className="mt-5 text-center">
+        <p className="text-gray-400 text-xs tracking-wide">TOTAL EARNED</p>
+
+        <div className="flex items-center justify-center gap-2 mt-1 text-2xl font-bold text-[#F5C451]">
+          <span>⭐</span>
+          <span>$1,240</span>
+          <span>⭐</span>
+        </div>
+      </div>
+
+      {/* Line Items */}
+      <div className="mt-5 space-y-3 text-sm">
+        <div className="flex justify-between text-gray-300">
+          <span>Claimable Rewards</span>
+          <span className="text-[#4FD1C5]">$150</span>
+        </div>
+
+        <div className="flex justify-between text-gray-300">
+          <span>Pending Payouts</span>
+          <span>$95</span>
+        </div>
+
+        <div className="flex justify-between">
+          <span className="text-gray-300">Wallet Balance</span>
+          <span className="text-[#4FD1C5] font-medium">420 XLM</span>
+        </div>
+      </div>
+
+      {/* Button */}
+      <button className="mt-6 w-full py-2 rounded-lg bg-[#F5C451] text-black font-semibold hover:opacity-90 transition">
+        Claim Rewards
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/component/dashboard-shell.tsx
+++ b/frontend/src/component/dashboard-shell.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import RewardsWalletCard from "@/component/RewardsWalletCard";
+
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -79,7 +81,9 @@ function SidebarContent({ onNavigate }: SidebarContentProps) {
             >
               <Icon
                 className={`h-4 w-4 ${
-                  isActive ? "text-[#4fd1c5]" : "text-[#8f98ae] group-hover:text-white"
+                  isActive
+                    ? "text-[#4fd1c5]"
+                    : "text-[#8f98ae] group-hover:text-white"
                 }`}
               />
               <span>{label}</span>
@@ -117,7 +121,8 @@ function TopNavigation() {
             Welcome back, Ayomide
           </h1>
           <p className="mt-2 max-w-2xl text-sm text-[#97a0b5] sm:text-base">
-            Here&apos;s a quick overview of your prediction activity and performance.
+            Here&apos;s a quick overview of your prediction activity and
+            performance.
           </p>
         </div>
         <div className="flex flex-col gap-3 sm:flex-row">
@@ -178,7 +183,13 @@ export function DashboardShell({ children }: DashboardShellProps) {
             <TopNavigation />
           </div>
 
-          <main className="min-h-0 flex-1">{children}</main>
+          <div className="flex gap-6 p-6">
+            <main className="flex-1">{children}</main>
+
+            <aside className="xl:block w-[300px]">
+              <RewardsWalletCard />
+            </aside>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #86

---

closes#83

### Summary
Implemented the "Rewards Wallet" sidebar card on the dashboard following the provided Figma design specification.

### What was done
- Built a reusable `RewardsWalletCard` component
- Added header with wallet icon (lucide-react)
- Implemented "TOTAL EARNED" section with emphasized gold styling
- Added line items:
  - Claimable Rewards
  - Pending Payouts
  - Wallet Balance
- Ensured all line items use `flex justify-between` for proper alignment
- Implemented full-width "Claim Rewards" button using brand gold color
- Added subtle top-edge gold highlight to match Figma visual detail
- Integrated the component into the dashboard layout (right sidebar)

### Design considerations
- Maintained consistent use of brand colors (gold `#F5C451`, accent teal)
- Ensured visual hierarchy (muted labels vs highlighted values)
- Preserved spacing and layout structure from Figma
- Kept component responsive within dashboard container

### Testing
- Verified component renders correctly on `/dashboard`
- Checked alignment and spacing across sections

### Evidence
(Screenshot attached below)
<img width="238" height="257" alt="Screenshot 2026-03-24 144230" src="https://github.com/user-attachments/assets/6714a9d0-ec55-436b-acac-36c1d10e6f34" />
