### PR TITLE
[Backend] Add GET /markets/:id/analytics endpoint

### DIFF
--- a/backend/API_REFERENCE.md
+++ b/backend/API_REFERENCE.md
@@ -1039,6 +1039,42 @@ Example curl:
 curl http://localhost:3000/api/v1/markets/<market-id>/predictions
 ```
 
+### `GET /markets/:id/analytics`
+One-line description: Get analytics for a specific market.
+
+Auth required: No
+
+Request body: none
+
+Query parameters: none
+
+Success response:
+- `200 OK`
+```json
+{
+  "market_id": "uuid",
+  "total_pool_stroops": "string",
+  "participant_count": number,
+  "outcome_distribution": [
+    {
+      "outcome": "string",
+      "count": number,
+      "percentage": number
+    }
+  ],
+  "time_remaining_seconds": number
+}
+```
+
+Error responses:
+- `404` if the market is not found
+- `500` on server error
+
+Example curl:
+```bash
+curl http://localhost:3000/api/v1/markets/<market-id>/analytics
+```
+
 ### `POST /markets/:id/comments`
 One-line description: Post a comment on a market.
 

--- a/backend/src/markets/markets.controller.ts
+++ b/backend/src/markets/markets.controller.ts
@@ -41,6 +41,7 @@ import { MarketTemplate } from './entities/market-template.entity';
 import { Market } from './entities/market.entity';
 import { MarketsService } from './markets.service';
 import { AnalyticsService } from '../analytics/analytics.service';
+import { MarketAnalyticsDto } from '../analytics/dto/market-analytics.dto';
 import { DisputesService } from '../disputes/disputes.service';
 
 @ApiTags('Markets')
@@ -90,6 +91,22 @@ export class MarketsController {
     @Param('id') id: string,
   ): Promise<PredictionStatsDto[]> {
     return this.marketsService.getPredictionStats(id);
+  }
+
+  @Get(':id/analytics')
+  @Public()
+  @ApiOperation({ summary: 'Get market analytics and statistics' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Market analytics including pool size, outcome distribution, and time remaining',
+    type: MarketAnalyticsDto,
+  })
+  @ApiResponse({ status: 404, description: 'Market not found' })
+  async getMarketAnalytics(
+    @Param('id') id: string,
+  ): Promise<MarketAnalyticsDto> {
+    return this.analyticsService.getMarketAnalytics(id);
   }
 
   @Post()


### PR DESCRIPTION
Closes #603
Closes #595 
Closes #597 

## Changes
- Added GET /markets/:id/analytics route in MarketsController.
- Reused existing AnalyticsService.getMarketAnalytics logic for endpoint behavior.
- Documented new endpoint in ackend/API_REFERENCE.md.

## Testing
- Could not run Jest locally because dependencies are not installed in this workspace (jest not found).

