### PR TITLE
Fix wallet connect flow + add /api docs

### DIFF
--- a/frontend/src/app/api/page.tsx
+++ b/frontend/src/app/api/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import Header from "@/component/Header";
+import Footer from "@/component/Footer";
+import PageBackground from "@/component/PageBackground";
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
+  <section className="rounded-[1.75rem] border border-white/10 bg-[#111726]/85 p-8 backdrop-blur">
+    <h2 className="text-2xl font-bold text-white">{title}</h2>
+    <div className="mt-4 text-[#9aa4bc]">{children}</div>
+  </section>
+);
+
+export default function ApiDocumentationPage() {
+  return (
+    <PageBackground>
+      <div className="flex min-h-screen flex-col">
+        <Header />
+
+        <main className="mx-auto w-full max-w-6xl flex-1 px-6 pb-16 pt-32">
+          <header className="mb-10 space-y-4">
+            <div className="inline-flex items-center rounded-full border border-[#4FD1C5]/25 bg-[#4FD1C5]/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-[#9debe4]">
+              Developer API
+            </div>
+            <h1 className="text-4xl font-extrabold tracking-tight text-white sm:text-5xl">
+              InsightArena API Documentation
+            </h1>
+            <p className="max-w-3xl text-base text-[#9aa4bc] sm:text-lg">
+              Integrate markets, leaderboards, and events into your own apps.
+              This page covers base URLs, authentication, endpoints, and common
+              examples.
+            </p>
+          </header>
+
+          <div className="space-y-8">
+            <Section title="Base URL">
+              <p className="mb-4">
+                All requests are served over HTTPS. Use the base URL below for
+                all REST endpoints.
+              </p>
+              <pre className="overflow-x-auto rounded-xl border border-white/10 bg-[#0b1220] p-4 text-sm text-white">
+                <code>{`https://api.insightarena.com/v1`}</code>
+              </pre>
+            </Section>
+
+            <Section title="Authentication">
+              <p className="mb-4">
+                Authenticate by connecting a wallet, signing a challenge, and
+                exchanging that signature for a short-lived bearer token.
+              </p>
+              <ol className="list-decimal space-y-2 pl-5">
+                <li>Request a challenge string for your address.</li>
+                <li>Sign the challenge with your wallet provider.</li>
+                <li>Exchange the signature for a JWT access token.</li>
+                <li>
+                  Send the token on subsequent requests via{" "}
+                  <span className="font-mono text-white">Authorization</span>.
+                </li>
+              </ol>
+              <pre className="mt-5 overflow-x-auto rounded-xl border border-white/10 bg-[#0b1220] p-4 text-sm text-white">
+                <code>{`Authorization: Bearer <token>`}</code>
+              </pre>
+            </Section>
+
+            <Section title="Key Endpoints">
+              <p className="mb-6">
+                Common endpoints are grouped below. Response bodies are JSON
+                unless otherwise noted.
+              </p>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-2xl border border-white/10 bg-[#0b1220] p-5">
+                  <h3 className="text-sm font-semibold uppercase tracking-widest text-orange-500">
+                    Events
+                  </h3>
+                  <ul className="mt-3 space-y-2 font-mono text-sm text-gray-200">
+                    <li>GET /events</li>
+                    <li>GET /events/:id</li>
+                    <li>GET /events/:id/markets</li>
+                  </ul>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-[#0b1220] p-5">
+                  <h3 className="text-sm font-semibold uppercase tracking-widest text-[#4FD1C5]">
+                    Markets
+                  </h3>
+                  <ul className="mt-3 space-y-2 font-mono text-sm text-gray-200">
+                    <li>GET /markets</li>
+                    <li>GET /markets/:id</li>
+                    <li>POST /markets/:id/orders</li>
+                  </ul>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-[#0b1220] p-5">
+                  <h3 className="text-sm font-semibold uppercase tracking-widest text-[#A78BFA]">
+                    Leaderboard
+                  </h3>
+                  <ul className="mt-3 space-y-2 font-mono text-sm text-gray-200">
+                    <li>GET /leaderboard</li>
+                    <li>GET /leaderboard/:address</li>
+                    <li>GET /leaderboard/stats</li>
+                  </ul>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-[#0b1220] p-5">
+                  <h3 className="text-sm font-semibold uppercase tracking-widest text-[#F5C451]">
+                    Wallet
+                  </h3>
+                  <ul className="mt-3 space-y-2 font-mono text-sm text-gray-200">
+                    <li>POST /auth/challenge</li>
+                    <li>POST /auth/verify</li>
+                    <li>GET /me</li>
+                  </ul>
+                </div>
+              </div>
+            </Section>
+
+            <Section title="Example Requests">
+              <p className="mb-4">
+                Fetch upcoming events and place an order. Replace identifiers
+                with real values from your environment.
+              </p>
+              <pre className="overflow-x-auto rounded-xl border border-white/10 bg-[#0b1220] p-4 text-sm text-white">
+                <code>{`# List events
+curl -s https://api.insightarena.com/v1/events | jq
+
+# Create an order (authenticated)
+curl -s https://api.insightarena.com/v1/markets/123/orders \\
+  -H "Authorization: Bearer <token>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"side":"YES","amount":"25"}'`}</code>
+              </pre>
+            </Section>
+
+            <Section title="Rate Limits & Errors">
+              <p className="mb-4">
+                Clients are rate-limited per IP and per token. When you exceed
+                a limit, you will receive an HTTP{" "}
+                <span className="font-mono text-white">429</span>.
+              </p>
+              <div className="overflow-hidden rounded-2xl border border-white/10">
+                <table className="w-full text-left text-sm">
+                  <thead className="bg-[#0b1220] text-xs uppercase tracking-widest text-[#6f7891]">
+                    <tr>
+                      <th className="px-4 py-3">Code</th>
+                      <th className="px-4 py-3">Meaning</th>
+                      <th className="px-4 py-3">Typical Fix</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-white/10 bg-[#111726] text-gray-200">
+                    <tr>
+                      <td className="px-4 py-3 font-mono">401</td>
+                      <td className="px-4 py-3">Missing/invalid token</td>
+                      <td className="px-4 py-3">Re-authenticate</td>
+                    </tr>
+                    <tr>
+                      <td className="px-4 py-3 font-mono">403</td>
+                      <td className="px-4 py-3">Insufficient permissions</td>
+                      <td className="px-4 py-3">Verify account/roles</td>
+                    </tr>
+                    <tr>
+                      <td className="px-4 py-3 font-mono">429</td>
+                      <td className="px-4 py-3">Rate limited</td>
+                      <td className="px-4 py-3">Backoff + retry</td>
+                    </tr>
+                    <tr>
+                      <td className="px-4 py-3 font-mono">500</td>
+                      <td className="px-4 py-3">Server error</td>
+                      <td className="px-4 py-3">Retry later</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </Section>
+          </div>
+        </main>
+
+        <Footer />
+      </div>
+    </PageBackground>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 
 import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+import { WalletProvider } from "@/context/WalletContext";
 
 import "./globals.css";
 
@@ -86,12 +87,16 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="font-sans antialiased bg-[#141824] text-white">
-        <a href="#main-content" className="skip-link">
-          Skip to main content
-        </a>
-        <div id="main-content" tabIndex={-1}>
-          <Suspense fallback={<StandardPageLoadingSkeleton />}>{children}</Suspense>
-        </div>
+        <WalletProvider>
+          <a href="#main-content" className="skip-link">
+            Skip to main content
+          </a>
+          <div id="main-content" tabIndex={-1}>
+            <Suspense fallback={<StandardPageLoadingSkeleton />}>
+              {children}
+            </Suspense>
+          </div>
+        </WalletProvider>
       </body>
     </html>
   );

--- a/frontend/src/component/Header.tsx
+++ b/frontend/src/component/Header.tsx
@@ -2,17 +2,13 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { ChevronDown, Copy } from "lucide-react";
-import { useOptionalWallet } from "@/context/WalletContext";
+import { useWallet } from "@/context/WalletContext";
 
 export default function Header() {
   const pathname = usePathname();
-  const router = useRouter();
-  const wallet = useOptionalWallet();
-  const address = wallet?.address ?? null;
-  const logout = wallet?.logout;
-  const isAuthenticated = Boolean(address);
+  const { address, isAuthenticated, logout, openConnectModal } = useWallet();
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -141,10 +137,9 @@ export default function Header() {
   };
 
   const handleDisconnect = () => {
-    logout?.();
+    logout();
     setIsDropdownOpen(false);
     setIsMobileMenuOpen(false);
-    router.push("/");
   };
 
   return (
@@ -207,7 +202,11 @@ export default function Header() {
               </button>
 
               {!isAuthenticated ? (
-                <button className="hidden md:inline-flex rounded-lg bg-orange-500 px-6 py-2 font-semibold text-white hover:bg-orange-600">
+                <button
+                  type="button"
+                  className="hidden md:inline-flex rounded-lg bg-orange-500 px-6 py-2 font-semibold text-white hover:bg-orange-600"
+                  onClick={() => openConnectModal()}
+                >
                   Connect Wallet
                 </button>
               ) : (
@@ -344,7 +343,10 @@ export default function Header() {
               <button
                 type="button"
                 className="w-full rounded-lg bg-orange-500 px-4 py-3 font-semibold text-white hover:bg-orange-600"
-                onClick={() => setIsMobileMenuOpen(false)}
+                onClick={() => {
+                  setIsMobileMenuOpen(false);
+                  openConnectModal();
+                }}
               >
                 Connect Wallet
               </button>

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -1,43 +1,174 @@
 "use client";
 
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import ConnectWalletModal from "@/component/ConnectWalletModal";
 
 export interface AuthUser {
   username: string;
 }
 
-interface WalletContextType {
+export interface WalletContextValue {
+  // Wallet state
+  isFreighterInstalled: boolean;
   address: string | null;
+
+  // Auth state
+  isAuthenticated: boolean;
+  isAuthenticating: boolean;
   user: AuthUser | null;
+  token: string | null;
+  authError: string | null;
+
+  // Actions
+  openConnectModal: () => void;
+  closeConnectModal: () => void;
+  isConnectModalOpen: boolean;
+  authenticate: (
+    address: string,
+    signMessage: (msg: string) => Promise<string | null>
+  ) => Promise<boolean>;
   logout: () => void;
 }
 
-const WalletContext = createContext<WalletContextType | undefined>(undefined);
+const DEFAULT_CONTEXT_VALUE: WalletContextValue = {
+  isFreighterInstalled: false,
+  address: null,
+  isAuthenticated: false,
+  isAuthenticating: false,
+  user: null,
+  token: null,
+  authError: null,
+  openConnectModal: () => {},
+  closeConnectModal: () => {},
+  isConnectModalOpen: false,
+  authenticate: async () => false,
+  logout: () => {},
+};
+
+const WalletContext = createContext<WalletContextValue>(DEFAULT_CONTEXT_VALUE);
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  const [address, setAddress] = useState<string | null>(
-    "0x71A42D08022BEe33757145ff8bc6cb38c8950f27"
-  );
-  const [user, setUser] = useState<AuthUser | null>({ username: "Ayomide" });
+  const router = useRouter();
+  const [isFreighterInstalled, setIsFreighterInstalled] = useState(false);
+  const [address, setAddress] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const win = window as unknown as {
+      freighterApi?: unknown;
+      freighter?: unknown;
+    };
+
+    setIsFreighterInstalled(Boolean(win.freighterApi ?? win.freighter));
+  }, []);
+
+  const isAuthenticated = useMemo(() => Boolean(address && token), [address, token]);
+
+  const openConnectModal = useCallback(() => {
+    setAuthError(null);
+    setIsConnectModalOpen(true);
+  }, []);
+
+  const closeConnectModal = useCallback(() => {
+    setIsConnectModalOpen(false);
+  }, []);
+
+  const authenticate = useCallback<
+    WalletContextValue["authenticate"]
+  >(async (walletAddress, signMessage) => {
+    setIsAuthenticating(true);
+    setAuthError(null);
+
+    try {
+      const challenge = `arena_challenge_${Date.now()}`;
+      const signature = await signMessage(challenge);
+      if (!signature) {
+        setAuthError("Authentication failed: signature was not provided.");
+        return false;
+      }
+
+      setAddress(walletAddress);
+      setToken(`mock_jwt_${btoa(signature).slice(0, 24)}`);
+      setUser({ username: walletAddress.slice(0, 6) });
+      return true;
+    } catch (error) {
+      console.error("Wallet authentication failed:", error);
+      setAuthError("Authentication failed. Please try again.");
+      return false;
+    } finally {
+      setIsAuthenticating(false);
+    }
+  }, []);
 
   const logout = useCallback(() => {
     setAddress(null);
     setUser(null);
+    setToken(null);
+    setAuthError(null);
+    setIsConnectModalOpen(false);
+    router.push("/");
   }, []);
 
+  const handleModalSuccess = useCallback((walletAddress: string, jwt: string) => {
+    setAddress(walletAddress);
+    setToken(jwt);
+    setUser({ username: walletAddress.slice(0, 6) });
+    setAuthError(null);
+  }, []);
+
+  const value = useMemo<WalletContextValue>(
+    () => ({
+      isFreighterInstalled,
+      address,
+      isAuthenticated,
+      isAuthenticating,
+      user,
+      token,
+      authError,
+      openConnectModal,
+      closeConnectModal,
+      isConnectModalOpen,
+      authenticate,
+      logout,
+    }),
+    [
+      isFreighterInstalled,
+      address,
+      isAuthenticated,
+      isAuthenticating,
+      user,
+      token,
+      authError,
+      openConnectModal,
+      closeConnectModal,
+      isConnectModalOpen,
+      authenticate,
+      logout,
+    ]
+  );
+
   return (
-    <WalletContext.Provider value={{ address, user, logout }}>
+    <WalletContext.Provider value={value}>
       {children}
+      <ConnectWalletModal
+        isOpen={isConnectModalOpen}
+        onClose={closeConnectModal}
+        onSuccess={handleModalSuccess}
+      />
     </WalletContext.Provider>
   );
 }
 
 export function useWallet() {
-  const context = useContext(WalletContext);
-  if (context === undefined) {
-    throw new Error("useWallet must be used within WalletProvider");
-  }
-  return context;
+  return useContext(WalletContext);
 }
 
 export function useOptionalWallet() {


### PR DESCRIPTION
Closes #675
Closes #679
Closes #667
Closes #663

- Adds `/api` documentation page with endpoints, auth and examples.
- Introduces a global `WalletProvider` that owns the connect modal and updates `Header` to use `openConnectModal`.
