### PR TITLE
feat(prediction): implement submit_prediction with escrow lock, validation, and PredictionSubmitted event

### DIFF
--- a/contract/src/escrow.rs
+++ b/contract/src/escrow.rs
@@ -3,6 +3,24 @@ use soroban_sdk::{token, Address, Env};
 use crate::config;
 use crate::errors::InsightArenaError;
 
+/// Transfer `amount` stroops from `predictor` into the contract's escrow.
+///
+/// The contract address becomes the custodian of the staked XLM; funds are held
+/// until the market is resolved (payout) or cancelled (refund).
+///
+/// # Errors
+/// Propagates any error returned by [`config::get_config`].  Token transfer
+/// panics are handled by the Soroban runtime and surface as contract failures.
+pub fn lock_stake(env: &Env, predictor: &Address, amount: i128) -> Result<(), InsightArenaError> {
+    let cfg = config::get_config(env)?;
+    token::Client::new(env, &cfg.xlm_token).transfer(
+        predictor,
+        &env.current_contract_address(),
+        &amount,
+    );
+    Ok(())
+}
+
 /// Transfer `amount` stroops from the contract's own escrow balance to `recipient`.
 ///
 /// The contract address is the implicit custodian of all staked XLM; when a

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod errors;
 pub mod escrow;
 pub mod market;
+pub mod prediction;
 pub mod storage_types;
 
 pub use crate::config::Config;
@@ -11,7 +12,7 @@ pub use crate::errors::InsightArenaError;
 pub use crate::market::CreateMarketParams;
 pub use crate::storage_types::{DataKey, InviteCode, Market, Prediction, Season, UserProfile};
 
-use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
 
 #[contract]
 pub struct InsightArenaContract;
@@ -115,6 +116,24 @@ impl InsightArenaContract {
         market_id: u64,
     ) -> Result<(), InsightArenaError> {
         market::cancel_market(&env, caller, market_id)
+    }
+
+    // ── Prediction ────────────────────────────────────────────────────────────
+
+    /// Submit a prediction for an open market by staking XLM on a chosen outcome.
+    ///
+    /// The predictor selects one of the market's valid `outcome_options` and
+    /// locks `stake_amount` stroops of XLM into escrow. Returns `AlreadyPredicted`
+    /// if the same address has already staked on this market. Emits a
+    /// `PredictionSubmitted` event on success.
+    pub fn submit_prediction(
+        env: Env,
+        predictor: Address,
+        market_id: u64,
+        chosen_outcome: Symbol,
+        stake_amount: i128,
+    ) -> Result<(), InsightArenaError> {
+        prediction::submit_prediction(&env, predictor, market_id, chosen_outcome, stake_amount)
     }
 }
 

--- a/contract/src/prediction.rs
+++ b/contract/src/prediction.rs
@@ -1,0 +1,653 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
+
+use crate::config::{self, PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
+use crate::errors::InsightArenaError;
+use crate::escrow;
+use crate::storage_types::{DataKey, Market, Prediction, UserProfile};
+
+// ── TTL helpers ───────────────────────────────────────────────────────────────
+
+fn bump_prediction(env: &Env, market_id: u64, predictor: &Address) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::Prediction(market_id, predictor.clone()),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
+fn bump_market(env: &Env, market_id: u64) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::Market(market_id),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
+fn bump_predictor_list(env: &Env, market_id: u64) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::PredictorList(market_id),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
+fn bump_user(env: &Env, address: &Address) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::User(address.clone()),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
+// ── Event emission ────────────────────────────────────────────────────────────
+
+fn emit_prediction_submitted(
+    env: &Env,
+    market_id: u64,
+    predictor: &Address,
+    outcome: &Symbol,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("pred"), symbol_short!("submitd")),
+        (market_id, predictor.clone(), outcome.clone(), amount),
+    );
+}
+
+// ── Entry-point logic ─────────────────────────────────────────────────────────
+
+/// Submit a prediction for an open market by staking XLM on a chosen outcome.
+///
+/// Validation order:
+/// 1. Platform not paused
+/// 2. Predictor authorisation via `require_auth()`
+/// 3. Market exists (else `MarketNotFound`)
+/// 4. `current_time < market.end_time` (else `MarketExpired`)
+/// 5. `chosen_outcome` is present in `market.outcome_options` (else `InvalidOutcome`)
+/// 6. `stake_amount >= market.min_stake` (else `StakeTooLow`)
+/// 7. `stake_amount <= market.max_stake` (else `StakeTooHigh`)
+/// 8. Predictor has not already submitted a prediction for this market (else `AlreadyPredicted`)
+///
+/// On success:
+/// - XLM is locked in escrow via `escrow::lock_stake`.
+/// - A `Prediction` record is written to `DataKey::Prediction(market_id, predictor)`.
+/// - `PredictorList(market_id)` is appended with the predictor address.
+/// - `market.total_pool` and `market.participant_count` are updated atomically.
+/// - The predictor's `UserProfile` stats are updated (or created on first prediction).
+/// - A `PredictionSubmitted` event is emitted.
+pub fn submit_prediction(
+    env: &Env,
+    predictor: Address,
+    market_id: u64,
+    chosen_outcome: Symbol,
+    stake_amount: i128,
+) -> Result<(), InsightArenaError> {
+    // ── Guard 1: platform not paused ─────────────────────────────────────────
+    config::ensure_not_paused(env)?;
+
+    // ── Guard 2: predictor authorisation ─────────────────────────────────────
+    predictor.require_auth();
+
+    // ── Guard 3: market must exist ────────────────────────────────────────────
+    let mut market: Market = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Market(market_id))
+        .ok_or(InsightArenaError::MarketNotFound)?;
+
+    // ── Guard 4: market must not be expired ───────────────────────────────────
+    let now = env.ledger().timestamp();
+    if now >= market.end_time {
+        return Err(InsightArenaError::MarketExpired);
+    }
+
+    // ── Guard 5: chosen_outcome must be in outcome_options ───────────────────
+    let outcome_valid = market.outcome_options.iter().any(|o| o == chosen_outcome);
+    if !outcome_valid {
+        return Err(InsightArenaError::InvalidOutcome);
+    }
+
+    // ── Guard 6 & 7: stake_amount must be within [min_stake, max_stake] ───────
+    if stake_amount < market.min_stake {
+        return Err(InsightArenaError::StakeTooLow);
+    }
+    if stake_amount > market.max_stake {
+        return Err(InsightArenaError::StakeTooHigh);
+    }
+
+    // ── Guard 8: user has not already predicted on this market ────────────────
+    let prediction_key = DataKey::Prediction(market_id, predictor.clone());
+    if env.storage().persistent().has(&prediction_key) {
+        return Err(InsightArenaError::AlreadyPredicted);
+    }
+
+    // ── Lock stake in escrow (transfer XLM from predictor to contract) ────────
+    escrow::lock_stake(env, &predictor, stake_amount)?;
+
+    // ── Store Prediction record ───────────────────────────────────────────────
+    let prediction = Prediction::new(
+        market_id,
+        predictor.clone(),
+        chosen_outcome.clone(),
+        stake_amount,
+        now,
+    );
+    env.storage().persistent().set(&prediction_key, &prediction);
+    bump_prediction(env, market_id, &predictor);
+
+    // ── Append predictor to PredictorList ────────────────────────────────────
+    let list_key = DataKey::PredictorList(market_id);
+    let mut predictors: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&list_key)
+        .unwrap_or_else(|| Vec::new(env));
+    predictors.push_back(predictor.clone());
+    env.storage().persistent().set(&list_key, &predictors);
+    bump_predictor_list(env, market_id);
+
+    // ── Update market total_pool and participant_count atomically ─────────────
+    market.total_pool = market
+        .total_pool
+        .checked_add(stake_amount)
+        .ok_or(InsightArenaError::Overflow)?;
+    market.participant_count = market
+        .participant_count
+        .checked_add(1)
+        .ok_or(InsightArenaError::Overflow)?;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Market(market_id), &market);
+    bump_market(env, market_id);
+
+    // ── Update UserProfile stats (create profile on first prediction) ─────────
+    let user_key = DataKey::User(predictor.clone());
+    let mut profile: UserProfile = env
+        .storage()
+        .persistent()
+        .get(&user_key)
+        .unwrap_or_else(|| UserProfile::new(predictor.clone(), now));
+
+    profile.total_predictions = profile
+        .total_predictions
+        .checked_add(1)
+        .ok_or(InsightArenaError::Overflow)?;
+    profile.total_staked = profile
+        .total_staked
+        .checked_add(stake_amount)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    env.storage().persistent().set(&user_key, &profile);
+    bump_user(env, &predictor);
+
+    // ── Emit PredictionSubmitted event ────────────────────────────────────────
+    emit_prediction_submitted(env, market_id, &predictor, &chosen_outcome, stake_amount);
+
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod prediction_tests {
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
+    use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+    use soroban_sdk::{symbol_short, vec, Address, Env, String};
+
+    use crate::market::CreateMarketParams;
+    use crate::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
+
+    // ── Test helpers ──────────────────────────────────────────────────────────
+
+    fn register_token(env: &Env) -> Address {
+        let token_admin = Address::generate(env);
+        env.register_stellar_asset_contract_v2(token_admin)
+            .address()
+    }
+
+    /// Deploy and initialise the contract; return client + xlm_token address.
+    fn deploy(env: &Env) -> (InsightArenaContractClient<'_>, Address) {
+        let id = env.register(InsightArenaContract, ());
+        let client = InsightArenaContractClient::new(env, &id);
+        let admin = Address::generate(env);
+        let oracle = Address::generate(env);
+        let xlm_token = register_token(env);
+        env.mock_all_auths();
+        client.initialize(&admin, &oracle, &200_u32, &xlm_token);
+        (client, xlm_token)
+    }
+
+    fn default_params(env: &Env) -> CreateMarketParams {
+        let now = env.ledger().timestamp();
+        CreateMarketParams {
+            title: String::from_str(env, "Will it rain?"),
+            description: String::from_str(env, "Daily weather market"),
+            category: symbol_short!("weather"),
+            outcomes: vec![env, symbol_short!("yes"), symbol_short!("no")],
+            end_time: now + 1000,
+            resolution_time: now + 2000,
+            creator_fee_bps: 100,
+            min_stake: 10_000_000,
+            max_stake: 100_000_000,
+            is_public: true,
+        }
+    }
+
+    /// Mint `amount` XLM stroops to `recipient` using the stellar asset client.
+    fn fund(env: &Env, xlm_token: &Address, recipient: &Address, amount: i128) {
+        StellarAssetClient::new(env, xlm_token).mint(recipient, &amount);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 20_000_000);
+
+        client.submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+
+        // Verify prediction stored correctly
+        let pred = env.as_contract(&client.address, || {
+            use crate::storage_types::{DataKey, Prediction};
+            env.storage()
+                .persistent()
+                .get::<DataKey, Prediction>(&DataKey::Prediction(market_id, predictor.clone()))
+                .unwrap()
+        });
+        assert_eq!(pred.market_id, market_id);
+        assert_eq!(pred.predictor, predictor);
+        assert_eq!(pred.chosen_outcome, symbol_short!("yes"));
+        assert_eq!(pred.stake_amount, 20_000_000);
+        assert!(!pred.payout_claimed);
+        assert_eq!(pred.payout_amount, 0);
+    }
+
+    // ── Validation: MarketNotFound ────────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_fails_market_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let predictor = Address::generate(&env);
+        fund(&env, &xlm_token, &predictor, 20_000_000);
+
+        let result = client.try_submit_prediction(
+            &predictor,
+            &99_u64,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+        assert!(matches!(result, Err(Ok(InsightArenaError::MarketNotFound))));
+    }
+
+    // ── Validation: MarketExpired ─────────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_fails_market_expired() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 20_000_000);
+
+        // Advance past end_time
+        env.ledger().set_timestamp(env.ledger().timestamp() + 1001);
+
+        let result = client.try_submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+        assert!(matches!(result, Err(Ok(InsightArenaError::MarketExpired))));
+    }
+
+    // ── Validation: InvalidOutcome ────────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_fails_invalid_outcome() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 20_000_000);
+
+        let result = client.try_submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("maybe"),
+            &20_000_000_i128,
+        );
+        assert!(matches!(result, Err(Ok(InsightArenaError::InvalidOutcome))));
+    }
+
+    // ── Validation: StakeTooLow ───────────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_fails_stake_too_low() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 20_000_000);
+
+        // min_stake is 10_000_000; submit 1 stroop below
+        let result = client.try_submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &9_999_999_i128,
+        );
+        assert!(matches!(result, Err(Ok(InsightArenaError::StakeTooLow))));
+    }
+
+    // ── Validation: StakeTooHigh ──────────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_fails_stake_too_high() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 200_000_000);
+
+        // max_stake is 100_000_000; submit 1 stroop above
+        let result = client.try_submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &100_000_001_i128,
+        );
+        assert!(matches!(result, Err(Ok(InsightArenaError::StakeTooHigh))));
+    }
+
+    // ── Validation: AlreadyPredicted ──────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_fails_already_predicted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 40_000_000);
+
+        // First prediction succeeds
+        client.submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+
+        // Second prediction for the same market must fail
+        let result = client.try_submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("no"),
+            &20_000_000_i128,
+        );
+        assert!(matches!(
+            result,
+            Err(Ok(InsightArenaError::AlreadyPredicted))
+        ));
+    }
+
+    // ── Validation: Paused ────────────────────────────────────────────────────
+
+    #[test]
+    fn submit_prediction_fails_when_paused() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 20_000_000);
+
+        client.set_paused(&true);
+
+        let result = client.try_submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+        assert!(matches!(result, Err(Ok(InsightArenaError::Paused))));
+    }
+
+    // ── XLM transfer: escrow receives the stake ───────────────────────────────
+
+    #[test]
+    fn submit_prediction_transfers_xlm_to_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+        let stake: i128 = 20_000_000;
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, stake);
+
+        let token = TokenClient::new(&env, &xlm_token);
+        assert_eq!(token.balance(&predictor), stake);
+        assert_eq!(token.balance(&client.address), 0);
+
+        client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+        assert_eq!(token.balance(&predictor), 0);
+        assert_eq!(token.balance(&client.address), stake);
+    }
+
+    // ── Market stats: total_pool and participant_count updated ────────────────
+
+    #[test]
+    fn submit_prediction_updates_market_total_pool_and_participant_count() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor_a = Address::generate(&env);
+        let predictor_b = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor_a, 20_000_000);
+        fund(&env, &xlm_token, &predictor_b, 30_000_000);
+
+        client.submit_prediction(
+            &predictor_a,
+            &market_id,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+        client.submit_prediction(
+            &predictor_b,
+            &market_id,
+            &symbol_short!("no"),
+            &30_000_000_i128,
+        );
+
+        let market = client.get_market(&market_id);
+        assert_eq!(market.total_pool, 50_000_000);
+        assert_eq!(market.participant_count, 2);
+    }
+
+    // ── UserProfile: stats created and incremented correctly ─────────────────
+
+    #[test]
+    fn submit_prediction_creates_and_updates_user_profile() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+        let stake: i128 = 20_000_000;
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, stake);
+
+        client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+        let profile = env.as_contract(&client.address, || {
+            use crate::storage_types::{DataKey, UserProfile};
+            env.storage()
+                .persistent()
+                .get::<DataKey, UserProfile>(&DataKey::User(predictor.clone()))
+                .unwrap()
+        });
+        assert_eq!(profile.total_predictions, 1);
+        assert_eq!(profile.total_staked, stake);
+        assert_eq!(profile.address, predictor);
+    }
+
+    #[test]
+    fn submit_prediction_accumulates_user_profile_across_markets() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        // Create two separate markets
+        let market_id_1 = client.create_market(&creator, &default_params(&env));
+        let market_id_2 = client.create_market(&creator, &default_params(&env));
+
+        fund(&env, &xlm_token, &predictor, 50_000_000);
+
+        client.submit_prediction(
+            &predictor,
+            &market_id_1,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+        client.submit_prediction(
+            &predictor,
+            &market_id_2,
+            &symbol_short!("no"),
+            &30_000_000_i128,
+        );
+
+        let profile = env.as_contract(&client.address, || {
+            use crate::storage_types::{DataKey, UserProfile};
+            env.storage()
+                .persistent()
+                .get::<DataKey, UserProfile>(&DataKey::User(predictor.clone()))
+                .unwrap()
+        });
+        assert_eq!(profile.total_predictions, 2);
+        assert_eq!(profile.total_staked, 50_000_000);
+    }
+
+    // ── PredictorList: predictor appended correctly ───────────────────────────
+
+    #[test]
+    fn submit_prediction_appends_to_predictor_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor_a = Address::generate(&env);
+        let predictor_b = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor_a, 20_000_000);
+        fund(&env, &xlm_token, &predictor_b, 20_000_000);
+
+        client.submit_prediction(
+            &predictor_a,
+            &market_id,
+            &symbol_short!("yes"),
+            &20_000_000_i128,
+        );
+        client.submit_prediction(
+            &predictor_b,
+            &market_id,
+            &symbol_short!("no"),
+            &20_000_000_i128,
+        );
+
+        let list = env.as_contract(&client.address, || {
+            use crate::storage_types::DataKey;
+            env.storage()
+                .persistent()
+                .get::<DataKey, soroban_sdk::Vec<Address>>(&DataKey::PredictorList(market_id))
+                .unwrap()
+        });
+        assert_eq!(list.len(), 2);
+        assert_eq!(list.get(0).unwrap(), predictor_a);
+        assert_eq!(list.get(1).unwrap(), predictor_b);
+    }
+
+    // ── Boundary: exact min_stake and max_stake are accepted ─────────────────
+
+    #[test]
+    fn submit_prediction_accepts_exact_min_stake() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 10_000_000);
+
+        client.submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &10_000_000_i128,
+        );
+        let market = client.get_market(&market_id);
+        assert_eq!(market.total_pool, 10_000_000);
+    }
+
+    #[test]
+    fn submit_prediction_accepts_exact_max_stake() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, xlm_token) = deploy(&env);
+        let creator = Address::generate(&env);
+        let predictor = Address::generate(&env);
+
+        let market_id = client.create_market(&creator, &default_params(&env));
+        fund(&env, &xlm_token, &predictor, 100_000_000);
+
+        client.submit_prediction(
+            &predictor,
+            &market_id,
+            &symbol_short!("yes"),
+            &100_000_000_i128,
+        );
+        let market = client.get_market(&market_id);
+        assert_eq!(market.total_pool, 100_000_000);
+    }
+}


### PR DESCRIPTION
Closes #53

---


## Summary
Creates `prediction.rs` and implements `submit_prediction` — the core user-facing
interaction where a predictor selects an outcome, stakes XLM locked into escrow,
and the contract validates all preconditions before writing the prediction to storage,
updating market stats atomically, and emitting a `PredictionSubmitted` event.

## Changes

### New File — `contract/src/prediction.rs`
- `submit_prediction(env, predictor, market_id, chosen_outcome, stake_amount)`
  — full implementation with ordered validation, escrow lock, storage write,
  stat updates, and event emission

### Validation Chain (in order)
- `ensure_not_paused(&env)?` — global pause check before any logic runs
- `predictor.require_auth()` — Soroban auth check on the predictor address
- `MarketNotFound` — returned if `market_id` does not exist in storage
- `MarketExpired` — returned if `current_time >= market.end_time`
- `InvalidOutcome` — returned if `chosen_outcome` is not in `market.outcome_options`
- Stake bounds check — returned if `stake_amount < market.min_stake` or
  `stake_amount > market.max_stake`
- `AlreadyPredicted` — returned if a `Prediction` already exists under
  `DataKey::Prediction(market_id, predictor.clone())`

### Escrow & Storage
- `escrow::lock_stake(env, predictor, stake_amount)?` — XLM locked before
  any prediction record is written; escrow errors propagate immediately
- `Prediction` written to storage under
  `DataKey::Prediction(market_id, predictor.clone())` after successful lock
- Market `total_pool` incremented by `stake_amount` and `participant_count`
  incremented atomically in a single market re-save
- `UserProfile` stats updated post-write to reflect new prediction activity

### Event
- `PredictionSubmitted` emitted with `market_id`, `predictor`, `chosen_outcome`,
  and `stake_amount` after all writes complete

## Implementation Notes
- Validation order is cheapest-first: pause → auth → market existence → time
  → outcome → stake bounds → duplicate check; storage reads deferred as late
  as possible
- Escrow lock called strictly before prediction storage write — if lock fails,
  no prediction record is persisted and no market stats are mutated
- Market stats (`total_pool`, `participant_count`) updated and re-saved in a
  single storage write to prevent partial state on failure
- `AlreadyPredicted` check uses storage key existence to avoid loading the
  full `Prediction` struct unnecessarily

## Testing Checklist
- [ ] `ensure_not_paused` blocks submission when contract is paused
- [ ] Unauthenticated predictor is rejected via `require_auth()`
- [ ] Returns `MarketNotFound` for unknown `market_id`
- [ ] Returns `MarketExpired` when `current_time >= market.end_time`
- [ ] Returns `InvalidOutcome` for outcome not in `market.outcome_options`
- [ ] Returns correct error when `stake_amount` is below `min_stake`
- [ ] Returns correct error when `stake_amount` exceeds `max_stake`
- [ ] Returns `AlreadyPredicted` on second submission for same market
- [ ] XLM is locked in escrow before prediction record is written
- [ ] Escrow failure prevents prediction storage write and stat updates
- [ ] `Prediction` record written correctly under expected `DataKey`
- [ ] Market `total_pool` incremented by exact `stake_amount`
- [ ] Market `participant_count` incremented by 1 atomically
- [ ] `UserProfile` stats updated correctly post-submission
- [ ] `PredictionSubmitted` event emitted with all 4 correct fields