### PR TITLE
fix: add route error boundaries for issue #394

### DIFF
--- a/frontend/src/app/(authenticated)/competitions/error.tsx
+++ b/frontend/src/app/(authenticated)/competitions/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type CompetitionsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function CompetitionsErrorPage({
+  error,
+  reset,
+}: CompetitionsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Competitions"
+      description="Your competitions view ran into a problem. Retry to reload the latest competition data."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/dashboard/error.tsx
+++ b/frontend/src/app/(authenticated)/dashboard/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type DashboardErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function DashboardErrorPage({
+  error,
+  reset,
+}: DashboardErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Dashboard"
+      description="The dashboard couldn't finish loading. Retry to restore your latest account overview."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/leaderboards/error.tsx
+++ b/frontend/src/app/(authenticated)/leaderboards/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type LeaderboardsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function LeaderboardsErrorPage({
+  error,
+  reset,
+}: LeaderboardsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Leaderboards"
+      description="Leaderboards are temporarily unavailable. Retry to fetch the latest standings."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/markets/error.tsx
+++ b/frontend/src/app/(authenticated)/markets/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type MarketsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function MarketsErrorPage({
+  error,
+  reset,
+}: MarketsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Markets"
+      description="Market data didn't load correctly. Retry to refresh the latest market activity."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/my-predictions/error.tsx
+++ b/frontend/src/app/(authenticated)/my-predictions/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type MyPredictionsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function MyPredictionsErrorPage({
+  error,
+  reset,
+}: MyPredictionsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="My Predictions"
+      description="We couldn't load your predictions right now. Retry to restore your latest picks and results."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/profile/error.tsx
+++ b/frontend/src/app/(authenticated)/profile/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type ProfileErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ProfileErrorPage({
+  error,
+  reset,
+}: ProfileErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Profile"
+      description="Your profile settings couldn't be displayed. Retry to reload your account details."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/rewards/error.tsx
+++ b/frontend/src/app/(authenticated)/rewards/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type RewardsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function RewardsErrorPage({
+  error,
+  reset,
+}: RewardsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Rewards"
+      description="Rewards information couldn't be loaded. Retry to fetch your latest earnings and payouts."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/settings/error.tsx
+++ b/frontend/src/app/(authenticated)/settings/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type SettingsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function SettingsErrorPage({
+  error,
+  reset,
+}: SettingsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Settings"
+      description="Your settings page ran into an unexpected issue. Retry to continue managing your preferences."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/wallet/error.tsx
+++ b/frontend/src/app/(authenticated)/wallet/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type WalletErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function WalletErrorPage({
+  error,
+  reset,
+}: WalletErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Wallet"
+      description="Wallet details couldn't be displayed. Retry to load your balances and transaction history."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/Courses/error.tsx
+++ b/frontend/src/app/Courses/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type CoursesErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function CoursesErrorPage({
+  error,
+  reset,
+}: CoursesErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Courses"
+      description="We hit a snag while loading the courses catalog. Try again and we'll attempt to restore the page."
+    />
+  );
+}

--- a/frontend/src/app/Faq/error.tsx
+++ b/frontend/src/app/Faq/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type FaqErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function FaqErrorPage({
+  error,
+  reset,
+}: FaqErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="FAQ"
+      description="We couldn't open the FAQ right now. Retry to reload the answers and support resources."
+    />
+  );
+}

--- a/frontend/src/app/community-courses/error.tsx
+++ b/frontend/src/app/community-courses/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type CommunityCoursesErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function CommunityCoursesErrorPage({
+  error,
+  reset,
+}: CommunityCoursesErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Community Courses"
+      description="We couldn't load the community courses right now. Try again to refresh the page and continue learning."
+    />
+  );
+}

--- a/frontend/src/app/competitions-demo/error.tsx
+++ b/frontend/src/app/competitions-demo/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type CompetitionsDemoErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function CompetitionsDemoErrorPage({
+  error,
+  reset,
+}: CompetitionsDemoErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Competitions Demo"
+      description="The competitions demo ran into an unexpected issue. Retry to fetch the latest demo state."
+    />
+  );
+}

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type RootErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function RootErrorPage({
+  error,
+  reset,
+}: RootErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="InsightArena"
+      description="We couldn't load the experience right now. Please retry, or head back home while we reset things behind the scenes."
+    />
+  );
+}

--- a/frontend/src/app/events/error.tsx
+++ b/frontend/src/app/events/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type EventsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function EventsErrorPage({
+  error,
+  reset,
+}: EventsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Events"
+      description="The events page couldn't finish loading. Retry to fetch the latest event details."
+    />
+  );
+}

--- a/frontend/src/app/externaltools/error.tsx
+++ b/frontend/src/app/externaltools/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type ExternalToolsErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ExternalToolsErrorPage({
+  error,
+  reset,
+}: ExternalToolsErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="External Tools"
+      description="Something interrupted the external tools page. Please retry to load the latest integrations."
+    />
+  );
+}

--- a/frontend/src/app/login/error.tsx
+++ b/frontend/src/app/login/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type LoginErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function LoginErrorPage({
+  error,
+  reset,
+}: LoginErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Login"
+      description="The login flow hit an unexpected error. Retry to continue signing in securely."
+    />
+  );
+}

--- a/frontend/src/app/notifications-demo/error.tsx
+++ b/frontend/src/app/notifications-demo/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type NotificationsDemoErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function NotificationsDemoErrorPage({
+  error,
+  reset,
+}: NotificationsDemoErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Notifications Demo"
+      description="Notifications couldn't be displayed right now. Retry to reload the latest updates."
+    />
+  );
+}

--- a/frontend/src/app/profilePage/error.tsx
+++ b/frontend/src/app/profilePage/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type ProfilePageErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ProfilePageErrorPage({
+  error,
+  reset,
+}: ProfilePageErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Profile Page"
+      description="Your profile page couldn't be loaded. Retry to restore your profile details."
+    />
+  );
+}

--- a/frontend/src/app/signin/error.tsx
+++ b/frontend/src/app/signin/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type SignInErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function SignInErrorPage({
+  error,
+  reset,
+}: SignInErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Sign In"
+      description="We couldn't finish loading the sign-in page. Retry to continue accessing your account."
+    />
+  );
+}

--- a/frontend/src/app/trading/error.tsx
+++ b/frontend/src/app/trading/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type TradingErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function TradingErrorPage({
+  error,
+  reset,
+}: TradingErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Trading"
+      description="Trading data couldn't be loaded. Please retry to refresh the market view."
+    />
+  );
+}

--- a/frontend/src/component/route-error-state.tsx
+++ b/frontend/src/component/route-error-state.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AlertTriangle, Home, RefreshCcw } from "lucide-react";
+
+import { Button } from "@/component/ui/button";
+
+type RouteErrorStateProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  routeLabel: string;
+  description: string;
+  fullScreen?: boolean;
+};
+
+export function RouteErrorState({
+  error,
+  reset,
+  routeLabel,
+  description,
+  fullScreen = true,
+}: RouteErrorStateProps) {
+  useEffect(() => {
+    console.error(`[Route Error Boundary] ${routeLabel}`, {
+      message: error.message,
+      digest: error.digest,
+      error,
+    });
+  }, [error, routeLabel]);
+
+  return (
+    <section className="dark relative overflow-hidden rounded-[2rem] border border-white/10 bg-[#171d2d] text-white shadow-[0_25px_80px_rgba(1,6,20,0.45)]">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(67,195,190,0.24),transparent_45%),radial-gradient(circle_at_bottom_right,rgba(79,209,197,0.18),transparent_35%)]" />
+
+      <div
+        className={`relative flex items-center justify-center px-6 py-16 sm:px-10 ${
+          fullScreen ? "min-h-screen" : "min-h-[60vh]"
+        }`}
+      >
+        <div className="w-full max-w-xl rounded-[1.75rem] border border-white/10 bg-[#111726]/90 p-8 text-center backdrop-blur">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-[#43c3be]/15 text-[#43c3be] shadow-[0_0_0_8px_rgba(67,195,190,0.08)]">
+            <AlertTriangle className="h-8 w-8" />
+          </div>
+
+          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.3em] text-[#43c3be]">
+            Something Went Wrong
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            {routeLabel} hit an unexpected problem
+          </h1>
+          <p className="mt-4 text-sm leading-7 text-[#97a0b5] sm:text-base">
+            {description}
+          </p>
+
+          <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
+            <Button
+              type="button"
+              onClick={reset}
+              className="h-11 rounded-xl bg-[#2f9e9d] px-6 text-sm font-semibold text-white hover:bg-[#38adaa]"
+            >
+              <RefreshCcw className="h-4 w-4" />
+              Try again
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="h-11 rounded-xl border-white/10 bg-white/5 px-6 text-sm font-medium text-white hover:bg-white/10 hover:text-white"
+            >
+              <Link href="/">
+                <Home className="h-4 w-4" />
+                Back to home
+              </Link>
+            </Button>
+          </div>
+
+          {error.digest ? (
+            <p className="mt-6 text-xs text-[#6f7891]">
+              Reference: {error.digest}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #394

## Changes
- add a shared route error boundary component for the Next.js app router
- add `error.tsx` files for all current public and authenticated routes
- show user-friendly fallback messaging with consistent InsightArena styling
- add retry support through Next.js `reset()`
- log route errors to the console for easier debugging

## Testing
- verified every current `page.tsx` route directory now has a matching `error.tsx`
- attempted frontend production build locally
- local Windows build was blocked by existing environment/platform issues unrelated to this change:
  - Next 16 Turbopack native binding issue on Windows
  - existing webpack module resolution failures for `react-icons/*` imports in unrelated files
