### PR TITLE
feat(contract): implement calculate_price with 6-decimal precision

### DIFF
--- a/contract/src/market.rs
+++ b/contract/src/market.rs
@@ -163,6 +163,23 @@ pub fn emit_market_resolved(env: &Env, market_id: u64, resolved_outcome: Symbol)
     );
 }
 
+/// Calculate price of outcome A in terms of outcome B.
+/// Returns price with 6 decimal precision (multiplied by 1_000_000).
+#[allow(dead_code)]
+fn calculate_price(reserve_a: i128, reserve_b: i128) -> Result<i128, InsightArenaError> {
+    if reserve_a <= 0 || reserve_b <= 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    let price = reserve_b
+        .checked_mul(1_000_000)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(reserve_a)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    Ok(price)
+}
+
 // ── Entry-point logic ─────────────────────────────────────────────────────────
 
 /// Create a new prediction market and return its auto-assigned `market_id`.
@@ -506,6 +523,34 @@ mod market_tests {
     use crate::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
 
     use super::CreateMarketParams;
+
+    #[test]
+    fn test_calculate_price_equal_reserves() {
+        // Reserves: 1000/1000 -> Expected: 1_000_000
+        let price = super::calculate_price(1000, 1000).unwrap();
+        assert_eq!(price, 1_000_000);
+    }
+
+    #[test]
+    fn test_calculate_price_double() {
+        // Reserves: 1000/2000 -> Expected: 2_000_000
+        let price = super::calculate_price(1000, 2000).unwrap();
+        assert_eq!(price, 2_000_000);
+    }
+
+    #[test]
+    fn test_calculate_price_half() {
+        // Reserves: 2000/1000 -> Expected: 500_000
+        let price = super::calculate_price(2000, 1000).unwrap();
+        assert_eq!(price, 500_000);
+    }
+
+    #[test]
+    fn test_calculate_price_precision() {
+        // Reserves: 3000/1000 -> Expected: 333_333
+        let price = super::calculate_price(3000, 1000).unwrap();
+        assert_eq!(price, 333_333);
+    }
 
     /// Register a mock XLM token (Stellar Asset Contract) and return its address.
     fn register_token(env: &Env) -> Address {


### PR DESCRIPTION
## Overview  
Implements a `calculate_price` helper for computing outcome pricing with fixed 6-decimal precision using safe integer arithmetic.

---

## Why This Matters  
Accurate and deterministic price calculation is critical for AMM-style reserve logic. This helper ensures precision is preserved without floating-point errors and provides a reusable foundation for upcoming pricing integrations.

---

##  Changes  
- Added `calculate_price(reserve_a, reserve_b) -> Result<i128, InsightArenaError>`  
  - Validates non-zero, positive reserves  
  - Uses `checked_mul` and `checked_div` for overflow-safe arithmetic  
  - Returns price scaled by `1_000_000` (6 decimal precision)

- Added 4 unit tests covering:
  - Equal reserves → `1_000_000`  
  - Double ratio → `2_000_000`  
  - Half ratio → `500_000`  
  - Precision truncation → `333_333`  

- Added `#[allow(dead_code)]` since this helper will be integrated in upcoming pricing logic

---

##  Validation  
- `cargo test calculate_price` → **4 passed, 0 failed**  
- No warnings after targeted dead-code allowance  

---

##  Scope  
- Changes limited to `contract/src/market.rs`  
- No impact on existing logic or storage  

---

##  Notes  
This function is introduced as a foundational utility for future AMM/reserve pricing features and is currently validated via unit tests.

---

Closes #367