### PR TITLE
Feature/market entity

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -56,4 +56,4 @@ import { MarketsModule } from './markets/markets.module';
     },
   ],
 })
-export class AppModule { }
+export class AppModule {}

--- a/backend/src/markets/entities/market.entity.ts
+++ b/backend/src/markets/entities/market.entity.ts
@@ -1,12 +1,18 @@
 import {
-    Entity,
-    PrimaryGeneratedColumn,
-    Column,
-    CreateDateColumn,
-    ManyToOne,
-    Index,
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  Index,
 } from 'typeorm';
-import { IsString, IsOptional, IsNumber, IsBoolean, Min } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsNumber,
+  IsBoolean,
+  Min,
+} from 'class-validator';
 import { User } from '../../users/entities/user.entity';
 
 @Entity('markets')
@@ -15,64 +21,64 @@ import { User } from '../../users/entities/user.entity';
 @Index(['category'])
 @Index(['is_resolved'])
 export class Market {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @Column({ unique: true })
-    @IsString()
-    on_chain_market_id: string;
+  @Column({ unique: true })
+  @IsString()
+  on_chain_market_id: string;
 
-    @ManyToOne(() => User, { onDelete: 'CASCADE' })
-    @IsOptional()
-    creator: User;
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @IsOptional()
+  creator: User;
 
-    @Column()
-    @IsString()
-    title: string;
+  @Column()
+  @IsString()
+  title: string;
 
-    @Column('text')
-    @IsString()
-    description: string;
+  @Column('text')
+  @IsString()
+  description: string;
 
-    @Column()
-    @IsString()
-    category: string;
+  @Column()
+  @IsString()
+  category: string;
 
-    @Column('simple-array')
-    outcome_options: string[];
+  @Column('simple-array')
+  outcome_options: string[];
 
-    @Column({ type: 'timestamptz' })
-    end_time: Date;
+  @Column({ type: 'timestamptz' })
+  end_time: Date;
 
-    @Column({ type: 'timestamptz' })
-    resolution_time: Date;
+  @Column({ type: 'timestamptz' })
+  resolution_time: Date;
 
-    @Column({ default: false })
-    @IsBoolean()
-    is_resolved: boolean;
+  @Column({ default: false })
+  @IsBoolean()
+  is_resolved: boolean;
 
-    @Column({ nullable: true })
-    @IsOptional()
-    @IsString()
-    resolved_outcome: string;
+  @Column({ nullable: true })
+  @IsOptional()
+  @IsString()
+  resolved_outcome: string;
 
-    @Column({ default: true })
-    @IsBoolean()
-    is_public: boolean;
+  @Column({ default: true })
+  @IsBoolean()
+  is_public: boolean;
 
-    @Column({ default: false })
-    @IsBoolean()
-    is_cancelled: boolean;
+  @Column({ default: false })
+  @IsBoolean()
+  is_cancelled: boolean;
 
-    @Column({ type: 'bigint', default: '0' })
-    @IsString()
-    total_pool_stroops: string;
+  @Column({ type: 'bigint', default: '0' })
+  @IsString()
+  total_pool_stroops: string;
 
-    @Column({ default: 0 })
-    @IsNumber()
-    @Min(0)
-    participant_count: number;
+  @Column({ default: 0 })
+  @IsNumber()
+  @Min(0)
+  participant_count: number;
 
-    @CreateDateColumn()
-    created_at: Date;
+  @CreateDateColumn()
+  created_at: Date;
 }

--- a/backend/src/markets/markets.module.ts
+++ b/backend/src/markets/markets.module.ts
@@ -3,7 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Market } from './entities/market.entity';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Market])],
-    exports: [TypeOrmModule],
+  imports: [TypeOrmModule.forFeature([Market])],
+  exports: [TypeOrmModule],
 })
-export class MarketsModule { }
+export class MarketsModule {}

--- a/backend/src/migrations/1774431698000-CreateMarketEntity.ts
+++ b/backend/src/migrations/1774431698000-CreateMarketEntity.ts
@@ -1,39 +1,31 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateMarketEntity1774431698000 implements MigrationInterface {
-    name = 'CreateMarketEntity1774431698000';
+  name = 'CreateMarketEntity1774431698000';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(
-            `CREATE TABLE "markets" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "on_chain_market_id" character varying NOT NULL, "title" character varying NOT NULL, "description" text NOT NULL, "category" character varying NOT NULL, "outcome_options" text NOT NULL, "end_time" TIMESTAMP WITH TIME ZONE NOT NULL, "resolution_time" TIMESTAMP WITH TIME ZONE NOT NULL, "is_resolved" boolean NOT NULL DEFAULT false, "resolved_outcome" character varying, "is_public" boolean NOT NULL DEFAULT true, "is_cancelled" boolean NOT NULL DEFAULT false, "total_pool_stroops" bigint NOT NULL DEFAULT '0', "participant_count" integer NOT NULL DEFAULT 0, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "creatorId" uuid, CONSTRAINT "UQ_on_chain_market_id" UNIQUE ("on_chain_market_id"), CONSTRAINT "PK_markets_id" PRIMARY KEY ("id"), CONSTRAINT "FK_markets_creator" FOREIGN KEY ("creatorId") REFERENCES "users"("id") ON DELETE CASCADE)`,
-        );
-        await queryRunner.query(
-            `CREATE INDEX "IDX_on_chain_market_id" ON "markets" ("on_chain_market_id")`,
-        );
-        await queryRunner.query(
-            `CREATE INDEX "IDX_creator" ON "markets" ("creatorId")`,
-        );
-        await queryRunner.query(
-            `CREATE INDEX "IDX_category" ON "markets" ("category")`,
-        );
-        await queryRunner.query(
-            `CREATE INDEX "IDX_is_resolved" ON "markets" ("is_resolved")`,
-        );
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "markets" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "on_chain_market_id" character varying NOT NULL, "title" character varying NOT NULL, "description" text NOT NULL, "category" character varying NOT NULL, "outcome_options" text NOT NULL, "end_time" TIMESTAMP WITH TIME ZONE NOT NULL, "resolution_time" TIMESTAMP WITH TIME ZONE NOT NULL, "is_resolved" boolean NOT NULL DEFAULT false, "resolved_outcome" character varying, "is_public" boolean NOT NULL DEFAULT true, "is_cancelled" boolean NOT NULL DEFAULT false, "total_pool_stroops" bigint NOT NULL DEFAULT '0', "participant_count" integer NOT NULL DEFAULT 0, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "creatorId" uuid, CONSTRAINT "UQ_on_chain_market_id" UNIQUE ("on_chain_market_id"), CONSTRAINT "PK_markets_id" PRIMARY KEY ("id"), CONSTRAINT "FK_markets_creator" FOREIGN KEY ("creatorId") REFERENCES "users"("id") ON DELETE CASCADE)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_on_chain_market_id" ON "markets" ("on_chain_market_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_creator" ON "markets" ("creatorId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_category" ON "markets" ("category")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_is_resolved" ON "markets" ("is_resolved")`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(
-            `DROP INDEX "public"."IDX_is_resolved"`,
-        );
-        await queryRunner.query(
-            `DROP INDEX "public"."IDX_category"`,
-        );
-        await queryRunner.query(
-            `DROP INDEX "public"."IDX_creator"`,
-        );
-        await queryRunner.query(
-            `DROP INDEX "public"."IDX_on_chain_market_id"`,
-        );
-        await queryRunner.query(`DROP TABLE "markets"`);
-    }
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_is_resolved"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_category"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_creator"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_on_chain_market_id"`);
+    await queryRunner.query(`DROP TABLE "markets"`);
+  }
 }


### PR DESCRIPTION
# [Backend] Create Market Entity with TypeORM

Closes #112

## Overview
This PR implements the Market entity for the InsightArena backend, providing an off-chain queryable index for markets stored on-chain in the Soroban contract. The entity mirrors on-chain data while enabling efficient API queries.

## Changes

### 1. Market Entity (`src/markets/entities/market.entity.ts`)
- Created Market entity with all required fields as specified in issue #112
- Includes TypeORM decorators for database mapping and class-validator decorators for validation
- Establishes ManyToOne relationship with User entity (creator) with CASCADE delete
- Uses appropriate column types: UUID for IDs, bigint for stroops, timestamptz for dates, simple-array for outcome options

### 2. Database Migration (`src/migrations/1774431698000-CreateMarketEntity.ts`)
- Creates `markets` table with all entity columns
- Implements foreign key constraint on `creator` with CASCADE delete
- Creates indices on:
  - `on_chain_market_id` (unique constraint for on-chain sync)
  - `creator` (for querying markets by creator)
  - `category` (for market filtering)
  - `is_resolved` (for market status queries)

### 3. Markets Module (`src/markets/markets.module.ts`)
- Registers Market entity with TypeORM
- Exports TypeOrmModule for use in other modules

### 4. App Module Integration (`src/app.module.ts`)
- Registers MarketsModule in the application

## Acceptance Criteria Met
✅ Migration creates markets table with all columns  
✅ Foreign key on creator references users.id with CASCADE delete  
✅ All required indices exist in the database  
✅ Entity follows project patterns (validation decorators, column types, relationships)  
✅ Build passes without errors  
✅ Lint checks pass  

## Testing
- Build verification: `npm run build` ✓
- Lint verification: `npm run lint` ✓
- No TypeScript diagnostics

## Migration Instructions
To apply the migration:
```bash
npm run migration:run
```

To revert if needed:
```bash
npm run migration:revert
```
