### PR TITLE
fix(backend): implement Soroban create calls and markets analytics endpoint

### DIFF
--- a/backend/src/analytics/analytics.service.history.spec.ts
+++ b/backend/src/analytics/analytics.service.history.spec.ts
@@ -22,6 +22,8 @@ describe('AnalyticsService - Market History', () => {
     outcome_options: ['YES', 'NO'],
     participant_count: 10,
     total_pool_stroops: '5000000',
+    end_time: new Date(Date.now() + 60 * 60 * 1000),
+    resolution_time: new Date(Date.now() + 2 * 60 * 60 * 1000),
     created_at: new Date(),
   } as Market;
 
@@ -123,5 +125,49 @@ describe('AnalyticsService - Market History', () => {
     marketsRepository.findOne.mockResolvedValue(null);
 
     await expect(service.getMarketHistory('invalid-id')).rejects.toThrow();
+  });
+
+  it('should calculate 24h volume in market analytics', async () => {
+    const recent = new Date(Date.now() - 60 * 60 * 1000);
+    const old = new Date(Date.now() - 26 * 60 * 60 * 1000);
+
+    predictionsRepository.find.mockResolvedValue([
+      {
+        chosen_outcome: 'YES',
+        stake_amount_stroops: '100',
+        submitted_at: recent,
+      },
+      {
+        chosen_outcome: 'NO',
+        stake_amount_stroops: '250',
+        submitted_at: old,
+      },
+      {
+        chosen_outcome: 'YES',
+        stake_amount_stroops: '300',
+        submitted_at: recent,
+      },
+    ] as Prediction[]);
+
+    const result = await service.getMarketAnalytics('market-1');
+
+    expect(result.volume_24h_stroops).toBe('400');
+    expect(result.outcome_distribution).toHaveLength(2);
+  });
+
+  it('should cache market analytics for five minutes', async () => {
+    predictionsRepository.find.mockResolvedValue([
+      {
+        chosen_outcome: 'YES',
+        stake_amount_stroops: '100',
+        submitted_at: new Date(),
+      },
+    ] as Prediction[]);
+
+    await service.getMarketAnalytics('market-1');
+    await service.getMarketAnalytics('market-1');
+
+    expect(marketsRepository.findOne).toHaveBeenCalledTimes(1);
+    expect(predictionsRepository.find).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -39,6 +39,11 @@ export function accuracyRateFromUser(user: User): string {
 @Injectable()
 export class AnalyticsService {
   private readonly logger = new Logger(AnalyticsService.name);
+  private readonly MARKET_ANALYTICS_CACHE_TTL_MS = 5 * 60 * 1000;
+  private readonly marketAnalyticsCache = new Map<
+    string,
+    { cachedAt: number; data: MarketAnalyticsDto }
+  >();
 
   constructor(
     @InjectRepository(User)
@@ -135,6 +140,15 @@ export class AnalyticsService {
    * Get market analytics: pool size, participant count, outcome distribution, and time remaining
    */
   async getMarketAnalytics(marketId: string): Promise<MarketAnalyticsDto> {
+    const nowMs = Date.now();
+    const cached = this.marketAnalyticsCache.get(marketId);
+    if (
+      cached &&
+      nowMs - cached.cachedAt < this.MARKET_ANALYTICS_CACHE_TTL_MS
+    ) {
+      return cached.data;
+    }
+
     const market = await this.marketsRepository.findOne({
       where: [{ id: marketId }, { on_chain_market_id: marketId }],
     });
@@ -171,7 +185,15 @@ export class AnalyticsService {
       };
     });
 
-    const now = new Date().getTime();
+    const volume24hStroops = predictions.reduce((sum, prediction) => {
+      const submittedAt = new Date(prediction.submitted_at).getTime();
+      if (nowMs - submittedAt <= 24 * 60 * 60 * 1000) {
+        return sum + BigInt(prediction.stake_amount_stroops);
+      }
+      return sum;
+    }, 0n);
+
+    const now = nowMs;
     const endTime = new Date(market.end_time).getTime();
     const timeRemainingSeconds = Math.max(
       0,
@@ -182,13 +204,30 @@ export class AnalyticsService {
       `Market analytics retrieved for "${market.title}" (${market.id}) - ${predictions.length} predictions`,
     );
 
-    return {
+    const payload: MarketAnalyticsDto = {
       market_id: market.id,
       total_pool_stroops: market.total_pool_stroops,
       participant_count: market.participant_count,
       outcome_distribution: outcomeDistribution,
       time_remaining_seconds: timeRemainingSeconds,
+      volume_24h_stroops: volume24hStroops.toString(),
     };
+
+    this.marketAnalyticsCache.set(marketId, { cachedAt: nowMs, data: payload });
+    if (marketId !== market.id) {
+      this.marketAnalyticsCache.set(market.id, {
+        cachedAt: nowMs,
+        data: payload,
+      });
+    }
+    if (market.on_chain_market_id && marketId !== market.on_chain_market_id) {
+      this.marketAnalyticsCache.set(market.on_chain_market_id, {
+        cachedAt: nowMs,
+        data: payload,
+      });
+    }
+
+    return payload;
   }
 
   /**

--- a/backend/src/analytics/dto/market-analytics.dto.ts
+++ b/backend/src/analytics/dto/market-analytics.dto.ts
@@ -27,4 +27,7 @@ export class MarketAnalyticsDto {
 
   @Expose()
   time_remaining_seconds: number;
+
+  @Expose()
+  volume_24h_stroops: string;
 }

--- a/backend/src/markets/dto/market-analytics-summary.dto.ts
+++ b/backend/src/markets/dto/market-analytics-summary.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MarketOutcomeDistributionItemDto {
+  @ApiProperty({ example: 'YES' })
+  outcome: string;
+
+  @ApiProperty({ example: 20 })
+  count: number;
+
+  @ApiProperty({ example: 66.67 })
+  percentage: number;
+}
+
+export class MarketAnalyticsSummaryDto {
+  @ApiProperty({ example: '5000000' })
+  poolSize: string;
+
+  @ApiProperty({ example: 25 })
+  participantCount: number;
+
+  @ApiProperty({
+    type: [MarketOutcomeDistributionItemDto],
+  })
+  outcomeDistribution: MarketOutcomeDistributionItemDto[];
+
+  @ApiProperty({ example: 3600 })
+  timeRemaining: number;
+
+  @ApiProperty({ example: '2500000' })
+  volume24h: string;
+}

--- a/backend/src/markets/markets.controller.spec.ts
+++ b/backend/src/markets/markets.controller.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MarketsController } from './markets.controller';
+import { MarketsService } from './markets.service';
+import { AnalyticsService } from '../analytics/analytics.service';
+
+describe('MarketsController', () => {
+  let controller: MarketsController;
+  const marketsService = {};
+  const analyticsService = {
+    getMarketAnalytics: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MarketsController],
+      providers: [
+        { provide: MarketsService, useValue: marketsService },
+        { provide: AnalyticsService, useValue: analyticsService },
+      ],
+    }).compile();
+
+    controller = module.get<MarketsController>(MarketsController);
+    jest.clearAllMocks();
+  });
+
+  it('maps analytics payload to markets summary response', async () => {
+    analyticsService.getMarketAnalytics.mockResolvedValue({
+      market_id: 'market-1',
+      total_pool_stroops: '5000000',
+      participant_count: 25,
+      outcome_distribution: [{ outcome: 'YES', count: 10, percentage: 40 }],
+      time_remaining_seconds: 3600,
+      volume_24h_stroops: '1500000',
+    });
+
+    const result = await controller.getMarketAnalytics('market-1');
+
+    expect(analyticsService.getMarketAnalytics).toHaveBeenCalledWith(
+      'market-1',
+    );
+    expect(result).toEqual({
+      poolSize: '5000000',
+      participantCount: 25,
+      outcomeDistribution: [{ outcome: 'YES', count: 10, percentage: 40 }],
+      timeRemaining: 3600,
+      volume24h: '1500000',
+    });
+  });
+});

--- a/backend/src/markets/markets.controller.ts
+++ b/backend/src/markets/markets.controller.ts
@@ -37,15 +37,20 @@ import {
   PaginatedTrendingMarketsResponse,
   TrendingMarketsQueryDto,
 } from './dto/trending-markets.dto';
+import { MarketAnalyticsSummaryDto } from './dto/market-analytics-summary.dto';
 import { Comment } from './entities/comment.entity';
 import { MarketTemplate } from './entities/market-template.entity';
 import { Market } from './entities/market.entity';
 import { MarketsService } from './markets.service';
+import { AnalyticsService } from '../analytics/analytics.service';
 
 @ApiTags('Markets')
 @Controller('markets')
 export class MarketsController {
-  constructor(private readonly marketsService: MarketsService) {}
+  constructor(
+    private readonly marketsService: MarketsService,
+    private readonly analyticsService: AnalyticsService,
+  ) {}
 
   @Get('templates')
   @Public()
@@ -85,6 +90,30 @@ export class MarketsController {
     @Param('id') id: string,
   ): Promise<PredictionStatsDto[]> {
     return this.marketsService.getPredictionStats(id);
+  }
+
+  @Get(':id/analytics')
+  @Public()
+  @ApiOperation({ summary: 'Get market analytics summary' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Market analytics summary including pool size, participants, outcomes, time remaining, and 24h volume',
+    type: MarketAnalyticsSummaryDto,
+  })
+  @ApiResponse({ status: 404, description: 'Market not found' })
+  async getMarketAnalytics(
+    @Param('id') id: string,
+  ): Promise<MarketAnalyticsSummaryDto> {
+    const analytics = await this.analyticsService.getMarketAnalytics(id);
+
+    return {
+      poolSize: analytics.total_pool_stroops,
+      participantCount: analytics.participant_count,
+      outcomeDistribution: analytics.outcome_distribution,
+      timeRemaining: analytics.time_remaining_seconds,
+      volume24h: analytics.volume_24h_stroops,
+    };
   }
 
   @Post()

--- a/backend/src/markets/markets.module.ts
+++ b/backend/src/markets/markets.module.ts
@@ -8,6 +8,7 @@ import { Prediction } from '../predictions/entities/prediction.entity';
 import { MarketsService } from './markets.service';
 import { MarketsController } from './markets.controller';
 import { UsersModule } from '../users/users.module';
+import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { UsersModule } from '../users/users.module';
       Prediction,
     ]),
     UsersModule,
+    AnalyticsModule,
   ],
   controllers: [MarketsController],
   providers: [MarketsService],

--- a/backend/src/markets/markets.service.bulk.spec.ts
+++ b/backend/src/markets/markets.service.bulk.spec.ts
@@ -63,7 +63,7 @@ describe('MarketsService - Bulk Creation', () => {
 
     sorobanService = {
       createMarket: jest.fn().mockResolvedValue({
-        market_id: 'market_123',
+        on_chain_market_id: 'market_123',
         tx_hash: 'tx_hash_123',
       }),
     } as any;

--- a/backend/src/markets/markets.service.spec.ts
+++ b/backend/src/markets/markets.service.spec.ts
@@ -137,7 +137,7 @@ describe('MarketsService', () => {
     const dto = makeCreateDto();
 
     sorobanService.createMarket.mockResolvedValue({
-      market_id: 'market-on-chain-1',
+      on_chain_market_id: 'market-on-chain-1',
       tx_hash: 'abc123',
     });
 
@@ -156,7 +156,19 @@ describe('MarketsService', () => {
 
     const result = await service.createMarket(dto, mockUser);
 
-    expect(sorobanService.createMarket).toHaveBeenCalled();
+    expect(sorobanService.createMarket).toHaveBeenCalledWith(
+      dto.title,
+      dto.description,
+      dto.category,
+      dto.outcome_options,
+      dto.end_time,
+      dto.resolution_time,
+      mockUser.stellar_address,
+      dto.creator_fee_bps,
+      dto.min_stake_stroops,
+      dto.max_stake_stroops,
+      dto.is_public,
+    );
     expect(marketsRepository.create).toHaveBeenCalled();
     expect(marketsRepository.save).toHaveBeenCalledWith(createdEntity);
     expect(result).toEqual(savedEntity);

--- a/backend/src/markets/markets.service.ts
+++ b/backend/src/markets/markets.service.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  HttpException,
   Injectable,
   Logger,
   NotFoundException,
@@ -161,9 +162,17 @@ export class MarketsService {
             dto.outcome_options,
             dto.end_time,
             dto.resolution_time,
+            user.stellar_address,
+            dto.creator_fee_bps,
+            dto.min_stake_stroops,
+            dto.max_stake_stroops,
+            dto.is_public,
           );
-          onChainMarketId = result.market_id;
+          onChainMarketId = result.on_chain_market_id;
         } catch (err) {
+          if (err instanceof HttpException) {
+            throw err;
+          }
           this.logger.error('Soroban createMarket failed', err);
           throw new BadGatewayException('Failed to create market on Soroban');
         }
@@ -219,12 +228,20 @@ export class MarketsService {
         dto.outcome_options,
         dto.end_time,
         dto.resolution_time,
+        user.stellar_address,
+        dto.creator_fee_bps,
+        dto.min_stake_stroops,
+        dto.max_stake_stroops,
+        dto.is_public,
       );
-      onChainMarketId = result.market_id;
+      onChainMarketId = result.on_chain_market_id;
       this.logger.log(
         `Soroban createMarket called for "${dto.title}" — on_chain_id: ${onChainMarketId}`,
       );
     } catch (err) {
+      if (err instanceof HttpException) {
+        throw err;
+      }
       this.logger.error('Soroban createMarket failed', err);
       throw new BadGatewayException('Failed to create market on Soroban');
     }

--- a/backend/src/seasons/seasons.service.spec.ts
+++ b/backend/src/seasons/seasons.service.spec.ts
@@ -310,6 +310,7 @@ describe('SeasonsService', () => {
       const result = await service.create(withSync);
 
       expect(sorobanService.createSeason).toHaveBeenCalledWith(
+        dto.season_number,
         Math.floor(new Date(dto.start_time).getTime() / 1000),
         Math.floor(new Date(dto.end_time).getTime() / 1000),
         dto.reward_pool_stroops,

--- a/backend/src/seasons/seasons.service.ts
+++ b/backend/src/seasons/seasons.service.ts
@@ -160,6 +160,7 @@ export class SeasonsService {
       const endUnix = Math.floor(endsAt.getTime() / 1000);
       try {
         const chain = await this.sorobanService.createSeason(
+          dto.season_number,
           startUnix,
           endUnix,
           dto.reward_pool_stroops,

--- a/backend/src/soroban/soroban.service.spec.ts
+++ b/backend/src/soroban/soroban.service.spec.ts
@@ -1,15 +1,23 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { rpc as SorobanRpc } from '@stellar/stellar-sdk';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  Keypair,
+  nativeToScVal,
+  rpc as SorobanRpc,
+} from '@stellar/stellar-sdk';
 import { SorobanService } from './soroban.service';
 
 describe('SorobanService', () => {
   let service: SorobanService;
+  let serverKeypair: Keypair;
 
   beforeEach(async () => {
     jest
       .spyOn(SorobanRpc.Server.prototype, 'getHealth')
       .mockResolvedValue({ status: 'healthy' } as never);
+
+    serverKeypair = Keypair.random();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -19,9 +27,10 @@ describe('SorobanService', () => {
           useValue: {
             get: jest.fn((key: string) => {
               const values: Record<string, string> = {
-                SOROBAN_CONTRACT_ID: 'contract-id-123',
+                SOROBAN_CONTRACT_ID:
+                  'CBYIU4E5KXQYWY7RM3L2WN2B4QBBSY7WQGPJAP6XTN6QH6NWSQBRW6UV',
                 STELLAR_NETWORK: 'testnet',
-                SERVER_SECRET_KEY: 'secret-key',
+                SERVER_SECRET_KEY: serverKeypair.secret(),
                 SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
               };
               return values[key];
@@ -41,5 +50,79 @@ describe('SorobanService', () => {
   it('initializes rpc client and passes connection test', async () => {
     expect(service.getRpcClient()).toBeInstanceOf(SorobanRpc.Server);
     await expect(service.testConnection()).resolves.toBe(true);
+  });
+
+  describe('createMarket', () => {
+    it('returns on-chain market id and tx hash from contract invocation', async () => {
+      jest.spyOn(service as any, 'invokeContract').mockResolvedValue({
+        txHash: 'txhash-1',
+        returnValue: nativeToScVal(123n, { type: 'u64' }),
+      });
+
+      await expect(
+        service.createMarket(
+          'Title',
+          'Description',
+          'Crypto',
+          ['YES', 'NO'],
+          new Date(Date.now() + 60_000).toISOString(),
+          new Date(Date.now() + 120_000).toISOString(),
+          serverKeypair.publicKey(),
+          100,
+          '1000',
+          '1000000',
+          true,
+        ),
+      ).resolves.toEqual({
+        on_chain_market_id: '123',
+        tx_hash: 'txhash-1',
+      });
+    });
+
+    it('maps contract InvalidTimeRange errors to BadRequestException', async () => {
+      jest
+        .spyOn(service as any, 'invokeContract')
+        .mockRejectedValue(new Error('Error(Contract, #17)'));
+
+      await expect(
+        service.createMarket(
+          'Title',
+          'Description',
+          'Crypto',
+          ['YES', 'NO'],
+          new Date(Date.now() + 60_000).toISOString(),
+          new Date(Date.now() + 120_000).toISOString(),
+          serverKeypair.publicKey(),
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('createSeason', () => {
+    it('throws ConflictException when active season overlaps', async () => {
+      jest.spyOn(service as any, 'getActiveSeasonIfAny').mockResolvedValue({
+        start_time: 100,
+        end_time: 200,
+      });
+
+      await expect(
+        service.createSeason(1, 150, 250, '1000'),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('returns on-chain season id and tx hash from contract invocation', async () => {
+      jest
+        .spyOn(service as any, 'getActiveSeasonIfAny')
+        .mockResolvedValue(null);
+      jest.spyOn(service as any, 'invokeContract').mockResolvedValue({
+        txHash: 'txhash-2',
+        returnValue: nativeToScVal(5, { type: 'u32' }),
+      });
+
+      await expect(service.createSeason(1, 10, 20, '1000')).resolves.toEqual({
+        on_chain_season_id: 5,
+        tx_hash: 'txhash-2',
+      });
+    });
   });
 });

--- a/backend/src/soroban/soroban.service.ts
+++ b/backend/src/soroban/soroban.service.ts
@@ -1,13 +1,32 @@
-import { Injectable, Logger } from '@nestjs/common';
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { rpc as SorobanRpc } from '@stellar/stellar-sdk';
+import {
+  Account,
+  Address,
+  BASE_FEE,
+  Contract,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc as SorobanRpc,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
 
 export interface SorobanPredictionResult {
   tx_hash: string;
 }
 
 export interface SorobanCreateMarketResult {
-  market_id: string;
+  on_chain_market_id: string;
   tx_hash: string;
 }
 
@@ -80,45 +99,106 @@ export class SorobanService {
     outcomeOptions: string[],
     endTime: string,
     resolutionTime: string,
+    creator: string,
+    creatorFeeBps = 0,
+    minStakeStroops = '0',
+    maxStakeStroops = '0',
+    isPublic = true,
   ): Promise<SorobanCreateMarketResult> {
-    return this.withSorobanErrorHandling('createMarket', () => {
+    return this.withSorobanErrorHandling('createMarket', async () => {
       this.logger.log(
-        `Soroban createMarket: title=${title} category=${category} outcomes=${outcomeOptions.length} end=${endTime} resolve=${resolutionTime}`,
+        `Soroban createMarket: title=${title} category=${category} outcomes=${outcomeOptions.length} end=${endTime} resolve=${resolutionTime} creator=${creator}`,
       );
 
-      const market_id = `market_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-      const tx_hash = Buffer.from(`${market_id}:${description}`)
-        .toString('hex')
-        .padEnd(64, '0')
-        .slice(0, 64);
+      const end = new Date(endTime);
+      const resolution = new Date(resolutionTime);
+      if (Number.isNaN(end.getTime()) || Number.isNaN(resolution.getTime())) {
+        throw new BadRequestException('Invalid end_time or resolution_time');
+      }
 
-      return Promise.resolve({ market_id, tx_hash });
+      const params = this.buildCreateMarketParamsScVal({
+        title,
+        description,
+        category,
+        outcomeOptions,
+        endTimeUnix: Math.floor(end.getTime() / 1000),
+        resolutionTimeUnix: Math.floor(resolution.getTime() / 1000),
+        disputeWindowSeconds: 24 * 60 * 60,
+        creatorFeeBps,
+        minStakeStroops,
+        maxStakeStroops,
+        isPublic,
+      });
+
+      const creatorAddr = Address.fromString(creator);
+      const { txHash, returnValue } = await this.invokeContract(
+        'create_market',
+        [creatorAddr.toScVal(), params],
+      );
+
+      const native = this.scValToNativeSafe(returnValue);
+      const on_chain_market_id = this.toStringId(native);
+
+      return { on_chain_market_id, tx_hash: txHash };
     });
   }
 
   /**
    * Create a season on the Soroban contract (admin flow).
-   * Stub implementation until real contract invocations are wired via stellar-sdk.
    */
   async createSeason(
+    seasonNumber: number,
     startTimeUnix: number,
     endTimeUnix: number,
     rewardPoolStroops: string,
   ): Promise<SorobanCreateSeasonResult> {
-    return this.withSorobanErrorHandling('createSeason', () => {
+    return this.withSorobanErrorHandling('createSeason', async () => {
       this.logger.log(
-        `Soroban createSeason: start=${startTimeUnix} end=${endTimeUnix} pool=${rewardPoolStroops}`,
+        `Soroban createSeason: season=${seasonNumber} start=${startTimeUnix} end=${endTimeUnix} pool=${rewardPoolStroops}`,
       );
-      const mix =
-        (BigInt(startTimeUnix) ^ BigInt(endTimeUnix)) & BigInt(0x7fffffff);
-      const on_chain_season_id = mix === 0n ? 1 : Number(mix);
-      const tx_hash = Buffer.from(
-        `season:${startTimeUnix}:${endTimeUnix}:${rewardPoolStroops}`,
-      )
-        .toString('hex')
-        .padEnd(64, '0')
-        .slice(0, 64);
-      return Promise.resolve({ on_chain_season_id, tx_hash });
+
+      const start = Number(startTimeUnix);
+      const end = Number(endTimeUnix);
+      if (!Number.isFinite(start) || !Number.isFinite(end)) {
+        throw new BadRequestException('Invalid start_time or end_time');
+      }
+
+      const active = await this.getActiveSeasonIfAny();
+      if (active) {
+        const activeStart = this.toNumber(
+          active.start_time ?? active.startTime,
+        );
+        const activeEnd = this.toNumber(active.end_time ?? active.endTime);
+        if (
+          activeStart !== null &&
+          activeEnd !== null &&
+          this.rangesOverlap(activeStart, activeEnd, startTimeUnix, endTimeUnix)
+        ) {
+          throw new ConflictException('SeasonAlreadyActive');
+        }
+      }
+
+      const keypair = this.getServerKeypair();
+      const adminAddr = Address.fromString(keypair.publicKey());
+
+      const { txHash, returnValue } = await this.invokeContract(
+        'create_season',
+        [
+          adminAddr.toScVal(),
+          nativeToScVal(BigInt(startTimeUnix), { type: 'u64' }),
+          nativeToScVal(BigInt(endTimeUnix), { type: 'u64' }),
+          nativeToScVal(BigInt(rewardPoolStroops), { type: 'i128' }),
+        ],
+        keypair,
+      );
+
+      const native = this.scValToNativeSafe(returnValue);
+      const on_chain_season_id = Number(this.toNumber(native) ?? 0);
+      if (!Number.isFinite(on_chain_season_id) || on_chain_season_id <= 0) {
+        throw new Error('Failed to parse on-chain season id');
+      }
+
+      return { on_chain_season_id, tx_hash: txHash };
     });
   }
 
@@ -260,10 +340,329 @@ export class SorobanService {
     try {
       return await fn();
     } catch (error) {
+      this.rethrowContractErrorAsHttp(operation, error);
       const message =
         error instanceof Error ? error.message : 'Unknown Soroban error';
       this.logger.error(`Soroban ${operation} failed: ${message}`);
       throw error;
+    }
+  }
+
+  private getNetworkPassphrase(): string {
+    const val = (this.network ?? '').toLowerCase().trim();
+    if (val === 'testnet') return Networks.TESTNET;
+    if (val === 'mainnet' || val === 'public') return Networks.PUBLIC;
+    return this.network;
+  }
+
+  private getServerKeypair(): Keypair {
+    if (!this.serverSecretKey) {
+      throw new Error('SERVER_SECRET_KEY is not configured');
+    }
+    return Keypair.fromSecret(this.serverSecretKey);
+  }
+
+  private async getActiveSeasonIfAny(): Promise<Record<
+    string,
+    unknown
+  > | null> {
+    if (!this.contractId) {
+      return null;
+    }
+
+    const { returnValue } = await this.simulateContract(
+      'get_active_season',
+      [],
+    );
+    const native = this.scValToNativeSafe(returnValue);
+
+    if (native instanceof Map) {
+      const obj: Record<string, unknown> = {};
+      for (const [k, v] of native.entries()) {
+        obj[String(k)] = v;
+      }
+      return obj;
+    }
+
+    if (!native || typeof native !== 'object') {
+      return null;
+    }
+    return native as Record<string, unknown>;
+  }
+
+  private rangesOverlap(
+    aStart: number,
+    aEnd: number,
+    bStart: number,
+    bEnd: number,
+  ): boolean {
+    return aStart < bEnd && aEnd > bStart;
+  }
+
+  private buildCreateMarketParamsScVal(input: {
+    title: string;
+    description: string;
+    category: string;
+    outcomeOptions: string[];
+    endTimeUnix: number;
+    resolutionTimeUnix: number;
+    disputeWindowSeconds: number;
+    creatorFeeBps: number;
+    minStakeStroops: string;
+    maxStakeStroops: string;
+    isPublic: boolean;
+  }): xdr.ScVal {
+    const outcomes = xdr.ScVal.scvVec(
+      input.outcomeOptions.map((o) =>
+        nativeToScVal(String(o), { type: 'symbol' }),
+      ),
+    );
+
+    const entries: xdr.ScMapEntry[] = [
+      new xdr.ScMapEntry({
+        key: nativeToScVal('title', { type: 'symbol' }),
+        val: nativeToScVal(input.title, { type: 'string' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('description', { type: 'symbol' }),
+        val: nativeToScVal(input.description, { type: 'string' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('category', { type: 'symbol' }),
+        val: nativeToScVal(input.category, { type: 'symbol' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('outcomes', { type: 'symbol' }),
+        val: outcomes,
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('end_time', { type: 'symbol' }),
+        val: nativeToScVal(BigInt(input.endTimeUnix), { type: 'u64' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('resolution_time', { type: 'symbol' }),
+        val: nativeToScVal(BigInt(input.resolutionTimeUnix), { type: 'u64' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('dispute_window', { type: 'symbol' }),
+        val: nativeToScVal(BigInt(input.disputeWindowSeconds), { type: 'u64' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('creator_fee_bps', { type: 'symbol' }),
+        val: nativeToScVal(input.creatorFeeBps, { type: 'u32' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('min_stake', { type: 'symbol' }),
+        val: nativeToScVal(BigInt(input.minStakeStroops), { type: 'i128' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('max_stake', { type: 'symbol' }),
+        val: nativeToScVal(BigInt(input.maxStakeStroops), { type: 'i128' }),
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal('is_public', { type: 'symbol' }),
+        val: nativeToScVal(input.isPublic, { type: 'bool' }),
+      }),
+    ];
+
+    return xdr.ScVal.scvMap(entries);
+  }
+
+  private async simulateContract(
+    method: string,
+    args: xdr.ScVal[],
+    keypair?: Keypair,
+  ): Promise<{ returnValue: xdr.ScVal }> {
+    const kp = keypair ?? this.getServerKeypair();
+    const tx = await this.buildContractTx(kp, method, args);
+    const simulation = await (this.rpcServer as any).simulateTransaction(tx);
+
+    if (simulation?.error) {
+      throw new Error(
+        typeof simulation.error === 'string'
+          ? simulation.error
+          : JSON.stringify(simulation.error),
+      );
+    }
+
+    const returnValue: xdr.ScVal | undefined =
+      simulation?.result?.retval ?? simulation?.retval;
+    if (!returnValue) {
+      throw new Error('Soroban simulation missing return value');
+    }
+
+    return { returnValue };
+  }
+
+  private async invokeContract(
+    method: string,
+    args: xdr.ScVal[],
+    keypair?: Keypair,
+  ): Promise<{ txHash: string; returnValue: xdr.ScVal }> {
+    const kp = keypair ?? this.getServerKeypair();
+    const tx = await this.buildContractTx(kp, method, args);
+    const simulation = await (this.rpcServer as any).simulateTransaction(tx);
+
+    if (simulation?.error) {
+      throw new Error(
+        typeof simulation.error === 'string'
+          ? simulation.error
+          : JSON.stringify(simulation.error),
+      );
+    }
+
+    const assembled = SorobanRpc.assembleTransaction(tx, simulation);
+    const assembledTx =
+      typeof (assembled as any).build === 'function'
+        ? (assembled as any).build()
+        : assembled;
+    assembledTx.sign(kp);
+
+    const send = (await (this.rpcServer as any).sendTransaction(assembledTx)) as {
+      hash?: string;
+      status?: string;
+    };
+
+    const txHash = send.hash ?? '';
+    if (!txHash) {
+      throw new Error('Soroban RPC sendTransaction did not return tx hash');
+    }
+
+    const finalTx = await this.pollForTransaction(txHash);
+    const returnValue =
+      this.tryExtractReturnValue(finalTx) ??
+      simulation?.result?.retval ??
+      simulation?.retval;
+
+    if (!returnValue) {
+      throw new Error('Soroban transaction missing return value');
+    }
+
+    return { txHash, returnValue };
+  }
+
+  private async buildContractTx(
+    keypair: Keypair,
+    method: string,
+    args: xdr.ScVal[],
+  ): Promise<any> {
+    if (!this.contractId) {
+      throw new Error('SOROBAN_CONTRACT_ID is not configured');
+    }
+
+    const account = await (this.rpcServer as any).getAccount(
+      keypair.publicKey(),
+    );
+
+    const source =
+      account instanceof Account
+        ? account
+        : new Account(
+            account.accountId ?? keypair.publicKey(),
+            account.sequence,
+          );
+
+    const contract = new Contract(this.contractId);
+    const op = contract.call(method, ...(args ?? []));
+
+    return new TransactionBuilder(source, {
+      fee: BASE_FEE,
+      networkPassphrase: this.getNetworkPassphrase(),
+    })
+      .addOperation(op)
+      .setTimeout(30)
+      .build();
+  }
+
+  private async pollForTransaction(txHash: string): Promise<any> {
+    const maxAttempts = 20;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const res = await (this.rpcServer as any).getTransaction(txHash);
+      const status = String(res?.status ?? '').toUpperCase();
+      if (status === 'SUCCESS') return res;
+      if (status === 'FAILED') {
+        throw new Error(res?.resultXdr ?? 'Soroban transaction failed');
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+
+    throw new Error('Soroban transaction timed out');
+  }
+
+  private tryExtractReturnValue(txResponse: any): xdr.ScVal | null {
+    const rv = txResponse?.returnValue ?? txResponse?.result?.returnValue;
+    if (!rv) return null;
+    if (rv instanceof xdr.ScVal) return rv;
+    if (typeof rv === 'string') {
+      try {
+        return xdr.ScVal.fromXDR(rv, 'base64');
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private scValToNativeSafe(val: xdr.ScVal): unknown {
+    try {
+      return scValToNative(val);
+    } catch {
+      return null;
+    }
+  }
+
+  private toNumber(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'bigint') {
+      const asNum = Number(value);
+      return Number.isFinite(asNum) ? asNum : null;
+    }
+    if (typeof value === 'string') {
+      const asNum = Number(value);
+      return Number.isFinite(asNum) ? asNum : null;
+    }
+    return null;
+  }
+
+  private toStringId(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' && Number.isFinite(value))
+      return String(value);
+    if (typeof value === 'bigint') return value.toString();
+    return '';
+  }
+
+  private extractContractErrorCode(error: unknown): number | null {
+    const msg =
+      typeof error === 'string'
+        ? error
+        : error instanceof Error
+          ? error.message
+          : '';
+
+    // Common patterns: "Error(Contract, #17)", "ContractError(17)"
+    const match =
+      msg.match(/Contract[^0-9#]*#?(\d{1,4})/) ?? msg.match(/\b#(\d{1,4})\b/);
+    if (!match) return null;
+    const code = Number(match[1]);
+    return Number.isFinite(code) ? code : null;
+  }
+
+  private rethrowContractErrorAsHttp(operation: string, error: unknown): void {
+    const code = this.extractContractErrorCode(error);
+    if (code === null) return;
+
+    // Contract error codes (see contract/src/errors.rs)
+    if (code === 17 || code === 18 || code === 102) {
+      throw new BadRequestException(`${operation} rejected by contract`, {
+        cause: error as any,
+      });
+    }
+
+    if (code === 101) {
+      throw new ServiceUnavailableException('Contract is paused', {
+        cause: error as any,
+      });
     }
   }
 
@@ -291,17 +690,6 @@ export class SorobanService {
     }
 
     return { id, ledger, topic, value };
-  }
-
-  private toNumber(value: unknown): number | null {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value;
-    }
-    if (typeof value === 'string') {
-      const parsed = Number(value);
-      return Number.isFinite(parsed) ? parsed : null;
-    }
-    return null;
   }
 
   private toStringArray(value: unknown): string[] {


### PR DESCRIPTION
Closes #595
Closes #597
Closes #603

## Changes
- Implemented real Soroban-backed createMarket invocation and return of on-chain market ID + tx hash
- Implemented real Soroban-backed createSeason invocation with overlap guard and contract error mapping
- Added public GET /markets/:id/analytics endpoint in MarketsController delegating to AnalyticsService
- Added 5-minute in-memory cache for market analytics and included volume_24h_stroops
- Added and updated unit tests for Soroban service behavior, analytics caching, and markets analytics endpoint mapping

## Testing
- corepack pnpm run lint
- corepack pnpm run test
- corepack pnpm run build