### PR TITLE
[Frontend] Fix Background on docs/page.tsx — Uses Custom bg-[#141824] Instead of Standard Background

### DIFF
--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Header from "@/component/Header";
 import Footer from "@/component/Footer";
+import PageBackground from "@/component/PageBackground";
 import { motion, AnimatePresence } from "framer-motion";
 import { 
   Search, 
@@ -103,19 +104,10 @@ export default function DocsPage() {
   );
 
   return (
-    <div className="relative min-h-screen bg-[#141824] text-white selection:bg-[#4FD1C5]/30">
-      {/* Background Elements */}
-      <div className="absolute inset-0 z-0 pointer-events-none overflow-hidden">
-        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] bg-blue-500/10 blur-[120px] rounded-full" />
-        <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] bg-teal-500/10 blur-[120px] rounded-full" />
-        <div className="absolute inset-0 opacity-20" 
-             style={{ backgroundImage: "radial-gradient(#ffffff10 1px, transparent 1px)", backgroundSize: "40px 40px" }} 
-        />
-      </div>
-
+    <PageBackground>
       <Header />
 
-      <main className="relative z-10 pt-32 pb-24 px-6 max-w-7xl mx-auto">
+      <main className="relative z-10 pt-32 pb-24 px-6 max-w-7xl mx-auto text-white selection:bg-[#4FD1C5]/30">
         {/* Hero Area */}
         <section className="text-center mb-20">
           <motion.div
@@ -287,6 +279,6 @@ export default function DocsPage() {
       </main>
 
       <Footer />
-    </div>
+    </PageBackground>
   );
 }


### PR DESCRIPTION
close #668 

Description
Imported PageBackground from @/component/PageBackground and wrapped the docs page root with it, replacing the custom bg-[#141824] wrapper.
Removed the three docs-only background elements (two blurred blob divs and the dot-grid overlay) and moved selection/text color styles onto the main container to preserve readability.
Kept the existing page structure and interactive components intact (Header, main content, Footer) and preserved all framer-motion usages (motion.div, AnimatePresence), search, doc cards grid, FAQ accordion, and external links.

Testing
Ran cd frontend && pnpm build, and the Next build completed successfully with TypeScript checks passing during the build process.
The build output shows static page generation for routes, including /docs, indicating the page still renders as a prerendered route.
Ran cd frontend && pnpm lint, which failed in this environment because next lint resolved to a non-existent /frontend/lint path, so linting could not be validated here.