### PR TITLE
feat: implement get_top_creators leaderboard and add tests

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::market::CreateMarketParams;
 pub use crate::storage_types::{
     ConditionalChain, ConditionalMarket, CreatorStats, DataKey, InviteCode, LPPosition, LeaderboardEntry,
     LeaderboardSnapshot, LiquidityPool, Market, MarketStats, PlatformStats, Prediction, Season,
-    SwapRecord, UserProfile,
+    SwapRecord, UserProfile, CreatorLeaderboardEntry,
 };
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
@@ -455,6 +455,11 @@ impl InsightArenaContract {
         creator: Address,
     ) -> Result<CreatorStats, InsightArenaError> {
         reputation::get_creator_stats(env, creator)
+    }
+
+    /// Return a sorted list of top creators by reputation score.
+    pub fn get_top_creators(env: Env, limit: u32) -> Vec<CreatorLeaderboardEntry> {
+        reputation::get_top_creators(&env, limit)
     }
 
     /// Admin function to forcefully reset a creator's statistics.

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -21,9 +21,9 @@ pub use crate::governance::{Proposal, ProposalType};
 pub use crate::liquidity::{calculate_liquidity_value, calculate_lp_tokens, calculate_swap_output};
 pub use crate::market::CreateMarketParams;
 pub use crate::storage_types::{
-    ConditionalChain, ConditionalMarket, CreatorStats, DataKey, InviteCode, LPPosition, LeaderboardEntry,
-    LeaderboardSnapshot, LiquidityPool, Market, MarketStats, PlatformStats, Prediction, Season,
-    SwapRecord, UserProfile, CreatorLeaderboardEntry,
+    ConditionalChain, ConditionalMarket, CreatorLeaderboardEntry, CreatorStats, DataKey,
+    InviteCode, LPPosition, LeaderboardEntry, LeaderboardSnapshot, LiquidityPool, Market,
+    MarketStats, PlatformStats, Prediction, Season, SwapRecord, UserProfile,
 };
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};

--- a/contract/src/liquidity.rs
+++ b/contract/src/liquidity.rs
@@ -453,7 +453,11 @@ pub fn update_pool_volume(env: &Env, market_id: u64, amount: i128) {
 
     let now = env.ledger().timestamp();
     let twenty_four_hours: u64 = 24 * 60 * 60;
-    let cutoff = if now > twenty_four_hours { now - twenty_four_hours } else { 0 };
+    let cutoff = if now > twenty_four_hours {
+        now - twenty_four_hours
+    } else {
+        0
+    };
 
     let mut new_entries = Vec::new(env);
     for entry in volume_entries.iter() {
@@ -461,14 +465,16 @@ pub fn update_pool_volume(env: &Env, market_id: u64, amount: i128) {
             new_entries.push_back(entry);
         }
     }
-    
+
     new_entries.push_back((now, amount));
     env.storage()
         .persistent()
         .set(&DataKey::PoolVolume(market_id), &new_entries);
-    env.storage()
-        .persistent()
-        .extend_ttl(&DataKey::PoolVolume(market_id), PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
+    env.storage().persistent().extend_ttl(
+        &DataKey::PoolVolume(market_id),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
 }
 
 pub fn get_pool_volume_24h(env: &Env, market_id: u64) -> i128 {
@@ -480,7 +486,11 @@ pub fn get_pool_volume_24h(env: &Env, market_id: u64) -> i128 {
 
     let now = env.ledger().timestamp();
     let twenty_four_hours: u64 = 24 * 60 * 60;
-    let cutoff = if now > twenty_four_hours { now - twenty_four_hours } else { 0 };
+    let cutoff = if now > twenty_four_hours {
+        now - twenty_four_hours
+    } else {
+        0
+    };
 
     let mut total: i128 = 0;
     for entry in volume_entries.iter() {
@@ -489,20 +499,32 @@ pub fn get_pool_volume_24h(env: &Env, market_id: u64) -> i128 {
         }
     }
 
-    if env.storage().persistent().has(&DataKey::PoolVolume(market_id)) {
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::PoolVolume(market_id), PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::PoolVolume(market_id))
+    {
+        env.storage().persistent().extend_ttl(
+            &DataKey::PoolVolume(market_id),
+            PERSISTENT_THRESHOLD,
+            PERSISTENT_BUMP,
+        );
     }
 
     total
 }
 
 pub fn get_swap_history(env: &Env, market_id: u64) -> Vec<SwapRecord> {
-    if env.storage().persistent().has(&DataKey::SwapHistory(market_id)) {
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::SwapHistory(market_id), PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::SwapHistory(market_id))
+    {
+        env.storage().persistent().extend_ttl(
+            &DataKey::SwapHistory(market_id),
+            PERSISTENT_THRESHOLD,
+            PERSISTENT_BUMP,
+        );
     }
     env.storage()
         .persistent()

--- a/contract/src/market.rs
+++ b/contract/src/market.rs
@@ -293,6 +293,7 @@ pub fn create_market(
 
     // ── Update creator reputation stats ──────────────────────────────────────
     reputation::on_market_created(env, &creator);
+    crate::season::track_user_profile(env, &creator);
 
     Ok(market_id)
 }

--- a/contract/src/prediction.rs
+++ b/contract/src/prediction.rs
@@ -687,5 +687,3 @@ pub fn batch_distribute_payouts(
 
     Ok(processed)
 }
-
-

--- a/contract/src/reputation.rs
+++ b/contract/src/reputation.rs
@@ -2,7 +2,8 @@ use soroban_sdk::{Address, Env};
 
 use crate::config::{PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
 use crate::errors::InsightArenaError;
-use crate::storage_types::{CreatorStats, DataKey};
+use crate::storage_types::{CreatorStats, DataKey, CreatorLeaderboardEntry};
+
 
 // ── Storage helpers ───────────────────────────────────────────────────────────
 
@@ -83,6 +84,66 @@ pub fn on_market_resolved(env: &Env, creator: &Address, participant_count: u32) 
 
 pub fn get_creator_stats(env: Env, creator: Address) -> Result<CreatorStats, InsightArenaError> {
     Ok(load_stats(&env, &creator))
+}
+
+pub fn get_top_creators(env: &Env, limit: u32) -> Vec<CreatorLeaderboardEntry> {
+    let mut limit = limit;
+    if limit > 50 {
+        limit = 50;
+    }
+
+    let users: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::UserList)
+        .unwrap_or_else(|| Vec::new(env));
+
+    let mut creators = Vec::new(env);
+
+    for user in users.iter() {
+        if let Some(stats) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, CreatorStats>(&DataKey::CreatorStats(user.clone()))
+        {
+            if stats.markets_created > 0 {
+                creators.push_back(CreatorLeaderboardEntry {
+                    address: user,
+                    stats,
+                });
+            }
+        }
+    }
+
+    // Sort by reputation_score descending
+    let n = creators.len();
+    for i in 1..n {
+        let mut j = i;
+        while j > 0 {
+            let a = creators.get(j).unwrap().stats.reputation_score;
+            let b = creators.get(j - 1).unwrap().stats.reputation_score;
+            if a > b {
+                let temp_a = creators.get(j).unwrap();
+                let temp_b = creators.get(j - 1).unwrap();
+                creators.set(j, temp_b);
+                creators.set(j - 1, temp_a);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    // Truncate to limit
+    if creators.len() > limit {
+        let mut truncated = Vec::new(env);
+        for i in 0..limit {
+            truncated.push_back(creators.get(i).unwrap());
+        }
+        creators = truncated;
+    }
+
+    creators
 }
 
 pub fn reset_creator_stats(env: &Env, admin: Address, creator: Address) -> Result<(), InsightArenaError> {

--- a/contract/src/reputation.rs
+++ b/contract/src/reputation.rs
@@ -1,9 +1,8 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Vec};
 
 use crate::config::{PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
 use crate::errors::InsightArenaError;
-use crate::storage_types::{CreatorStats, DataKey, CreatorLeaderboardEntry};
-
+use crate::storage_types::{CreatorLeaderboardEntry, CreatorStats, DataKey};
 
 // ── Storage helpers ───────────────────────────────────────────────────────────
 
@@ -146,20 +145,24 @@ pub fn get_top_creators(env: &Env, limit: u32) -> Vec<CreatorLeaderboardEntry> {
     creators
 }
 
-pub fn reset_creator_stats(env: &Env, admin: Address, creator: Address) -> Result<(), InsightArenaError> {
+pub fn reset_creator_stats(
+    env: &Env,
+    admin: Address,
+    creator: Address,
+) -> Result<(), InsightArenaError> {
     admin.require_auth();
     let cfg = crate::config::get_config(env)?;
     if admin != cfg.admin {
         return Err(InsightArenaError::Unauthorized);
     }
-    
+
     let mut stats = load_stats(env, &creator);
     stats.markets_created = 0;
     stats.markets_resolved = 0;
     stats.average_participant_count = 0;
     stats.dispute_count = 0;
     stats.reputation_score = 0;
-    
+
     save_stats(env, &creator, &stats);
     Ok(())
 }

--- a/contract/src/storage_types.rs
+++ b/contract/src/storage_types.rs
@@ -121,6 +121,13 @@ pub struct CreatorStats {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreatorLeaderboardEntry {
+    pub address: Address,
+    pub stats: CreatorStats,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Prediction {
     /// The ID of the market this prediction is designated for.
     pub market_id: u64,

--- a/contract/tests/analytics_tests.rs
+++ b/contract/tests/analytics_tests.rs
@@ -244,7 +244,7 @@ fn get_platform_stats_after_activity() {
     let stats = client.get_platform_stats();
     assert_eq!(stats.total_markets, 1);
     assert_eq!(stats.total_volume_xlm, 50_000_000);
-    assert_eq!(stats.active_users, 2);
+    assert_eq!(stats.active_users, 3);
 }
 
 #[test]
@@ -294,7 +294,7 @@ fn test_analytics_aggregation() {
     let stats = client.get_platform_stats();
     assert_eq!(stats.total_markets, 2);
     assert_eq!(stats.total_volume_xlm, 140_000_000);
-    assert_eq!(stats.active_users, 2);
+    assert_eq!(stats.active_users, 3);
 
     let u1_stats = client.get_user_stats(&u1);
     assert_eq!(u1_stats.total_predictions, 2);

--- a/contract/tests/conditional_tests.rs
+++ b/contract/tests/conditional_tests.rs
@@ -660,8 +660,18 @@ fn test_check_conditional_activation_chain() {
     let creator = Address::generate(&env);
 
     let a = client.create_market(&creator, &default_params(&env));
-    let b = client.create_conditional_market(&creator, &a, &symbol_short!("yes"), &default_params(&env));
-    let c = client.create_conditional_market(&creator, &b, &symbol_short!("yes"), &default_params(&env));
+    let b = client.create_conditional_market(
+        &creator,
+        &a,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c = client.create_conditional_market(
+        &creator,
+        &b,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 10_000);
     client.resolve_market(&oracle, &a, &symbol_short!("yes"));
@@ -725,8 +735,18 @@ fn test_create_conditional_market_increments_depth_for_nested_children() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let c1 = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let c2 = client.create_conditional_market(&creator, &c1, &symbol_short!("yes"), &default_params(&env));
+    let c1 = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c2 = client.create_conditional_market(
+        &creator,
+        &c1,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     assert_eq!(read_conditional(&env, &client, c1).conditional_depth, 1);
     assert_eq!(read_conditional(&env, &client, c2).conditional_depth, 2);
@@ -740,8 +760,18 @@ fn test_get_conditional_markets_returns_only_direct_children() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let direct = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let _nested = client.create_conditional_market(&creator, &direct, &symbol_short!("yes"), &default_params(&env));
+    let direct = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let _nested = client.create_conditional_market(
+        &creator,
+        &direct,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     let root_children = client.get_conditional_markets(&root);
     assert_eq!(root_children.len(), 1);
@@ -756,7 +786,12 @@ fn test_activation_sets_activation_timestamp_to_ledger_time() {
     let creator = Address::generate(&env);
 
     let parent_id = client.create_market(&creator, &default_params(&env));
-    let child_id = client.create_conditional_market(&creator, &parent_id, &symbol_short!("yes"), &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 6_000);
     client.resolve_market(&oracle, &parent_id, &symbol_short!("yes"));
@@ -773,7 +808,12 @@ fn test_non_matching_outcome_never_sets_activation_time() {
     let creator = Address::generate(&env);
 
     let parent_id = client.create_market(&creator, &default_params(&env));
-    let child_id = client.create_conditional_market(&creator, &parent_id, &symbol_short!("yes"), &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 7_000);
     client.resolve_market(&oracle, &parent_id, &symbol_short!("no"));
@@ -800,8 +840,18 @@ fn test_get_parent_market_returns_immediate_parent_not_root() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let grandchild = client.create_conditional_market(
+        &creator,
+        &child,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     let parent = client.get_parent_market(&grandchild);
     assert_eq!(parent.market_id, child);
@@ -815,8 +865,18 @@ fn test_chain_order_is_leaf_to_root() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let grandchild = client.create_conditional_market(
+        &creator,
+        &child,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     let chain = client.get_conditional_chain(&grandchild);
     assert_eq!(chain.market_ids.get(0), Some(grandchild));
@@ -846,8 +906,18 @@ fn test_resolving_parent_with_wrong_outcome_keeps_all_children_inactive() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
-    let c2 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let c1 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c2 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 9_000);
     client.resolve_market(&oracle, &parent, &symbol_short!("no"));
@@ -864,7 +934,12 @@ fn test_creation_child_market_is_persisted() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     let market = read_market(&env, &client, child);
     assert_eq!(market.market_id, child);
@@ -878,8 +953,18 @@ fn test_creation_multiple_children_have_unique_ids() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
-    let c2 = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+    let c1 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c2 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("no"),
+        &default_params(&env),
+    );
     assert_ne!(c1, c2);
 }
 
@@ -892,9 +977,19 @@ fn test_creation_children_list_length_increases() {
 
     let parent = client.create_market(&creator, &default_params(&env));
     assert_eq!(client.get_conditional_markets(&parent).len(), 0);
-    client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
     assert_eq!(client.get_conditional_markets(&parent).len(), 1);
-    client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+    client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("no"),
+        &default_params(&env),
+    );
     assert_eq!(client.get_conditional_markets(&parent).len(), 2);
 }
 
@@ -906,7 +1001,12 @@ fn test_creation_required_outcome_is_persisted() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("no"),
+        &default_params(&env),
+    );
 
     let conditional = read_conditional(&env, &client, child);
     assert_eq!(conditional.required_outcome, symbol_short!("no"));
@@ -920,7 +1020,12 @@ fn test_creation_new_conditional_starts_inactive() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     assert!(!read_conditional(&env, &client, child).is_activated);
 }
@@ -933,7 +1038,12 @@ fn test_creation_activation_time_none_initially() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     assert_eq!(read_conditional(&env, &client, child).activation_time, None);
 }
@@ -946,8 +1056,18 @@ fn test_creation_nested_parent_link_points_to_immediate_parent() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let grandchild = client.create_conditional_market(
+        &creator,
+        &child,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     let parent = client.get_parent_market(&grandchild);
     assert_eq!(parent.market_id, child);
@@ -961,7 +1081,12 @@ fn test_creation_child_market_can_be_fetched_with_get_market() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
     let loaded = client.get_market(&child);
     assert_eq!(loaded.market_id, child);
 }
@@ -974,9 +1099,24 @@ fn test_creation_depth_three_levels_values() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let c1 = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let c2 = client.create_conditional_market(&creator, &c1, &symbol_short!("yes"), &default_params(&env));
-    let c3 = client.create_conditional_market(&creator, &c2, &symbol_short!("yes"), &default_params(&env));
+    let c1 = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c2 = client.create_conditional_market(
+        &creator,
+        &c1,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c3 = client.create_conditional_market(
+        &creator,
+        &c2,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     assert_eq!(read_conditional(&env, &client, c1).conditional_depth, 1);
     assert_eq!(read_conditional(&env, &client, c2).conditional_depth, 2);
@@ -992,7 +1132,12 @@ fn test_creation_limit_allows_depth_five() {
 
     let mut parent = client.create_market(&creator, &default_params(&env));
     for _ in 0..5 {
-        parent = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+        parent = client.create_conditional_market(
+            &creator,
+            &parent,
+            &symbol_short!("yes"),
+            &default_params(&env),
+        );
     }
 
     assert_eq!(read_conditional(&env, &client, parent).conditional_depth, 5);
@@ -1006,9 +1151,24 @@ fn test_activation_only_matching_child_activates_among_many() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
-    let c2 = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
-    let c3 = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let c1 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c2 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("no"),
+        &default_params(&env),
+    );
+    let c3 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 11_000);
     client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
@@ -1026,7 +1186,12 @@ fn test_activation_children_with_other_outcomes_remain_inactive() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let c1 = client.create_conditional_market(&creator, &parent, &symbol_short!("no"), &default_params(&env));
+    let c1 = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("no"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 12_000);
     client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
@@ -1042,8 +1207,18 @@ fn test_activation_with_multiple_levels_only_first_level() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let c1 = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let c2 = client.create_conditional_market(&creator, &c1, &symbol_short!("yes"), &default_params(&env));
+    let c1 = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c2 = client.create_conditional_market(
+        &creator,
+        &c1,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 13_000);
     client.resolve_market(&oracle, &root, &symbol_short!("yes"));
@@ -1060,11 +1235,19 @@ fn test_activation_after_parent_resolution_stores_timestamp() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 14_000);
     client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
-    assert_eq!(read_conditional(&env, &client, child).activation_time, Some(14_000));
+    assert_eq!(
+        read_conditional(&env, &client, child).activation_time,
+        Some(14_000)
+    );
 }
 
 #[test]
@@ -1075,7 +1258,12 @@ fn test_activation_parent_resolve_wrong_outcome_keeps_timestamp_none() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 15_000);
     client.resolve_market(&oracle, &parent, &symbol_short!("no"));
@@ -1094,7 +1282,10 @@ fn test_activation_resolving_parent_twice_fails() {
     client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
 
     let result = client.try_resolve_market(&oracle, &parent, &symbol_short!("yes"));
-    assert!(matches!(result, Err(Ok(InsightArenaError::MarketAlreadyResolved))));
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyResolved))
+    ));
 }
 
 #[test]
@@ -1106,7 +1297,12 @@ fn test_activation_unrelated_market_resolution_does_not_affect_child() {
 
     let parent_a = client.create_market(&creator, &default_params(&env));
     let parent_b = client.create_market(&creator, &default_params(&env));
-    let child_a = client.create_conditional_market(&creator, &parent_a, &symbol_short!("yes"), &default_params(&env));
+    let child_a = client.create_conditional_market(
+        &creator,
+        &parent_a,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 17_000);
     client.resolve_market(&oracle, &parent_b, &symbol_short!("yes"));
@@ -1122,8 +1318,18 @@ fn test_activation_non_matching_in_nested_structure() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("no"), &default_params(&env));
-    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("no"),
+        &default_params(&env),
+    );
+    let grandchild = client.create_conditional_market(
+        &creator,
+        &child,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 18_000);
     client.resolve_market(&oracle, &root, &symbol_short!("yes"));
@@ -1140,8 +1346,18 @@ fn test_query_get_parent_market_for_second_level() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let grandchild = client.create_conditional_market(
+        &creator,
+        &child,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     let parent = client.get_parent_market(&grandchild);
     assert_eq!(parent.market_id, child);
@@ -1167,8 +1383,18 @@ fn test_query_chain_second_level_depth_is_three() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
-    let grandchild = client.create_conditional_market(&creator, &child, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let grandchild = client.create_conditional_market(
+        &creator,
+        &child,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     let chain = client.get_conditional_chain(&grandchild);
     assert_eq!(chain.depth, 3);
@@ -1182,7 +1408,12 @@ fn test_query_chain_cached_after_first_call_storage_exists() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
     let _ = client.get_conditional_chain(&child);
 
     let contract_id = client.address.clone();
@@ -1202,7 +1433,12 @@ fn test_query_conditional_markets_returns_struct_fields() {
     let creator = Address::generate(&env);
 
     let root = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &root, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &root,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
     let items = client.get_conditional_markets(&root);
     let first = items.get(0).unwrap();
 
@@ -1229,7 +1465,12 @@ fn test_integration_market_lifecycle_parent_then_child_resolution() {
     let creator = Address::generate(&env);
 
     let parent = client.create_market(&creator, &default_params(&env));
-    let child = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+    let child = client.create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 20_000);
     client.resolve_market(&oracle, &parent, &symbol_short!("yes"));
@@ -1247,8 +1488,18 @@ fn test_integration_resolution_chain_progression_requires_each_parent_resolution
     let creator = Address::generate(&env);
 
     let a = client.create_market(&creator, &default_params(&env));
-    let b = client.create_conditional_market(&creator, &a, &symbol_short!("yes"), &default_params(&env));
-    let c = client.create_conditional_market(&creator, &b, &symbol_short!("yes"), &default_params(&env));
+    let b = client.create_conditional_market(
+        &creator,
+        &a,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
+    let c = client.create_conditional_market(
+        &creator,
+        &b,
+        &symbol_short!("yes"),
+        &default_params(&env),
+    );
 
     set_timestamp(&env, 21_000);
     client.resolve_market(&oracle, &a, &symbol_short!("yes"));
@@ -1284,7 +1535,12 @@ fn test_edge_max_depth_boundary() {
 
     let mut parent = client.create_market(&creator, &default_params(&env));
     for _ in 0..5 {
-        parent = client.create_conditional_market(&creator, &parent, &symbol_short!("yes"), &default_params(&env));
+        parent = client.create_conditional_market(
+            &creator,
+            &parent,
+            &symbol_short!("yes"),
+            &default_params(&env),
+        );
     }
 
     let fail = client.try_create_conditional_market(
@@ -1293,7 +1549,10 @@ fn test_edge_max_depth_boundary() {
         &symbol_short!("yes"),
         &default_params(&env),
     );
-    assert!(matches!(fail, Err(Ok(InsightArenaError::ConditionalDepthExceeded))));
+    assert!(matches!(
+        fail,
+        Err(Ok(InsightArenaError::ConditionalDepthExceeded))
+    ));
 }
 
 #[test]

--- a/contract/tests/governance_tests.rs
+++ b/contract/tests/governance_tests.rs
@@ -7,7 +7,8 @@ use soroban_sdk::{Address, Env};
 
 fn register_token(env: &Env) -> Address {
     let token_admin = Address::generate(env);
-    env.register_stellar_asset_contract_v2(token_admin).address()
+    env.register_stellar_asset_contract_v2(token_admin)
+        .address()
 }
 
 fn deploy(env: &Env) -> (InsightArenaContractClient<'_>, Address) {

--- a/contract/tests/liquidity_tests.rs
+++ b/contract/tests/liquidity_tests.rs
@@ -695,8 +695,6 @@ fn test_pool_volume_returns_zero_for_unknown_market() {
     assert_eq!(client.get_pool_volume_24h(&999), 0);
 }
 
- 
-
 #[test]
 fn test_get_swap_history_empty_before_any_swaps() {
     let env = Env::default();
@@ -706,4 +704,3 @@ fn test_get_swap_history_empty_before_any_swaps() {
     let history = client.get_swap_history(&123);
     assert_eq!(history.len(), 0);
 }
- 

--- a/contract/tests/reputation_tests.rs
+++ b/contract/tests/reputation_tests.rs
@@ -350,7 +350,79 @@ fn test_reset_creator_stats_reputation_becomes_zero() {
     assert!(stats_before.reputation_score > 0);
 
     client.reset_creator_stats(&admin, &creator);
-
+    
     let stats_after = client.get_creator_stats(&creator);
     assert_eq!(stats_after.reputation_score, 0);
+}
+
+#[test]
+fn test_get_top_creators_empty_before_any_markets() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = deploy(&env);
+
+    let top_creators = client.get_top_creators(&10);
+    assert_eq!(top_creators.len(), 0);
+}
+
+#[test]
+fn test_get_top_creators_returns_sorted_by_reputation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, oracle) = deploy(&env);
+
+    let creator1 = Address::generate(&env);
+    let creator2 = Address::generate(&env);
+    let creator3 = Address::generate(&env);
+
+    // Creator 1: 1/1 resolved -> 600
+    let id1 = client.create_market(&creator1, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 2000);
+    client.resolve_market(&oracle, &id1, &symbol_short!("yes"));
+
+    // Creator 2: 2/2 resolved -> 600 (same as creator 1 for now, but we'll add participants)
+    // Actually, let's just make them different.
+    // Creator 2: 2/2 resolved, 50 avg participants -> 600 + 100 = 700
+    let id2 = client.create_market(&creator2, &default_params(&env));
+    let id3 = client.create_market(&creator2, &default_params(&env));
+    client.resolve_market(&oracle, &id2, &symbol_short!("yes"));
+    client.resolve_market(&oracle, &id3, &symbol_short!("no"));
+    // Manual stats update for simplicity in testing if needed, 
+    // but resolving with participants would be better.
+    // Wait, on_market_resolved takes participant_count. 
+    // In our resolve_market call, it uses market.participant_count which is 0 by default.
+    
+    // Let's just use different resolution ratios.
+    // Creator 1: 1/1 = 600
+    // Creator 3: 1/2 = (1/2)*600 = 300
+    let id4 = client.create_market(&creator3, &default_params(&env));
+    let _id5 = client.create_market(&creator3, &default_params(&env));
+    client.resolve_market(&oracle, &id4, &symbol_short!("yes"));
+
+    let top = client.get_top_creators(&10);
+    assert_eq!(top.len(), 3);
+    assert_eq!(top.get(0).unwrap().address, creator1); // 600
+    assert_eq!(top.get(1).unwrap().address, creator2); // 600 (depends on order if same)
+    assert_eq!(top.get(2).unwrap().address, creator3); // 300
+    
+    assert_eq!(top.get(0).unwrap().stats.reputation_score, 600);
+    assert_eq!(top.get(2).unwrap().stats.reputation_score, 300);
+}
+
+#[test]
+fn test_get_top_creators_respects_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = deploy(&env);
+
+    for _ in 0..5 {
+        let creator = Address::generate(&env);
+        client.create_market(&creator, &default_params(&env));
+    }
+
+    let top = client.get_top_creators(&3);
+    assert_eq!(top.len(), 3);
+    
+    let top_more = client.get_top_creators(&10);
+    assert_eq!(top_more.len(), 5);
 }

--- a/contract/tests/reputation_tests.rs
+++ b/contract/tests/reputation_tests.rs
@@ -350,7 +350,7 @@ fn test_reset_creator_stats_reputation_becomes_zero() {
     assert!(stats_before.reputation_score > 0);
 
     client.reset_creator_stats(&admin, &creator);
-    
+
     let stats_after = client.get_creator_stats(&creator);
     assert_eq!(stats_after.reputation_score, 0);
 }
@@ -387,11 +387,11 @@ fn test_get_top_creators_returns_sorted_by_reputation() {
     let id3 = client.create_market(&creator2, &default_params(&env));
     client.resolve_market(&oracle, &id2, &symbol_short!("yes"));
     client.resolve_market(&oracle, &id3, &symbol_short!("no"));
-    // Manual stats update for simplicity in testing if needed, 
+    // Manual stats update for simplicity in testing if needed,
     // but resolving with participants would be better.
-    // Wait, on_market_resolved takes participant_count. 
+    // Wait, on_market_resolved takes participant_count.
     // In our resolve_market call, it uses market.participant_count which is 0 by default.
-    
+
     // Let's just use different resolution ratios.
     // Creator 1: 1/1 = 600
     // Creator 3: 1/2 = (1/2)*600 = 300
@@ -404,7 +404,7 @@ fn test_get_top_creators_returns_sorted_by_reputation() {
     assert_eq!(top.get(0).unwrap().address, creator1); // 600
     assert_eq!(top.get(1).unwrap().address, creator2); // 600 (depends on order if same)
     assert_eq!(top.get(2).unwrap().address, creator3); // 300
-    
+
     assert_eq!(top.get(0).unwrap().stats.reputation_score, 600);
     assert_eq!(top.get(2).unwrap().stats.reputation_score, 300);
 }
@@ -422,7 +422,7 @@ fn test_get_top_creators_respects_limit() {
 
     let top = client.get_top_creators(&3);
     assert_eq!(top.len(), 3);
-    
+
     let top_more = client.get_top_creators(&10);
     assert_eq!(top_more.len(), 5);
 }

--- a/contract/tests/reputation_tests.rs
+++ b/contract/tests/reputation_tests.rs
@@ -385,6 +385,7 @@ fn test_get_top_creators_returns_sorted_by_reputation() {
     // Creator 2: 2/2 resolved, 50 avg participants -> 600 + 100 = 700
     let id2 = client.create_market(&creator2, &default_params(&env));
     let id3 = client.create_market(&creator2, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 2000);
     client.resolve_market(&oracle, &id2, &symbol_short!("yes"));
     client.resolve_market(&oracle, &id3, &symbol_short!("no"));
     // Manual stats update for simplicity in testing if needed,
@@ -397,6 +398,7 @@ fn test_get_top_creators_returns_sorted_by_reputation() {
     // Creator 3: 1/2 = (1/2)*600 = 300
     let id4 = client.create_market(&creator3, &default_params(&env));
     let _id5 = client.create_market(&creator3, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 2000);
     client.resolve_market(&oracle, &id4, &symbol_short!("yes"));
 
     let top = client.get_top_creators(&10);


### PR DESCRIPTION
### Description
This PR implements the `get_top_creators` functionality to allow querying a sorted leaderboard of creators by their reputation score.

### Changes
- **Storage**: Added `CreatorLeaderboardEntry` struct to `storage_types.rs` to represent a creator and their stats in the leaderboard.
- **Logic**: Implemented `get_top_creators` in `reputation.rs`. It iterates through the `UserList`, filters for creators, and sorts them by `reputation_score` in descending order.
- **Tracking**: Updated `create_market` in `market.rs` to call `track_user_profile`, ensuring market creators are added to the `UserList` even if they haven't submitted predictions.
- **Interface**: Exposed `get_top_creators(limit: u32)` in the contract's main implementation (`lib.rs`).
- **Testing**: Added 3 new tests to `reputation_tests.rs`:
    - `test_get_top_creators_empty_before_any_markets`
    - `test_get_top_creators_returns_sorted_by_reputation`
    - `test_get_top_creators_respects_limit`

### Verification
- All new tests cover success paths and limits.
- Built for WASM target to ensure type-safety and protocol compatibility.

Fixes #564
