### PR TITLE
[contract] Add get_season_participants Query Function to season.rs

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -442,6 +442,13 @@ impl InsightArenaContract {
         season::get_leaderboard(&env, season_id)
     }
 
+    pub fn get_season_participants(
+        env: Env,
+        season_id: u32,
+    ) -> Result<Vec<Address>, InsightArenaError> {
+        season::get_season_participants(&env, season_id)
+    }
+
     pub fn finalize_season(
         env: Env,
         admin: Address,

--- a/contract/src/season.rs
+++ b/contract/src/season.rs
@@ -176,6 +176,20 @@ pub(crate) fn track_user_profile(env: &Env, address: &Address) {
 
     users.push_back(address.clone());
     store_user_list(env, &users);
+
+    let has_predictions = env
+        .storage()
+        .persistent()
+        .get::<DataKey, UserProfile>(&DataKey::User(address.clone()))
+        .map(|profile| profile.total_predictions > 0)
+        .unwrap_or(false);
+
+    if has_predictions {
+        if let Some(mut season) = get_active_season(env) {
+            season.participant_count = season.participant_count.saturating_add(1);
+            store_season(env, &season);
+        }
+    }
 }
 
 pub fn load_season(env: &Env, season_id: u32) -> Result<Season, InsightArenaError> {
@@ -528,6 +542,26 @@ pub fn get_leaderboard(
         .ok_or(InsightArenaError::SeasonNotFound)?;
     bump_leaderboard(env, season_id);
     Ok(snapshot)
+}
+
+pub fn get_season_participants(
+    env: &Env,
+    season_id: u32,
+) -> Result<Vec<Address>, InsightArenaError> {
+    let snapshot = get_leaderboard(env, season_id)?;
+    let mut participants = Vec::new(env);
+
+    for entry in snapshot.entries.iter() {
+        if entry.points == 0 {
+            continue;
+        }
+
+        if !participants.iter().any(|user| user == entry.user) {
+            participants.push_back(entry.user);
+        }
+    }
+
+    Ok(participants)
 }
 
 pub fn finalize_season(env: &Env, admin: Address, season_id: u32) -> Result<(), InsightArenaError> {

--- a/contract/tests/season_tests.rs
+++ b/contract/tests/season_tests.rs
@@ -524,3 +524,90 @@ fn test_season_leaderboard_update_validation() {
     assert_eq!(snapshot.entries.get(0).unwrap().rank, 1);
     assert_eq!(snapshot.entries.get(19).unwrap().rank, 20);
 }
+
+#[test]
+fn test_participant_count_increments_on_first_prediction() {
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 200_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 100_000_000);
+    let season_id = client.create_season(&admin, &0, &10_000, &100_000_000);
+    assert_eq!(client.get_season(&season_id).participant_count, 0);
+
+    let predictor = Address::generate(&env);
+    fund(&env, &xlm_token, &predictor, 50_000_000);
+    let market_id = client.create_market(&admin, &default_market_params(&env));
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &10_000_000);
+
+    let season = client.get_season(&season_id);
+    assert_eq!(season.participant_count, 1);
+}
+
+#[test]
+fn test_get_season_participants_returns_correct_users() {
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 200_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 100_000_000);
+    let season_id = client.create_season(&admin, &0, &10_000, &100_000_000);
+
+    let user_one = Address::generate(&env);
+    let user_two = Address::generate(&env);
+    let entries = vec![
+        &env,
+        LeaderboardEntry {
+            rank: 1,
+            user: user_one.clone(),
+            points: 120,
+            correct_predictions: 3,
+            total_predictions: 4,
+        },
+        LeaderboardEntry {
+            rank: 2,
+            user: user_two.clone(),
+            points: 75,
+            correct_predictions: 2,
+            total_predictions: 3,
+        },
+        LeaderboardEntry {
+            rank: 3,
+            user: user_two.clone(),
+            points: 0,
+            correct_predictions: 1,
+            total_predictions: 3,
+        },
+    ];
+    client.update_leaderboard(&admin, &season_id, &entries);
+
+    let participants = client.get_season_participants(&season_id);
+    assert_eq!(participants.len(), 2);
+    assert_eq!(participants.get(0).unwrap(), user_one);
+    assert_eq!(participants.get(1).unwrap(), user_two);
+}
+
+#[test]
+fn test_participant_count_does_not_double_count() {
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 200_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 100_000_000);
+    let season_id = client.create_season(&admin, &0, &10_000, &100_000_000);
+
+    let predictor = Address::generate(&env);
+    fund(&env, &xlm_token, &predictor, 100_000_000);
+
+    let market_one = client.create_market(&admin, &default_market_params(&env));
+    client.submit_prediction(&predictor, &market_one, &symbol_short!("yes"), &10_000_000);
+
+    let mut second_market_params = default_market_params(&env);
+    second_market_params.end_time += 100;
+    second_market_params.resolution_time += 100;
+    let market_two = client.create_market(&admin, &second_market_params);
+    client.submit_prediction(&predictor, &market_two, &symbol_short!("yes"), &10_000_000);
+
+    let season = client.get_season(&season_id);
+    assert_eq!(season.participant_count, 1);
+}


### PR DESCRIPTION
close #578 

Description
Incremented Season.participant_count inside track_user_profile when a newly tracked user has total_predictions > 0 and an active season exists, and persist the updated season state.
Implemented pub fn get_season_participants(env: &Env, season_id: u32) -> Result<Vec<Address>, InsightArenaError> which loads the leaderboard snapshot and returns unique users who have points > 0.
Exposed the new query via the contract API in lib.rs as get_season_participants so it is callable from the generated client.
Added three integration tests in contract/tests/season_tests.rs: test_participant_count_increments_on_first_prediction, test_get_season_participants_returns_correct_users, and test_participant_count_does_not_double_count.

Testing
Ran the three new tests individually with cargo test --test season_tests <test_name> -- --nocapture and they passed.
Ran the full test suite with cargo test and all tests passed (no regressions).
The contract CONTRIBUTING.md was reviewed prior to implementation as part of the change process.