### PR TITLE
feat: Implement invite code generation functionality and add new test snapshots for invite and escrow modules.

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -257,7 +257,7 @@ impl InsightArenaContract {
         expires_in_seconds: u64,
     ) -> Result<Symbol, InsightArenaError> {
         invite::generate_invite_code(env, creator, market_id, max_uses, expires_in_seconds)
-    // ── Season / Leaderboard ────────────────────────────────────────────────
+        // ── Season / Leaderboard ────────────────────────────────────────────────
     }
 
     /// List all season IDs which have snapshots available.


### PR DESCRIPTION
## Description

Implements the `generate_invite_code` functionality for the InsightArena contract.  
This feature enables market creators to generate unique, 8-character invite codes for private markets, allowing restricted participation.

Closes #235 

---

## Overview

This PR introduces a secure and collision-resistant invite code system tied to market creation and access control.

---

## Key Changes

### New Module: `invite.rs`

- Implemented logic for generating 8-character alphanumeric invite codes
- Ensured collision resistance using SHA-256 hashing
- Seed includes:
  - `market_id`
  - `creator_address`
  - `ledger_sequence`
  - `ledger_timestamp`
- Added validation:
  - Only the market creator can generate invite codes
  - `max_uses` must be at least 1
- Stored `InviteCode` metadata on-chain
- Emitted `InviteCodeGenerated` event upon creation

---

### Contract Interface Update: `lib.rs`

- Registered the `invite` module
- Exposed `generate_invite_code` as a public contract function

---

## Verification

### Automated Tests

- Added comprehensive unit tests in `invite.rs` covering:
  - Successful invite code generation
  - Authorization failures
  - Invalid input handling
  - Code uniqueness validation

---

### CI/CD Compliance

- All tests passing:
  - `100 passed; 0 failed`
- Code formatted using `cargo fmt`
- Resolved all Clippy warnings

---

### Build

- Successfully compiled contract for `wasm32-unknown-unknown`

```bash
# Verification Command
cd contract && cargo test

# Result
test result: ok. 100 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.22s