### PR TITLE
feat: useAuth hook, contracts page, markets page, wallet page (#661-678-681-686)

### DIFF
--- a/frontend/src/app/(authenticated)/markets/page.tsx
+++ b/frontend/src/app/(authenticated)/markets/page.tsx
@@ -1,5 +1,167 @@
-import { notFound } from "next/navigation";
+"use client";
 
-export default function MyPredictionsPage() {
-  notFound();
+import { useState, useMemo } from "react";
+
+type MarketStatus = "Open" | "Resolved" | "Cancelled";
+type Tab = "All Markets" | "My Markets" | "Bookmarked";
+
+interface Market {
+  id: string;
+  title: string;
+  category: string;
+  status: MarketStatus;
+  endsAt: string;
+  pool: string;
+  participants: number;
+  yesPercent: number;
+  myPrediction?: string;
+  bookmarked?: boolean;
+  createdByMe?: boolean;
+}
+
+const PLACEHOLDER_MARKETS: Market[] = [
+  { id: "1", title: "Will XLM close above $0.25 this month?", category: "Crypto", status: "Open", endsAt: "3d 12h", pool: "4,200 XLM", participants: 84, yesPercent: 62, myPrediction: "YES" },
+  { id: "2", title: "Bitcoin price above $100k by year end?", category: "Crypto", status: "Open", endsAt: "18d 5h", pool: "12,800 XLM", participants: 312, yesPercent: 55, bookmarked: true },
+  { id: "3", title: "Ethereum ETF approval in Q3?", category: "Finance", status: "Open", endsAt: "25d 0h", pool: "7,500 XLM", participants: 147, yesPercent: 48, createdByMe: true },
+  { id: "4", title: "Argentina wins Copa América 2025?", category: "Sports", status: "Open", endsAt: "10d 8h", pool: "3,100 XLM", participants: 92, yesPercent: 71, bookmarked: true },
+  { id: "5", title: "OpenAI releases GPT-5 before July?", category: "Tech", status: "Resolved", endsAt: "Ended", pool: "5,600 XLM", participants: 203, yesPercent: 100 },
+  { id: "6", title: "US Fed cuts rates in September meeting?", category: "Finance", status: "Open", endsAt: "45d 3h", pool: "9,000 XLM", participants: 275, yesPercent: 39, myPrediction: "NO", createdByMe: true },
+];
+
+const STATUS_COLORS: Record<MarketStatus, string> = {
+  Open: "bg-emerald-500/20 text-emerald-400",
+  Resolved: "bg-blue-500/20 text-blue-400",
+  Cancelled: "bg-red-500/20 text-red-400",
+};
+
+export default function MarketsPage() {
+  const [activeTab, setActiveTab] = useState<Tab>("All Markets");
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("All");
+  const [statusFilter, setStatusFilter] = useState<"All" | MarketStatus>("All");
+  const [sort, setSort] = useState("Newest");
+
+  const categories = ["All", ...Array.from(new Set(PLACEHOLDER_MARKETS.map((m) => m.category)))];
+
+  const filtered = useMemo(() => {
+    let list = PLACEHOLDER_MARKETS;
+    if (activeTab === "My Markets") list = list.filter((m) => m.createdByMe);
+    if (activeTab === "Bookmarked") list = list.filter((m) => m.bookmarked);
+    if (search) list = list.filter((m) => m.title.toLowerCase().includes(search.toLowerCase()));
+    if (categoryFilter !== "All") list = list.filter((m) => m.category === categoryFilter);
+    if (statusFilter !== "All") list = list.filter((m) => m.status === statusFilter);
+    if (sort === "Popular") list = [...list].sort((a, b) => b.participants - a.participants);
+    if (sort === "Ending Soon") list = [...list].sort((a, b) => a.endsAt.localeCompare(b.endsAt));
+    return list;
+  }, [activeTab, search, categoryFilter, statusFilter, sort]);
+
+  const isEmpty = filtered.length === 0;
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Markets</h1>
+          <p className="text-sm text-gray-400">Browse and predict on live prediction markets.</p>
+        </div>
+        <button className="inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-500 px-4 py-2 text-sm font-semibold text-white transition-colors">
+          + Create Market
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 rounded-lg bg-white/5 p-1 w-fit">
+        {(["All Markets", "My Markets", "Bookmarked"] as Tab[]).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              activeTab === tab ? "bg-blue-600 text-white" : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Search & Filter */}
+      <div className="flex flex-wrap gap-3">
+        <input
+          type="text"
+          placeholder="Search markets..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 min-w-[200px] rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+        />
+        <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)} className="rounded-lg border border-white/10 bg-gray-900 px-3 py-2 text-sm text-gray-300 focus:outline-none">
+          {categories.map((c) => <option key={c}>{c}</option>)}
+        </select>
+        <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as typeof statusFilter)} className="rounded-lg border border-white/10 bg-gray-900 px-3 py-2 text-sm text-gray-300 focus:outline-none">
+          {["All", "Open", "Resolved", "Cancelled"].map((s) => <option key={s}>{s}</option>)}
+        </select>
+        <select value={sort} onChange={(e) => setSort(e.target.value)} className="rounded-lg border border-white/10 bg-gray-900 px-3 py-2 text-sm text-gray-300 focus:outline-none">
+          {["Newest", "Popular", "Ending Soon"].map((s) => <option key={s}>{s}</option>)}
+        </select>
+      </div>
+
+      {/* Empty States */}
+      {isEmpty && activeTab === "My Markets" && (
+        <div className="flex flex-col items-center justify-center py-20 text-center space-y-3">
+          <p className="text-4xl">📋</p>
+          <p className="text-white font-semibold">No markets created yet</p>
+          <p className="text-gray-400 text-sm">Create your first prediction market to get started.</p>
+        </div>
+      )}
+      {isEmpty && activeTab === "Bookmarked" && (
+        <div className="flex flex-col items-center justify-center py-20 text-center space-y-3">
+          <p className="text-4xl">🔖</p>
+          <p className="text-white font-semibold">No bookmarks yet</p>
+          <p className="text-gray-400 text-sm">Bookmark markets to find them quickly later.</p>
+        </div>
+      )}
+      {isEmpty && activeTab === "All Markets" && (
+        <div className="flex flex-col items-center justify-center py-20 text-center space-y-3">
+          <p className="text-4xl">🔍</p>
+          <p className="text-white font-semibold">No markets match your filters</p>
+          <p className="text-gray-400 text-sm">Try adjusting your search or filters.</p>
+        </div>
+      )}
+
+      {/* Markets Grid */}
+      {!isEmpty && (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {filtered.map((market) => (
+            <div key={market.id} className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-3 hover:border-blue-500/40 transition-colors">
+              <div className="flex items-start justify-between gap-2">
+                <span className="text-xs font-semibold text-blue-400 bg-blue-500/10 px-2 py-0.5 rounded-full">{market.category}</span>
+                <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${STATUS_COLORS[market.status]}`}>{market.status}</span>
+              </div>
+              <p className="text-sm font-medium text-white leading-snug">{market.title}</p>
+              <div className="flex items-center justify-between text-xs text-gray-400">
+                <span>⏱ {market.endsAt}</span>
+                <span>👥 {market.participants}</span>
+                <span>💰 {market.pool}</span>
+              </div>
+              <div className="space-y-1">
+                <div className="flex justify-between text-xs text-gray-400">
+                  <span>YES {market.yesPercent}%</span>
+                  <span>NO {100 - market.yesPercent}%</span>
+                </div>
+                <div className="h-1.5 rounded-full bg-white/10 overflow-hidden">
+                  <div className="h-full rounded-full bg-emerald-500" style={{ width: `${market.yesPercent}%` }} />
+                </div>
+              </div>
+              {market.myPrediction && (
+                <p className="text-xs text-yellow-400 font-medium">You predicted: {market.myPrediction}</p>
+              )}
+              <button className="w-full rounded-lg border border-blue-500/40 bg-blue-500/10 py-1.5 text-sm font-semibold text-blue-400 hover:bg-blue-500/20 transition-colors">
+                {market.status === "Open" ? "Predict" : "View"}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/app/(authenticated)/wallet/page.tsx
+++ b/frontend/src/app/(authenticated)/wallet/page.tsx
@@ -1,5 +1,165 @@
-import { notFound } from "next/navigation";
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type TxType = "Stake" | "Payout" | "Refund" | "Season Reward";
+type TxStatus = "Confirmed" | "Pending";
+type TxFilter = "All" | TxType;
+
+interface Transaction {
+  id: string;
+  date: string;
+  type: TxType;
+  description: string;
+  amount: string;
+  status: TxStatus;
+}
+
+const PLACEHOLDER_ADDRESS = "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37";
+
+const TRANSACTIONS: Transaction[] = [
+  { id: "1", date: "2025-06-10", type: "Stake", description: "Will XLM close above $0.25?", amount: "-50 XLM", status: "Confirmed" },
+  { id: "2", date: "2025-06-09", type: "Payout", description: "BTC above $80k — YES won", amount: "+120 XLM", status: "Confirmed" },
+  { id: "3", date: "2025-06-08", type: "Stake", description: "Argentina wins Copa América?", amount: "-30 XLM", status: "Confirmed" },
+  { id: "4", date: "2025-06-07", type: "Refund", description: "Ethereum ETF — Market Cancelled", amount: "+30 XLM", status: "Confirmed" },
+  { id: "5", date: "2025-06-06", type: "Season Reward", description: "Season 7 top-100 finish", amount: "+200 XLM", status: "Confirmed" },
+  { id: "6", date: "2025-06-05", type: "Stake", description: "US Fed rate cut Sept?", amount: "-25 XLM", status: "Pending" },
+  { id: "7", date: "2025-06-04", type: "Payout", description: "GPT-5 before July — YES won", amount: "+60 XLM", status: "Confirmed" },
+  { id: "8", date: "2025-06-03", type: "Stake", description: "OpenAI GPT-5 release", amount: "-40 XLM", status: "Confirmed" },
+];
+
+const TYPE_COLORS: Record<TxType, string> = {
+  Stake: "bg-orange-500/20 text-orange-400",
+  Payout: "bg-emerald-500/20 text-emerald-400",
+  Refund: "bg-blue-500/20 text-blue-400",
+  "Season Reward": "bg-yellow-500/20 text-yellow-400",
+};
+
+const STATUS_COLORS: Record<TxStatus, string> = {
+  Confirmed: "text-emerald-400",
+  Pending: "text-yellow-400",
+};
+
+function truncateAddress(addr: string) {
+  return `${addr.slice(0, 8)}...${addr.slice(-6)}`;
+}
 
 export default function WalletPage() {
-  notFound();
+  const [copied, setCopied] = useState(false);
+  const [typeFilter, setTypeFilter] = useState<TxFilter>("All");
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(PLACEHOLDER_ADDRESS).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const filteredTx = typeFilter === "All"
+    ? TRANSACTIONS
+    : TRANSACTIONS.filter((t) => t.type === typeFilter);
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      {/* Wallet Header */}
+      <div className="rounded-xl border border-white/10 bg-white/5 p-5 space-y-3">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-mono text-sm text-white break-all">{PLACEHOLDER_ADDRESS}</span>
+          <button
+            onClick={handleCopy}
+            className="shrink-0 rounded-lg border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-gray-300 hover:bg-white/10 transition-colors"
+          >
+            {copied ? "✓ Copied!" : "Copy"}
+          </button>
+          <span className="inline-block rounded-full bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-400">
+            Testnet
+          </span>
+        </div>
+        <button className="text-sm text-red-400 hover:text-red-300 transition-colors">
+          Disconnect Wallet
+        </button>
+      </div>
+
+      {/* Balance Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {[
+          { label: "Available Balance", value: "1,240.50 XLM", accent: "text-emerald-400" },
+          { label: "Staked in Predictions", value: "145.00 XLM", accent: "text-orange-400" },
+          { label: "Total Winnings", value: "380.00 XLM", accent: "text-yellow-400" },
+        ].map((card) => (
+          <div key={card.label} className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-1">
+            <p className="text-xs text-gray-400">{card.label}</p>
+            <p className={`text-xl font-bold ${card.accent}`}>{card.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Quick Actions */}
+      <div className="flex flex-wrap gap-3">
+        <Link
+          href={`https://stellar.expert/explorer/testnet/account/${PLACEHOLDER_ADDRESS}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-white/10 transition-colors"
+        >
+          View on Stellar Explorer ↗
+        </Link>
+        <button className="rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-gray-400 cursor-not-allowed" disabled>
+          Export Transaction History
+        </button>
+      </div>
+
+      {/* Transaction History */}
+      <div className="space-y-3">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <h2 className="text-lg font-semibold text-white">Transaction History</h2>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value as TxFilter)}
+            className="rounded-lg border border-white/10 bg-gray-900 px-3 py-1.5 text-sm text-gray-300 focus:outline-none"
+          >
+            {["All", "Stake", "Payout", "Refund", "Season Reward"].map((t) => (
+              <option key={t}>{t}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="overflow-x-auto rounded-xl border border-white/10">
+          <table className="w-full text-sm text-left">
+            <thead className="bg-white/5 text-gray-400 uppercase text-xs tracking-wider">
+              <tr>
+                <th className="px-4 py-3">Date</th>
+                <th className="px-4 py-3">Type</th>
+                <th className="px-4 py-3">Market / Description</th>
+                <th className="px-4 py-3">Amount</th>
+                <th className="px-4 py-3">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {filteredTx.map((tx) => (
+                <tr key={tx.id} className="bg-black/20 hover:bg-white/5">
+                  <td className="px-4 py-3 text-gray-400 whitespace-nowrap">{tx.date}</td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${TYPE_COLORS[tx.type]}`}>
+                      {tx.type}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-gray-300 max-w-[200px] truncate">{tx.description}</td>
+                  <td className={`px-4 py-3 font-medium whitespace-nowrap ${tx.amount.startsWith("+") ? "text-emerald-400" : "text-gray-300"}`}>
+                    {tx.amount}
+                  </td>
+                  <td className={`px-4 py-3 font-medium ${STATUS_COLORS[tx.status]}`}>
+                    {tx.status}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {filteredTx.length === 0 && (
+            <div className="py-10 text-center text-gray-400 text-sm">No transactions match the filter.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/contracts/page.tsx
+++ b/frontend/src/app/contracts/page.tsx
@@ -1,0 +1,181 @@
+import Link from "next/link";
+
+import Footer from "@/component/Footer";
+import Header from "@/component/Header";
+import PageBackground from "@/component/PageBackground";
+
+const CONTRACT_MODULES = [
+  {
+    name: "Market",
+    description:
+      "Manages prediction market creation, lifecycle, and outcome resolution. The core contract powering every market on InsightArena.",
+  },
+  {
+    name: "Prediction",
+    description:
+      "Records user predictions, stake amounts, and computes payouts based on market outcomes and pool share.",
+  },
+  {
+    name: "Escrow",
+    description:
+      "Holds staked XLM in trust until a market resolves. Ensures funds are only released to winners or refunded on cancellation.",
+  },
+  {
+    name: "Season",
+    description:
+      "Tracks reputation-point accumulation across a time-bounded season and distributes season-end rewards.",
+  },
+  {
+    name: "Invite",
+    description:
+      "Manages referral codes and invite-based onboarding bonuses, incentivising community growth.",
+  },
+  {
+    name: "Governance",
+    description:
+      "Allows token holders to vote on protocol parameters such as fee rates, oracle sources, and feature flags.",
+  },
+  {
+    name: "Liquidity",
+    description:
+      "Provides automated market-making depth so thin markets still offer competitive odds on both sides.",
+  },
+  {
+    name: "Dispute",
+    description:
+      "Enables users to challenge market resolutions they believe are incorrect, triggering a decentralised arbitration process.",
+  },
+];
+
+const DEPLOYED_ADDRESSES = [
+  {
+    network: "Testnet",
+    contractId: "CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    status: "Active",
+  },
+  {
+    network: "Mainnet",
+    contractId: "TBD",
+    status: "Pending",
+  },
+];
+
+export default function ContractsPage() {
+  return (
+    <PageBackground>
+      <Header />
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-20 space-y-20">
+        {/* Hero */}
+        <section className="text-center space-y-4">
+          <h1 className="text-4xl sm:text-5xl font-bold text-white">
+            Smart Contracts
+          </h1>
+          <p className="text-lg text-gray-400 max-w-2xl mx-auto">
+            InsightArena is built on Soroban — Stellar&rsquo;s smart-contract
+            platform. Every market, prediction, and payout is governed by
+            open-source, auditable on-chain logic.
+          </p>
+        </section>
+
+        {/* Contract Modules */}
+        <section className="space-y-6">
+          <h2 className="text-2xl font-semibold text-white">Contract Modules</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {CONTRACT_MODULES.map((mod) => (
+              <div
+                key={mod.name}
+                className="rounded-xl border border-white/10 bg-white/5 p-5 space-y-2 hover:border-blue-500/40 transition-colors"
+              >
+                <h3 className="text-lg font-semibold text-blue-400">
+                  {mod.name}
+                </h3>
+                <p className="text-sm text-gray-400">{mod.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Deployed Addresses */}
+        <section className="space-y-6">
+          <h2 className="text-2xl font-semibold text-white">
+            Deployed Addresses
+          </h2>
+          <div className="overflow-x-auto rounded-xl border border-white/10">
+            <table className="w-full text-sm text-left">
+              <thead className="bg-white/5 text-gray-400 uppercase text-xs tracking-wider">
+                <tr>
+                  <th className="px-4 py-3">Network</th>
+                  <th className="px-4 py-3">Contract ID</th>
+                  <th className="px-4 py-3">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {DEPLOYED_ADDRESSES.map((row) => (
+                  <tr key={row.network} className="bg-black/20 hover:bg-white/5">
+                    <td className="px-4 py-3 text-white font-medium">
+                      {row.network}
+                    </td>
+                    <td className="px-4 py-3 text-gray-300 font-mono text-xs">
+                      {row.contractId}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${
+                          row.status === "Active"
+                            ? "bg-emerald-500/20 text-emerald-400"
+                            : "bg-yellow-500/20 text-yellow-400"
+                        }`}
+                      >
+                        {row.status}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Security */}
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold text-white">Security</h2>
+          <div className="rounded-xl border border-white/10 bg-white/5 p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="space-y-1">
+              <p className="text-gray-300 text-sm">
+                All InsightArena contracts are open-source and available for
+                public review on GitHub.
+              </p>
+              <p className="text-gray-500 text-xs">
+                A third-party security audit is currently in progress.
+              </p>
+            </div>
+            <span className="shrink-0 inline-flex items-center gap-2 rounded-full border border-yellow-500/40 bg-yellow-500/10 px-3 py-1 text-xs font-semibold text-yellow-400">
+              <span className="size-2 rounded-full bg-yellow-400 animate-pulse" />
+              Audit Pending
+            </span>
+          </div>
+        </section>
+
+        {/* Source Code */}
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold text-white">Source Code</h2>
+          <p className="text-gray-400 text-sm">
+            The full contract source is available on GitHub. Contributions and
+            security disclosures are welcome.
+          </p>
+          <Link
+            href="https://github.com/Arena1X/InsightArena/tree/main/contract"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-500/40 bg-blue-500/10 px-4 py-2 text-sm font-semibold text-blue-400 hover:bg-blue-500/20 transition-colors"
+          >
+            View on GitHub →
+          </Link>
+        </section>
+      </main>
+
+      <Footer />
+    </PageBackground>
+  );
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { AuthUser, UseAuthReturn } from "@/types/auth";
+
+const TOKEN_KEY = "ia_token";
+const USER_KEY = "ia_user";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+function isTokenExpired(token: string): boolean {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return typeof payload.exp === "number" && Date.now() / 1000 > payload.exp;
+  } catch {
+    return true;
+  }
+}
+
+export function useAuth(): UseAuthReturn {
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Hydrate from localStorage on mount
+  useEffect(() => {
+    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedUser = localStorage.getItem(USER_KEY);
+
+    if (storedToken && storedUser) {
+      if (isTokenExpired(storedToken)) {
+        logout();
+      } else {
+        try {
+          setToken(storedToken);
+          setUser(JSON.parse(storedUser) as AuthUser);
+          setIsAuthenticated(true);
+        } catch {
+          logout();
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+    setIsAuthenticated(false);
+    setUser(null);
+    setToken(null);
+    window.location.href = "/";
+  }, []);
+
+  const authenticate = useCallback(
+    async (
+      address: string,
+      signMessage: (msg: string) => Promise<string | null>
+    ): Promise<boolean> => {
+      setIsAuthenticating(true);
+      setError(null);
+
+      try {
+        // Step 1: request challenge
+        const challengeRes = await fetch(`${API_BASE}/api/auth/challenge`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ stellar_address: address }),
+        });
+
+        if (!challengeRes.ok) {
+          setError("Failed to generate challenge");
+          return false;
+        }
+
+        const { challenge } = (await challengeRes.json()) as { challenge: string };
+
+        // Step 2: sign challenge
+        const signature = await signMessage(challenge);
+        if (!signature) {
+          setError("Signing was rejected");
+          return false;
+        }
+
+        // Step 3: verify signature
+        const verifyRes = await fetch(`${API_BASE}/api/auth/verify`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ stellar_address: address, signed_challenge: signature }),
+        });
+
+        if (!verifyRes.ok) {
+          setError("Signature verification failed");
+          return false;
+        }
+
+        const { access_token, user: authUser } = (await verifyRes.json()) as {
+          access_token: string;
+          user: AuthUser;
+        };
+
+        // Step 4: persist and update state
+        localStorage.setItem(TOKEN_KEY, access_token);
+        localStorage.setItem(USER_KEY, JSON.stringify(authUser));
+        setToken(access_token);
+        setUser(authUser);
+        setIsAuthenticated(true);
+        return true;
+      } catch {
+        setError("Authentication failed. Please try again.");
+        return false;
+      } finally {
+        setIsAuthenticating(false);
+      }
+    },
+    []
+  );
+
+  return { isAuthenticating, isAuthenticated, user, token, error, authenticate, logout };
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,21 @@
+export interface AuthUser {
+  id: string;
+  stellar_address: string;
+  username: string | null;
+  avatar_url: string | null;
+  reputation_score: number;
+  role: string;
+}
+
+export interface UseAuthReturn {
+  isAuthenticating: boolean;
+  isAuthenticated: boolean;
+  user: AuthUser | null;
+  token: string | null;
+  error: string | null;
+  authenticate: (
+    address: string,
+    signMessage: (msg: string) => Promise<string | null>
+  ) => Promise<boolean>;
+  logout: () => void;
+}


### PR DESCRIPTION
Fixes #661
Fixes #678
Fixes #681
Fixes #686

## What changed

### #661 — `useAuth` hook with full JWT auth flow
- **`frontend/src/types/auth.ts`** — `AuthUser` and `UseAuthReturn` interfaces
- **`frontend/src/hooks/useAuth.ts`** — 4-step auth flow: `POST /api/auth/challenge` → sign with Freighter → `POST /api/auth/verify` → store JWT in `localStorage`; hydration on mount with `atob` JWT expiry check; `logout()` clears storage and redirects to `/`

### #678 — `/contracts` page (was 404)
- **`frontend/src/app/contracts/page.tsx`** — 5 sections: hero, 8 contract module cards (Market / Prediction / Escrow / Season / Invite / Governance / Liquidity / Dispute), deployed addresses table, security section with Audit Pending badge, GitHub source link. Uses `PageBackground`, `Header`, `Footer`, Tailwind only.

### #681 — `/markets` — replaced `notFound()` with full page
- **`frontend/src/app/(authenticated)/markets/page.tsx`** — tab navigation (All / My Markets / Bookmarked), search + category / status / sort filters (client-side), responsive market cards grid with probability bars, outcome badges, user prediction labels, and empty states for each tab.

### #686 — `/wallet` — replaced `notFound()` with full page
- **`frontend/src/app/(authenticated)/wallet/page.tsx`** — wallet header with full address + copy-to-clipboard + network badge; 3 balance cards (Available / Staked / Winnings); quick actions; 8-row transaction history table with type and status colour badges; client-side type filter.

## How to test
```bash
cd frontend && npm run dev
# Navigate to /contracts, /markets, /wallet
```