### PR TITLE
feat: expand contract test coverage for analytics, leaderboard, and liquidity

### DIFF
--- a/contract/tests/analytics_tests.rs
+++ b/contract/tests/analytics_tests.rs
@@ -393,3 +393,76 @@ fn test_analytics_after_market_resolution() {
     assert_eq!(stats.leading_outcome, symbol_short!("yes"));
     assert_eq!(stats.leading_outcome_pool, 60_000_000);
 }
+
+#[test]
+fn test_get_platform_stats_reflects_market_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = deploy(&env);
+    let creator = Address::generate(&env);
+
+    assert_eq!(client.get_platform_stats().total_markets, 0);
+
+    client.create_market(&creator, &default_params(&env));
+    assert_eq!(client.get_platform_stats().total_markets, 1);
+
+    client.create_market(&creator, &default_params(&env));
+    assert_eq!(client.get_platform_stats().total_markets, 2);
+}
+
+#[test]
+fn test_get_platform_stats_reflects_total_volume() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm) = deploy(&env);
+    let creator = Address::generate(&env);
+    let id = client.create_market(&creator, &default_params(&env));
+
+    let u1 = Address::generate(&env);
+    let amount = 50_000_000;
+    fund(&env, &xlm, &u1, amount);
+
+    client.submit_prediction(&u1, &id, &symbol_short!("yes"), &amount);
+
+    let stats = client.get_platform_stats();
+    assert_eq!(stats.total_volume_xlm, amount);
+}
+
+#[test]
+fn test_get_market_stats_returns_correct_pool_and_participants() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm) = deploy(&env);
+    let creator = Address::generate(&env);
+    let id = client.create_market(&creator, &default_params(&env));
+
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    fund(&env, &xlm, &u1, 25_000_000);
+    fund(&env, &xlm, &u2, 35_000_000);
+
+    client.submit_prediction(&u1, &id, &symbol_short!("yes"), &25_000_000);
+    client.submit_prediction(&u2, &id, &symbol_short!("no"), &35_000_000);
+
+    let stats = client.get_market_stats(&id);
+    assert_eq!(stats.total_pool, 60_000_000);
+    assert_eq!(stats.participant_count, 2);
+}
+
+#[test]
+fn test_get_user_stats_returns_correct_profile() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm) = deploy(&env);
+    let creator = Address::generate(&env);
+    let id = client.create_market(&creator, &default_params(&env));
+
+    let user = Address::generate(&env);
+    fund(&env, &xlm, &user, 40_000_000);
+
+    client.submit_prediction(&user, &id, &symbol_short!("yes"), &40_000_000);
+
+    let profile = client.get_user_stats(&user);
+    assert_eq!(profile.total_predictions, 1);
+    assert_eq!(profile.total_staked, 40_000_000);
+}

--- a/contract/tests/leaderboard_tests.rs
+++ b/contract/tests/leaderboard_tests.rs
@@ -1,7 +1,7 @@
 use insightarena_contract::{
     InsightArenaContract, InsightArenaContractClient, InsightArenaError, LeaderboardEntry,
 };
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::{vec, Address, Env};
 
 fn deploy(env: &Env) -> (InsightArenaContractClient<'_>, Address, Address) {
@@ -189,6 +189,226 @@ fn test_update_leaderboard_empty_entries() {
 
     client.update_leaderboard(&admin, &season_id, &empty_entries);
 
+    let snapshot = client.get_leaderboard(&season_id);
+    assert_eq!(snapshot.entries.len(), 0);
+}
+
+#[test]
+fn test_leaderboard_ranking_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, xlm_token) = deploy(&env);
+    let reward_pool = 10_000_000;
+    fund_reward_pool(&env, &client, &admin, &xlm_token, reward_pool);
+
+    let season_id = client.create_season(&admin, &100, &200, &reward_pool);
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    let u3 = Address::generate(&env);
+
+    let entries = vec![
+        &env,
+        LeaderboardEntry {
+            rank: 1,
+            user: u1.clone(),
+            points: 1000,
+            correct_predictions: 10,
+            total_predictions: 10,
+        },
+        LeaderboardEntry {
+            rank: 2,
+            user: u2.clone(),
+            points: 500,
+            correct_predictions: 5,
+            total_predictions: 10,
+        },
+        LeaderboardEntry {
+            rank: 3,
+            user: u3.clone(),
+            points: 100,
+            correct_predictions: 1,
+            total_predictions: 10,
+        },
+    ];
+
+    client.update_leaderboard(&admin, &season_id, &entries);
+
+    let snapshot = client.get_leaderboard(&season_id);
+    assert_eq!(snapshot.entries.get(0).unwrap().points, 1000);
+    assert_eq!(snapshot.entries.get(1).unwrap().points, 500);
+    assert_eq!(snapshot.entries.get(2).unwrap().points, 100);
+}
+
+#[test]
+fn test_leaderboard_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, xlm_token) = deploy(&env);
+    let reward_pool = 10_000_000;
+    fund_reward_pool(&env, &client, &admin, &xlm_token, reward_pool);
+
+    let season_id = client.create_season(&admin, &100, &200, &reward_pool);
+    
+    let mut entries = vec![&env];
+    for i in 1..=10 {
+        entries.push_back(LeaderboardEntry {
+            rank: i,
+            user: Address::generate(&env),
+            points: 1000 - (i * 10),
+            correct_predictions: 10,
+            total_predictions: 20,
+        });
+    }
+
+    client.update_leaderboard(&admin, &season_id, &entries);
+
+    let snapshot = client.get_leaderboard(&season_id);
+    let all_entries = snapshot.entries;
+    
+    // Simulate pagination locally since the contract returns the full list
+    let limit = 5;
+    let offset = 2;
+    let page = all_entries.slice(offset..(offset + limit));
+    
+    assert_eq!(page.len(), 5);
+    assert_eq!(page.get(0).unwrap().rank, 3);
+}
+
+#[test]
+fn test_update_existing_leaderboard_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, xlm_token) = deploy(&env);
+    let reward_pool = 10_000_000;
+    fund_reward_pool(&env, &client, &admin, &xlm_token, reward_pool);
+
+    let season_id = client.create_season(&admin, &100, &200, &reward_pool);
+    let user = Address::generate(&env);
+
+    let entries1 = vec![
+        &env,
+        LeaderboardEntry {
+            rank: 1,
+            user: user.clone(),
+            points: 100,
+            correct_predictions: 1,
+            total_predictions: 1,
+        },
+    ];
+    client.update_leaderboard(&admin, &season_id, &entries1);
+
+    let entries2 = vec![
+        &env,
+        LeaderboardEntry {
+            rank: 1,
+            user: user.clone(),
+            points: 200,
+            correct_predictions: 2,
+            total_predictions: 2,
+        },
+    ];
+    client.update_leaderboard(&admin, &season_id, &entries2);
+
+    let snapshot = client.get_leaderboard(&season_id);
+    assert_eq!(snapshot.entries.len(), 1);
+    assert_eq!(snapshot.entries.get(0).unwrap().points, 200);
+}
+
+#[test]
+fn test_leaderboard_season_transition() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, xlm_token) = deploy(&env);
+    
+    fund_reward_pool(&env, &client, &admin, &xlm_token, 20_000_000);
+
+    let s1 = client.create_season(&admin, &100, &200, &10_000_000);
+    let user1 = Address::generate(&env);
+    client.update_leaderboard(&admin, &s1, &vec![&env, LeaderboardEntry {
+        rank: 1,
+        user: user1.clone(),
+        points: 100,
+        correct_predictions: 1,
+        total_predictions: 1,
+    }]);
+
+    let s2 = client.create_season(&admin, &201, &300, &10_000_000);
+    let user2 = Address::generate(&env);
+    client.update_leaderboard(&admin, &s2, &vec![&env, LeaderboardEntry {
+        rank: 1,
+        user: user2.clone(),
+        points: 500,
+        correct_predictions: 5,
+        total_predictions: 5,
+    }]);
+
+    let snap1 = client.get_leaderboard(&s1);
+    let snap2 = client.get_leaderboard(&s2);
+
+    assert_eq!(snap1.entries.get(0).unwrap().user, user1);
+    assert_eq!(snap2.entries.get(0).unwrap().user, user2);
+}
+
+#[test]
+fn test_leaderboard_rewards_distribution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, xlm_token) = deploy(&env);
+    let reward_pool = 10_000_000;
+    fund_reward_pool(&env, &client, &admin, &xlm_token, reward_pool);
+
+    let now = 100;
+    let end = 200;
+    env.ledger().with_mut(|li| li.timestamp = now);
+    let season_id = client.create_season(&admin, &now, &end, &reward_pool);
+    
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    
+    client.update_leaderboard(&admin, &season_id, &vec![&env, 
+        LeaderboardEntry {
+            rank: 1,
+            user: u1.clone(),
+            points: 200,
+            correct_predictions: 2,
+            total_predictions: 2,
+        },
+        LeaderboardEntry {
+            rank: 2,
+            user: u2.clone(),
+            points: 100,
+            correct_predictions: 1,
+            total_predictions: 2,
+        }
+    ]);
+
+    env.ledger().with_mut(|li| li.timestamp = end + 1);
+    
+    let token = soroban_sdk::token::Client::new(&env, &xlm_token);
+    let b1_before = token.balance(&u1);
+    let b2_before = token.balance(&u2);
+
+    client.finalize_season(&admin, &season_id);
+
+    let b1_after = token.balance(&u1);
+    let b2_after = token.balance(&u2);
+
+    assert!(b1_after > b1_before);
+    assert!(b2_after > b2_before);
+    // Rank 1 gets more than Rank 2
+    assert!(b1_after - b1_before > b2_after - b2_before);
+}
+
+#[test]
+fn test_get_leaderboard_empty_season() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, xlm_token) = deploy(&env);
+    let reward_pool = 10_000_000;
+    fund_reward_pool(&env, &client, &admin, &xlm_token, reward_pool);
+
+    let season_id = client.create_season(&admin, &100, &200, &reward_pool);
+    
     let snapshot = client.get_leaderboard(&season_id);
     assert_eq!(snapshot.entries.len(), 0);
 }

--- a/contract/tests/liquidity_tests.rs
+++ b/contract/tests/liquidity_tests.rs
@@ -883,3 +883,189 @@ fn test_get_all_lp_providers_reflects_removals() {
     let providers = client.get_all_lp_providers(&market_id);
     assert_eq!(providers.len(), 0);
 }
+
+#[test]
+fn test_swap_outcome_transfers_correct_amounts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let trader = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    // Add liquidity first
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 100_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    let trader_balance_before = token.balance(&trader);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+    let trader_balance_after = token.balance(&trader);
+
+    assert_eq!(trader_balance_before, swap_amount);
+    assert_eq!(trader_balance_after, 0); // All swapped in
+}
+
+#[test]
+fn test_swap_outcome_updates_pool_reserves() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let trader = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let price_yes_before = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+    let price_no_before = client.get_outcome_price(&market_id, &symbol_short!("no"));
+
+    let swap_amount = 100_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let reserve_yes_after = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+    let reserve_no_after = client.get_outcome_price(&market_id, &symbol_short!("no"));
+
+    // Swapping YES for NO increases YES reserve and decreases NO reserve.
+    assert!(reserve_yes_after > price_yes_before);
+    assert!(reserve_no_after < price_no_before);
+}
+
+#[test]
+fn test_swap_outcome_fails_below_min_amount_out() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let trader = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 100_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    let result = client.try_swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &1_000_000_000_i128,
+    );
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn test_swap_outcome_records_swap_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let trader = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    assert_eq!(client.get_swap_history(&market_id).len(), 0);
+
+    let swap_amount = 100_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let history = client.get_swap_history(&market_id);
+    assert_eq!(history.len(), 1);
+    let record = history.get(0).unwrap();
+    assert_eq!(record.trader, trader);
+    assert_eq!(record.amount_in, swap_amount);
+}
+
+#[test]
+fn test_swap_outcome_distributes_fees_to_lps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let trader = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let position_before = client.get_lp_position(&provider, &market_id);
+    assert_eq!(position_before.fees_earned, 0);
+
+    let swap_amount = 500_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let position_after = client.get_lp_position(&provider, &market_id);
+    assert!(position_after.fees_earned > 0);
+}


### PR DESCRIPTION
This PR adds comprehensive test coverage for the analytics, leaderboard, and liquidity modules of the InsightArena contract.

Changes:
- Added tests to analytics_tests.rs for platform stats, market stats, and user profiles.
- Added tests to leaderboard_tests.rs for ranking, pagination, and reward distribution.
- Added integration tests to liquidity_tests.rs for the swap_outcome function.

All tests pass and no clippy warnings were introduced.

Closes #586, #529, #528, #585