### PR TITLE
feat(contract): implement conditional parent/chain queries and comprehensive conditional tests

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::governance::{Proposal, ProposalType};
 pub use crate::liquidity::{calculate_liquidity_value, calculate_lp_tokens, calculate_swap_output};
 pub use crate::market::CreateMarketParams;
 pub use crate::storage_types::{
-    ConditionalMarket, CreatorStats, DataKey, InviteCode, LPPosition, LeaderboardEntry,
+    ConditionalChain, ConditionalMarket, CreatorStats, DataKey, InviteCode, LPPosition, LeaderboardEntry,
     LeaderboardSnapshot, LiquidityPool, Market, MarketStats, PlatformStats, Prediction, Season,
     SwapRecord, UserProfile,
 };
@@ -187,6 +187,19 @@ impl InsightArenaContract {
         parent_market_id: u64,
     ) -> Vec<crate::storage_types::ConditionalMarket> {
         market::get_conditional_markets(&env, parent_market_id)
+    }
+
+    /// Get the direct parent market for a conditional market.
+    pub fn get_parent_market(env: Env, market_id: u64) -> Result<Market, InsightArenaError> {
+        market::get_parent_market(&env, market_id)
+    }
+
+    /// Get full conditional ancestry chain for a market.
+    pub fn get_conditional_chain(
+        env: Env,
+        market_id: u64,
+    ) -> Result<crate::storage_types::ConditionalChain, InsightArenaError> {
+        market::get_conditional_chain(&env, market_id)
     }
 
     // ── Dispute ───────────────────────────────────────────────────────────────

--- a/contract/src/market.rs
+++ b/contract/src/market.rs
@@ -712,8 +712,66 @@ pub fn get_conditional_markets(env: &Env, parent_market_id: u64) -> Vec<Conditio
     results
 }
 
+/// Get the direct parent market for a conditional market.
+///
+/// Returns `MarketNotFound` when `market_id` is not a conditional market.
+pub fn get_parent_market(env: &Env, market_id: u64) -> Result<Market, InsightArenaError> {
+    let parent_market_id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ConditionalParent(market_id))
+        .ok_or(InsightArenaError::MarketNotFound)?;
+
+    get_market(env, parent_market_id)
+}
+
+/// Return the ancestry chain for a market, from the provided market up to root.
+///
+/// The returned chain always includes `market_id` as the first element.
+/// The computed result is cached at `DataKey::ConditionalChain(market_id)`.
+pub fn get_conditional_chain(
+    env: &Env,
+    market_id: u64,
+) -> Result<crate::storage_types::ConditionalChain, InsightArenaError> {
+    if !env.storage().persistent().has(&DataKey::Market(market_id)) {
+        return Err(InsightArenaError::MarketNotFound);
+    }
+
+    if let Some(cached) = env
+        .storage()
+        .persistent()
+        .get::<_, crate::storage_types::ConditionalChain>(&DataKey::ConditionalChain(market_id))
+    {
+        return Ok(cached);
+    }
+
+    let mut chain_ids: Vec<u64> = Vec::new(env);
+    chain_ids.push_back(market_id);
+
+    let mut cursor = market_id;
+    while let Some(parent_id) = env
+        .storage()
+        .persistent()
+        .get::<_, u64>(&DataKey::ConditionalParent(cursor))
+    {
+        chain_ids.push_back(parent_id);
+        cursor = parent_id;
+    }
+
+    let depth = chain_ids.len();
+    let chain = crate::storage_types::ConditionalChain {
+        market_ids: chain_ids,
+        depth,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::ConditionalChain(market_id), &chain);
+
+    Ok(chain)
+}
+
 // TODO: validate_conditional_params
-// TODO: get_parent_market / get_conditional_chain
 // TODO: calculate_conditional_depth / validate_no_circular_dependency
 
 fn activate_conditional_market(env: &Env, market_id: u64) -> Result<(), InsightArenaError> {

--- a/contract/tests/conditional_tests.rs
+++ b/contract/tests/conditional_tests.rs
@@ -23,6 +23,45 @@ fn deploy(env: &Env) -> InsightArenaContractClient<'_> {
     client
 }
 
+fn deploy_with_admin_and_oracle(env: &Env) -> (InsightArenaContractClient<'_>, Address, Address) {
+    let id = env.register(InsightArenaContract, ());
+    let client = InsightArenaContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+    let xlm_token = register_token(env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle, &200_u32, &xlm_token);
+    (client, admin, oracle)
+}
+
+fn read_market(env: &Env, client: &InsightArenaContractClient<'_>, market_id: u64) -> Market {
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Market(market_id))
+            .unwrap()
+    })
+}
+
+fn read_conditional(
+    env: &Env,
+    client: &InsightArenaContractClient<'_>,
+    market_id: u64,
+) -> ConditionalMarket {
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ConditionalMarket(market_id))
+            .unwrap()
+    })
+}
+
+fn set_timestamp(env: &Env, timestamp: u64) {
+    env.ledger().with_mut(|l| l.timestamp = timestamp);
+}
+
 fn deploy_with_oracle(env: &Env) -> (InsightArenaContractClient<'_>, Address) {
     let id = env.register(InsightArenaContract, ());
     let client = InsightArenaContractClient::new(env, &id);
@@ -379,4 +418,914 @@ fn test_conditional_market_activation_time_is_set() {
 
     assert!(conditional.is_activated);
     assert_eq!(conditional.activation_time, Some(resolve_time));
+}
+
+// ── Issue #555: get_parent_market ───────────────────────────────────────────
+
+#[test]
+fn test_get_parent_market_returns_correct_parent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+
+    let parent = client.get_parent_market(&child_id);
+    assert_eq!(parent.market_id, parent_id);
+}
+
+#[test]
+fn test_get_parent_market_fails_for_non_conditional_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root_id = client.create_market(&creator, &default_params(&env));
+    let result = client.try_get_parent_market(&root_id);
+
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketNotFound))));
+}
+
+#[test]
+fn test_get_parent_market_fails_for_unknown_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    let result = client.try_get_parent_market(&404_u64);
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketNotFound))));
+}
+
+// ── Issue #556: get_conditional_chain ───────────────────────────────────────
+
+#[test]
+fn test_get_conditional_chain_depth_1() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &root_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+
+    let chain = client.get_conditional_chain(&child_id);
+
+    assert_eq!(chain.depth, 2);
+    assert_eq!(chain.market_ids.len(), 2);
+    assert_eq!(chain.market_ids.get(0), Some(child_id));
+    assert_eq!(chain.market_ids.get(1), Some(root_id));
+}
+
+#[test]
+fn test_get_conditional_chain_depth_3() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root_id = client.create_market(&creator, &default_params(&env));
+    let level1_id = client.create_conditional_market(
+        &creator,
+        &root_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let level2_id = client.create_conditional_market(
+        &creator,
+        &level1_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let level3_id = client.create_conditional_market(
+        &creator,
+        &level2_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+
+    let chain = client.get_conditional_chain(&level3_id);
+
+    assert_eq!(chain.depth, 4);
+    assert_eq!(chain.market_ids.len(), 4);
+    assert_eq!(chain.market_ids.get(0), Some(level3_id));
+    assert_eq!(chain.market_ids.get(1), Some(level2_id));
+    assert_eq!(chain.market_ids.get(2), Some(level1_id));
+    assert_eq!(chain.market_ids.get(3), Some(root_id));
+}
+
+#[test]
+fn test_get_conditional_chain_for_root_market_returns_single() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root_id = client.create_market(&creator, &default_params(&env));
+    let chain = client.get_conditional_chain(&root_id);
+
+    assert_eq!(chain.depth, 1);
+    assert_eq!(chain.market_ids.len(), 1);
+    assert_eq!(chain.market_ids.get(0), Some(root_id));
+}
+
+#[test]
+fn test_get_conditional_chain_caches_result() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &root_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+
+    let first = client.get_conditional_chain(&child_id);
+    let second = client.get_conditional_chain(&child_id);
+
+    assert_eq!(first, second);
+}
+
+// ── Issue #512: Activation Validation Tests ─────────────────────────────────
+
+#[test]
+fn test_check_conditional_activation_invalid_market_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+
+    set_timestamp(&env, 10_000);
+    let result = client.try_resolve_market(&oracle, &999_u64, &symbol_short!("yes"));
+
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketNotFound))));
+}
+
+#[test]
+fn test_check_conditional_activation_parent_cancelled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle) = deploy_with_admin_and_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+
+    client.cancel_market(&admin, &parent_id);
+
+    let child = read_conditional(&env, &client, child_id);
+    assert!(!child.is_activated);
+}
+
+#[test]
+fn test_check_conditional_activation_multiple_outcomes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let parent_params = CreateMarketParams {
+        title: String::from_str(&env, "3-way"),
+        description: String::from_str(&env, "three outcomes"),
+        category: Symbol::new(&env, "Sports"),
+        outcomes: vec![
+            &env,
+            symbol_short!("yes"),
+            symbol_short!("no"),
+            symbol_short!("draw"),
+        ],
+        end_time: now + 1000,
+        resolution_time: now + 2000,
+        dispute_window: 86_400,
+        creator_fee_bps: 100,
+        min_stake: 10_000_000,
+        max_stake: 100_000_000,
+        is_public: true,
+    };
+
+    let parent_id = client.create_market(&creator, &parent_params);
+    let c_yes = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c_no = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("no"),
+        &default_params(&env),
+    );
+    let c_draw = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("draw"),
+        &default_params(&env),
+    );
+
+    set_timestamp(&env, 10_000);
+    client.resolve_market(&oracle, &parent_id, &symbol_short!("draw"));
+
+    assert!(!read_conditional(&env, &client, c_yes).is_activated);
+    assert!(!read_conditional(&env, &client, c_no).is_activated);
+    assert!(read_conditional(&env, &client, c_draw).is_activated);
+}
+
+#[test]
+fn test_check_conditional_activation_chain() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let a = client.create_market(&creator, &default_params(&env));
+    let b = client.create_conditional_market(&creator, &a, &symbol_short!("yes"), &default_params(&env));
+    let c = client.create_conditional_market(&creator, &b, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 10_000);
+    client.resolve_market(&oracle, &a, &symbol_short!("yes"));
+
+    assert!(read_conditional(&env, &client, b).is_activated);
+    assert!(!read_conditional(&env, &client, c).is_activated);
+}
+
+// ── Additional comprehensive coverage for Issue #520 ────────────────────────
+
+#[test]
+fn test_create_conditional_market_sets_parent_link_storage() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+
+    let contract_id = client.address.clone();
+    let stored_parent: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ConditionalParent(child_id))
+            .unwrap()
+    });
+
+    assert_eq!(stored_parent, parent_id);
+}
+
+#[test]
+fn test_create_conditional_market_sets_depth_to_1_for_root_parent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+
+    let child = read_conditional(&env, &client, child_id);
+    assert_eq!(child.conditional_depth, 1);
+}
+
+#[test]
+fn test_create_conditional_market_increments_depth_for_nested_children() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let c1 = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let c2 = client.create_conditional_market(&creator, &c1, &symbol_short!("yes"), &default_params(&env));
+
+    assert_eq!(read_conditional(&env, &client, c1).conditional_depth, 1);
+    assert_eq!(read_conditional(&env, &client, c2).conditional_depth, 2);
+}
+
+#[test]
+fn test_get_conditional_markets_returns_only_direct_children() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let direct = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let _nested = client.create_conditional_market(&creator, &direct, &symbol_short!("yes"), &default_params(&env));
+
+    let root_children = client.get_conditional_markets(&root);
+    assert_eq!(root_children.len(), 1);
+    assert_eq!(root_children.get(0).unwrap().market_id, direct);
+}
+
+#[test]
+fn test_activation_sets_activation_timestamp_to_ledger_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(&creator, &parent_id, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 6_000);
+    client.resolve_market(&oracle, &parent_id, &symbol_short!("yes"));
+
+    let child = read_conditional(&env, &client, child_id);
+    assert_eq!(child.activation_time, Some(6_000));
+}
+
+#[test]
+fn test_non_matching_outcome_never_sets_activation_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(&creator, &parent_id, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 7_000);
+    client.resolve_market(&oracle, &parent_id, &symbol_short!("no"));
+
+    let child = read_conditional(&env, &client, child_id);
+    assert_eq!(child.activation_time, None);
+}
+
+#[test]
+fn test_conditional_chain_for_unknown_market_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    let result = client.try_get_conditional_chain(&808_u64);
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketNotFound))));
+}
+
+#[test]
+fn test_get_parent_market_returns_immediate_parent_not_root() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+
+    let parent = client.get_parent_market(&grandchild);
+    assert_eq!(parent.market_id, child);
+}
+
+#[test]
+fn test_chain_order_is_leaf_to_root() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+
+    let chain = client.get_conditional_chain(&grandchild);
+    assert_eq!(chain.market_ids.get(0), Some(grandchild));
+    assert_eq!(chain.market_ids.get(1), Some(child));
+    assert_eq!(chain.market_ids.get(2), Some(root));
+}
+
+#[test]
+fn test_cancel_parent_sets_market_cancelled_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle) = deploy_with_admin_and_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    client.cancel_market(&admin, &parent);
+
+    let market = read_market(&env, &client, parent);
+    assert!(market.is_cancelled);
+}
+
+#[test]
+fn test_resolving_parent_with_wrong_outcome_keeps_all_children_inactive() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let c2 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 9_000);
+    client.resolve_market(&oracle, &parent, &symbol_short!("no"));
+
+    assert!(!read_conditional(&env, &client, c1).is_activated);
+    assert!(!read_conditional(&env, &client, c2).is_activated);
+}
+
+#[test]
+fn test_creation_child_market_is_persisted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    let market = read_market(&env, &client, child);
+    assert_eq!(market.market_id, child);
+}
+
+#[test]
+fn test_creation_multiple_children_have_unique_ids() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let c2 = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+    assert_ne!(c1, c2);
+}
+
+#[test]
+fn test_creation_children_list_length_increases() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    assert_eq!(client.get_conditional_markets(&parent).len(), 0);
+    client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    assert_eq!(client.get_conditional_markets(&parent).len(), 1);
+    client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+    assert_eq!(client.get_conditional_markets(&parent).len(), 2);
+}
+
+#[test]
+fn test_creation_required_outcome_is_persisted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+
+    let conditional = read_conditional(&env, &client, child);
+    assert_eq!(conditional.required_outcome, symbol_short!("no"));
+}
+
+#[test]
+fn test_creation_new_conditional_starts_inactive() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    assert!(!read_conditional(&env, &client, child).is_activated);
+}
+
+#[test]
+fn test_creation_activation_time_none_initially() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    assert_eq!(read_conditional(&env, &client, child).activation_time, None);
+}
+
+#[test]
+fn test_creation_nested_parent_link_points_to_immediate_parent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+
+    let parent = client.get_parent_market(&grandchild);
+    assert_eq!(parent.market_id, child);
+}
+
+#[test]
+fn test_creation_child_market_can_be_fetched_with_get_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let loaded = client.get_market(&child);
+    assert_eq!(loaded.market_id, child);
+}
+
+#[test]
+fn test_creation_depth_three_levels_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let c1 = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let c2 = client.create_conditional_market(&creator, &c1, &symbol_short!("yes"), &default_params(&env));
+    let c3 = client.create_conditional_market(&creator, &c2, &symbol_short!("yes"), &default_params(&env));
+
+    assert_eq!(read_conditional(&env, &client, c1).conditional_depth, 1);
+    assert_eq!(read_conditional(&env, &client, c2).conditional_depth, 2);
+    assert_eq!(read_conditional(&env, &client, c3).conditional_depth, 3);
+}
+
+#[test]
+fn test_creation_limit_allows_depth_five() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let mut parent = client.create_market(&creator, &default_params(&env));
+    for _ in 0..5 {
+        parent = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    }
+
+    assert_eq!(read_conditional(&env, &client, parent).conditional_depth, 5);
+}
+
+#[test]
+fn test_activation_only_matching_child_activates_among_many() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let c2 = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+    let c3 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 11_000);
+    client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
+
+    assert!(read_conditional(&env, &client, c1).is_activated);
+    assert!(!read_conditional(&env, &client, c2).is_activated);
+    assert!(read_conditional(&env, &client, c3).is_activated);
+}
+
+#[test]
+fn test_activation_children_with_other_outcomes_remain_inactive() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+
+    set_timestamp(&env, 12_000);
+    client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
+
+    assert!(!read_conditional(&env, &client, c1).is_activated);
+}
+
+#[test]
+fn test_activation_with_multiple_levels_only_first_level() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let c1 = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let c2 = client.create_conditional_market(&creator, &c1, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 13_000);
+    client.resolve_market(&oracle, &root, &symbol_short!("yes"));
+
+    assert!(read_conditional(&env, &client, c1).is_activated);
+    assert!(!read_conditional(&env, &client, c2).is_activated);
+}
+
+#[test]
+fn test_activation_after_parent_resolution_stores_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 14_000);
+    client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
+    assert_eq!(read_conditional(&env, &client, child).activation_time, Some(14_000));
+}
+
+#[test]
+fn test_activation_parent_resolve_wrong_outcome_keeps_timestamp_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 15_000);
+    client.resolve_market(&oracle, &parent, &symbol_short!("no"));
+    assert_eq!(read_conditional(&env, &client, child).activation_time, None);
+}
+
+#[test]
+fn test_activation_resolving_parent_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    set_timestamp(&env, 16_000);
+    client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
+
+    let result = client.try_resolve_market(&oracle, &parent, &symbol_short!("yes"));
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketAlreadyResolved))));
+}
+
+#[test]
+fn test_activation_unrelated_market_resolution_does_not_affect_child() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent_a = client.create_market(&creator, &default_params(&env));
+    let parent_b = client.create_market(&creator, &default_params(&env));
+    let child_a = client.create_conditional_market(&creator, &parent_a, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 17_000);
+    client.resolve_market(&oracle, &parent_b, &symbol_short!("yes"));
+
+    assert!(!read_conditional(&env, &client, child_a).is_activated);
+}
+
+#[test]
+fn test_activation_non_matching_in_nested_structure() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("no"), &default_params(&env));
+    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 18_000);
+    client.resolve_market(&oracle, &root, &symbol_short!("yes"));
+
+    assert!(!read_conditional(&env, &client, child).is_activated);
+    assert!(!read_conditional(&env, &client, grandchild).is_activated);
+}
+
+#[test]
+fn test_query_get_parent_market_for_second_level() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+
+    let parent = client.get_parent_market(&grandchild);
+    assert_eq!(parent.market_id, child);
+}
+
+#[test]
+fn test_query_chain_root_depth_is_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let chain = client.get_conditional_chain(&root);
+    assert_eq!(chain.depth, 1);
+}
+
+#[test]
+fn test_query_chain_second_level_depth_is_three() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+
+    let chain = client.get_conditional_chain(&grandchild);
+    assert_eq!(chain.depth, 3);
+}
+
+#[test]
+fn test_query_chain_cached_after_first_call_storage_exists() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let _ = client.get_conditional_chain(&child);
+
+    let contract_id = client.address.clone();
+    let cached = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .has(&DataKey::ConditionalChain(child))
+    });
+    assert!(cached);
+}
+
+#[test]
+fn test_query_conditional_markets_returns_struct_fields() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let root = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let items = client.get_conditional_markets(&root);
+    let first = items.get(0).unwrap();
+
+    assert_eq!(first.market_id, child);
+    assert_eq!(first.parent_market_id, root);
+    assert_eq!(first.required_outcome, symbol_short!("yes"));
+}
+
+#[test]
+fn test_query_conditional_markets_empty_for_unknown_parent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    let items = client.get_conditional_markets(&1_000_000_u64);
+    assert_eq!(items.len(), 0);
+}
+
+#[test]
+fn test_integration_market_lifecycle_parent_then_child_resolution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 20_000);
+    client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
+    client.resolve_market(&oracle, &child, &symbol_short!("yes"));
+
+    assert!(read_market(&env, &client, parent).is_resolved);
+    assert!(read_market(&env, &client, child).is_resolved);
+}
+
+#[test]
+fn test_integration_resolution_chain_progression_requires_each_parent_resolution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+
+    let a = client.create_market(&creator, &default_params(&env));
+    let b = client.create_conditional_market(&creator, &a, &symbol_short!("yes"), &default_params(&env));
+    let c = client.create_conditional_market(&creator, &b, &symbol_short!("yes"), &default_params(&env));
+
+    set_timestamp(&env, 21_000);
+    client.resolve_market(&oracle, &a, &symbol_short!("yes"));
+    assert!(read_conditional(&env, &client, b).is_activated);
+    assert!(!read_conditional(&env, &client, c).is_activated);
+
+    client.resolve_market(&oracle, &b, &symbol_short!("yes"));
+    assert!(read_conditional(&env, &client, c).is_activated);
+}
+
+#[test]
+fn test_edge_invalid_parent_id_large_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let result = client.try_create_conditional_market(
+        &creator,
+        &u64::MAX,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketNotFound))));
+}
+
+#[test]
+fn test_edge_max_depth_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let mut parent = client.create_market(&creator, &default_params(&env));
+    for _ in 0..5 {
+        parent = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    }
+
+    let fail = client.try_create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    assert!(matches!(fail, Err(Ok(InsightArenaError::ConditionalDepthExceeded))));
+}
+
+#[test]
+fn test_security_unauthorized_resolve_parent_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+    let attacker_oracle = Address::generate(&env);
+
+    let parent = client.create_market(&creator, &default_params(&env));
+    set_timestamp(&env, 30_000);
+    let res = client.try_resolve_market(&attacker_oracle, &parent, &symbol_short!("yes"));
+    assert!(matches!(res, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+#[test]
+fn test_security_get_parent_unknown_id_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    let res = client.try_get_parent_market(&77_777_u64);
+    assert!(matches!(res, Err(Ok(InsightArenaError::MarketNotFound))));
+}
+
+#[test]
+fn test_security_conditional_chain_unknown_id_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    let res = client.try_get_conditional_chain(&88_888_u64);
+    assert!(matches!(res, Err(Ok(InsightArenaError::MarketNotFound))));
 }


### PR DESCRIPTION
## Summary
This PR implements missing conditional-market query functionality and expands conditional test coverage to satisfy the assigned contract issues.

## What changed
- Implemented `get_parent_market(env, market_id)` in `contract/src/market.rs`
  - Reads `DataKey::ConditionalParent(market_id)`
  - Returns `MarketNotFound` when `market_id` is not conditional or unknown
  - Loads and returns the parent `Market`
- Implemented `get_conditional_chain(env, market_id)` in `contract/src/market.rs`
  - Walks ancestry from market to root via `DataKey::ConditionalParent`
  - Builds and returns `ConditionalChain { market_ids, depth }`
  - Caches computed chains in `DataKey::ConditionalChain(market_id)`
  - Returns `MarketNotFound` for unknown market IDs
- Exposed both query functions via public contract methods in `contract/src/lib.rs`
- Expanded `contract/tests/conditional_tests.rs` to a comprehensive suite (63 tests)
  - Includes the required tests for Issues #555 and #556
  - Includes the 4 activation validation tests for Issue #512
  - Adds broader creation/activation/query/integration/edge/security coverage for Issue #520

## Validation
- `cargo test --test conditional_tests` passes with **63/63** tests
- `cargo test` passes with no regressions across the contract test suite
- `make build` passes after ensuring `wasm32-unknown-unknown` target is installed

## Notes
- Followed repository contribution and CI guidance from `contract/CONTRIBUTING.md`.

Closes #555
Closes #556
Closes #512
Closes #520