### PR TITLE
 enforce market category whitelist (#262)

### DIFF
--- a/contract/src/config.rs
+++ b/contract/src/config.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 use crate::errors::InsightArenaError;
 use crate::storage_types::DataKey;
@@ -78,8 +78,25 @@ pub fn initialize(
 
     env.storage().persistent().set(&DataKey::Config, &config);
     bump_config(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::Categories, &default_categories(env));
+    env.storage()
+        .instance()
+        .extend_ttl(PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
 
     Ok(())
+}
+
+pub(crate) fn default_categories(env: &Env) -> Vec<Symbol> {
+    let mut categories = Vec::new(env);
+    categories.push_back(Symbol::new(env, "Sports"));
+    categories.push_back(Symbol::new(env, "Crypto"));
+    categories.push_back(Symbol::new(env, "Politics"));
+    categories.push_back(Symbol::new(env, "Entertainment"));
+    categories.push_back(Symbol::new(env, "Science"));
+    categories.push_back(Symbol::new(env, "Other"));
+    categories
 }
 
 /// Return the current global [`Config`] and extend its TTL.

--- a/contract/src/escrow.rs
+++ b/contract/src/escrow.rs
@@ -257,14 +257,14 @@ mod escrow_tests {
 
     fn seed_unresolved_market(env: &Env, client: &InsightArenaContractClient<'_>, market_id: u64) {
         use crate::storage_types::Market;
-        use soroban_sdk::{symbol_short, vec, String};
+        use soroban_sdk::{symbol_short, vec, String, Symbol};
 
         let market = Market::new(
             market_id,
             Address::generate(env),
             String::from_str(env, "seeded market"),
             String::from_str(env, "seeded for escrow tests"),
-            symbol_short!("audit"),
+            Symbol::new(env, "Sports"),
             vec![env, symbol_short!("yes"), symbol_short!("no")],
             env.ledger().timestamp(),
             env.ledger().timestamp() + 100,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -105,6 +105,39 @@ impl InsightArenaContract {
         market::create_market(&env, creator, params)
     }
 
+    /// Add a category to the admin-managed whitelist used during market creation.
+    pub fn add_category(
+        env: Env,
+        admin: Address,
+        category: Symbol,
+    ) -> Result<(), InsightArenaError> {
+        market::add_category(&env, admin, category)
+    }
+
+    /// Remove a category from the whitelist for future market creation.
+    pub fn remove_category(
+        env: Env,
+        admin: Address,
+        category: Symbol,
+    ) -> Result<(), InsightArenaError> {
+        market::remove_category(&env, admin, category)
+    }
+
+    /// Return the current category whitelist.
+    pub fn list_categories(env: Env) -> Vec<Symbol> {
+        market::list_categories(&env)
+    }
+
+    /// Return markets for a category using a zero-based offset in that category's index.
+    pub fn get_markets_by_category(
+        env: Env,
+        category: Symbol,
+        start: u64,
+        limit: u32,
+    ) -> Vec<Market> {
+        market::get_markets_by_category(&env, category, start, limit)
+    }
+
     /// Fetch a market by ID. Returns `MarketNotFound` if it does not exist.
     pub fn get_market(env: Env, market_id: u64) -> Result<Market, InsightArenaError> {
         market::get_market(&env, market_id)

--- a/contract/src/market.rs
+++ b/contract/src/market.rs
@@ -40,6 +40,80 @@ fn bump_counter(env: &Env) {
     );
 }
 
+fn bump_categories(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
+}
+
+fn bump_category_index(env: &Env, category: &Symbol) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::CategoryIndex(category.clone()),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
+fn load_categories(env: &Env) -> Vec<Symbol> {
+    let categories = env
+        .storage()
+        .instance()
+        .get(&DataKey::Categories)
+        .unwrap_or_else(|| config::default_categories(env));
+
+    if env.storage().instance().has(&DataKey::Categories) {
+        bump_categories(env);
+    }
+
+    categories
+}
+
+fn save_categories(env: &Env, categories: &Vec<Symbol>) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Categories, categories);
+    bump_categories(env);
+}
+
+fn load_category_index(env: &Env, category: &Symbol) -> Vec<u64> {
+    let key = DataKey::CategoryIndex(category.clone());
+    let market_ids = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    if env.storage().persistent().has(&key) {
+        bump_category_index(env, category);
+    }
+
+    market_ids
+}
+
+fn save_category_index(env: &Env, category: &Symbol, market_ids: &Vec<u64>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CategoryIndex(category.clone()), market_ids);
+    bump_category_index(env, category);
+}
+
+fn append_market_to_category_index(env: &Env, category: &Symbol, market_id: u64) {
+    let mut market_ids = load_category_index(env, category);
+    market_ids.push_back(market_id);
+    save_category_index(env, category, &market_ids);
+}
+
+fn require_admin(env: &Env, admin: &Address) -> Result<(), InsightArenaError> {
+    admin.require_auth();
+
+    let cfg = config::get_config(env)?;
+    if admin != &cfg.admin {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    Ok(())
+}
+
 // ── Counter helpers ───────────────────────────────────────────────────────────
 
 fn load_market_count(env: &Env) -> u64 {
@@ -97,8 +171,9 @@ pub fn emit_market_resolved(env: &Env, market_id: u64, resolved_outcome: Symbol)
 /// 3. `end_time` must be strictly after the current ledger timestamp
 /// 4. `resolution_time` must be >= `end_time`
 /// 5. At least two distinct outcomes required
-/// 6. `creator_fee_bps` must not exceed the platform cap
-/// 7. `min_stake` >= platform minimum; `max_stake` >= `min_stake`
+/// 6. `category` must be in the admin-managed whitelist
+/// 7. `creator_fee_bps` must not exceed the platform cap
+/// 8. `min_stake` >= platform minimum; `max_stake` >= `min_stake`
 pub fn create_market(
     env: &Env,
     creator: Address,
@@ -128,6 +203,9 @@ pub fn create_market(
 
     // ── Load config for fee and stake floor checks ────────────────────────────
     let cfg = config::get_config(env)?;
+    if !load_categories(env).contains(params.category.clone()) {
+        return Err(InsightArenaError::InvalidInput);
+    }
 
     // ── Guard 6: creator fee must not exceed the platform cap ─────────────────
     if params.creator_fee_bps > cfg.max_creator_fee_bps {
@@ -166,6 +244,7 @@ pub fn create_market(
         .persistent()
         .set(&DataKey::Market(market_id), &market);
     bump_market(env, market_id);
+    append_market_to_category_index(env, &market.category, market_id);
 
     // ── Emit MarketCreated event ──────────────────────────────────────────────
     emit_market_created(env, market_id, &creator, params.end_time);
@@ -226,6 +305,76 @@ pub fn list_markets(env: &Env, start: u64, limit: u32) -> Vec<Market> {
             collected += 1;
         }
         id += 1;
+    }
+
+    result
+}
+
+pub fn add_category(env: &Env, admin: Address, category: Symbol) -> Result<(), InsightArenaError> {
+    require_admin(env, &admin)?;
+
+    let mut categories = load_categories(env);
+    if !categories.contains(category.clone()) {
+        categories.push_back(category);
+        save_categories(env, &categories);
+    }
+
+    Ok(())
+}
+
+pub fn remove_category(
+    env: &Env,
+    admin: Address,
+    category: Symbol,
+) -> Result<(), InsightArenaError> {
+    require_admin(env, &admin)?;
+
+    let mut categories = load_categories(env);
+    let mut index: u32 = 0;
+
+    while index < categories.len() {
+        if categories.get(index) == Some(category.clone()) {
+            categories.remove(index);
+            save_categories(env, &categories);
+            break;
+        }
+        index += 1;
+    }
+
+    Ok(())
+}
+
+pub fn list_categories(env: &Env) -> Vec<Symbol> {
+    load_categories(env)
+}
+
+pub fn get_markets_by_category(env: &Env, category: Symbol, start: u64, limit: u32) -> Vec<Market> {
+    const MAX_LIMIT: u32 = 50;
+    let effective_limit = if limit > MAX_LIMIT { MAX_LIMIT } else { limit };
+    let market_ids = load_category_index(env, &category);
+    let mut result = Vec::new(env);
+    let total = u64::from(market_ids.len());
+
+    if effective_limit == 0 || start >= total {
+        return result;
+    }
+
+    let mut collected: u32 = 0;
+    let mut offset = start as u32;
+
+    while u64::from(offset) < total && collected < effective_limit {
+        if let Some(market_id) = market_ids.get(offset) {
+            if let Some(market) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Market>(&DataKey::Market(market_id))
+            {
+                bump_market(env, market_id);
+                result.push_back(market);
+                collected += 1;
+            }
+        }
+        offset += 1;
     }
 
     result
@@ -345,8 +494,9 @@ pub fn cancel_market(env: &Env, caller: Address, market_id: u64) -> Result<(), I
 #[cfg(test)]
 mod market_tests {
     use soroban_sdk::testutils::{Address as _, Ledger as _};
-    use soroban_sdk::{symbol_short, vec, Address, Env, String};
+    use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol, Vec};
 
+    use crate::storage_types::DataKey;
     use crate::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
 
     use super::CreateMarketParams;
@@ -374,7 +524,7 @@ mod market_tests {
         CreateMarketParams {
             title: String::from_str(env, "Will it rain?"),
             description: String::from_str(env, "Daily weather market"),
-            category: symbol_short!("weather"),
+            category: Symbol::new(env, "Sports"),
             outcomes: vec![env, symbol_short!("yes"), symbol_short!("no")],
             end_time: now + 1000,
             resolution_time: now + 2000,
@@ -487,6 +637,89 @@ mod market_tests {
         assert!(matches!(result, Err(Ok(InsightArenaError::StakeTooLow))));
     }
 
+    #[test]
+    fn create_market_fails_when_category_not_whitelisted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = deploy(&env);
+        let creator = Address::generate(&env);
+
+        let mut p = default_params(&env);
+        p.category = Symbol::new(&env, "Weather");
+
+        let result = client.try_create_market(&creator, &p);
+        assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+    }
+
+    #[test]
+    fn list_categories_returns_seeded_defaults() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = deploy(&env);
+        let categories = client.list_categories();
+
+        assert!(categories.contains(Symbol::new(&env, "Sports")));
+        assert!(categories.contains(Symbol::new(&env, "Crypto")));
+        assert!(categories.contains(Symbol::new(&env, "Politics")));
+        assert!(categories.contains(Symbol::new(&env, "Entertainment")));
+        assert!(categories.contains(Symbol::new(&env, "Science")));
+        assert!(categories.contains(Symbol::new(&env, "Other")));
+    }
+
+    #[test]
+    fn add_category_allows_admin_to_extend_whitelist() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _oracle) = deploy_with_actors(&env);
+        let weather = Symbol::new(&env, "Weather");
+
+        client.add_category(&admin, &weather);
+
+        let categories = client.list_categories();
+        assert!(categories.contains(weather));
+    }
+
+    #[test]
+    fn remove_category_blocks_future_market_creation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _oracle) = deploy_with_actors(&env);
+        let creator = Address::generate(&env);
+        let science = Symbol::new(&env, "Science");
+
+        client.remove_category(&admin, &science);
+
+        let categories = client.list_categories();
+        assert!(!categories.contains(science.clone()));
+
+        let mut p = default_params(&env);
+        p.category = science;
+        let result = client.try_create_market(&creator, &p);
+        assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+    }
+
+    #[test]
+    fn non_admin_cannot_mutate_categories() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _oracle) = deploy_with_actors(&env);
+        let random = Address::generate(&env);
+        let weather = Symbol::new(&env, "Weather");
+        let sports = Symbol::new(&env, "Sports");
+
+        let add_result = client.try_add_category(&random, &weather);
+        assert!(matches!(
+            add_result,
+            Err(Ok(InsightArenaError::Unauthorized))
+        ));
+
+        let remove_result = client.try_remove_category(&random, &sports);
+        assert!(matches!(
+            remove_result,
+            Err(Ok(InsightArenaError::Unauthorized))
+        ));
+    }
+
     // ── get_market ────────────────────────────────────────────────────────────
 
     #[test]
@@ -547,6 +780,63 @@ mod market_tests {
 
         let list = client.list_markets(&1_u64, &10_u32);
         assert_eq!(list.len(), 0);
+    }
+
+    #[test]
+    fn get_markets_by_category_returns_paginated_results() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = deploy(&env);
+        let creator = Address::generate(&env);
+
+        let sports_category = Symbol::new(&env, "Sports");
+        let crypto_category = Symbol::new(&env, "Crypto");
+
+        let first_sports = client.create_market(&creator, &default_params(&env));
+
+        let mut crypto = default_params(&env);
+        crypto.category = crypto_category;
+        client.create_market(&creator, &crypto);
+
+        let second_sports_id = client.create_market(&creator, &default_params(&env));
+        let third_sports_id = client.create_market(&creator, &default_params(&env));
+
+        let first_page = client.get_markets_by_category(&sports_category, &0_u64, &2_u32);
+        assert_eq!(first_page.len(), 2);
+        assert_eq!(first_page.get(0).unwrap().market_id, first_sports);
+        assert_eq!(first_page.get(1).unwrap().market_id, second_sports_id);
+
+        let second_page = client.get_markets_by_category(&sports_category, &2_u64, &2_u32);
+        assert_eq!(second_page.len(), 1);
+        assert_eq!(second_page.get(0).unwrap().market_id, third_sports_id);
+    }
+
+    #[test]
+    fn category_index_is_kept_in_sync_on_market_creation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = deploy(&env);
+        let creator = Address::generate(&env);
+        let sports = Symbol::new(&env, "Sports");
+
+        let first_id = client.create_market(&creator, &default_params(&env));
+
+        let mut crypto = default_params(&env);
+        crypto.category = Symbol::new(&env, "Crypto");
+        client.create_market(&creator, &crypto);
+
+        let second_id = client.create_market(&creator, &default_params(&env));
+
+        let stored_index = env.as_contract(&client.address, || {
+            env.storage()
+                .persistent()
+                .get::<DataKey, Vec<u64>>(&DataKey::CategoryIndex(sports.clone()))
+                .unwrap()
+        });
+
+        assert_eq!(stored_index.len(), 2);
+        assert_eq!(stored_index.get(0), Some(first_id));
+        assert_eq!(stored_index.get(1), Some(second_id));
     }
 
     #[test]

--- a/contract/src/oracle.rs
+++ b/contract/src/oracle.rs
@@ -78,7 +78,7 @@ pub fn resolve_market(
 #[cfg(test)]
 mod resolve_tests {
     use soroban_sdk::testutils::{Address as _, Ledger as _};
-    use soroban_sdk::{symbol_short, vec, Address, Env, String};
+    use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
 
     use crate::market::CreateMarketParams;
     use crate::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
@@ -105,7 +105,7 @@ mod resolve_tests {
         CreateMarketParams {
             title: String::from_str(env, "Will it rain?"),
             description: String::from_str(env, "Daily weather market"),
-            category: symbol_short!("weather"),
+            category: Symbol::new(env, "Sports"),
             outcomes: vec![env, symbol_short!("yes"), symbol_short!("no")],
             end_time: now + 1000,
             resolution_time: now + 2000,

--- a/contract/src/prediction.rs
+++ b/contract/src/prediction.rs
@@ -671,7 +671,7 @@ pub fn batch_distribute_payouts(
 mod prediction_tests {
     use soroban_sdk::testutils::{Address as _, Ledger as _};
     use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
-    use soroban_sdk::{symbol_short, vec, Address, Env, String};
+    use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
 
     use crate::market::CreateMarketParams;
     use crate::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
@@ -701,7 +701,7 @@ mod prediction_tests {
         CreateMarketParams {
             title: String::from_str(env, "Will it rain?"),
             description: String::from_str(env, "Daily weather market"),
-            category: symbol_short!("weather"),
+            category: Symbol::new(env, "Sports"),
             outcomes: vec![env, symbol_short!("yes"), symbol_short!("no")],
             end_time: now + 1000,
             resolution_time: now + 2000,

--- a/contract/src/storage_types.rs
+++ b/contract/src/storage_types.rs
@@ -36,6 +36,10 @@ pub enum DataKey {
     SeasonCount,
     /// Emergency pause flag. Used to halt sensitive operations across the platform.
     Paused,
+    /// Singleton category whitelist stored in instance storage.
+    Categories,
+    /// Keyed by category symbol. Stores market IDs in creation order for that category.
+    CategoryIndex(Symbol),
 }
 
 #[contracttype]

--- a/contract/src/ttl.rs
+++ b/contract/src/ttl.rs
@@ -70,7 +70,7 @@ pub fn extend_season_ttl(env: &Env, season_id: u32) {
 #[cfg(test)]
 mod tests {
     use soroban_sdk::testutils::{storage::Persistent as _, Address as _};
-    use soroban_sdk::{symbol_short, vec, Address, Env, String};
+    use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
 
     use crate::market::CreateMarketParams;
     use crate::storage_types::DataKey;
@@ -102,7 +102,7 @@ mod tests {
         let params = CreateMarketParams {
             title: String::from_str(&env, "TTL Test"),
             description: String::from_str(&env, "TTL Test Description"),
-            category: symbol_short!("test"),
+            category: Symbol::new(&env, "Sports"),
             outcomes: vec![&env, symbol_short!("yes"), symbol_short!("no")],
             end_time: env.ledger().timestamp() + 1_000,
             resolution_time: env.ledger().timestamp() + 2_000,


### PR DESCRIPTION
Closes #261   .

## Summary
InsightArena already stored a category on each market, but the contract did not enforce any whitelist and it exposed no admin or view surface for category management. That meant clients could create markets with arbitrary symbols, and there was no on-chain way to list supported categories or fetch markets grouped by category.

This change adds contract-level category enforcement and retrieval. Markets can now only be created with categories from an admin-managed whitelist. The contract also exposes category listing and category-scoped market pagination so SDK and UI consumers can discover supported categories and query markets by category without re-scanning all markets client-side.

## What Changed
- added `DataKey::Categories` in instance storage for the whitelist and `DataKey::CategoryIndex(Symbol)` for category-to-market indexing
- seeded the standard default categories on initialize: `Sports`, `Crypto`, `Politics`, `Entertainment`, `Science`, `Other`
- made `create_market` reject non-whitelisted categories with `InsightArenaError::InvalidInput`
- added `add_category`, `remove_category`, `list_categories`, and `get_markets_by_category`
- updated market creation to keep the per-category index in sync
- added unit tests for whitelist enforcement, admin mutation, non-admin rejection, seeded defaults, category pagination, and index synchronization
- updated existing test helpers to use supported categories so the suite matches the production rule

## Compatibility Notes
Two compatibility protections are included in the implementation:

1. `DataKey` additions were appended to the enum instead of inserted earlier, so existing serialized storage keys keep their original discriminants.
2. If an already-initialized deployment upgrades before `DataKey::Categories` exists in instance storage, reads fall back to the standard default category set. The first admin category mutation persists the whitelist explicitly.

## Verification
Local checks:
- `cargo fmt` ?
- `cargo test` could not complete locally because this Windows machine does not have the MSVC linker `link.exe` installed

The test command currently stops at:
`linker 'link.exe' not found`

That is an environment limitation on this machine, not a contract test assertion failure, so GitHub Actions is the first full compiler and test validation for this branch.
