### PR TITLE
fix(contract): add analytics test coverage and clear clippy blockers

### DIFF
--- a/contract/src/liquidity.rs
+++ b/contract/src/liquidity.rs
@@ -453,7 +453,7 @@ pub fn update_pool_volume(env: &Env, market_id: u64, amount: i128) {
 
     let now = env.ledger().timestamp();
     let twenty_four_hours: u64 = 24 * 60 * 60;
-    let cutoff = if now > twenty_four_hours { now - twenty_four_hours } else { 0 };
+    let cutoff = now.saturating_sub(twenty_four_hours);
 
     let mut new_entries = Vec::new(env);
     for entry in volume_entries.iter() {
@@ -480,7 +480,7 @@ pub fn get_pool_volume_24h(env: &Env, market_id: u64) -> i128 {
 
     let now = env.ledger().timestamp();
     let twenty_four_hours: u64 = 24 * 60 * 60;
-    let cutoff = if now > twenty_four_hours { now - twenty_four_hours } else { 0 };
+    let cutoff = now.saturating_sub(twenty_four_hours);
 
     let mut total: i128 = 0;
     for entry in volume_entries.iter() {

--- a/contract/tests/analytics_tests.rs
+++ b/contract/tests/analytics_tests.rs
@@ -1,5 +1,6 @@
 use insightarena_contract::*;
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger as _;
 use soroban_sdk::token::StellarAssetClient;
 use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
 
@@ -18,6 +19,17 @@ fn deploy(env: &Env) -> (InsightArenaContractClient<'_>, Address) {
     env.mock_all_auths();
     client.initialize(&admin, &oracle, &200_u32, &xlm_token);
     (client, xlm_token)
+}
+
+fn deploy_with_oracle(env: &Env) -> (InsightArenaContractClient<'_>, Address, Address) {
+    let id = env.register(InsightArenaContract, ());
+    let client = InsightArenaContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+    let xlm_token = register_token(env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle, &200_u32, &xlm_token);
+    (client, xlm_token, oracle)
 }
 
 fn default_params(env: &Env) -> CreateMarketParams {
@@ -291,4 +303,93 @@ fn test_analytics_aggregation() {
     let u2_stats = client.get_user_stats(&u2);
     assert_eq!(u2_stats.total_predictions, 2);
     assert_eq!(u2_stats.total_staked, 70_000_000);
+}
+
+#[test]
+fn test_get_market_stats_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm) = deploy(&env);
+    let creator = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    fund(&env, &xlm, &u1, 40_000_000);
+    fund(&env, &xlm, &u2, 60_000_000);
+
+    client.submit_prediction(&u1, &market_id, &symbol_short!("yes"), &40_000_000);
+    client.submit_prediction(&u2, &market_id, &symbol_short!("no"), &60_000_000);
+
+    let stats = client.get_market_stats(&market_id);
+    assert_eq!(stats.total_pool, 100_000_000);
+    assert_eq!(stats.participant_count, 2);
+    assert_eq!(stats.leading_outcome, symbol_short!("no"));
+    assert_eq!(stats.leading_outcome_pool, 60_000_000);
+}
+
+#[test]
+fn test_track_multiple_markets_analytics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm) = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let market_a = client.create_market(&creator, &default_params(&env));
+    let market_b = client.create_market(&creator, &default_params(&env));
+
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    let u3 = Address::generate(&env);
+    fund(&env, &xlm, &u1, 50_000_000);
+    fund(&env, &xlm, &u2, 70_000_000);
+    fund(&env, &xlm, &u3, 30_000_000);
+
+    client.submit_prediction(&u1, &market_a, &symbol_short!("yes"), &50_000_000);
+    client.submit_prediction(&u2, &market_a, &symbol_short!("yes"), &20_000_000);
+    client.submit_prediction(&u3, &market_b, &symbol_short!("no"), &30_000_000);
+
+    let stats_a = client.get_market_stats(&market_a);
+    assert_eq!(stats_a.total_pool, 70_000_000);
+    assert_eq!(stats_a.participant_count, 2);
+    assert_eq!(stats_a.leading_outcome, symbol_short!("yes"));
+    assert_eq!(stats_a.leading_outcome_pool, 70_000_000);
+
+    let stats_b = client.get_market_stats(&market_b);
+    assert_eq!(stats_b.total_pool, 30_000_000);
+    assert_eq!(stats_b.participant_count, 1);
+    assert_eq!(stats_b.leading_outcome, symbol_short!("no"));
+    assert_eq!(stats_b.leading_outcome_pool, 30_000_000);
+}
+
+#[test]
+fn test_analytics_after_market_resolution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm, oracle) = deploy_with_oracle(&env);
+    let creator = Address::generate(&env);
+    let params = default_params(&env);
+    let market_id = client.create_market(&creator, &params);
+
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    fund(&env, &xlm, &u1, 60_000_000);
+    fund(&env, &xlm, &u2, 40_000_000);
+
+    client.submit_prediction(&u1, &market_id, &symbol_short!("yes"), &60_000_000);
+    client.submit_prediction(&u2, &market_id, &symbol_short!("no"), &40_000_000);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    let market = client.get_market(&market_id);
+    assert!(market.is_resolved);
+    assert_eq!(market.resolved_outcome.unwrap(), symbol_short!("yes"));
+
+    let stats = client.get_market_stats(&market_id);
+    assert_eq!(stats.total_pool, 100_000_000);
+    assert_eq!(stats.participant_count, 2);
+    assert_eq!(stats.leading_outcome, symbol_short!("yes"));
+    assert_eq!(stats.leading_outcome_pool, 60_000_000);
 }

--- a/contract/tests/liquidity_tests.rs
+++ b/contract/tests/liquidity_tests.rs
@@ -256,10 +256,6 @@ fn test_overflow_protection_large_amounts() {
 fn test_minimum_liquidity_enforcement() {
     // MIN_LIQUIDITY should be enforced (1000)
     assert_eq!(MIN_LIQUIDITY, 1000);
-
-    // Deposits below minimum should be rejected in actual implementation
-    // This is a constant check
-    assert!(MIN_LIQUIDITY > 0);
 }
 
 #[test]
@@ -444,10 +440,6 @@ fn test_liquidity_module_constants() {
     // Verify all constants are set correctly
     assert_eq!(MIN_LIQUIDITY, 1000);
     assert_eq!(DEFAULT_FEE_BPS, 30);
-
-    // Verify constants are reasonable
-    assert!(MIN_LIQUIDITY > 0);
-    assert!(DEFAULT_FEE_BPS < 10_000); // Fee should be less than 100%
 }
 
 #[test]
@@ -648,36 +640,6 @@ fn test_calculate_lp_tokens_multiple_deposits() {
 }
 
 // ── Volume & History Tests (Issues #559, #560) ────────────────────────────────
-
-use insightarena_contract::market::CreateMarketParams;
-use soroban_sdk::{symbol_short, vec, String, Symbol};
-
-fn deploy_with_admin(env: &Env) -> (InsightArenaContractClient<'_>, Address) {
-    let id = env.register(InsightArenaContract, ());
-    let client = InsightArenaContractClient::new(env, &id);
-    let admin = Address::generate(env);
-    let oracle = Address::generate(env);
-    let xlm_token = register_token(env);
-    env.mock_all_auths();
-    client.initialize(&admin, &oracle, &200_u32, &xlm_token);
-    (client, admin)
-}
-
-fn create_market_params(env: &Env, now: u64) -> CreateMarketParams {
-    CreateMarketParams {
-        title: String::from_str(env, "Title"),
-        description: String::from_str(env, "Desc"),
-        category: Symbol::new(env, "Cat"),
-        outcomes: vec![env, symbol_short!("A"), symbol_short!("B")],
-        end_time: now + 1000,
-        resolution_time: now + 2000,
-        dispute_window: 1000,
-        creator_fee_bps: 0,
-        min_stake: 10_000_000,
-        max_stake: 100_000_000,
-        is_public: true,
-    }
-}
 
 #[test]
 fn test_pool_volume_zero_before_any_swaps() {


### PR DESCRIPTION
## Overview
This PR adds the missing analytics test coverage requested in issue #522 by introducing 3 new tests in `contract/tests/analytics_tests.rs`.  
It also includes small clippy-compliance fixes in liquidity code/tests so strict CI checks pass cleanly.

## Related Issue
Closes #522

## Changes

### 🧪 Analytics Test Coverage
- **[MODIFY]** `contract/tests/analytics_tests.rs`
  - Added `test_get_market_stats_success`
  - Added `test_track_multiple_markets_analytics`
  - Added `test_analytics_after_market_resolution`
  - Added a small helper (`deploy_with_oracle`) and imported `Ledger` testutils trait for resolution-time mocking.

### 🔧 Clippy Cleanup (to keep CI green)
- **[MODIFY]** `contract/src/liquidity.rs`
  - Replaced manual subtraction guard logic with `saturating_sub` in 24h cutoff calculations.

- **[MODIFY]** `contract/tests/liquidity_tests.rs`
  - Removed clippy-denied constant assertions.
  - Removed unused helper functions/imports flagged as dead code.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| 3 new tests added to `analytics_tests.rs` | ✅ |
| Tests follow existing patterns/helpers | ✅ |
| `cargo test --test analytics_tests` passes | ✅ (16 passed) |
| `cargo clippy --tests -- -D warnings` passes | ✅ |

## How to Test


# 1. Confirm branch
git branch --show-current

# 2. Run clippy with warnings denied
```bash
cargo clippy --tests -- -D warnings
```
<img width="534" height="523" alt="image" src="https://github.com/user-attachments/assets/35178305-c2a3-4975-91ab-fe8f19811a91" />

# 3. Run analytics test suite
```bash
cargo test --test analytics_tests
```
<img width="538" height="533" alt="image" src="https://github.com/user-attachments/assets/897925b6-d5f5-4546-b198-1f146533ce3e" />
