### PR TITLE
[Frontend] Loading States for All Pages

### DIFF
--- a/frontend/src/app/(authenticated)/competitions/loading.tsx
+++ b/frontend/src/app/(authenticated)/competitions/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/dashboard/loading.tsx
+++ b/frontend/src/app/(authenticated)/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/layout.tsx
+++ b/frontend/src/app/(authenticated)/layout.tsx
@@ -1,11 +1,19 @@
 import type { ReactNode } from "react";
+import { Suspense } from "react";
 
 import { DashboardShell } from "@/component/dashboard-shell";
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
 
 export default function AuthenticatedLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  return <DashboardShell>{children}</DashboardShell>;
+  return (
+    <DashboardShell>
+      <Suspense fallback={<AuthenticatedPageLoadingSkeleton />}>
+        {children}
+      </Suspense>
+    </DashboardShell>
+  );
 }

--- a/frontend/src/app/(authenticated)/leaderboards/loading.tsx
+++ b/frontend/src/app/(authenticated)/leaderboards/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/my-predictions/loading.tsx
+++ b/frontend/src/app/(authenticated)/my-predictions/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/profile/loading.tsx
+++ b/frontend/src/app/(authenticated)/profile/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/rewards/loading.tsx
+++ b/frontend/src/app/(authenticated)/rewards/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/settings/loading.tsx
+++ b/frontend/src/app/(authenticated)/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/wallet/loading.tsx
+++ b/frontend/src/app/(authenticated)/wallet/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/Courses/loading.tsx
+++ b/frontend/src/app/Courses/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/Faq/loading.tsx
+++ b/frontend/src/app/Faq/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/community-courses/loading.tsx
+++ b/frontend/src/app/community-courses/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/competitions-demo/loading.tsx
+++ b/frontend/src/app/competitions-demo/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/events/loading.tsx
+++ b/frontend/src/app/events/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/externaltools/loading.tsx
+++ b/frontend/src/app/externaltools/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
+
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -18,7 +22,7 @@ export default function RootLayout({
           Skip to main content
         </a>
         <div id="main-content" tabIndex={-1}>
-          {children}
+          <Suspense fallback={<StandardPageLoadingSkeleton />}>{children}</Suspense>
         </div>
       </body>
     </html>

--- a/frontend/src/app/leaderboard/loading.tsx
+++ b/frontend/src/app/leaderboard/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { MarketingPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <MarketingPageLoadingSkeleton />;
+}

--- a/frontend/src/app/login/loading.tsx
+++ b/frontend/src/app/login/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/markets/loading.tsx
+++ b/frontend/src/app/markets/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/notifications-demo/loading.tsx
+++ b/frontend/src/app/notifications-demo/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/profilePage/loading.tsx
+++ b/frontend/src/app/profilePage/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/signin/loading.tsx
+++ b/frontend/src/app/signin/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/trading/loading.tsx
+++ b/frontend/src/app/trading/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/component/loading-route-skeletons.tsx
+++ b/frontend/src/component/loading-route-skeletons.tsx
@@ -1,0 +1,88 @@
+import { Skeleton } from "@/component/ui/skeleton";
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-[#0f172a]/70 p-6 backdrop-blur-sm">
+      <Skeleton className="mb-4 h-5 w-40 bg-white/15" />
+      <Skeleton className="mb-2 h-8 w-24 bg-white/20" />
+      <Skeleton className="h-4 w-32 bg-white/10" />
+    </div>
+  );
+}
+
+export function MarketingPageLoadingSkeleton() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 p-6 md:p-10">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <Skeleton className="h-14 w-full rounded-2xl bg-white/10" />
+
+        <section className="space-y-4 rounded-3xl border border-white/10 bg-[#111827]/60 p-8">
+          <Skeleton className="h-12 w-3/4 bg-white/15" />
+          <Skeleton className="h-5 w-full max-w-3xl bg-white/10" />
+          <Skeleton className="h-5 w-2/3 bg-white/10" />
+          <div className="flex gap-4 pt-2">
+            <Skeleton className="h-10 w-36 rounded-xl bg-[#4FD1C5]/30" />
+            <Skeleton className="h-10 w-32 rounded-xl bg-white/20" />
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <SkeletonCard key={idx} />
+          ))}
+        </section>
+
+        <Skeleton className="h-24 w-full rounded-2xl bg-white/10" />
+      </div>
+    </div>
+  );
+}
+
+export function StandardPageLoadingSkeleton() {
+  return (
+    <div className="min-h-screen p-6 md:p-10">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-72 bg-white/15" />
+          <Skeleton className="h-5 w-[28rem] max-w-full bg-white/10" />
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <SkeletonCard key={idx} />
+          ))}
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-[#0f172a]/70 p-6">
+          <Skeleton className="mb-6 h-5 w-48 bg-white/15" />
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, idx) => (
+              <Skeleton key={idx} className="h-12 w-full bg-white/10" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AuthenticatedPageLoadingSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <SkeletonCard key={idx} />
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-[#0f172a]/70 p-6">
+        <Skeleton className="mb-6 h-6 w-56 bg-white/15" />
+        <div className="space-y-4">
+          {Array.from({ length: 6 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-11 w-full bg-white/10" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #393 


Description:
Added frontend/src/component/loading-route-skeletons.tsx exporting:
MarketingPageLoadingSkeleton
StandardPageLoadingSkeleton
AuthenticatedPageLoadingSkeleton
Wrapped RootLayout and authenticated layout with Suspense fallbacks using the appropriate skeletons.
Added loading.tsx route files for public and authenticated pages to show route-level loading UI.
Changes are UI-only; no business logic or API modifications.

Testing:

cd frontend && pnpm lint → failed due to pre-existing invalid lint script.
cd frontend && pnpm exec tsc --noEmit → failed due to unrelated missing SVG declarations.
Local validation confirms components compile and exports/imports work.