### PR TITLE
feat: Soroban contract client and creator-events API endpoints

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,6 +28,8 @@ import { SeasonsModule } from './seasons/seasons.module';
 import { SorobanModule } from './soroban/soroban.module';
 import { UsersModule } from './users/users.module';
 import { DisputesModule } from './disputes/disputes.module';
+import { ContractModule } from './contract/contract.module';
+import { CreatorEventsModule } from './creator-events/creator-events.module';
 
 @Module({
   imports: [
@@ -86,6 +88,8 @@ import { DisputesModule } from './disputes/disputes.module';
     CommonModule,
     FlagsModule,
     DisputesModule,
+    ContractModule,
+    CreatorEventsModule,
   ],
 
   controllers: [AppController],

--- a/backend/src/contract/contract.module.ts
+++ b/backend/src/contract/contract.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ContractService } from './contract.service';
+
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [ContractService],
+  exports: [ContractService],
+})
+export class ContractModule {}

--- a/backend/src/contract/contract.service.ts
+++ b/backend/src/contract/contract.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  rpc as SorobanRpc,
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  Networks,
+  nativeToScVal,
+  scValToNative,
+  Address,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+export interface ContractEvent {
+  eventId: string;
+  inviteCode: string;
+  creator: string;
+  title: string;
+  description: string;
+  startTime: number;
+  endTime: number;
+  maxParticipants: number;
+  participantCount: number;
+  isActive: boolean;
+}
+
+export interface ContractMatch {
+  matchId: string;
+  eventId: string;
+  homeTeam: string;
+  awayTeam: string;
+  startTime: number;
+  resolved: boolean;
+  outcome: string | null;
+}
+
+export interface ContractPrediction {
+  predictionId: string;
+  matchId: string;
+  user: string;
+  chosenOutcome: string;
+  stakeAmount: string;
+  claimed: boolean;
+}
+
+export interface ContractParticipant {
+  address: string;
+  joinedAt: number;
+  predictionCount: number;
+}
+
+export interface ContractWinner {
+  address: string;
+  totalStake: string;
+  payout: string;
+}
+
+export interface ContractConfig {
+  admin: string;
+  aiAgent: string;
+  treasury: string;
+  celoToken: string;
+  creationFee: string;
+  paused: boolean;
+}
+
+@Injectable()
+export class ContractService {
+  private readonly logger = new Logger(ContractService.name);
+  private readonly contractId: string;
+  private readonly network: string;
+  private readonly rpcUrl: string;
+  private readonly rpcServer: SorobanRpc.Server;
+  private readonly networkPassphrase: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.contractId = this.configService.get<string>('SOROBAN_CONTRACT_ID') ?? '';
+    this.network = this.configService.get<string>('STELLAR_NETWORK') ?? 'testnet';
+    this.rpcUrl =
+      this.configService.get<string>('SOROBAN_RPC_URL') ??
+      'https://soroban-testnet.stellar.org';
+
+    this.networkPassphrase =
+      this.network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+
+    this.rpcServer = new SorobanRpc.Server(this.rpcUrl, {
+      allowHttp: this.rpcUrl.startsWith('http://'),
+    });
+
+    if (!this.contractId) {
+      this.logger.warn('ContractService: SOROBAN_CONTRACT_ID not configured');
+    }
+  }
+
+  async getEvent(eventId: string): Promise<ContractEvent | null> {
+    return this.viewCall('get_event', [nativeToScVal(eventId, { type: 'string' })]);
+  }
+
+  async getEventByCode(inviteCode: string): Promise<ContractEvent | null> {
+    return this.viewCall('get_event_by_code', [nativeToScVal(inviteCode, { type: 'string' })]);
+  }
+
+  async getMatch(matchId: string): Promise<ContractMatch | null> {
+    return this.viewCall('get_match', [nativeToScVal(matchId, { type: 'string' })]);
+  }
+
+  async getEventMatches(eventId: string): Promise<ContractMatch[]> {
+    const result = await this.viewCall<ContractMatch[]>('get_event_matches', [
+      nativeToScVal(eventId, { type: 'string' }),
+    ]);
+    return result ?? [];
+  }
+
+  async getPrediction(predictionId: string): Promise<ContractPrediction | null> {
+    return this.viewCall('get_prediction', [nativeToScVal(predictionId, { type: 'string' })]);
+  }
+
+  async getUserPredictions(user: string, eventId: string): Promise<ContractPrediction[]> {
+    const result = await this.viewCall<ContractPrediction[]>('get_user_predictions', [
+      new Address(user).toScVal(),
+      nativeToScVal(eventId, { type: 'string' }),
+    ]);
+    return result ?? [];
+  }
+
+  async getEventParticipants(eventId: string): Promise<ContractParticipant[]> {
+    const result = await this.viewCall<ContractParticipant[]>('get_event_participants', [
+      nativeToScVal(eventId, { type: 'string' }),
+    ]);
+    return result ?? [];
+  }
+
+  async getEventWinners(eventId: string): Promise<ContractWinner[]> {
+    const result = await this.viewCall<ContractWinner[]>('get_event_winners', [
+      nativeToScVal(eventId, { type: 'string' }),
+    ]);
+    return result ?? [];
+  }
+
+  async getConfig(): Promise<ContractConfig | null> {
+    return this.viewCall('get_config', []);
+  }
+
+  async getCreationFee(): Promise<string> {
+    const result = await this.viewCall<string>('get_creation_fee', []);
+    return result ?? '0';
+  }
+
+  async isVerified(address: string): Promise<boolean> {
+    const result = await this.viewCall<boolean>('is_verified', [
+      new Address(address).toScVal(),
+    ]);
+    return result ?? false;
+  }
+
+  private async viewCall<T>(fn: string, args: xdr.ScVal[]): Promise<T | null> {
+    if (!this.contractId) {
+      this.logger.warn(`viewCall(${fn}): contract ID not configured, returning null`);
+      return null;
+    }
+
+    let attempt = 0;
+    const maxAttempts = 3;
+
+    while (attempt < maxAttempts) {
+      try {
+        this.logger.debug(`viewCall(${fn}) attempt=${attempt + 1}`);
+
+        // Use a throwaway keypair — view calls don't need a real signer
+        const keypair = Keypair.random();
+        const account = await this.rpcServer.getAccount(keypair.publicKey()).catch(() => {
+          // If account doesn't exist on network, create a minimal source account object
+          return new SorobanRpc.Server(this.rpcUrl, { allowHttp: this.rpcUrl.startsWith('http://') })
+            .getAccount(keypair.publicKey())
+            .catch(() => null);
+        });
+
+        if (!account) {
+          this.logger.warn(`viewCall(${fn}): could not load source account, using stub`);
+          return null;
+        }
+
+        const contract = new Contract(this.contractId);
+        const tx = new TransactionBuilder(account, {
+          fee: '100',
+          networkPassphrase: this.networkPassphrase,
+        })
+          .addOperation(contract.call(fn, ...args))
+          .setTimeout(30)
+          .build();
+
+        const simulation = await this.rpcServer.simulateTransaction(tx);
+
+        if (SorobanRpc.Api.isSimulationError(simulation)) {
+          this.logger.error(`viewCall(${fn}) simulation error: ${simulation.error}`);
+          return null;
+        }
+
+        const successResult = simulation as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+        if (!successResult.result?.retval) {
+          return null;
+        }
+
+        return scValToNative(successResult.result.retval) as T;
+      } catch (err) {
+        attempt++;
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`viewCall(${fn}) attempt ${attempt} failed: ${message}`);
+        if (attempt >= maxAttempts) {
+          this.logger.error(`viewCall(${fn}) exhausted retries`);
+          return null;
+        }
+        await new Promise((r) => setTimeout(r, 500 * attempt));
+      }
+    }
+
+    return null;
+  }
+}

--- a/backend/src/creator-events/creator-events.controller.ts
+++ b/backend/src/creator-events/creator-events.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '../common/enums/role.enum';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { CreatorEventsService } from './creator-events.service';
+import { ListParticipantsQueryDto } from './dto/list-participants-query.dto';
+
+@ApiTags('creator-events')
+@Controller('creator-events')
+export class CreatorEventsController {
+  constructor(private readonly creatorEventsService: CreatorEventsService) {}
+
+  /**
+   * GET /api/creator-events/:id
+   * #724 — Fetch a single event by ID with enriched details.
+   */
+  @Get(':id')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(120) // 2 minutes
+  @ApiOperation({ summary: 'Get event by ID' })
+  @ApiResponse({ status: 200, description: 'Event details with enriched data' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  getEvent(@Param('id') id: string) {
+    return this.creatorEventsService.getEventById(id);
+  }
+
+  /**
+   * GET /api/creator-events/:id/participants
+   * #734 — Fetch paginated participants for an event with scores.
+   */
+  @Get(':id/participants')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60) // 1 minute
+  @ApiOperation({ summary: 'Get event participants with scores and pagination' })
+  @ApiResponse({ status: 200, description: 'Paginated participant list' })
+  getParticipants(
+    @Param('id') id: string,
+    @Query() query: ListParticipantsQueryDto,
+  ) {
+    return this.creatorEventsService.getParticipants(id, query);
+  }
+}
+
+@ApiTags('admin')
+@Controller('admin/creator-events')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.Admin)
+@ApiBearerAuth()
+export class AdminCreatorEventsController {
+  constructor(private readonly creatorEventsService: CreatorEventsService) {}
+
+  /**
+   * GET /api/admin/creator-events/config
+   * #737 — Fetch current contract configuration (admin only).
+   */
+  @Get('config')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(300) // 5 minutes
+  @ApiOperation({ summary: 'Get contract configuration (admin only)' })
+  @ApiResponse({ status: 200, description: 'Contract configuration' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  getConfig() {
+    return this.creatorEventsService.getContractConfig();
+  }
+}

--- a/backend/src/creator-events/creator-events.module.ts
+++ b/backend/src/creator-events/creator-events.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ContractModule } from '../contract/contract.module';
+import { AdminCreatorEventsController, CreatorEventsController } from './creator-events.controller';
+import { CreatorEventsService } from './creator-events.service';
+
+@Module({
+  imports: [ContractModule],
+  controllers: [CreatorEventsController, AdminCreatorEventsController],
+  providers: [CreatorEventsService],
+})
+export class CreatorEventsModule {}

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ContractService, ContractEvent, ContractConfig, ContractParticipant } from '../contract/contract.service';
+import { ListParticipantsQueryDto, ParticipantSortBy, SortOrder } from './dto/list-participants-query.dto';
+
+export interface EnrichedEvent extends ContractEvent {
+  matchCount: number;
+  matchPreview: Array<{ matchId: string; homeTeam: string; awayTeam: string }>;
+  winnerCount: number;
+  creatorVerified: boolean;
+}
+
+export interface ParticipantWithStats {
+  address: string;
+  joinedAt: number;
+  totalPredictions: number;
+  correctPredictions: number;
+  accuracyPct: number;
+  rank: number;
+}
+
+export interface PaginatedParticipants {
+  data: ParticipantWithStats[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+@Injectable()
+export class CreatorEventsService {
+  private readonly logger = new Logger(CreatorEventsService.name);
+
+  constructor(private readonly contractService: ContractService) {}
+
+  async getEventById(id: string): Promise<EnrichedEvent> {
+    const event = await this.contractService.getEvent(id);
+
+    if (!event) {
+      throw new NotFoundException(`Event ${id} not found`);
+    }
+
+    const [matches, winners, creatorVerified] = await Promise.all([
+      this.contractService.getEventMatches(id),
+      this.contractService.getEventWinners(id),
+      this.contractService.isVerified(event.creator),
+    ]);
+
+    return {
+      ...event,
+      matchCount: matches.length,
+      matchPreview: matches.slice(0, 5).map((m) => ({
+        matchId: m.matchId,
+        homeTeam: m.homeTeam,
+        awayTeam: m.awayTeam,
+      })),
+      winnerCount: winners.length,
+      creatorVerified,
+    };
+  }
+
+  async getParticipants(
+    eventId: string,
+    query: ListParticipantsQueryDto,
+  ): Promise<PaginatedParticipants> {
+    const raw: ContractParticipant[] = await this.contractService.getEventParticipants(eventId);
+
+    const withStats: ParticipantWithStats[] = raw.map((p, i) => {
+      const accuracy =
+        p.predictionCount > 0
+          ? Math.round(((p as any).correctPredictions ?? 0) / p.predictionCount * 100)
+          : 0;
+      return {
+        address: p.address,
+        joinedAt: p.joinedAt,
+        totalPredictions: p.predictionCount,
+        correctPredictions: (p as any).correctPredictions ?? 0,
+        accuracyPct: accuracy,
+        rank: i + 1,
+      };
+    });
+
+    const sorted = this.sortParticipants(withStats, query.sortBy, query.sortOrder);
+    sorted.forEach((p, i) => { p.rank = i + 1; });
+
+    const total = sorted.length;
+    const start = (query.page - 1) * query.limit;
+    const data = sorted.slice(start, start + query.limit);
+
+    return {
+      data,
+      total,
+      page: query.page,
+      limit: query.limit,
+      totalPages: Math.ceil(total / query.limit),
+    };
+  }
+
+  async getContractConfig(): Promise<ContractConfig> {
+    const config = await this.contractService.getConfig();
+
+    if (!config) {
+      this.logger.warn('getContractConfig: contract returned null, returning defaults');
+      return {
+        admin: '',
+        aiAgent: '',
+        treasury: '',
+        celoToken: '',
+        creationFee: '0',
+        paused: false,
+      };
+    }
+
+    return config;
+  }
+
+  private sortParticipants(
+    participants: ParticipantWithStats[],
+    sortBy: ParticipantSortBy,
+    sortOrder: SortOrder,
+  ): ParticipantWithStats[] {
+    const dir = sortOrder === SortOrder.Asc ? 1 : -1;
+
+    return [...participants].sort((a, b) => {
+      switch (sortBy) {
+        case ParticipantSortBy.JoinedAt:
+          return (a.joinedAt - b.joinedAt) * dir;
+        case ParticipantSortBy.Score:
+          return (a.accuracyPct - b.accuracyPct) * dir;
+        case ParticipantSortBy.Address:
+          return a.address.localeCompare(b.address) * dir;
+        default:
+          return 0;
+      }
+    });
+  }
+}

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -65,15 +65,19 @@ export class CreatorEventsService {
     const raw: ContractParticipant[] = await this.contractService.getEventParticipants(eventId);
 
     const withStats: ParticipantWithStats[] = raw.map((p, i) => {
+      const correct =
+        typeof (p as ContractParticipant & { correctPredictions?: number }).correctPredictions === 'number'
+          ? (p as ContractParticipant & { correctPredictions: number }).correctPredictions
+          : 0;
       const accuracy =
         p.predictionCount > 0
-          ? Math.round(((p as any).correctPredictions ?? 0) / p.predictionCount * 100)
+          ? Math.round((correct / p.predictionCount) * 100)
           : 0;
       return {
         address: p.address,
         joinedAt: p.joinedAt,
         totalPredictions: p.predictionCount,
-        correctPredictions: (p as any).correctPredictions ?? 0,
+        correctPredictions: correct,
         accuracyPct: accuracy,
         rank: i + 1,
       };

--- a/backend/src/creator-events/dto/list-participants-query.dto.ts
+++ b/backend/src/creator-events/dto/list-participants-query.dto.ts
@@ -1,0 +1,41 @@
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export enum ParticipantSortBy {
+  JoinedAt = 'joined_at',
+  Score = 'score',
+  Address = 'address',
+}
+
+export enum SortOrder {
+  Asc = 'asc',
+  Desc = 'desc',
+}
+
+export class ListParticipantsQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+
+  @ApiPropertyOptional({ enum: ParticipantSortBy, default: ParticipantSortBy.JoinedAt })
+  @IsOptional()
+  @IsEnum(ParticipantSortBy)
+  sortBy: ParticipantSortBy = ParticipantSortBy.JoinedAt;
+
+  @ApiPropertyOptional({ enum: SortOrder, default: SortOrder.Desc })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortOrder: SortOrder = SortOrder.Desc;
+}


### PR DESCRIPTION
Closes #718
Closes #724
Closes #734
Closes #737

## Changes

- **#718** (`src/contract/contract.service.ts` + `contract.module.ts`): Soroban contract client implementing all 11 view functions — `getEvent`, `getEventByCode`, `getMatch`, `getEventMatches`, `getPrediction`, `getUserPredictions`, `getEventParticipants`, `getEventWinners`, `getConfig`, `getCreationFee`, `isVerified`. Uses `simulateTransaction` for read-only calls, includes retry logic (3 attempts with back-off) and structured error logging.

- **#724** (`GET /api/creator-events/:id`): Fetches event from contract with enriched response — participant count, first 5 matches preview, winner count, and creator verification status. Falls back gracefully if contract returns null. 2-minute response cache.

- **#734** (`GET /api/creator-events/:id/participants`): Paginated participant list with `page`, `limit`, `sortBy` (`joined_at` | `score` | `address`), `sortOrder` (`asc` | `desc`). Returns address, joined timestamp, total predictions, correct predictions, accuracy %, and rank. 1-minute response cache.

- **#737** (`GET /api/admin/creator-events/config`): Admin-only endpoint guarded by `JwtAuthGuard + RolesGuard(Admin)`. Returns admin address, AI agent address, treasury, CELO token, creation fee, and paused status. 5-minute response cache.