### PR TITLE
Implement Prediction & Winner Data Structures + Storage Layer

### DIFF
--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
 
 mod token;
+pub mod storage;
 pub mod storage_types;

--- a/contracts/creator-event-manager/src/storage.rs
+++ b/contracts/creator-event-manager/src/storage.rs
@@ -1,0 +1,296 @@
+/// Storage helper functions for the CreatorEventManager contract.
+///
+/// All reads extend the TTL of the accessed entry by one year (~6_307_200 ledgers
+/// at ~5 s/ledger).  All writes apply the same TTL so freshly written entries
+/// do not expire before they can be read.
+///
+/// Counter helpers return the *new* value after incrementing so callers can use
+/// the returned ID immediately.
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::storage_types::{DataKey, Event, Match, Prediction, Winner};
+
+// ---------------------------------------------------------------------------
+// TTL constant
+// ---------------------------------------------------------------------------
+
+/// Extend storage entries by approximately one year (in ledgers).
+/// Soroban ledgers close roughly every 5 seconds:
+///   365 days × 24 h × 3600 s / 5 s ≈ 6_307_200 ledgers.
+pub const TTL_LEDGERS: u32 = 6_307_200;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors returned by storage helpers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageError {
+    /// The requested key does not exist in storage.
+    NotFound,
+}
+
+// ---------------------------------------------------------------------------
+// Event helpers
+// ---------------------------------------------------------------------------
+
+/// Read an `Event` from persistent storage. Extends the TTL on success.
+pub fn get_event(env: &Env, event_id: u64) -> Result<Event, StorageError> {
+    let key = DataKey::Event(event_id);
+    match env.storage().persistent().get::<DataKey, Event>(&key) {
+        Some(event) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            Ok(event)
+        }
+        None => Err(StorageError::NotFound),
+    }
+}
+
+/// Write an `Event` to persistent storage and set its TTL.
+pub fn set_event(env: &Env, event_id: u64, event: &Event) {
+    let key = DataKey::Event(event_id);
+    env.storage().persistent().set(&key, event);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+// ---------------------------------------------------------------------------
+// Match helpers
+// ---------------------------------------------------------------------------
+
+/// Read a `Match` from persistent storage. Extends the TTL on success.
+pub fn get_match(env: &Env, match_id: u64) -> Result<Match, StorageError> {
+    let key = DataKey::Match(match_id);
+    match env.storage().persistent().get::<DataKey, Match>(&key) {
+        Some(m) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            Ok(m)
+        }
+        None => Err(StorageError::NotFound),
+    }
+}
+
+/// Write a `Match` to persistent storage and set its TTL.
+pub fn set_match(env: &Env, match_id: u64, m: &Match) {
+    let key = DataKey::Match(match_id);
+    env.storage().persistent().set(&key, m);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+// ---------------------------------------------------------------------------
+// Prediction helpers
+// ---------------------------------------------------------------------------
+
+/// Read a `Prediction` from persistent storage. Extends the TTL on success.
+pub fn get_prediction(env: &Env, prediction_id: u64) -> Result<Prediction, StorageError> {
+    let key = DataKey::Prediction(prediction_id);
+    match env
+        .storage()
+        .persistent()
+        .get::<DataKey, Prediction>(&key)
+    {
+        Some(pred) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            Ok(pred)
+        }
+        None => Err(StorageError::NotFound),
+    }
+}
+
+/// Write a `Prediction` to persistent storage and set its TTL.
+pub fn set_prediction(env: &Env, prediction_id: u64, prediction: &Prediction) {
+    let key = DataKey::Prediction(prediction_id);
+    env.storage().persistent().set(&key, prediction);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+// ---------------------------------------------------------------------------
+// Counter helpers
+// ---------------------------------------------------------------------------
+
+/// Increment the global event counter and return the new value (starts at 1).
+pub fn next_event_id(env: &Env) -> u64 {
+    let key = DataKey::EventCounter(0);
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u64>(&key)
+        .unwrap_or(0);
+    let next = current + 1;
+    env.storage().instance().set(&key, &next);
+    next
+}
+
+/// Increment the global match counter and return the new value (starts at 1).
+pub fn next_match_id(env: &Env) -> u64 {
+    let key = DataKey::MatchCounter(0);
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u64>(&key)
+        .unwrap_or(0);
+    let next = current + 1;
+    env.storage().instance().set(&key, &next);
+    next
+}
+
+/// Increment the global prediction counter and return the new value (starts at 1).
+pub fn next_prediction_id(env: &Env) -> u64 {
+    let key = DataKey::PredictionCounter(0);
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u64>(&key)
+        .unwrap_or(0);
+    let next = current + 1;
+    env.storage().instance().set(&key, &next);
+    next
+}
+
+// ---------------------------------------------------------------------------
+// Batch / list helpers
+// ---------------------------------------------------------------------------
+
+/// Return the list of match IDs for an event, or an empty Vec if none exist.
+pub fn get_event_matches(env: &Env, event_id: u64) -> Vec<u64> {
+    let key = DataKey::EventMatches(event_id);
+    match env.storage().persistent().get::<DataKey, Vec<u64>>(&key) {
+        Some(list) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            list
+        }
+        None => Vec::new(env),
+    }
+}
+
+/// Append a match ID to the event's match list.
+pub fn add_event_match(env: &Env, event_id: u64, match_id: u64) {
+    let key = DataKey::EventMatches(event_id);
+    let mut list = get_event_matches(env, event_id);
+    list.push_back(match_id);
+    env.storage().persistent().set(&key, &list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+/// Return the list of prediction IDs for a match, or an empty Vec if none exist.
+pub fn get_match_predictions(env: &Env, match_id: u64) -> Vec<u64> {
+    let key = DataKey::MatchPredictions(match_id);
+    match env.storage().persistent().get::<DataKey, Vec<u64>>(&key) {
+        Some(list) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            list
+        }
+        None => Vec::new(env),
+    }
+}
+
+/// Append a prediction ID to the match's prediction list.
+pub fn add_match_prediction(env: &Env, match_id: u64, prediction_id: u64) {
+    let key = DataKey::MatchPredictions(match_id);
+    let mut list = get_match_predictions(env, match_id);
+    list.push_back(prediction_id);
+    env.storage().persistent().set(&key, &list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+/// Return the list of prediction IDs a user has placed in an event.
+pub fn get_user_predictions(env: &Env, user: &Address, event_id: u64) -> Vec<u64> {
+    let key = DataKey::UserPredictions(user.clone(), event_id);
+    match env.storage().persistent().get::<DataKey, Vec<u64>>(&key) {
+        Some(list) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            list
+        }
+        None => Vec::new(env),
+    }
+}
+
+/// Append a prediction ID to the user's prediction list for an event.
+pub fn add_user_prediction(env: &Env, user: &Address, event_id: u64, prediction_id: u64) {
+    let key = DataKey::UserPredictions(user.clone(), event_id);
+    let mut list = get_user_predictions(env, user, event_id);
+    list.push_back(prediction_id);
+    env.storage().persistent().set(&key, &list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+/// Return the list of participant addresses for an event.
+pub fn get_event_participants(env: &Env, event_id: u64) -> Vec<Address> {
+    let key = DataKey::EventParticipants(event_id);
+    match env
+        .storage()
+        .persistent()
+        .get::<DataKey, Vec<Address>>(&key)
+    {
+        Some(list) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            list
+        }
+        None => Vec::new(env),
+    }
+}
+
+/// Append a participant address to the event's participant list.
+pub fn add_event_participant(env: &Env, event_id: u64, participant: &Address) {
+    let key = DataKey::EventParticipants(event_id);
+    let mut list = get_event_participants(env, event_id);
+    list.push_back(participant.clone());
+    env.storage().persistent().set(&key, &list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+/// Return the list of verified winners for an event.
+pub fn get_event_winners(env: &Env, event_id: u64) -> Vec<Winner> {
+    let key = DataKey::EventWinners(event_id);
+    match env
+        .storage()
+        .persistent()
+        .get::<DataKey, Vec<Winner>>(&key)
+    {
+        Some(list) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            list
+        }
+        None => Vec::new(env),
+    }
+}
+
+/// Append a winner to the event's winners list.
+pub fn add_event_winner(env: &Env, event_id: u64, winner: &Winner) {
+    let key = DataKey::EventWinners(event_id);
+    let mut list = get_event_winners(env, event_id);
+    list.push_back(winner.clone());
+    env.storage().persistent().set(&key, &list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -13,6 +13,11 @@ pub const MAX_TEAM_NAME_LEN: u32 = 100;
 /// Required length for invite codes (characters)
 pub const INVITE_CODE_LEN: u32 = 8;
 
+/// Valid predicted outcome symbols
+pub const OUTCOME_TEAM_A: &str = "TEAM_A";
+pub const OUTCOME_TEAM_B: &str = "TEAM_B";
+pub const OUTCOME_DRAW: &str = "DRAW";
+
 // ---------------------------------------------------------------------------
 // MatchResult
 // ---------------------------------------------------------------------------
@@ -96,38 +101,77 @@ pub enum EventStatus {
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    /// Global contract configuration (token address, fee %, admin, …)
-    Config,
+    // ── Global admin / config keys ──────────────────────────────────────────
 
-    /// Global monotonic event counter → u64
-    EventCounter,
+    /// Contract administrator address
+    Admin(Address),
+
+    /// AI agent address authorised to submit match results
+    AIAgent(Address),
+
+    /// Treasury address that receives creation fees
+    Treasury(Address),
+
+    /// XLM creation fee in stroops (i128)
+    CreationFee(i128),
+
+    /// Emergency pause flag — when true, sensitive operations are halted
+    Paused(bool),
+
+    /// Native XLM token contract address
+    XLMToken(Address),
+
+    // ── Global counters ─────────────────────────────────────────────────────
+
+    /// Monotonically increasing event counter → u64
+    EventCounter(u64),
+
+    /// Monotonically increasing match counter → u64
+    MatchCounter(u64),
+
+    /// Monotonically increasing prediction counter → u64
+    PredictionCounter(u64),
+
+    // ── Core entity keys ────────────────────────────────────────────────────
 
     /// Core event data keyed by event_id
     Event(u64),
 
-    /// Per-event match counter → u64  (event_id)
-    MatchCounter(u64),
+    /// Individual match keyed by match_id
+    Match(u64),
 
-    /// Individual match keyed by (event_id, match_id)
-    Match(u64, u64),
+    /// A user's prediction keyed by prediction_id
+    Prediction(u64),
 
-    /// A user's prediction for a specific match  (event_id, match_id, predictor)
-    Prediction(u64, u64, Address),
+    // ── Relationship / index keys ────────────────────────────────────────────
 
-    /// All event_ids a user has joined  (user) → Vec<u64>
-    UserEvents(Address),
+    /// Vec<u64> of match IDs belonging to an event  (event_id)
+    EventMatches(u64),
 
-    /// All participant addresses for an event  (event_id) → Vec<Address>
+    /// Vec<u64> of prediction IDs for a match  (match_id)
+    MatchPredictions(u64),
+
+    /// Vec<u64> of prediction IDs a user has placed in an event  (user, event_id)
+    UserPredictions(Address, u64),
+
+    /// Vec<Address> of participants for an event  (event_id)
     EventParticipants(u64),
+
+    /// Vec<Winner> of verified winners for an event  (event_id)
+    EventWinners(u64),
+
+    // ── Access / invite keys ─────────────────────────────────────────────────
+
+    /// Whether an address has passed KYC / verification  (address) → bool
+    VerifiedAddresses(Address),
 
     /// Invite code → event_id mapping  (8-char Symbol)
     InviteCode(Symbol),
 
-    /// Whether an address has passed KYC / verification
-    VerifiedAddress(Address),
+    // ── Legacy / compatibility keys ──────────────────────────────────────────
 
-    /// Verified winners for an event  (event_id) → Vec<Winner>
-    Winners(u64),
+    /// Global contract configuration singleton
+    Config,
 
     /// Running XLM balance held by the contract treasury
     TreasuryBalance,
@@ -267,6 +311,16 @@ impl Event {
         }
         Ok(())
     }
+
+    /// Returns true when the title length is within the 200-character limit.
+    pub fn is_valid_title(title: &String) -> bool {
+        title.len() <= MAX_TITLE_LEN
+    }
+
+    /// Returns true when the description length is within the 1000-character limit.
+    pub fn is_valid_description(description: &String) -> bool {
+        description.len() <= MAX_DESCRIPTION_LEN
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -275,11 +329,11 @@ impl Event {
 
 /// A single prediction match within an event.
 ///
-/// Stored under `DataKey::Match(event_id, match_id)`.
+/// Stored under `DataKey::Match(match_id)`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Match {
-    /// Unique identifier scoped to the parent event
+    /// Unique identifier (global, assigned via MatchCounter)
     pub match_id: u64,
 
     /// ID of the parent event
@@ -442,7 +496,6 @@ impl Match {
             if self.submitted_at.is_none() {
                 return Err("Result submitted but submitted_at is None");
             }
-            // Validate the encoded value is a legal outcome
             if let Some(v) = self.winning_team {
                 if v > 2 {
                     return Err("winning_team value must be 0 (TeamA), 1 (TeamB), or 2 (Draw)");
@@ -467,22 +520,27 @@ impl Match {
 
 /// A user's prediction for a single match inside an event.
 ///
-/// Stored under `DataKey::Prediction(event_id, match_id, predictor)`.
+/// Stored under `DataKey::Prediction(prediction_id)`.
+///
+/// The `predicted_outcome` field uses a `Symbol` with one of three values:
+/// `"TEAM_A"`, `"TEAM_B"`, or `"DRAW"` (see `OUTCOME_*` constants).
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Prediction {
-    /// Address of the user who placed this prediction
-    pub predictor: Address,
-
-    /// Parent event identifier
-    pub event_id: u64,
+    /// Global unique identifier assigned via PredictionCounter
+    pub prediction_id: u64,
 
     /// Match this prediction is for
     pub match_id: u64,
 
-    /// Predicted outcome: 0 = Team A, 1 = Team B, 2 = Draw.
-    /// Stored as `u32` because Soroban's `#[contracttype]` does not support `u8`.
-    pub predicted_winner: u32,
+    /// Parent event identifier
+    pub event_id: u64,
+
+    /// Address of the user who placed this prediction
+    pub predictor: Address,
+
+    /// Predicted outcome: Symbol of "TEAM_A", "TEAM_B", or "DRAW"
+    pub predicted_outcome: Symbol,
 
     /// Unix timestamp when the prediction was submitted
     pub predicted_at: u64,
@@ -494,25 +552,42 @@ pub struct Prediction {
 impl Prediction {
     /// Create a new ungraded prediction.
     pub fn new(
-        predictor: Address,
-        event_id: u64,
+        prediction_id: u64,
         match_id: u64,
-        predicted_winner: u32,
+        event_id: u64,
+        predictor: Address,
+        predicted_outcome: Symbol,
         predicted_at: u64,
     ) -> Self {
         Self {
-            predictor,
-            event_id,
+            prediction_id,
             match_id,
-            predicted_winner,
+            event_id,
+            predictor,
+            predicted_outcome,
             predicted_at,
             is_correct: None,
         }
     }
 
-    /// Grade this prediction against the actual match result.
-    pub fn grade(&mut self, actual_result: &MatchResult) {
-        self.is_correct = Some(self.predicted_winner == actual_result.to_u32());
+    /// Validate that `predicted_outcome` is one of the three legal symbols.
+    ///
+    /// Valid values: `"TEAM_A"`, `"TEAM_B"`, `"DRAW"`.
+    pub fn validate_outcome(env: &soroban_sdk::Env, outcome: &Symbol) -> Result<(), &'static str> {
+        let team_a = Symbol::new(env, OUTCOME_TEAM_A);
+        let team_b = Symbol::new(env, OUTCOME_TEAM_B);
+        let draw = Symbol::new(env, OUTCOME_DRAW);
+
+        if *outcome == team_a || *outcome == team_b || *outcome == draw {
+            Ok(())
+        } else {
+            Err("predicted_outcome must be TEAM_A, TEAM_B, or DRAW")
+        }
+    }
+
+    /// Grade this prediction against the actual match result symbol.
+    pub fn grade(&mut self, actual_outcome: &Symbol) {
+        self.is_correct = Some(self.predicted_outcome == *actual_outcome);
     }
 
     /// `true` if the prediction has been graded and was correct.
@@ -520,12 +595,11 @@ impl Prediction {
         self.is_correct == Some(true)
     }
 
-    /// Validate that `predicted_winner` encodes a legal outcome (0, 1, or 2).
-    pub fn validate(&self) -> Result<(), &'static str> {
-        if self.predicted_winner > 2 {
-            return Err("predicted_winner must be 0 (Team A), 1 (Team B), or 2 (Draw)");
-        }
-        Ok(())
+    /// Returns `true` if `predicted_at` is strictly before `match_time`.
+    ///
+    /// Used to verify the prediction was placed before the match started.
+    pub fn is_before_match_time(&self, match_time: u64) -> bool {
+        self.predicted_at < match_time
     }
 }
 
@@ -533,22 +607,30 @@ impl Prediction {
 // Winner
 // ---------------------------------------------------------------------------
 
-/// Records a user who correctly predicted every match in an event.
+/// Records a user who correctly predicted matches in an event.
 ///
-/// Stored inside the `Vec<Winner>` at `DataKey::Winners(event_id)`.
+/// Stored inside the `Vec<Winner>` at `DataKey::EventWinners(event_id)`.
+/// Used for leaderboard ranking and reward distribution.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Winner {
     /// Address of the winning predictor
     pub user: Address,
 
-    /// Event they won
+    /// Event they participated in
     pub event_id: u64,
 
-    /// How many matches they predicted correctly (should equal event.match_count)
-    pub total_correct_predictions: u32,
+    /// How many matches they predicted correctly
+    pub total_correct: u32,
 
-    /// Unix timestamp when the win was verified on-chain
+    /// Total number of matches in the event (denominator for accuracy)
+    pub total_matches: u32,
+
+    /// Unix timestamp when the user submitted their last prediction
+    /// (used as tiebreaker — earlier completion ranks higher)
+    pub completion_time: u64,
+
+    /// Unix timestamp when winner status was verified on-chain
     pub verified_at: u64,
 }
 
@@ -557,20 +639,46 @@ impl Winner {
     pub fn new(
         user: Address,
         event_id: u64,
-        total_correct_predictions: u32,
+        total_correct: u32,
+        total_matches: u32,
+        completion_time: u64,
         verified_at: u64,
     ) -> Self {
         Self {
             user,
             event_id,
-            total_correct_predictions,
+            total_correct,
+            total_matches,
+            completion_time,
             verified_at,
         }
+    }
+
+    /// Returns accuracy as an integer percentage in the range [0, 100].
+    ///
+    /// Returns 0 when `total_matches` is 0 to avoid division by zero.
+    pub fn get_accuracy_percentage(&self) -> u32 {
+        if self.total_matches == 0 {
+            return 0;
+        }
+        (self.total_correct * 100) / self.total_matches
+    }
+
+    /// Returns `true` if this winner outranks `other` for leaderboard purposes.
+    ///
+    /// Primary sort: higher `total_correct` wins.
+    /// Tiebreaker: earlier `completion_time` wins (submitted predictions sooner).
+    pub fn outranks(&self, other: &Winner) -> bool {
+        if self.total_correct != other.total_correct {
+            return self.total_correct > other.total_correct;
+        }
+        // Earlier completion time is better (lower value = higher rank)
+        self.completion_time < other.completion_time
     }
 }
 
 // ---------------------------------------------------------------------------
-// EventMetadata  (unchanged — kept for backward compatibility)
+// EventMetadata  (kept for backward compatibility)
 // ---------------------------------------------------------------------------
 
 /// Extended metadata stored separately from the core `Event` to keep the

--- a/contracts/creator-event-manager/tests/storage_types_tests.rs
+++ b/contracts/creator-event-manager/tests/storage_types_tests.rs
@@ -3,6 +3,7 @@
 
 use creator_event_manager::storage_types::{
     Event, EventMetadata, Match, MatchResult, Prediction, Winner,
+    OUTCOME_DRAW, OUTCOME_TEAM_A, OUTCOME_TEAM_B,
 };
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
 
@@ -21,6 +22,18 @@ fn test_match_result_encoding() {
     assert_eq!(MatchResult::from_u32(2), Some(MatchResult::Draw));
     assert_eq!(MatchResult::from_u32(3), None);
     assert_eq!(MatchResult::from_u32(999), None);
+}
+
+#[test]
+fn test_match_result_u8_roundtrip() {
+    assert_eq!(MatchResult::TeamA.to_u8(), 0u8);
+    assert_eq!(MatchResult::TeamB.to_u8(), 1u8);
+    assert_eq!(MatchResult::Draw.to_u8(), 2u8);
+
+    assert_eq!(MatchResult::from_u8(0), Some(MatchResult::TeamA));
+    assert_eq!(MatchResult::from_u8(1), Some(MatchResult::TeamB));
+    assert_eq!(MatchResult::from_u8(2), Some(MatchResult::Draw));
+    assert_eq!(MatchResult::from_u8(3), None);
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +185,29 @@ fn test_event_age_calculation() {
     assert_eq!(event.get_age_seconds(1_640_995_200 - 1000), 0); // saturating_sub
 }
 
+#[test]
+fn test_event_is_valid_title() {
+    let env = Env::default();
+    let short = String::from_str(&env, "Short");
+    assert!(Event::is_valid_title(&short));
+
+    // Build a 201-char string to exceed the limit
+    let long_bytes = [b'x'; 201];
+    let long = String::from_bytes(&env, &long_bytes);
+    assert!(!Event::is_valid_title(&long));
+}
+
+#[test]
+fn test_event_is_valid_description() {
+    let env = Env::default();
+    let short = String::from_str(&env, "Short description");
+    assert!(Event::is_valid_description(&short));
+
+    let long_bytes = [b'y'; 1001];
+    let long = String::from_bytes(&env, &long_bytes);
+    assert!(!Event::is_valid_description(&long));
+}
+
 // ---------------------------------------------------------------------------
 // Match helpers
 // ---------------------------------------------------------------------------
@@ -216,7 +252,6 @@ fn test_match_result_submission() {
     assert!(m.submit_result(MatchResult::TeamA, oracle.clone(), result_time).is_ok());
 
     assert!(m.result_submitted);
-    // winning_team is stored as Option<u32>
     assert_eq!(m.winning_team, Some(0u32));
     assert_eq!(m.submitted_by, Some(oracle.clone()));
     assert_eq!(m.submitted_at, Some(result_time));
@@ -305,37 +340,117 @@ fn test_match_validation_inconsistent_result() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_prediction_creation_and_validation() {
+fn test_prediction_creation() {
     let env = Env::default();
     let predictor = Address::generate(&env);
+    let outcome = Symbol::new(&env, OUTCOME_TEAM_A);
 
-    let pred = Prediction::new(predictor.clone(), 1, 1, 0u32, 1_640_995_200);
+    let pred = Prediction::new(
+        1u64,
+        5u64,
+        10u64,
+        predictor.clone(),
+        outcome.clone(),
+        1_640_995_200u64,
+    );
+
+    assert_eq!(pred.prediction_id, 1);
+    assert_eq!(pred.match_id, 5);
+    assert_eq!(pred.event_id, 10);
     assert_eq!(pred.predictor, predictor);
-    assert_eq!(pred.predicted_winner, 0u32);
+    assert_eq!(pred.predicted_outcome, outcome);
+    assert_eq!(pred.predicted_at, 1_640_995_200);
     assert!(pred.is_correct.is_none());
-    assert!(pred.validate().is_ok());
-
-    // Invalid outcome value
-    let bad = Prediction::new(predictor, 1, 1, 3u32, 1_640_995_200);
-    assert!(bad.validate().is_err());
 }
 
 #[test]
-fn test_prediction_grading() {
+fn test_prediction_validate_outcome_valid() {
+    let env = Env::default();
+
+    let team_a = Symbol::new(&env, OUTCOME_TEAM_A);
+    let team_b = Symbol::new(&env, OUTCOME_TEAM_B);
+    let draw = Symbol::new(&env, OUTCOME_DRAW);
+
+    assert!(Prediction::validate_outcome(&env, &team_a).is_ok());
+    assert!(Prediction::validate_outcome(&env, &team_b).is_ok());
+    assert!(Prediction::validate_outcome(&env, &draw).is_ok());
+}
+
+#[test]
+fn test_prediction_validate_outcome_invalid() {
+    let env = Env::default();
+    let bad = Symbol::new(&env, "INVALID");
+    assert!(Prediction::validate_outcome(&env, &bad).is_err());
+}
+
+#[test]
+fn test_prediction_grading_correct() {
     let env = Env::default();
     let predictor = Address::generate(&env);
+    let outcome = Symbol::new(&env, OUTCOME_TEAM_A);
 
-    // Predicted TeamA (0), actual TeamA → correct
-    let mut pred = Prediction::new(predictor.clone(), 1, 1, 0u32, 1_640_995_200);
-    pred.grade(&MatchResult::TeamA);
+    let mut pred = Prediction::new(1, 5, 10, predictor, outcome.clone(), 1_640_995_200);
+    pred.grade(&outcome);
+
     assert_eq!(pred.is_correct, Some(true));
     assert!(pred.is_winner());
+}
 
-    // Predicted TeamB (1), actual TeamA → wrong
-    let mut pred2 = Prediction::new(predictor, 1, 1, 1u32, 1_640_995_200);
-    pred2.grade(&MatchResult::TeamA);
-    assert_eq!(pred2.is_correct, Some(false));
-    assert!(!pred2.is_winner());
+#[test]
+fn test_prediction_grading_wrong() {
+    let env = Env::default();
+    let predictor = Address::generate(&env);
+    let predicted = Symbol::new(&env, OUTCOME_TEAM_A);
+    let actual = Symbol::new(&env, OUTCOME_TEAM_B);
+
+    let mut pred = Prediction::new(1, 5, 10, predictor, predicted, 1_640_995_200);
+    pred.grade(&actual);
+
+    assert_eq!(pred.is_correct, Some(false));
+    assert!(!pred.is_winner());
+}
+
+#[test]
+fn test_prediction_grading_draw() {
+    let env = Env::default();
+    let predictor = Address::generate(&env);
+    let draw = Symbol::new(&env, OUTCOME_DRAW);
+
+    let mut pred = Prediction::new(1, 5, 10, predictor, draw.clone(), 1_640_995_200);
+    pred.grade(&draw);
+
+    assert_eq!(pred.is_correct, Some(true));
+    assert!(pred.is_winner());
+}
+
+#[test]
+fn test_prediction_is_before_match_time() {
+    let env = Env::default();
+    let predictor = Address::generate(&env);
+    let outcome = Symbol::new(&env, OUTCOME_TEAM_A);
+    let match_time = 1_640_995_200u64;
+
+    // Predicted 1 hour before match
+    let pred_before = Prediction::new(1, 5, 10, predictor.clone(), outcome.clone(), match_time - 3600);
+    assert!(pred_before.is_before_match_time(match_time));
+
+    // Predicted exactly at match time — not before
+    let pred_at = Prediction::new(2, 5, 10, predictor.clone(), outcome.clone(), match_time);
+    assert!(!pred_at.is_before_match_time(match_time));
+
+    // Predicted after match time
+    let pred_after = Prediction::new(3, 5, 10, predictor, outcome, match_time + 1);
+    assert!(!pred_after.is_before_match_time(match_time));
+}
+
+#[test]
+fn test_prediction_ungraded_is_not_winner() {
+    let env = Env::default();
+    let predictor = Address::generate(&env);
+    let outcome = Symbol::new(&env, OUTCOME_TEAM_A);
+
+    let pred = Prediction::new(1, 5, 10, predictor, outcome, 1_640_995_200);
+    assert!(!pred.is_winner()); // None → not a winner
 }
 
 // ---------------------------------------------------------------------------
@@ -347,11 +462,89 @@ fn test_winner_creation() {
     let env = Env::default();
     let user = Address::generate(&env);
 
-    let winner = Winner::new(user.clone(), 42, 5, 1_640_995_200);
+    let winner = Winner::new(user.clone(), 42, 5, 5, 1_640_995_100, 1_640_995_200);
     assert_eq!(winner.user, user);
     assert_eq!(winner.event_id, 42);
-    assert_eq!(winner.total_correct_predictions, 5);
+    assert_eq!(winner.total_correct, 5);
+    assert_eq!(winner.total_matches, 5);
+    assert_eq!(winner.completion_time, 1_640_995_100);
     assert_eq!(winner.verified_at, 1_640_995_200);
+}
+
+#[test]
+fn test_winner_accuracy_percentage_perfect() {
+    let env = Env::default();
+    let user = Address::generate(&env);
+    let winner = Winner::new(user, 1, 5, 5, 0, 0);
+    assert_eq!(winner.get_accuracy_percentage(), 100);
+}
+
+#[test]
+fn test_winner_accuracy_percentage_partial() {
+    let env = Env::default();
+    let user = Address::generate(&env);
+    // 3 correct out of 5 = 60%
+    let winner = Winner::new(user, 1, 3, 5, 0, 0);
+    assert_eq!(winner.get_accuracy_percentage(), 60);
+}
+
+#[test]
+fn test_winner_accuracy_percentage_zero_matches() {
+    let env = Env::default();
+    let user = Address::generate(&env);
+    // total_matches = 0 → should not panic, returns 0
+    let winner = Winner::new(user, 1, 0, 0, 0, 0);
+    assert_eq!(winner.get_accuracy_percentage(), 0);
+}
+
+#[test]
+fn test_winner_accuracy_percentage_zero_correct() {
+    let env = Env::default();
+    let user = Address::generate(&env);
+    let winner = Winner::new(user, 1, 0, 5, 0, 0);
+    assert_eq!(winner.get_accuracy_percentage(), 0);
+}
+
+#[test]
+fn test_winner_outranks_by_correct_count() {
+    let env = Env::default();
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+
+    // w1 has more correct predictions
+    let w1 = Winner::new(u1, 1, 5, 5, 1000, 0);
+    let w2 = Winner::new(u2, 1, 3, 5, 500, 0);
+
+    assert!(w1.outranks(&w2));
+    assert!(!w2.outranks(&w1));
+}
+
+#[test]
+fn test_winner_outranks_tiebreak_by_completion_time() {
+    let env = Env::default();
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+
+    // Same correct count; w1 finished earlier → w1 outranks w2
+    let w1 = Winner::new(u1, 1, 5, 5, 500, 0);  // earlier completion
+    let w2 = Winner::new(u2, 1, 5, 5, 1000, 0); // later completion
+
+    assert!(w1.outranks(&w2));
+    assert!(!w2.outranks(&w1));
+}
+
+#[test]
+fn test_winner_does_not_outrank_equal() {
+    let env = Env::default();
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+
+    // Identical stats — neither outranks the other
+    let w1 = Winner::new(u1, 1, 5, 5, 500, 0);
+    let w2 = Winner::new(u2, 1, 5, 5, 500, 0);
+
+    assert!(!w1.outranks(&w2));
+    assert!(!w2.outranks(&w1));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
What changed
storage_types.rs

Replaced the old Prediction struct with a fully-specified version: prediction_id, match_id, event_id, predictor (Address), predicted_outcome (Symbol — TEAM_A / TEAM_B / DRAW), predicted_at, is_correct

Added validate_outcome() — rejects any Symbol outside the three legal values
Added is_before_match_time(match_time) — guards against late predictions
Added grade() and is_winner() helpers
Replaced the old Winner struct with the leaderboard-ready version: user, event_id, total_correct, total_matches, completion_time, verified_at

Added get_accuracy_percentage() — returns (total_correct * 100) / total_matches, safe against divide-by-zero
Added outranks() — primary sort by total_correct desc, tiebreak by completion_time asc
Expanded DataKey enum with all contract storage keys:

Admin config: Admin, AIAgent, Treasury, CreationFee, Paused, XLMToken
Global counters: EventCounter(u64), MatchCounter(u64), PredictionCounter(u64)
Entity keys: Event(u64), Match(u64), Prediction(u64)
Index/relationship keys: EventMatches(u64), MatchPredictions(u64), UserPredictions(Address, u64), EventParticipants(u64), EventWinners(u64)
Access keys: VerifiedAddresses(Address), InviteCode(Symbol)
storage.rs
 (new file)

get_event / set_event — persistent storage with TTL extension on read
get_match / set_match
get_prediction / set_prediction
next_event_id / next_match_id / next_prediction_id — instance storage counters, start at 1, each independent
Batch list helpers (all extend TTL on read, append-only writes):
get_event_matches / add_event_match
get_match_predictions / add_match_prediction
get_user_predictions / add_user_prediction
get_event_participants / add_event_participant
get_event_winners / add_event_winner
All persistent entries extend TTL by 6_307_200 ledgers (~1 year at 5 s/ledger)
lib.rs
 — added pub mod storage

Testing
Existing storage_types_tests.rs integration tests pass. Storage helper tests require a registered contract context (env.as_contract) and are deferred to a future integration test suite.


closes #781
closes #782
closes #783
closes #784