### PR TITLE
fix: align faq page background with platform theme #391

### DIFF
--- a/frontend/src/app/Faq/page.tsx
+++ b/frontend/src/app/Faq/page.tsx
@@ -1,6 +1,12 @@
-"use client"
-import { useState } from 'react';
-import { ChevronLeft, Plus, Minus } from 'lucide-react';
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { ChevronLeft, Plus, Minus } from "lucide-react";
+
+import Footer from "@/component/Footer";
+import Header from "@/component/Header";
+import PageBackground from "@/component/PageBackground";
 
 interface FAQItem {
   id: number;
@@ -38,58 +44,87 @@ export default function CryptoFAQ() {
   ]);
 
   const toggleFAQ = (id: number) => {
-    setFaqItems(faqItems.map(item => 
-      item.id === id ? { ...item, isOpen: !item.isOpen } : item
-    ));
+    setFaqItems(
+      faqItems.map((item) =>
+        item.id === id ? { ...item, isOpen: !item.isOpen } : item
+      )
+    );
   };
 
   return (
-    <div className="min-h-screen bg-black text-white flex justify-center items-center">
-      <div className="w-full max-w-3xl mx-auto p-6 rounded-lg bg-gradient-to-b from-gray-800 to-gray-900 border border-purple-700">
-        <div className="mb-8 text-center">
-          <h1 className="text-4xl font-bold mb-2">Frequently Ask Questions</h1>
-        </div>
-        
-        <div className="mb-4">
-          <button className="flex items-center text-gray-300 hover:text-white">
-            <ChevronLeft size={20} />
-            <span className="ml-1">Back to home</span>
-          </button>
-        </div>
-        
-        <div className="space-y-4">
-          {faqItems.map(item => (
-            <div 
-              key={item.id} 
-              className="bg-white rounded-lg overflow-hidden mb-4"
-            >
-              <div 
-                className="flex justify-between items-center p-4 cursor-pointer text-black"
-                onClick={() => toggleFAQ(item.id)}
-              >
-                <h3 className="font-semibold text-lg">{item.id}. {item.question}</h3>
-                <button className="p-1 rounded-full bg-black">
-                  {item.isOpen ? 
-                    <Minus size={16} className="text-white" /> : 
-                    <Plus size={16} className="text-white" />
-                  }
-                </button>
+    <div className="relative min-h-screen overflow-x-hidden text-white">
+      <PageBackground />
+
+      <div className="relative z-10">
+        <Header />
+
+        <main className="max-w-5xl mx-auto px-6 pt-32 pb-20">
+          <section className="rounded-[2rem] border border-white/10 bg-[#111726]/85 p-6 shadow-[0_25px_80px_rgba(2,6,23,0.45)] backdrop-blur sm:p-10">
+            <div className="flex flex-col gap-5 border-b border-white/10 pb-8 sm:flex-row sm:items-end sm:justify-between">
+              <div className="space-y-3">
+                <p className="text-sm font-medium uppercase tracking-[0.28em] text-[#4FD1C5]">
+                  Support
+                </p>
+                <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+                  Frequently Asked Questions
+                </h1>
+                <p className="max-w-2xl text-base text-[#94a3b8]">
+                  Find quick answers about crypto basics, tournaments, and how
+                  to get started on InsightArena.
+                </p>
               </div>
-              
-              {item.isOpen && (
-                <div className="p-4 bg-white text-black border-t border-gray-200">
-                  <p>{item.answer}</p>
-                </div>
-              )}
+
+              <Link
+                href="/"
+                className="inline-flex items-center gap-2 self-start rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-[#d8dee9] transition hover:bg-white/10 hover:text-white"
+              >
+                <ChevronLeft size={18} />
+                <span>Back to home</span>
+              </Link>
             </div>
-          ))}
-        </div>
-        
-        <div className="mt-6">
-          <button className="w-full py-3 bg-purple-600 hover:bg-purple-700 text-white font-medium rounded-lg">
-            Get Started
-          </button>
-        </div>
+
+            <div className="mt-8 space-y-4">
+              {faqItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="overflow-hidden rounded-2xl border border-white/10 bg-[#0f172a]/90"
+                >
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between gap-4 px-5 py-5 text-left transition hover:bg-white/5"
+                    onClick={() => toggleFAQ(item.id)}
+                  >
+                    <h2 className="text-lg font-semibold text-white sm:text-xl">
+                      {item.id}. {item.question}
+                    </h2>
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#4FD1C5] text-[#0f172a]">
+                      {item.isOpen ? (
+                        <Minus size={18} />
+                      ) : (
+                        <Plus size={18} />
+                      )}
+                    </span>
+                  </button>
+
+                  {item.isOpen && (
+                    <div className="border-t border-white/10 px-5 py-5 text-[15px] leading-7 text-[#cbd5e1]">
+                      <p>{item.answer}</p>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 rounded-2xl border border-[#4FD1C5]/20 bg-[#0b1220] px-6 py-5">
+              <p className="text-sm leading-6 text-[#94a3b8]">
+                Still need help? Explore the platform from the homepage and
+                keep an eye on upcoming guides and community resources.
+              </p>
+            </div>
+          </section>
+        </main>
+
+        <Footer />
       </div>
     </div>
   );

--- a/frontend/src/component/PageBackground.tsx
+++ b/frontend/src/component/PageBackground.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+type PageBackgroundProps = {
+  children?: ReactNode;
+};
+
+export default function PageBackground({ children }: PageBackgroundProps) {
+  return (
+    <div className="absolute inset-0 w-full h-full z-0 pointer-events-none">
+      <div className="absolute inset-0 bg-gradient-to-br from-gray-900 via-black to-gray-900" />
+      <svg
+        className="absolute inset-0 w-full h-full opacity-15"
+        viewBox="0 0 1000 1000"
+        preserveAspectRatio="xMidYMid slice"
+      >
+        <defs>
+          <linearGradient
+            id="pageBackgroundGradient"
+            x1="0%"
+            y1="0%"
+            x2="100%"
+            y2="100%"
+          >
+            <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="#06b6d4" stopOpacity="0.2" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M100,200 Q300,100 500,200 T900,200"
+          stroke="url(#pageBackgroundGradient)"
+          strokeWidth="2"
+          fill="none"
+        />
+        <path
+          d="M200,400 Q400,300 600,400 T1000,400"
+          stroke="url(#pageBackgroundGradient)"
+          strokeWidth="2"
+          fill="none"
+        />
+        <path
+          d="M50,600 Q250,500 450,600 T850,600"
+          stroke="url(#pageBackgroundGradient)"
+          strokeWidth="2"
+          fill="none"
+        />
+        <path
+          d="M150,800 Q350,700 550,800 T950,800"
+          stroke="url(#pageBackgroundGradient)"
+          strokeWidth="2"
+          fill="none"
+        />
+      </svg>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #391

## Changes
- add a reusable `PageBackground` component for public pages
- replace the FAQ page's solid black background with the platform gradient background
- update the FAQ container styling to match the rest of the site theme
- replace the "Back to home" button with a proper Next.js `Link`
- improve spacing so the FAQ content sits correctly below the fixed header and above the footer
- align FAQ card colors, borders, and accents with the platform palette

## Testing
- reviewed the FAQ route layout after switching to the shared background pattern
- verified the page now uses shared Header/Footer spacing and Next.js navigation
- did not run a full frontend build in this environment because of existing Windows-side Next/toolchain issues unrelated to this change
