### PR TITLE
feat: add sitemap and robots.txt for SEO (#397)

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+
+Disallow: /api/
+Disallow: /admin/
+
+Sitemap: https://insightarena.com/sitemap.xml

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,30 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://insightarena.com",
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: "https://insightarena.com/markets",
+      lastModified: new Date(),
+      changeFrequency: "hourly",
+      priority: 0.9,
+    },
+    {
+      url: "https://insightarena.com/leaderboard",
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: "https://insightarena.com/docs",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+  ];
+}


### PR DESCRIPTION
## 🚀 Overview
Added SEO essentials by implementing a dynamic sitemap and robots.txt configuration.

## ✅ Changes Made
- Created `sitemap.ts` using Next.js MetadataRoute
- Included key application routes in sitemap
- Added `robots.txt` with proper crawl rules
- Blocked sensitive routes like `/api` and `/admin`
- Linked sitemap in robots.txt

## 🧪 Testing
- Verified sitemap at `/sitemap.xml`
- Verified robots.txt at `/robots.txt`
- Confirmed correct structure and accessibility

## 📈 Impact
- Improves search engine indexing
- Enhances SEO visibility
- Provides better crawl control for bots

## 🔗 Issue
Closes #397