### PR TITLE
feat: refactor leave competition logic to use atomic database transactions

### DIFF
--- a/backend/src/competitions/competitions.controller.spec.ts
+++ b/backend/src/competitions/competitions.controller.spec.ts
@@ -6,7 +6,6 @@ import {
   Competition,
   CompetitionVisibility,
 } from './entities/competition.entity';
-import { CompetitionsService } from './competitions.service';
 import { CreateCompetitionDto } from './dto/create-competition.dto';
 import { UserRankResponseDto } from './dto/user-rank-response.dto';
 import { User } from '../users/entities/user.entity';
@@ -43,6 +42,8 @@ describe('CompetitionsController', () => {
             findById: jest.fn(),
             list: jest.fn(),
             getMyRank: jest.fn(),
+            joinCompetition: jest.fn(),
+            leave: jest.fn(),
           },
         },
       ],
@@ -147,6 +148,33 @@ describe('CompetitionsController', () => {
 
       await expect(
         controller.getMyRank('nonexistent', mockUser as User),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('leaveCompetition', () => {
+    it('should successfully leave competition', async () => {
+      const spy = jest.spyOn(service, 'leave').mockResolvedValue(undefined);
+
+      const result = await controller.leaveCompetition(
+        'comp-uuid-1',
+        mockUser as User,
+      );
+
+      expect(spy).toHaveBeenCalledWith('comp-uuid-1', mockUser.id);
+      expect(result).toEqual({
+        message: 'Successfully left competition',
+        competition_id: 'comp-uuid-1',
+      });
+    });
+
+    it('should throw error if service throws it', async () => {
+      jest
+        .spyOn(service, 'leave')
+        .mockRejectedValue(new NotFoundException('Not found'));
+
+      await expect(
+        controller.leaveCompetition('nonexistent', mockUser as User),
       ).rejects.toThrow(NotFoundException);
     });
   });

--- a/backend/src/competitions/competitions.controller.ts
+++ b/backend/src/competitions/competitions.controller.ts
@@ -172,7 +172,7 @@ export class CompetitionsController {
     @Param('id') id: string,
     @CurrentUser() user: User,
   ): Promise<LeaveCompetitionResponseDto> {
-    await this.competitionsService.leaveCompetition(id, user);
+    await this.competitionsService.leave(id, user.id);
     return {
       message: 'Successfully left competition',
       competition_id: id,

--- a/backend/src/competitions/competitions.service.spec.ts
+++ b/backend/src/competitions/competitions.service.spec.ts
@@ -323,7 +323,9 @@ describe('CompetitionsService', () => {
         decrement: jest.fn().mockResolvedValue({}),
       };
 
-      mockRepository.manager.transaction.mockImplementation((cb) => cb(mockManager));
+      mockRepository.manager.transaction.mockImplementation(
+        (cb: (manager: unknown) => Promise<unknown>) => cb(mockManager),
+      );
 
       await service.leave('comp-uuid-1', 'user-uuid-1');
 
@@ -371,7 +373,9 @@ describe('CompetitionsService', () => {
         findOne: jest.fn().mockResolvedValue(null),
       };
 
-      mockRepository.manager.transaction.mockImplementation((cb) => cb(mockManager));
+      mockRepository.manager.transaction.mockImplementation(
+        (cb: (manager: unknown) => Promise<unknown>) => cb(mockManager),
+      );
 
       await expect(service.leave('comp-1', 'user-1')).rejects.toThrow(
         'You are not a participant in this competition',

--- a/backend/src/competitions/competitions.service.spec.ts
+++ b/backend/src/competitions/competitions.service.spec.ts
@@ -37,6 +37,9 @@ describe('CompetitionsService', () => {
     find: jest.fn(),
     findOne: jest.fn(),
     createQueryBuilder: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
   };
 
   const mockParticipantsRepository = {
@@ -303,6 +306,76 @@ describe('CompetitionsService', () => {
       expect(
         mockParticipantsRepository.createQueryBuilder,
       ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('leave', () => {
+    it('should remove participant and decrement count before competition starts', async () => {
+      const futureDate = new Date();
+      futureDate.setHours(futureDate.getHours() + 1);
+
+      const comp = { ...mockCompetition, start_time: futureDate };
+      mockRepository.findOne.mockResolvedValue(comp);
+
+      const mockManager = {
+        findOne: jest.fn().mockResolvedValue({ id: 'part-1' }),
+        remove: jest.fn().mockResolvedValue({}),
+        decrement: jest.fn().mockResolvedValue({}),
+      };
+
+      mockRepository.manager.transaction.mockImplementation((cb) => cb(mockManager));
+
+      await service.leave('comp-uuid-1', 'user-uuid-1');
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'comp-uuid-1' },
+      });
+      expect(mockManager.findOne).toHaveBeenCalled();
+      expect(mockManager.remove).toHaveBeenCalled();
+      expect(mockManager.decrement).toHaveBeenCalledWith(
+        Competition,
+        { id: 'comp-uuid-1' },
+        'participant_count',
+        1,
+      );
+    });
+
+    it('should throw NotFoundException if competition does not exist', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.leave('non-existent', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException if competition has already started', async () => {
+      const pastDate = new Date();
+      pastDate.setHours(pastDate.getHours() - 1);
+
+      const comp = { ...mockCompetition, start_time: pastDate };
+      mockRepository.findOne.mockResolvedValue(comp);
+
+      await expect(service.leave('comp-1', 'user-1')).rejects.toThrow(
+        'Cannot leave competition after it has started',
+      );
+    });
+
+    it('should throw NotFoundException if user is not a participant', async () => {
+      const futureDate = new Date();
+      futureDate.setHours(futureDate.getHours() + 1);
+
+      const comp = { ...mockCompetition, start_time: futureDate };
+      mockRepository.findOne.mockResolvedValue(comp);
+
+      const mockManager = {
+        findOne: jest.fn().mockResolvedValue(null),
+      };
+
+      mockRepository.manager.transaction.mockImplementation((cb) => cb(mockManager));
+
+      await expect(service.leave('comp-1', 'user-1')).rejects.toThrow(
+        'You are not a participant in this competition',
+      );
     });
   });
 });

--- a/backend/src/competitions/competitions.service.ts
+++ b/backend/src/competitions/competitions.service.ts
@@ -349,7 +349,7 @@ export class CompetitionsService {
     return saved;
   }
 
-  async leaveCompetition(competitionId: string, user: User): Promise<void> {
+  async leave(competitionId: string, userId: string): Promise<void> {
     const competition = await this.competitionsRepository.findOne({
       where: { id: competitionId },
     });
@@ -368,28 +368,29 @@ export class CompetitionsService {
       );
     }
 
-    // Find participant
-    const participant = await this.participantsRepository.findOne({
-      where: {
-        user_id: user.id,
-        competition_id: competitionId,
-      },
-    });
+    // Use transaction for atomic removal and decrement
+    await this.competitionsRepository.manager.transaction(async (manager) => {
+      const participant = await manager.findOne(CompetitionParticipant, {
+        where: {
+          user_id: userId,
+          competition_id: competitionId,
+        },
+      });
 
-    if (!participant) {
-      throw new NotFoundException(
-        'You are not a participant in this competition',
+      if (!participant) {
+        throw new NotFoundException(
+          'You are not a participant in this competition',
+        );
+      }
+
+      await manager.remove(participant);
+
+      await manager.decrement(
+        Competition,
+        { id: competitionId },
+        'participant_count',
+        1,
       );
-    }
-
-    // Remove participant
-    await this.participantsRepository.remove(participant);
-
-    // Update participant count
-    await this.competitionsRepository.decrement(
-      { id: competitionId },
-      'participant_count',
-      1,
-    );
+    });
   }
 }

--- a/backend/src/flags/flags.service.spec.ts
+++ b/backend/src/flags/flags.service.spec.ts
@@ -1,7 +1,7 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder, UpdateResult } from 'typeorm';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
@@ -226,7 +226,7 @@ describe('FlagsService', () => {
 
       jest
         .spyOn(flagsRepository, 'createQueryBuilder')
-        .mockReturnValue(mockQueryBuilder as any);
+        .mockReturnValue(mockQueryBuilder as unknown as SelectQueryBuilder<Flag>);
 
       const result = await service.listFlags(query);
 
@@ -291,7 +291,7 @@ describe('FlagsService', () => {
       jest
         .spyOn(flagsRepository, 'findOne')
         .mockResolvedValue(createMockFlag());
-      jest.spyOn(marketsRepository, 'update').mockResolvedValue({} as any);
+      jest.spyOn(marketsRepository, 'update').mockResolvedValue({} as unknown as UpdateResult);
       jest.spyOn(flagsRepository, 'save').mockResolvedValue({
         ...createMockFlag(),
         status: FlagStatus.RESOLVED,
@@ -322,7 +322,7 @@ describe('FlagsService', () => {
       jest
         .spyOn(flagsRepository, 'findOne')
         .mockResolvedValue(createMockFlag());
-      jest.spyOn(usersRepository, 'update').mockResolvedValue({} as any);
+      jest.spyOn(usersRepository, 'update').mockResolvedValue({} as unknown as UpdateResult);
       jest.spyOn(flagsRepository, 'save').mockResolvedValue({
         ...createMockFlag(),
         status: FlagStatus.RESOLVED,

--- a/backend/src/markets/markets.service.spec.ts
+++ b/backend/src/markets/markets.service.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, Repository, SelectQueryBuilder } from 'typeorm';
 import { SorobanService } from '../soroban/soroban.service';
 import { User } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
@@ -325,7 +325,7 @@ describe('MarketsService.findFeaturedMarkets', () => {
     };
 
     marketsRepository.createQueryBuilder.mockReturnValue(
-      mockQueryBuilder as any,
+      mockQueryBuilder as unknown as SelectQueryBuilder<Market>,
     );
 
     const featuredMarkets = [makeFeaturedMarket(), makeFeaturedMarket()];
@@ -373,7 +373,7 @@ describe('MarketsService.findFeaturedMarkets', () => {
     };
 
     marketsRepository.createQueryBuilder.mockReturnValue(
-      mockQueryBuilder as any,
+      mockQueryBuilder as unknown as SelectQueryBuilder<Market>,
     );
     mockQueryBuilder.getManyAndCount.mockResolvedValue([[], 0]);
 


### PR DESCRIPTION
### Description 
feat: refactor leave competition logic to use atomic database transactions

- closes #609 
- closes #610 
- closes #611 
- closes #613 
- 