### PR TITLE
fix: improve frontend accessibility for issue #395

### DIFF
--- a/frontend/src/app/community-courses/page.tsx
+++ b/frontend/src/app/community-courses/page.tsx
@@ -172,7 +172,11 @@ export default function CommunityCoursesPage() {
               Explore Courses Created By The Community Or Share Your Own
             </p>
           </div>
-          <button className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded">
+          <button
+            type="button"
+            aria-label="Create a new course"
+            className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded"
+          >
             Create Course
           </button>
         </div>
@@ -180,14 +184,22 @@ export default function CommunityCoursesPage() {
         {/* Search and Create Course */}
         <div className="flex mb-6">
           <div className="flex-grow mr-4">
+            <label htmlFor="community-course-search" className="sr-only">
+              Search community courses
+            </label>
             <input
+              id="community-course-search"
               type="text"
               placeholder="Create Course"
+              aria-label="Search community courses"
               className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded text-white"
             />
           </div>
           <div className="flex space-x-2">
-            <select  className="bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white" aria-label="Sort by">
+            <label htmlFor="community-course-sort" className="sr-only">
+              Sort community courses
+            </label>
+            <select id="community-course-sort" className="bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white" aria-label="Sort community courses">
               <option>Newest</option>
               <option>Most Popular</option>
               <option>Top Rated</option>
@@ -206,6 +218,8 @@ export default function CommunityCoursesPage() {
       ].map((filter) => (
         <button
           key={filter.id}
+          type="button"
+          aria-pressed={selectedTag === filter.id}
           onClick={() => setSelectedTag(filter.id)}
           className={`px-4 py-2 rounded-full ${
             selectedTag === filter.id

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -119,4 +119,45 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  a,
+  button,
+  input,
+  select,
+  textarea,
+  [role="button"],
+  [tabindex]:not([tabindex="-1"]) {
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4FD1C5] focus-visible:ring-offset-2 focus-visible:ring-offset-[#141824];
+  }
+}
+
+.skip-link {
+  position: fixed;
+  left: 1rem;
+  top: 1rem;
+  z-index: 1000;
+  transform: translateY(-200%);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(79, 209, 197, 0.45);
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  transition: transform 0.2s ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,7 +14,12 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="font-sans antialiased bg-[#141824] text-white">
-        {children}
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
+        <div id="main-content" tabIndex={-1}>
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -31,7 +31,7 @@ const Login: NextPage = () => {
         <title>Login</title>
         <meta name="description" content="Login to your account" />
       </Head>
-      <div className="flex items-center justify-center min-h-screen bg-black">
+      <main className="flex min-h-screen items-center justify-center bg-black px-4">
         <div className="w-full max-w-md p-6 space-y-8">
           {/* Progress Indicators */}
           <div className="flex justify-center space-x-4">
@@ -51,7 +51,11 @@ const Login: NextPage = () => {
           <div className="mt-8 space-y-6">
             {/* OAuth Buttons */}
             <div className="grid grid-cols-2 gap-4">
-              <button className="flex items-center justify-center w-full py-2 px-4 bg-purple-800 text-white rounded-md hover:bg-purple-700 transition">
+              <button
+                type="button"
+                aria-label="Continue with Google"
+                className="flex items-center justify-center w-full py-2 px-4 bg-purple-800 text-white rounded-md hover:bg-purple-700 transition"
+              >
                 <img
                   src="/google-logo.svg"
                   alt="Google"
@@ -59,7 +63,11 @@ const Login: NextPage = () => {
                 />
                 Google
               </button>
-              <button className="flex items-center justify-center w-full py-2 px-4 bg-purple-800 text-white rounded-md hover:bg-purple-700 transition">
+              <button
+                type="button"
+                aria-label="Continue with GitHub"
+                className="flex items-center justify-center w-full py-2 px-4 bg-purple-800 text-white rounded-md hover:bg-purple-700 transition"
+              >
                 <Github className="w-5 h-5 mr-2" />
                 Git Hub
               </button>
@@ -90,7 +98,8 @@ const Login: NextPage = () => {
                   type="email"
                   required
                   placeholder="john@example.com"
-                  className="w-full p-2 bg-gray-700 border border-gray-600 rounded text-white"
+                  autoComplete="email"
+                  className="w-full rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder:text-gray-300"
                   value={formData.email}
                   onChange={handleChange}
                 />
@@ -109,7 +118,8 @@ const Login: NextPage = () => {
                   type="password"
                   required
                   placeholder="••••••••"
-                  className="w-full p-2 bg-gray-700 border border-gray-600 rounded text-white"
+                  autoComplete="current-password"
+                  className="w-full rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder:text-gray-300"
                   value={formData.password}
                   onChange={handleChange}
                 />
@@ -139,7 +149,7 @@ const Login: NextPage = () => {
             </div>
           </div>
         </div>
-      </div>
+      </main>
     </>
   );
 };

--- a/frontend/src/app/signin/page.tsx
+++ b/frontend/src/app/signin/page.tsx
@@ -33,7 +33,7 @@ const SignUp: NextPage = () => {
         <title>Sign Up</title>
         <meta name="description" content="Create your account" />
       </Head>
-      <div className="flex items-center justify-center min-h-screen bg-black">
+      <main className="flex min-h-screen items-center justify-center bg-black px-4">
         <div className="w-full max-w-md p-6 space-y-8">
           <div className="text-center">
             <h1 className="text-2xl font-bold text-white">Sign Up Account</h1>
@@ -44,12 +44,16 @@ const SignUp: NextPage = () => {
             {/* OAuth Buttons */}
             <div className="grid grid-cols-2 gap-4">
               <button
+                type="button"
+                aria-label="Continue with Google"
                 className="flex items-center justify-center w-full py-2 px-4 bg-purple-800 text-white rounded-md hover:bg-purple-700 transition"
               >
                 <img src="/google-logo.svg" alt="Google" className="w-5 h-5 mr-2" />
                 Google
               </button>
               <button
+                type="button"
+                aria-label="Continue with GitHub"
                 className="flex items-center justify-center w-full py-2 px-4 bg-purple-800 text-white rounded-md hover:bg-purple-700 transition"
               >
                 <Github className="w-5 h-5 mr-2" />
@@ -80,7 +84,8 @@ const SignUp: NextPage = () => {
                     type="text"
                     required
                     placeholder="Ex: John"
-                    className="w-full p-2 bg-gray-700 border border-gray-600 rounded text-white"
+                    autoComplete="given-name"
+                    className="w-full rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder:text-gray-300"
                     value={formData.firstName}
                     onChange={handleChange}
                   />
@@ -95,7 +100,8 @@ const SignUp: NextPage = () => {
                     type="text"
                     required
                     placeholder="Ex: John"
-                    className="w-full p-2 bg-gray-700 border border-gray-600 rounded text-white"
+                    autoComplete="family-name"
+                    className="w-full rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder:text-gray-300"
                     value={formData.lastName}
                     onChange={handleChange}
                   />
@@ -112,7 +118,8 @@ const SignUp: NextPage = () => {
                   type="email"
                   required
                   placeholder="john@example.com"
-                  className="w-full p-2 bg-gray-700 border border-gray-600 rounded text-white"
+                  autoComplete="email"
+                  className="w-full rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder:text-gray-300"
                   value={formData.email}
                   onChange={handleChange}
                 />
@@ -128,7 +135,8 @@ const SignUp: NextPage = () => {
                   type="password"
                   required
                   placeholder="••••••••"
-                  className="w-full p-2 bg-gray-700 border border-gray-600 rounded text-white"
+                  autoComplete="new-password"
+                  className="w-full rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder:text-gray-300"
                   value={formData.password}
                   onChange={handleChange}
                 />
@@ -153,7 +161,7 @@ const SignUp: NextPage = () => {
             </div>
           </div>
         </div>
-      </div>
+      </main>
     </>
   );
 };

--- a/frontend/src/component/CourseCompletionModal.tsx
+++ b/frontend/src/component/CourseCompletionModal.tsx
@@ -34,14 +34,23 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
-      <div className=" backdrop-blur-3xl  border-2  border-gray-400 bg-white/5 z-50 rounded-xl shadow-2xl w-full max-w-md mx-auto">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="presentation"
+    >
+      <div
+        className="backdrop-blur-3xl border-2 border-gray-400 bg-white/5 z-50 mx-auto w-full max-w-md rounded-xl shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="course-completion-title"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-6">
-              <h2 className="text-white text-2xl font-bold">
+              <h2 id="course-completion-title" className="text-white text-2xl font-bold">
                 Stark Academy
               </h2>
               <button
+                type="button"
                 onClick={onClose}
                 className="text-gray-400 hover:text-white w-8 h-8 rounded-full border border-gray-600 hover:border-gray-400 flex items-center justify-center transition-colors"
                 aria-label="Close modal"
@@ -54,7 +63,11 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
         {/* Content */}
         <div className="p-6">
           <div className="text-gray-300 mb-6">
-            <img src='/assets/modal_img.png' className='w-40 h- mx-auto' />
+            <img
+              src="/assets/modal_img.png"
+              alt="Celebration illustration for course completion"
+              className="w-40 h-auto mx-auto"
+            />
             <p className="mb-4 text-center pt-2">
             CONGRATULATION ON FINISHING YOUR COURSE  TIME TO CLAIM YOUR BADGE.
             </p>
@@ -70,6 +83,7 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
           {/* Action Buttons */}
           <div className="flex flex-col gap-3 sm:flex-row">
             <button
+              type="button"
               onClick={handleClaimBadge}
               disabled={isClaimLoading || badgeClaimed}
               className={`flex-1 py-3 px-4 rounded-lg font-medium flex items-center justify-center gap-2 ${
@@ -89,6 +103,7 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
             </button>
 
             <button
+              type="button"
               onClick={handleJoinCommunity}
               disabled={isJoinLoading}
               className="flex-1 py-3 px-4 rounded-lg font-medium bg-purple-600 hover:bg-purple-700 text-white flex items-center justify-center gap-2"

--- a/frontend/src/component/Header.tsx
+++ b/frontend/src/component/Header.tsx
@@ -11,11 +11,18 @@ export default function Header() {
     { name: "Dashboard", link: "/dashboard" },
   ];
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-sm border-b border-gray-800">
+    <header className="fixed top-0 left-0 right-0 z-50 border-b border-gray-800 bg-black/80 backdrop-blur-sm">
       <div className="max-w-7xl mx-auto px-6 py-4">
-        <nav className="flex items-center justify-between">
+        <nav
+          className="flex items-center justify-between"
+          aria-label="Primary navigation"
+        >
           <div>
-            <Link href="/" className="text-white font-bold text-xl">
+            <Link
+              href="/"
+              className="text-xl font-bold text-white hover:text-[#4FD1C5] transition-colors"
+              aria-label="Go to InsightArena homepage"
+            >
               InsightArena
             </Link>
           </div>
@@ -25,7 +32,7 @@ export default function Header() {
                 <Link
                   key={link.name}
                   href={link.link}
-                  className="text-gray-300 hover:text-white transition-colors"
+                  className="text-gray-200 transition-colors hover:text-white"
                 >
                   {link.name}
                 </Link>
@@ -33,7 +40,11 @@ export default function Header() {
             </div>
           </div>
 
-          <button className="bg-orange-500 hover:bg-orange-600 text-white px-6 py-2 rounded-lg font-semibold transition-colors">
+          <button
+            type="button"
+            aria-label="Connect wallet"
+            className="rounded-lg bg-orange-500 px-6 py-2 font-semibold text-white transition-colors hover:bg-orange-600"
+          >
             Connect Wallet
           </button>
         </nav>

--- a/frontend/src/component/coursenav.tsx
+++ b/frontend/src/component/coursenav.tsx
@@ -21,7 +21,10 @@ const Navbar = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
-    <nav className="bg-black border-1 rounded-lg border-white text-white px-6 py-4 flex justify-between w-full items-center m-auto mt-4 ">
+    <nav
+      className="bg-black border-1 rounded-lg border-white text-white px-6 py-4 flex justify-between w-full items-center m-auto mt-4 "
+      aria-label="Courses navigation"
+    >
       <Link href="/" className="text-[2rem] font-bold">Stark Academy</Link>
 
       {/* Desktop Menu */}
@@ -29,6 +32,10 @@ const Navbar = () => {
         {/* Course section */}
         <div className="relative">
           <button
+            type="button"
+            aria-haspopup="dialog"
+            aria-expanded={isCoursesOpen}
+            aria-label="Open courses menu"
             onClick={() => setIsCoursesOpen(!isCoursesOpen)}
             className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer"
           >
@@ -52,7 +59,11 @@ const Navbar = () => {
         </div>
 
         {/* Trading section */}
-        <div className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer">
+        <button
+          type="button"
+          aria-label="Open trading section"
+          className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer"
+        >
           <Image
             src={tradingicon}
             alt="Trading icon"
@@ -61,10 +72,14 @@ const Navbar = () => {
             className="w-6 h-6"
           />
           <span className="text-lg font-medium">Trading</span>
-        </div>
+        </button>
 
         {/* Airdrops */}
-        <div className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer">
+        <button
+          type="button"
+          aria-label="Open airdrops section"
+          className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer"
+        >
           <Image
             src={airdropicon}
             alt="Airdrop icon"
@@ -73,11 +88,15 @@ const Navbar = () => {
             className="w-6 h-6"
           />
           <span className="text-lg font-medium">Airdrops</span>
-        </div>
+        </button>
 
         {/* Resources Section */}
         <div className="relative">
           <button
+            type="button"
+            aria-haspopup="dialog"
+            aria-expanded={isResourcesOpen}
+            aria-label="Open resources menu"
             onClick={() => setIsResourcesOpen(!isResourcesOpen)}
             className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer"
           >
@@ -99,19 +118,30 @@ const Navbar = () => {
             />
           )}
         </div>
-        <Bell className="cursor-pointer text-gray-400 hover:text-white" />
-        <Moon className="cursor-pointer" />
-        <div
+        <button type="button" aria-label="View notifications">
+          <Bell className="cursor-pointer text-gray-400 hover:text-white" />
+        </button>
+        <button type="button" aria-label="Toggle theme">
+          <Moon className="cursor-pointer" />
+        </button>
+        <button
+          type="button"
+          aria-label="Open profile"
           className="bg-purple-500 text-white rounded-full w-8 h-8 flex items-center justify-center cursor-pointer"
           onClick={() => router.push("/profile")}
         >
           PH
-        </div>
+        </button>
       </div>
 
       {/* Mobile Hamburger */}
       <div className="md:hidden">
-        <button onClick={() => setMobileMenuOpen(true)} className="cursor-pointer">
+        <button
+          type="button"
+          aria-label="Open mobile menu"
+          onClick={() => setMobileMenuOpen(true)}
+          className="cursor-pointer"
+        >
           <Menu />
         </button>
       </div>
@@ -126,13 +156,15 @@ const Navbar = () => {
         <div className="fixed top-0 right-0 w-2/3 h-full bg-black p-6 space-y-6 cursor-pointer">
           <div className="flex justify-between items-center">
             <h2 className="text-xl font-bold">Menu</h2>
-            <button onClick={() => setMobileMenuOpen(false)}>
+            <button type="button" aria-label="Close mobile menu" onClick={() => setMobileMenuOpen(false)}>
               <X />
             </button>
           </div>
           
           {/* Mobile menu items with consistent styling */}
           <button 
+            type="button"
+            aria-label="Open courses menu"
             onClick={() => {
               setIsCoursesOpen(true);
               setMobileMenuOpen(false);
@@ -149,7 +181,11 @@ const Navbar = () => {
             <span className="text-lg font-medium">Courses</span>
           </button>
           
-          <div className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer">
+          <button
+            type="button"
+            aria-label="Open trading section"
+            className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer"
+          >
             <Image
               src={tradingicon}
               alt="Trading icon"
@@ -158,9 +194,13 @@ const Navbar = () => {
               className="w-6 h-6"
             />
             <span className="text-lg font-medium">Trading</span>
-          </div>
+          </button>
           
-          <div className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer">
+          <button
+            type="button"
+            aria-label="Open airdrops section"
+            className="flex items-center gap-3 text-white hover:text-gray-300 transition-colors cursor-pointer"
+          >
             <Image
               src={airdropicon}
               alt="Airdrop icon"
@@ -169,9 +209,11 @@ const Navbar = () => {
               className="w-6 h-6"
             />
             <span className="text-lg font-medium">Airdrops</span>
-          </div>
+          </button>
           
           <button 
+            type="button"
+            aria-label="Open resources menu"
             onClick={() => {
               setIsResourcesOpen(true);
               setMobileMenuOpen(false);
@@ -189,14 +231,20 @@ const Navbar = () => {
           </button>
           
           <div className="flex items-center gap-4">
-            <Bell className="cursor-pointer text-gray-400 hover:text-white" />
-            <Moon />
-            <div
+            <button type="button" aria-label="View notifications">
+              <Bell className="cursor-pointer text-gray-400 hover:text-white" />
+            </button>
+            <button type="button" aria-label="Toggle theme">
+              <Moon />
+            </button>
+            <button
+              type="button"
+              aria-label="Open profile"
               className="bg-purple-500 text-white rounded-full w-8 h-8 flex items-center justify-center cursor-pointer"
               onClick={() => router.push("/profile")}
             >
               PH
-            </div>
+            </button>
           </div>
         </div>
       </Dialog>

--- a/frontend/src/component/dashboard-shell.tsx
+++ b/frontend/src/component/dashboard-shell.tsx
@@ -65,7 +65,10 @@ function SidebarContent({ onNavigate }: SidebarContentProps) {
         <Brand />
       </div>
 
-      <nav className="flex-1 space-y-1 overflow-y-auto px-3 py-5">
+      <nav
+        className="flex-1 space-y-1 overflow-y-auto px-3 py-5"
+        aria-label="Dashboard navigation"
+      >
         {navigation.map(({ href, label, icon: Icon }) => {
           const isActive = pathname === href;
 
@@ -74,6 +77,7 @@ function SidebarContent({ onNavigate }: SidebarContentProps) {
               key={href}
               href={href}
               onClick={onNavigate}
+              aria-current={isActive ? "page" : undefined}
               className={`group relative flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition ${
                 isActive
                   ? "bg-[#232b3f] text-white shadow-[inset_3px_0_0_0_#39bdb8]"
@@ -103,6 +107,7 @@ function SidebarContent({ onNavigate }: SidebarContentProps) {
           </p>
           <button
             type="button"
+            aria-label="Disconnect wallet"
             className="mt-3 text-sm font-medium text-[#4fd1c5] transition hover:text-[#72ddd3]"
           >
             Disconnect
@@ -129,12 +134,14 @@ function TopNavigation() {
         <div className="flex flex-col gap-3 sm:flex-row">
           <button
             type="button"
+            aria-label="Make a prediction"
             className="rounded-xl bg-[#2f9e9d] px-6 py-3 text-sm font-semibold text-white transition hover:bg-[#38adaa]"
           >
             Make Prediction
           </button>
           <button
             type="button"
+            aria-label="Create a competition"
             className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-transparent px-6 py-3 text-sm font-medium text-[#d6daea] transition hover:bg-white/5"
           >
             Create Competition
@@ -185,7 +192,9 @@ export function DashboardShell({ children }: DashboardShellProps) {
           </div>
 
           <div className="flex gap-6 p-6">
-            <main className="flex-1">{children}</main>
+            <main id="dashboard-main-content" className="flex-1">
+              {children}
+            </main>
 
             {pathname === "/dashboard" && (
               <aside className="xl:block w-[300px] space-y-6">

--- a/frontend/src/component/leaderboard/LeaderboardFilters.tsx
+++ b/frontend/src/component/leaderboard/LeaderboardFilters.tsx
@@ -61,6 +61,7 @@ export default function LeaderboardFilters({ onChange }: LeaderboardFiltersProps
           <button
             key={value}
             type="button"
+            aria-pressed={filters.timeRange === value}
             onClick={() => update("timeRange", value)}
             className={`rounded-lg px-3 py-1.5 text-xs font-medium transition ${
               filters.timeRange === value
@@ -75,7 +76,12 @@ export default function LeaderboardFilters({ onChange }: LeaderboardFiltersProps
 
       {/* Category select */}
       <div className="relative">
+        <label htmlFor="leaderboard-category" className="sr-only">
+          Filter leaderboard by category
+        </label>
         <select
+          id="leaderboard-category"
+          aria-label="Filter leaderboard by category"
           value={filters.category}
           onChange={(e) => update("category", e.target.value as Category)}
           className="appearance-none rounded-xl border border-white/10 bg-[#0f172a] px-4 py-2 pr-8 text-xs font-medium text-gray-300 transition hover:border-white/20 focus:outline-none focus:ring-1 focus:ring-[#4FD1C5]/50 cursor-pointer"
@@ -99,7 +105,12 @@ export default function LeaderboardFilters({ onChange }: LeaderboardFiltersProps
 
       {/* Sort by select */}
       <div className="relative sm:ml-auto">
+        <label htmlFor="leaderboard-sort" className="sr-only">
+          Sort leaderboard results
+        </label>
         <select
+          id="leaderboard-sort"
+          aria-label="Sort leaderboard results"
           value={filters.sortBy}
           onChange={(e) => update("sortBy", e.target.value as SortBy)}
           className="appearance-none rounded-xl border border-white/10 bg-[#0f172a] px-4 py-2 pr-8 text-xs font-medium text-gray-300 transition hover:border-white/20 focus:outline-none focus:ring-1 focus:ring-[#4FD1C5]/50 cursor-pointer"

--- a/frontend/src/component/trading/MarketRow.tsx
+++ b/frontend/src/component/trading/MarketRow.tsx
@@ -73,15 +73,18 @@ const MarketRow: React.FC<MarketRowProps> = ({
       </div>
       <div className="flex items-center gap-2">
         <button
+          type="button"
           className="focus:outline-none"
           onClick={onFavorite}
-          aria-label="Favorite"
+          aria-label={isFavorite ? `Remove ${name} from favorites` : `Add ${name} to favorites`}
         >
           <StarIcon filled={isFavorite} />
         </button>
         <button
+          type="button"
           className="px-4 py-1.5 bg-[#7C3AED] text-white font-bold rounded-lg hover:bg-[#6D28D9] focus:outline-none text-sm"
           onClick={onTrade}
+          aria-label={`Trade ${name}`}
         >
           Trade
         </button>
@@ -90,4 +93,4 @@ const MarketRow: React.FC<MarketRowProps> = ({
   );
 };
 
-export default MarketRow; 
+export default MarketRow;

--- a/frontend/src/component/trading/MarketSearchBar.tsx
+++ b/frontend/src/component/trading/MarketSearchBar.tsx
@@ -7,14 +7,17 @@ interface MarketSearchBarProps {
 }
 
 const SearchIcon = () => (
-  <svg width="20" height="20" fill="none" viewBox="0 0 20 20">
+  <svg width="20" height="20" fill="none" viewBox="0 0 20 20" aria-hidden="true">
     <circle cx="9" cy="9" r="7" stroke="#A3A3A3" strokeWidth="2" />
     <path d="M15.5 15.5L13 13" stroke="#A3A3A3" strokeWidth="2" strokeLinecap="round" />
   </svg>
 );
 
 const FilterIcon = () => (
-  <span className="inline-flex items-center justify-center w-6 h-6 bg-white rounded-full mr-2">
+  <span
+    className="inline-flex items-center justify-center w-6 h-6 bg-white rounded-full mr-2"
+    aria-hidden="true"
+  >
     <span className="text-black font-bold text-lg">i</span>
   </span>
 );
@@ -23,10 +26,15 @@ const MarketSearchBar: React.FC<MarketSearchBarProps> = ({ searchValue, onSearch
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-end gap-4 my-4 w-full">
       <div className="flex items-center border border-gray-500 rounded-xl px-4 h-[42px] w-full md:max-w-md bg-transparent">
+        <label htmlFor="market-search" className="sr-only">
+          Search tokens
+        </label>
         <span className="mr-2"><SearchIcon /></span>
         <input
+          id="market-search"
           type="text"
           placeholder="Search token"
+          aria-label="Search tokens"
           value={searchValue}
           onChange={onSearchChange}
           className="bg-transparent outline-none border-none text-lg font-semibold text-gray-300 w-full placeholder:font-bold placeholder:text-gray-400"
@@ -34,6 +42,8 @@ const MarketSearchBar: React.FC<MarketSearchBarProps> = ({ searchValue, onSearch
       </div>
       <div className="flex gap-2">
         <button
+          type="button"
+          aria-label="Filter market tokens"
           onClick={onFilterClick}
           className="flex items-center border border-gray-500 rounded-xl px-4 h-[42px] font-bold text-white bg-transparent hover:border-white transition-all"
           style={{ minWidth: 0, width: 'auto', padding: '10px', gap: '10px' }}
@@ -42,6 +52,8 @@ const MarketSearchBar: React.FC<MarketSearchBarProps> = ({ searchValue, onSearch
           All tokens
         </button>
         <button
+          type="button"
+          aria-label="Start trading"
           className="font-bold text-white rounded-xl px-4 h-[42px]"
           style={{ background: '#9747FF9E', border: '1px solid #9747FF9E', minWidth: 0, width: 'auto', padding: '10px', gap: '10px' }}
         >
@@ -52,4 +64,4 @@ const MarketSearchBar: React.FC<MarketSearchBarProps> = ({ searchValue, onSearch
   );
 };
 
-export default MarketSearchBar; 
+export default MarketSearchBar;


### PR DESCRIPTION
Closes #395

## Changes
- add a global skip-to-content link in the root layout
- add stronger shared focus-visible styles for links, buttons, inputs, selects, and other keyboard-focusable controls
- improve accessibility in shared navigation components with better ARIA labels, button semantics, and current-page states
- add accessible labels and autocomplete hints for login and sign-up forms
- add labels for leaderboard filters, trading search/filter controls, and community course controls
- improve button semantics and screen-reader text in trading rows and course navigation
- add dialog semantics and missing alt text in the course completion modal

## Testing
- reviewed the updated shared layout, header, dashboard shell, auth pages, trading controls, leaderboard filters, community courses page, and course modal
- ran `git diff --check` to ensure the final patch is clean
- did not run a full frontend build in this environment because the workspace has existing Windows-side Next/toolchain issues unrelated to these accessibility changes
