### PR TITLE
[Backend] Set Up Competitions Module Structure

### DIFF
--- a/backend/src/competitions/competitions.module.ts
+++ b/backend/src/competitions/competitions.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Competition } from './entities/competition.entity';
 import { CompetitionsService } from './competitions.service';
 import { CompetitionsController } from './competitions.controller';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Competition])],
+  imports: [TypeOrmModule.forFeature([Competition]), UsersModule],
   controllers: [CompetitionsController],
   providers: [CompetitionsService],
   exports: [CompetitionsService],


### PR DESCRIPTION
## Summary
- Add `CompetitionsModule` (controller/service/DTO) for creating and viewing competitions.
- Wire `TypeOrmModule.forFeature([Competition])` and import `UsersModule` so the competition `creator` relation resolves correctly.

closes #167

## Endpoints
- `POST /competitions` (authenticated): create a competition
- `GET /competitions` (public): list public competitions
- `GET /competitions/:id` (public): fetch a competition by id

## Test Plan
- Backend: `npm run lint && npm test && npm run build`

