### PR TITLE
feat(backend): complete users module with PATCH /users/me profile update

### DIFF
--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,0 +1,33 @@
+import {
+  IsOptional,
+  IsString,
+  IsUrl,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateUserDto {
+  @ApiPropertyOptional({
+    description: 'Display name (alphanumeric, 3–30 chars)',
+    example: 'StellarTrader42',
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(3, { message: 'username must be at least 3 characters' })
+  @MaxLength(30, { message: 'username must be at most 30 characters' })
+  @Matches(/^[a-zA-Z0-9_]+$/, {
+    message: 'username must be alphanumeric (letters, numbers, underscores)',
+  })
+  username?: string;
+
+  @ApiPropertyOptional({
+    description: 'Profile avatar URL',
+    example: 'https://example.com/avatar.png',
+  })
+  @IsOptional()
+  @IsString()
+  @IsUrl({}, { message: 'avatar_url must be a valid URL' })
+  avatar_url?: string;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Patch, Param, Body, UsePipes, ValidationPipe } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
 import { Public } from '../common/decorators/public.decorator';
@@ -6,6 +6,7 @@ import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { UsersService } from './users.service';
 import { PublicUserDto } from './dto/public-user.dto';
 import { UserResponseDto } from './dto/user-response.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
 
 @Controller('users')
@@ -22,6 +23,26 @@ export class UsersController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   getOwnProfile(@CurrentUser() user: User) {
     return plainToInstance(UserResponseDto, user, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  @Patch('me')
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: false }))
+  @ApiOperation({ summary: 'Update own profile (username, avatar_url)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Profile updated successfully',
+    type: UserResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async updateOwnProfile(
+    @CurrentUser() user: User,
+    @Body() dto: UpdateUserDto,
+  ) {
+    const updated = await this.usersService.updateProfile(user.id, dto);
+    return plainToInstance(UserResponseDto, updated, {
       excludeExtraneousValues: true,
     });
   }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Injectable()
 export class UsersService {
@@ -10,15 +11,34 @@ export class UsersService {
     private readonly usersRepository: Repository<User>,
   ) {}
 
+  async findById(id: string): Promise<User> {
+    const user = await this.usersRepository.findOneBy({ id });
+    if (!user) {
+      throw new NotFoundException(`User with id ${id} not found`);
+    }
+    return user;
+  }
+
   async findByAddress(stellar_address: string): Promise<User> {
     const user = await this.usersRepository.findOneBy({ stellar_address });
-
     if (!user) {
       throw new NotFoundException(
         `User with address ${stellar_address} not found`,
       );
     }
-
     return user;
+  }
+
+  async updateProfile(userId: string, dto: UpdateUserDto): Promise<User> {
+    const user = await this.findById(userId);
+
+    if (dto.username !== undefined) {
+      user.username = dto.username;
+    }
+    if (dto.avatar_url !== undefined) {
+      user.avatar_url = dto.avatar_url;
+    }
+
+    return this.usersRepository.save(user);
   }
 }


### PR DESCRIPTION
Closes #108
Closes #110

## Summary
Completes the Users module structure and implements the `PATCH /users/me` endpoint for profile updates with DTO validation and whitelist enforcement.

## Changes

### Users Module (#108)
- `users.module.ts` — already had `TypeOrmModule.forFeature([User])`, controller, service, and exports
- `users.service.ts` — added `findById()` and `updateProfile()` methods
- `dto/` directory — added `UpdateUserDto`
- Module already registered in `AppModule` and `UsersService` already exported

### PATCH /users/me (#110)
- Added `@Patch('me')` endpoint to `UsersController`
- Created `UpdateUserDto` with class-validator rules:
  - `username`: optional, alphanumeric + underscores, 3–30 characters
  - `avatar_url`: optional, must be a valid URL
- `ValidationPipe` with `whitelist: true` strips unknown fields (reputation_score, role, etc. are silently ignored)
- Only `username` and `avatar_url` are updatable — enforced by DTO whitelist
- Returns `200` with updated user serialized via `UserResponseDto`
- Returns `400` for invalid username (too short, special chars) or invalid URL

## How to test
```bash
# Start backend
cd backend && npm run dev

# Update profile (requires JWT)
curl -X PATCH http://localhost:3000/users/me \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"username": "NewName42", "avatar_url": "https://example.com/pic.png"}'

# Attempting to set reputation_score is ignored
curl -X PATCH http://localhost:3000/users/me \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"reputation_score": 9999}'
# → returns 200 with unchanged reputation_score
```