### PR TITLE
Feature/notifications read all

### DIFF
--- a/backend/src/notifications/notifications.controller.spec.ts
+++ b/backend/src/notifications/notifications.controller.spec.ts
@@ -95,12 +95,13 @@ describe('NotificationsController', () => {
   });
 
   describe('markAllAsRead', () => {
-    it('should call service markAllAsRead with userId', async () => {
-      const spy = jest.spyOn(service, 'markAllAsRead').mockResolvedValue();
+    it('should call service markAllAsRead with userId and return count', async () => {
+      const spy = jest.spyOn(service, 'markAllAsRead').mockResolvedValue({ updated: 3 });
 
-      await controller.markAllAsRead(mockUser as User);
+      const result = await controller.markAllAsRead(mockUser as User);
 
       expect(spy).toHaveBeenCalledWith('user-uuid-1');
+      expect(result).toEqual({ updated: 3 });
     });
   });
 });

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -71,10 +71,9 @@ export class NotificationsController {
   }
 
   @Patch('read-all')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Mark all notifications as read' })
-  @ApiResponse({ status: 204, description: 'All notifications marked as read' })
-  async markAllAsRead(@CurrentUser() user: User): Promise<void> {
+  @ApiResponse({ status: 200, description: 'All notifications marked as read', schema: { example: { updated: 3 } } })
+  async markAllAsRead(@CurrentUser() user: User): Promise<{ updated: number }> {
     return this.notificationsService.markAllAsRead(user.id);
   }
 }

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -139,15 +139,16 @@ describe('NotificationsService', () => {
   });
 
   describe('markAllAsRead', () => {
-    it('should mark all unread notifications as read', async () => {
+    it('should mark all unread notifications as read and return count', async () => {
       mockRepository.update.mockResolvedValue({ affected: 3 });
 
-      await service.markAllAsRead('user-uuid-1');
+      const result = await service.markAllAsRead('user-uuid-1');
 
       expect(mockRepository.update).toHaveBeenCalledWith(
         { user_id: 'user-uuid-1', is_read: false },
         { is_read: true },
       );
+      expect(result).toEqual({ updated: 3 });
     });
   });
 });

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -68,10 +68,11 @@ export class NotificationsService {
     );
   }
 
-  async markAllAsRead(userId: string): Promise<void> {
-    await this.notificationsRepository.update(
+  async markAllAsRead(userId: string): Promise<{ updated: number }> {
+    const result = await this.notificationsRepository.update(
       { user_id: userId, is_read: false },
       { is_read: true },
     );
+    return { updated: result.affected ?? 0 };
   }
 }


### PR DESCRIPTION
## Description
This PR addresses the requirements for the `PATCH /notifications/read-all` endpoint to correctly bulk-update unread notifications and return the count of updated rows.

### Acceptance Criteria Met:
- Marks only the current authenticated user's `is_read = false` notifications to `true`.
- Returns the total count of notifications that were successfully marked as read in the format `{ updated: number }`.
- Subsequent calls to `GET /notifications?unread_only=true` will correctly return an empty list.

## Implementation Details
1. **Service ([notifications.service.ts](cci:7://file:///c:/Users/HP/Desktop/Arena/InsightArena/backend/src/notifications/notifications.service.ts:0:0-0:0))**:
   - Modified [markAllAsRead](cci:1://file:///c:/Users/HP/Desktop/Arena/InsightArena/backend/src/notifications/notifications.controller.ts:75:2-77:3) to capture the `UpdateResult` returned by TypeORM.
   - Updated the return signature to resolve with `{ updated: result.affected ?? 0 }`.
2. **Controller ([notifications.controller.ts](cci:7://file:///c:/Users/HP/Desktop/Arena/InsightArena/backend/src/notifications/notifications.controller.ts:0:0-0:0))**:
   - Removed the `@HttpCode(HttpStatus.NO_CONTENT)` decorator so the endpoint correctly defaults to `200 OK`.
   - Updated the `@ApiResponse` Swagger descriptor to indicate a status `200` returning the `{ updated: 3 }` schema.
   - Adjusted the controller signature to proxy the return value of the service back to the client.
3. **Tests**:
   - Updated [markAllAsRead](cci:1://file:///c:/Users/HP/Desktop/Arena/InsightArena/backend/src/notifications/notifications.controller.ts:75:2-77:3) in [notifications.service.spec.ts](cci:7://file:///c:/Users/HP/Desktop/Arena/InsightArena/backend/src/notifications/notifications.service.spec.ts:0:0-0:0) mocking `update()` to resolve an `{ affected: 3 }` object, then asserting the return value is `{ updated: 3 }`.
   - Re-aligned the controller mocks in [notifications.controller.spec.ts](cci:7://file:///c:/Users/HP/Desktop/Arena/InsightArena/backend/src/notifications/notifications.controller.spec.ts:0:0-0:0) to simulate the new return data shape.

## How to Test
1. Create several unread notifications for a user.
2. Ensure `GET /notifications?unread_only=true` returns those results.
3. Call `PATCH /notifications/read-all` and verify you receive `{ updated: <count> }` and a `200` status.
4. Perform the query in step 2 again and verify it returns an empty data set.

this pr closes #173 #174