### PR TITLE
[Backend] Implement GET /markets — List & Filter Markets

### DIFF
--- a/backend/src/markets/dto/list-markets.dto.ts
+++ b/backend/src/markets/dto/list-markets.dto.ts
@@ -1,0 +1,68 @@
+import {
+  IsOptional,
+  IsString,
+  IsNumber,
+  IsBoolean,
+  IsEnum,
+  Min,
+  Max,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+
+export enum MarketStatus {
+  Open = 'open',
+  Resolved = 'resolved',
+  Cancelled = 'cancelled',
+}
+
+export class ListMarketsDto {
+  @ApiPropertyOptional({ description: 'Page number', default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page (max 50)',
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(50)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ description: 'Filter by category' })
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by status',
+    enum: MarketStatus,
+  })
+  @IsOptional()
+  @IsEnum(MarketStatus)
+  status?: MarketStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by public/private' })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  is_public?: boolean;
+
+  @ApiPropertyOptional({ description: 'Keyword search on title' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}
+
+export class PaginatedMarketsResponse {
+  data: any[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/backend/src/markets/markets.controller.ts
+++ b/backend/src/markets/markets.controller.ts
@@ -1,24 +1,33 @@
-import { Controller, Get, Param } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MarketsService } from './markets.service';
 import { Market } from './entities/market.entity';
+import {
+  ListMarketsDto,
+  PaginatedMarketsResponse,
+} from './dto/list-markets.dto';
+import { Public } from '../common/decorators/public.decorator';
 
+@ApiTags('Markets')
 @Controller('markets')
 export class MarketsController {
   constructor(private readonly marketsService: MarketsService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Fetch all markets' })
+  @Public()
+  @ApiOperation({ summary: 'List and filter markets with pagination' })
   @ApiResponse({
     status: 200,
-    description: 'Markets retrieved successfully',
-    type: [Market],
+    description: 'Paginated markets list',
   })
-  async getAllMarkets(): Promise<Market[]> {
-    return this.marketsService.findAll();
+  async listMarkets(
+    @Query() query: ListMarketsDto,
+  ): Promise<PaginatedMarketsResponse> {
+    return this.marketsService.findAllFiltered(query);
   }
 
   @Get(':id')
+  @Public()
   @ApiOperation({ summary: 'Fetch market by ID' })
   @ApiResponse({
     status: 200,

--- a/backend/src/markets/markets.service.ts
+++ b/backend/src/markets/markets.service.ts
@@ -3,6 +3,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Market } from './entities/market.entity';
 import { UsersService } from '../users/users.service';
+import {
+  ListMarketsDto,
+  MarketStatus,
+  PaginatedMarketsResponse,
+} from './dto/list-markets.dto';
 
 @Injectable()
 export class MarketsService {
@@ -11,6 +16,63 @@ export class MarketsService {
     private readonly marketsRepository: Repository<Market>,
     private readonly usersService: UsersService,
   ) {}
+
+  /**
+   * List markets with pagination, filtering, and keyword search.
+   */
+  async findAllFiltered(
+    dto: ListMarketsDto,
+  ): Promise<PaginatedMarketsResponse> {
+    const page = dto.page ?? 1;
+    const limit = Math.min(dto.limit ?? 20, 50);
+    const skip = (page - 1) * limit;
+
+    const qb = this.marketsRepository
+      .createQueryBuilder('market')
+      .leftJoinAndSelect('market.creator', 'creator');
+
+    // Category filter
+    if (dto.category) {
+      qb.andWhere('market.category = :category', { category: dto.category });
+    }
+
+    // Status filter
+    if (dto.status) {
+      switch (dto.status) {
+        case MarketStatus.Open:
+          qb.andWhere(
+            'market.is_resolved = false AND market.is_cancelled = false',
+          );
+          break;
+        case MarketStatus.Resolved:
+          qb.andWhere('market.is_resolved = true');
+          break;
+        case MarketStatus.Cancelled:
+          qb.andWhere('market.is_cancelled = true');
+          break;
+      }
+    }
+
+    // Public/private filter
+    if (dto.is_public !== undefined) {
+      qb.andWhere('market.is_public = :is_public', {
+        is_public: dto.is_public,
+      });
+    }
+
+    // Keyword search (case-insensitive)
+    if (dto.search) {
+      qb.andWhere('market.title ILIKE :search', {
+        search: `%${dto.search}%`,
+      });
+    }
+
+    qb.orderBy('market.created_at', 'DESC').skip(skip).take(limit);
+
+    const [data, total] = await qb.getManyAndCount();
+
+    return { data, total, page, limit };
+  }
 
   async findAll(): Promise<Market[]> {
     return this.marketsRepository.find({


### PR DESCRIPTION
## Description
Add paginated, filterable GET /markets endpoint.

## Changes
- Create ListMarketsDto with page, limit (max 50), category, status, is_public, search params
- Implement findAllFiltered() using TypeORM QueryBuilder
- ILIKE search on title, AND combination of filters
- Returns { data, total, page, limit }
- Empty array (not 404) when no results

## How to test
- GET /markets?category=Crypto&status=open&page=1&limit=10
- Verify limit > 50 is clamped
- Verify empty array for no matches

Closes #152