### PR TITLE
Update Header navigation links with proper routes

### DIFF
--- a/frontend/src/component/Header.tsx
+++ b/frontend/src/component/Header.tsx
@@ -3,6 +3,14 @@
 import Link from "next/link";
 
 export default function Header() {
+
+  const navLinks = [
+    {name: 'Home', link: '/'},
+    {name: 'Markets', link: '/markets'},
+    {name: 'Leaderboard', link: '/leaderboards'},
+    {name: 'Docs', link: '/docs'},
+    {name: 'Dashboard', link: '/dashboard'},
+  ]
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-sm border-b border-gray-800">
       <div className="max-w-7xl mx-auto px-6 py-4">
@@ -14,24 +22,15 @@ export default function Header() {
           </div>
           <div>
             <div className="hidden md:flex items-center space-x-6">
-              <Link
-                href="/"
-                className="text-gray-300 hover:text-white transition-colors"
-              >
-                Global Markets
-              </Link>
-              <Link
-                href="/"
-                className="text-gray-300 hover:text-white transition-colors"
-              >
-                Create Event
-              </Link>
-              <Link
-                href="/"
-                className="text-gray-300 hover:text-white transition-colors"
-              >
-                Profile
-              </Link>
+              {navLinks.map((link) => (
+                <Link
+                  key={link.name}
+                  href={link.link}
+                  className="text-gray-300 hover:text-white transition-colors"
+                >
+                  {link.name}
+                </Link>
+              ))}
             </div>
           </div>
 


### PR DESCRIPTION

<img width="1285" height="308" alt="Screenshot From 2026-03-25 15-29-28" src="https://github.com/user-attachments/assets/23919430-b3ac-47be-8dfe-bd8fcbfc06f5" />
- Update Markets link to /markets
- Update Leaderboard link to /leaderboards
- Update Docs link to /docs
- Update Dashboard link to /dashboard

Fixes #81