### PR TITLE
test(governance): add execute_proposal tests for all ProposalType variants [#567]

### DIFF
--- a/contract/tests/governance_tests.rs
+++ b/contract/tests/governance_tests.rs
@@ -1,7 +1,7 @@
 use insightarena_contract::governance::ProposalType;
 use insightarena_contract::storage_types::DataKey;
 use insightarena_contract::{InsightArenaContract, InsightArenaContractClient};
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -142,7 +142,7 @@ fn test_execute_proposal_updates_protocol_fee() {
     let executor = Address::generate(&env);
     client.execute_proposal(&executor, &id);
 
-    let cfg = client.get_config().unwrap();
+    let cfg = client.get_config();
     assert_eq!(cfg.protocol_fee_bps, 500);
 }
 
@@ -164,7 +164,7 @@ fn test_execute_proposal_updates_oracle() {
     let executor = Address::generate(&env);
     client.execute_proposal(&executor, &id);
 
-    let cfg = client.get_config().unwrap();
+    let cfg = client.get_config();
     assert_eq!(cfg.oracle_address, new_oracle);
 }
 
@@ -186,7 +186,7 @@ fn test_execute_proposal_updates_min_stake() {
     let executor = Address::generate(&env);
     client.execute_proposal(&executor, &id);
 
-    let cfg = client.get_config().unwrap();
+    let cfg = client.get_config();
     assert_eq!(cfg.min_stake_xlm, new_min);
 }
 

--- a/contract/tests/governance_tests.rs
+++ b/contract/tests/governance_tests.rs
@@ -1,7 +1,8 @@
 use insightarena_contract::governance::ProposalType;
+use insightarena_contract::storage_types::DataKey;
 use insightarena_contract::{InsightArenaContract, InsightArenaContractClient};
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Symbol, Vec};
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -28,6 +29,35 @@ fn create_fee_proposal(
     duration: u64,
 ) -> u32 {
     client.create_proposal(proposer, &ProposalType::UpdateProtocolFee(300), &duration)
+}
+
+/// Seed `n` addresses into the UserList so quorum can be met.
+fn seed_users(env: &Env, client: &InsightArenaContractClient<'_>, n: u32) -> Vec<Address> {
+    let mut users: Vec<Address> = Vec::new(env);
+    for _ in 0..n {
+        users.push_back(Address::generate(env));
+    }
+    env.as_contract(&client.address, || {
+        env.storage().persistent().set(&DataKey::UserList, &users);
+    });
+    users
+}
+
+/// Create a proposal, cast enough votes to meet quorum, then advance time past voting_end.
+fn pass_proposal(
+    env: &Env,
+    client: &InsightArenaContractClient<'_>,
+    proposal_type: &ProposalType,
+    voters: &Vec<Address>,
+) -> u32 {
+    let duration = 3_600_u64;
+    let proposer = Address::generate(env);
+    let id = client.create_proposal(&proposer, proposal_type, &duration);
+    for voter in voters.iter() {
+        client.vote(&voter, &id, &true);
+    }
+    env.ledger().with_mut(|l| l.timestamp += duration + 1);
+    id
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -96,4 +126,128 @@ fn test_list_proposals_pagination_works() {
     // Limit capped at 50
     let big = client.list_proposals(&1_u32, &100_u32);
     assert_eq!(big.len(), 5); // only 5 proposals exist
+}
+
+// ── execute_proposal Tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_proposal_updates_protocol_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let id = pass_proposal(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+
+    let executor = Address::generate(&env);
+    client.execute_proposal(&executor, &id);
+
+    let cfg = client.get_config().unwrap();
+    assert_eq!(cfg.protocol_fee_bps, 500);
+}
+
+#[test]
+fn test_execute_proposal_updates_oracle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let new_oracle = Address::generate(&env);
+    let id = pass_proposal(
+        &env,
+        &client,
+        &ProposalType::UpdateOracle(new_oracle.clone()),
+        &voters,
+    );
+
+    let executor = Address::generate(&env);
+    client.execute_proposal(&executor, &id);
+
+    let cfg = client.get_config().unwrap();
+    assert_eq!(cfg.oracle_address, new_oracle);
+}
+
+#[test]
+fn test_execute_proposal_updates_min_stake() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let new_min = 50_000_000_i128; // 5 XLM in stroops
+    let id = pass_proposal(
+        &env,
+        &client,
+        &ProposalType::UpdateMinStake(new_min),
+        &voters,
+    );
+
+    let executor = Address::generate(&env);
+    client.execute_proposal(&executor, &id);
+
+    let cfg = client.get_config().unwrap();
+    assert_eq!(cfg.min_stake_xlm, new_min);
+}
+
+#[test]
+fn test_execute_proposal_adds_category() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let new_cat = Symbol::new(&env, "Gaming");
+    let id = pass_proposal(
+        &env,
+        &client,
+        &ProposalType::AddSupportedCategory(new_cat.clone()),
+        &voters,
+    );
+
+    let executor = Address::generate(&env);
+    client.execute_proposal(&executor, &id);
+
+    let categories = client.list_categories();
+    assert!(categories.contains(new_cat));
+}
+
+#[test]
+fn test_execute_proposal_fails_without_quorum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = deploy(&env);
+
+    // Seed 10 users but cast 0 votes — quorum (1) not met
+    seed_users(&env, &client, 10);
+
+    let duration = 3_600_u64;
+    let proposer = Address::generate(&env);
+    let id = client.create_proposal(&proposer, &ProposalType::UpdateProtocolFee(400), &duration);
+
+    env.ledger().with_mut(|l| l.timestamp += duration + 1);
+
+    let executor = Address::generate(&env);
+    let result = client.try_execute_proposal(&executor, &id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_execute_proposal_fails_before_voting_ends() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let duration = 3_600_u64;
+    let proposer = Address::generate(&env);
+    let id = client.create_proposal(&proposer, &ProposalType::UpdateProtocolFee(400), &duration);
+    for voter in voters.iter() {
+        client.vote(&voter, &id, &true);
+    }
+
+    // Do NOT advance time — voting period still active
+    let executor = Address::generate(&env);
+    let result = client.try_execute_proposal(&executor, &id);
+    assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary

Closes #567

Adds 6 tests to `contract/tests/governance_tests.rs` covering `execute_proposal` — the most critical governance function.

## Tests Added

| Test | What it covers |
|------|---------------|
| `test_execute_proposal_updates_protocol_fee` | `UpdateProtocolFee` variant mutates `protocol_fee_bps` |
| `test_execute_proposal_updates_oracle` | `UpdateOracle` variant mutates `oracle_address` |
| `test_execute_proposal_updates_min_stake` | `UpdateMinStake` variant mutates `min_stake_xlm` |
| `test_execute_proposal_adds_category` | `AddSupportedCategory` variant appends to category list |
| `test_execute_proposal_fails_without_quorum` | Rejects execution when votes < quorum |
| `test_execute_proposal_fails_before_voting_ends` | Rejects execution while voting period is still active |

## Acceptance Criteria

- [x] All 4 `ProposalType` variants tested
- [x] Quorum guard tested (`test_execute_proposal_fails_without_quorum`)
- [x] Timing guard tested (`test_execute_proposal_fails_before_voting_ends`)
- [x] Contributor has read `contract/CONTRIBUTING.md`

## Helpers Added

- `seed_users(env, client, n)` — seeds `n` addresses into `UserList` storage so quorum can be met
- `pass_proposal(env, client, proposal_type, voters)` — creates a proposal, casts votes, advances ledger time past `voting_end`