### PR TITLE
feat: add seasons module scaffold (#262)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { CompetitionsModule } from './competitions/competitions.module';
 import { LeaderboardModule } from './leaderboard/leaderboard.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { SorobanModule } from './soroban/soroban.module';
+import { SeasonsModule } from './seasons/seasons.module';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { SorobanModule } from './soroban/soroban.module';
     MarketsModule,
     PredictionsModule,
     CompetitionsModule,
+    SeasonsModule,
     LeaderboardModule,
     NotificationsModule,
     SorobanModule,

--- a/backend/src/seasons/entities/season.entity.ts
+++ b/backend/src/seasons/entities/season.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('seasons')
+export class Season {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @Column({ type: 'timestamp' })
+  starts_at: Date;
+
+  @Column({ type: 'timestamp' })
+  ends_at: Date;
+
+  @Column({ type: 'boolean', default: false })
+  is_active: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/seasons/seasons.controller.ts
+++ b/backend/src/seasons/seasons.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Season } from './entities/season.entity';
+import { SeasonsService } from './seasons.service';
+
+@ApiTags('Seasons')
+@Controller('seasons')
+export class SeasonsController {
+  constructor(private readonly seasonsService: SeasonsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List seasons' })
+  @ApiResponse({ status: 200, type: [Season] })
+  async findAll(): Promise<Season[]> {
+    return this.seasonsService.findAll();
+  }
+}

--- a/backend/src/seasons/seasons.module.ts
+++ b/backend/src/seasons/seasons.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from '../users/users.module';
+import { Season } from './entities/season.entity';
+import { SeasonsController } from './seasons.controller';
+import { SeasonsService } from './seasons.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Season]), UsersModule],
+  controllers: [SeasonsController],
+  providers: [SeasonsService],
+  exports: [SeasonsService],
+})
+export class SeasonsModule {}

--- a/backend/src/seasons/seasons.service.ts
+++ b/backend/src/seasons/seasons.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Season } from './entities/season.entity';
+
+@Injectable()
+export class SeasonsService {
+  constructor(
+    @InjectRepository(Season)
+    private readonly seasonsRepository: Repository<Season>,
+  ) {}
+
+  async findAll(): Promise<Season[]> {
+    return this.seasonsRepository.find({
+      order: {
+        starts_at: 'DESC',
+      },
+    });
+  }
+}


### PR DESCRIPTION
Fixes #262 

## Summary
This adds the missing Nest `seasons` module scaffold under `backend/src/seasons` and wires it into the application so the backend compiles with the new module registered in `AppModule`.

## Changes
- added `backend/src/seasons/seasons.module.ts`
- added `backend/src/seasons/seasons.service.ts`
- added `backend/src/seasons/seasons.controller.ts`
- registered `TypeOrmModule.forFeature([Season])` inside `SeasonsModule`
- imported `UsersModule` into `SeasonsModule`
- imported `SeasonsModule` into `backend/src/app.module.ts`
- added a minimal `Season` TypeORM entity at `backend/src/seasons/entities/season.entity.ts` so the module can compile cleanly with `forFeature([Season])`

## Validation
Passed:
- `npm.cmd run build` from `backend/`

## Notes
- the repository did not contain a `Season` entity yet, so a minimal entity was added to satisfy the compile requirement and keep the module self-contained
