### PR TITLE
feat: add validation for overlapping seasons during creation

### DIFF
--- a/contract/src/errors.rs
+++ b/contract/src/errors.rs
@@ -100,6 +100,9 @@ pub enum InsightArenaError {
     /// No season exists for the given `season_id`.
     /// Raised on any season lookup that returns nothing from storage.
     SeasonNotFound = 42,
+    /// The new season's time range overlaps with an existing non-finalized season.
+    /// Raised when creating a season that would be active simultaneously with another.
+    SeasonOverlap = 43,
 
     // ── Invite ────────────────────────────────────────────────────────────────
     /// The supplied invite code symbol does not exist in storage or does not

--- a/contract/src/season.rs
+++ b/contract/src/season.rs
@@ -423,6 +423,23 @@ pub fn create_season(
         return Err(InsightArenaError::InvalidTimeRange);
     }
 
+    let total = season_count(env);
+    let mut season_id = 1_u32;
+    while season_id <= total {
+        if let Some(season) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Season>(&DataKey::Season(season_id))
+        {
+            if !season.is_finalized {
+                if season.start_time < end_time && start_time < season.end_time {
+                    return Err(InsightArenaError::SeasonOverlap);
+                }
+            }
+        }
+        season_id = season_id.saturating_add(1);
+    }
+
     let season_id = season_count(env)
         .checked_add(1)
         .ok_or(InsightArenaError::Overflow)?;

--- a/contract/tests/season_tests.rs
+++ b/contract/tests/season_tests.rs
@@ -721,3 +721,47 @@ fn test_reset_season_points_fails_for_finalized_season() {
     let result = client.try_reset_season_points(&admin, &season_id);
     assert_eq!(result, Err(Ok(InsightArenaError::SeasonAlreadyFinalized)));
 }
+
+#[test]
+fn test_create_season_overlapping_active_season_fails() {
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 300_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 200_000_000);
+
+    client.create_season(&admin, &100, &200, &100_000_000);
+
+    let result = client.try_create_season(&admin, &150, &250, &100_000_000);
+    assert_eq!(result, Err(Ok(InsightArenaError::SeasonOverlap)));
+}
+
+#[test]
+fn test_create_season_after_previous_ends_succeeds() {
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 300_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 200_000_000);
+
+    let season1_id = client.create_season(&admin, &100, &200, &100_000_000);
+    assert_eq!(season1_id, 1);
+
+    let season2_id = client.create_season(&admin, &200, &300, &100_000_000);
+    assert_eq!(season2_id, 2);
+}
+
+#[test]
+fn test_create_season_before_previous_starts_succeeds() {
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 300_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 200_000_000);
+
+    let season1_id = client.create_season(&admin, &300, &400, &100_000_000);
+    assert_eq!(season1_id, 1);
+
+    let season2_id = client.create_season(&admin, &100, &200, &100_000_000);
+    assert_eq!(season2_id, 2);
+}


### PR DESCRIPTION
feat: Add season overlap validation to create_season

Add validation to prevent creating seasons with overlapping time ranges to ensure only one non-finalized season is active at any given time.
Changes:
- errors.rs: Added SeasonOverlap = 43 error variant
- season.rs: Added overlap check in create_season - iterates all existing non-finalized seasons and rejects if time ranges overlap
- season_tests.rs: Added 3 tests:
  - test_create_season_overlapping_active_season_fails
  - test_create_season_after_previous_ends_succeeds
  - test_create_season_before_previous_starts_succeeds
Acceptance Criteria Met:
- Overlapping seasons are rejected with SeasonOverlap error
- Non-overlapping seasons (adjacent or non-overlapping time ranges) succeed
- Finalized seasons are excluded from overlap check

Closes #576  