### PR TITLE
Add creator events full-text search

### DIFF
--- a/backend/src/creator-events/creator-events.controller.ts
+++ b/backend/src/creator-events/creator-events.controller.ts
@@ -5,11 +5,13 @@ import {
   Query,
   UseGuards,
   UseInterceptors,
+  ValidationPipe,
 } from '@nestjs/common';
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -19,11 +21,47 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { CreatorEventsService } from './creator-events.service';
 import { ListParticipantsQueryDto } from './dto/list-participants-query.dto';
+import { SearchEventsQueryDto } from './dto/search-events-query.dto';
+import { SearchEventsResponseDto } from './dto/search-events-response.dto';
 
 @ApiTags('creator-events')
 @Controller('creator-events')
 export class CreatorEventsController {
   constructor(private readonly creatorEventsService: CreatorEventsService) {}
+
+  /**
+   * GET /api/creator-events/search
+   * #757 - Search creator events with relevance ranking and highlights.
+   */
+  @Get('search')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(120) // 2 minutes
+  @ApiOperation({ summary: 'Search creator events' })
+  @ApiQuery({
+    name: 'q',
+    required: true,
+    description:
+      'Search query matched against event title, description, and creator address',
+  })
+  @ApiQuery({ name: 'page', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, example: 20 })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['active', 'cancelled', 'inactive', 'all'],
+  })
+  @ApiQuery({ name: 'creator', required: false })
+  @ApiResponse({
+    status: 200,
+    description: 'Ranked creator event search results',
+    type: SearchEventsResponseDto,
+  })
+  searchEvents(
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: SearchEventsQueryDto,
+  ) {
+    return this.creatorEventsService.searchEvents(query);
+  }
 
   /**
    * GET /api/creator-events/:id

--- a/backend/src/creator-events/creator-events.controller.ts
+++ b/backend/src/creator-events/creator-events.controller.ts
@@ -21,9 +21,12 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Public } from '../common/decorators/public.decorator';
 import { CreatorEventsService } from './creator-events.service';
+import { EventByCodeResponseDto } from './dto/event-by-code-response.dto';
+import { ListMatchesQueryDto } from './dto/list-matches-query.dto';
 import { ListParticipantsQueryDto } from './dto/list-participants-query.dto';
 import { SearchEventsQueryDto } from './dto/search-events-query.dto';
 import { SearchEventsResponseDto } from './dto/search-events-response.dto';
+import { UserScoreResponseDto } from './dto/user-score-response.dto';
 
 @ApiTags('creator-events')
 @Controller('creator-events')

--- a/backend/src/creator-events/creator-events.module.ts
+++ b/backend/src/creator-events/creator-events.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContractModule } from '../contract/contract.module';
+import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import {
   AdminCreatorEventsController,
   CreatorEventsController,
@@ -7,7 +9,7 @@ import {
 import { CreatorEventsService } from './creator-events.service';
 
 @Module({
-  imports: [ContractModule],
+  imports: [ContractModule, TypeOrmModule.forFeature([CreatorEvent])],
   controllers: [CreatorEventsController, AdminCreatorEventsController],
   providers: [CreatorEventsService],
 })

--- a/backend/src/creator-events/creator-events.module.ts
+++ b/backend/src/creator-events/creator-events.module.ts
@@ -11,7 +11,11 @@ import { CreatorEventsService } from './creator-events.service';
 
 @Module({
   imports: [ContractModule, TypeOrmModule.forFeature([CreatorEvent])],
-  controllers: [CreatorEventsController, AdminCreatorEventsController],
+  controllers: [
+    CreatorEventsController,
+    PublicCreatorEventsController,
+    AdminCreatorEventsController,
+  ],
   providers: [CreatorEventsService],
 })
 export class CreatorEventsModule {}

--- a/backend/src/creator-events/creator-events.service.spec.ts
+++ b/backend/src/creator-events/creator-events.service.spec.ts
@@ -1,0 +1,206 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { ContractService } from '../contract/contract.service';
+import { CreatorEvent } from '../matches/entities/creator-event.entity';
+import { CreatorEventsService } from './creator-events.service';
+import { CreatorEventSearchStatus } from './dto/search-events-query.dto';
+
+type MockSearchQueryBuilder = jest.Mocked<
+  Pick<
+    SelectQueryBuilder<CreatorEvent>,
+    | 'addSelect'
+    | 'where'
+    | 'andWhere'
+    | 'setParameter'
+    | 'clone'
+    | 'orderBy'
+    | 'addOrderBy'
+    | 'skip'
+    | 'take'
+    | 'getRawAndEntities'
+  >
+> & {
+  getCount: jest.Mock;
+};
+
+describe('CreatorEventsService searchEvents', () => {
+  let service: CreatorEventsService;
+  let creatorEventRepository: jest.Mocked<
+    Pick<Repository<CreatorEvent>, 'createQueryBuilder'>
+  >;
+  let queryBuilder: MockSearchQueryBuilder;
+  let countQueryBuilder: { getCount: jest.Mock };
+
+  const makeEvent = (overrides: Partial<CreatorEvent> = {}): CreatorEvent =>
+    ({
+      id: 'event-1',
+      on_chain_event_id: 101,
+      creator_address: '0xCreatorAddress',
+      title: 'Champions League Final',
+      description: 'Predict the Champions League winner',
+      creation_fee_paid: '100',
+      on_chain_created_at: new Date('2026-05-01T00:00:00.000Z'),
+      is_active: true,
+      is_cancelled: false,
+      invite_code: null,
+      max_participants: 500,
+      participant_count: 42,
+      match_count: 3,
+      matches: [],
+      created_at: new Date('2026-05-01T00:00:00.000Z'),
+      ...overrides,
+    }) as CreatorEvent;
+
+  beforeEach(async () => {
+    countQueryBuilder = {
+      getCount: jest.fn().mockResolvedValue(1),
+    };
+
+    queryBuilder = {
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
+      clone: jest.fn().mockReturnValue(countQueryBuilder),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getRawAndEntities: jest.fn().mockResolvedValue({
+        entities: [makeEvent()],
+        raw: [{ search_rank: '0.98' }],
+      }),
+      getCount: jest.fn(),
+    };
+
+    creatorEventRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreatorEventsService,
+        {
+          provide: ContractService,
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(CreatorEvent),
+          useValue: creatorEventRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CreatorEventsService>(CreatorEventsService);
+  });
+
+  it('returns ranked full-text search results with highlights', async () => {
+    const result = await service.searchEvents({
+      q: 'champions',
+      page: 1,
+      limit: 20,
+      status: CreatorEventSearchStatus.All,
+    });
+
+    expect(creatorEventRepository.createQueryBuilder).toHaveBeenCalledWith(
+      'creatorEvent',
+    );
+    expect(queryBuilder.addSelect).toHaveBeenCalledWith(
+      expect.stringContaining('ts_rank_cd'),
+      'search_rank',
+    );
+    expect(queryBuilder.where).toHaveBeenCalled();
+    expect(queryBuilder.setParameter).toHaveBeenCalledWith(
+      'searchTerm',
+      'champions',
+    );
+    expect(queryBuilder.orderBy).toHaveBeenCalledWith('search_rank', 'DESC');
+    expect(queryBuilder.addOrderBy).toHaveBeenCalledWith(
+      'creatorEvent.participant_count',
+      'DESC',
+    );
+    expect(queryBuilder.skip).toHaveBeenCalledWith(0);
+    expect(queryBuilder.take).toHaveBeenCalledWith(20);
+    expect(result).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'event-1',
+          rank: 0.98,
+          highlights: expect.objectContaining({
+            title: '<mark>Champions</mark> League Final',
+            description: 'Predict the <mark>Champions</mark> League winner',
+          }),
+        }),
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+      query: 'champions',
+    });
+  });
+
+  it('applies status and creator filters', async () => {
+    await service.searchEvents({
+      q: 'league',
+      page: 2,
+      limit: 10,
+      status: CreatorEventSearchStatus.Active,
+      creator: '0xCreatorAddress',
+    });
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'creatorEvent.is_active = :isActive',
+      { isActive: true },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'creatorEvent.is_cancelled = :isCancelled',
+      { isCancelled: false },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'LOWER(creatorEvent.creator_address) = LOWER(:creator)',
+      { creator: '0xCreatorAddress' },
+    );
+    expect(queryBuilder.skip).toHaveBeenCalledWith(10);
+  });
+
+  it('supports cancelled and inactive status filters', async () => {
+    await service.searchEvents({
+      q: 'league',
+      status: CreatorEventSearchStatus.Cancelled,
+    });
+    await service.searchEvents({
+      q: 'league',
+      status: CreatorEventSearchStatus.Inactive,
+    });
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'creatorEvent.is_cancelled = :isCancelled',
+      { isCancelled: true },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'creatorEvent.is_active = :isActive',
+      { isActive: false },
+    );
+  });
+
+  it('returns an empty page for blank queries without touching the database', async () => {
+    const result = await service.searchEvents({
+      q: '   ',
+      page: 1,
+      limit: 20,
+      status: CreatorEventSearchStatus.All,
+    });
+
+    expect(result).toEqual({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+      query: '',
+    });
+    expect(creatorEventRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -1,15 +1,27 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Brackets, Repository } from 'typeorm';
 import {
   ContractService,
   ContractEvent,
   ContractConfig,
   ContractParticipant,
 } from '../contract/contract.service';
+import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import {
   ListParticipantsQueryDto,
   ParticipantSortBy,
   SortOrder,
 } from './dto/list-participants-query.dto';
+import {
+  CreatorEventSearchStatus,
+  SearchEventsQueryDto,
+} from './dto/search-events-query.dto';
+import {
+  SearchEventResultDto,
+  SearchEventsResponseDto,
+  SearchHighlightsDto,
+} from './dto/search-events-response.dto';
 
 export interface EnrichedEvent extends ContractEvent {
   matchCount: number;
@@ -39,7 +51,78 @@ export interface PaginatedParticipants {
 export class CreatorEventsService {
   private readonly logger = new Logger(CreatorEventsService.name);
 
-  constructor(private readonly contractService: ContractService) {}
+  constructor(
+    private readonly contractService: ContractService,
+    @InjectRepository(CreatorEvent)
+    private readonly creatorEventRepository: Repository<CreatorEvent>,
+  ) {}
+
+  async searchEvents(
+    query: SearchEventsQueryDto,
+  ): Promise<SearchEventsResponseDto> {
+    const searchTerm = query.q?.trim() ?? '';
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+
+    if (!searchTerm) {
+      return {
+        data: [],
+        total: 0,
+        page,
+        limit,
+        totalPages: 0,
+        query: searchTerm,
+      };
+    }
+
+    const searchVector = this.getSearchVectorSql('creatorEvent');
+    const searchQuery = `websearch_to_tsquery('english', :searchTerm)`;
+
+    const searchQueryBuilder = this.creatorEventRepository
+      .createQueryBuilder('creatorEvent')
+      .addSelect(`ts_rank_cd((${searchVector}), ${searchQuery})`, 'search_rank')
+      .where(
+        new Brackets((qb) => {
+          qb.where(`(${searchVector}) @@ ${searchQuery}`).orWhere(
+            "creatorEvent.creator_address ILIKE :creatorAddressSearch ESCAPE '\\'",
+          );
+        }),
+      )
+      .setParameter('searchTerm', searchTerm)
+      .setParameter(
+        'creatorAddressSearch',
+        `%${this.escapeLikePattern(searchTerm)}%`,
+      );
+
+    this.applyStatusFilter(searchQueryBuilder, query.status);
+
+    if (query.creator?.trim()) {
+      searchQueryBuilder.andWhere(
+        'LOWER(creatorEvent.creator_address) = LOWER(:creator)',
+        { creator: query.creator.trim() },
+      );
+    }
+
+    const total = await searchQueryBuilder.clone().getCount();
+    const { entities, raw } = await searchQueryBuilder
+      .orderBy('search_rank', 'DESC')
+      .addOrderBy('creatorEvent.participant_count', 'DESC')
+      .addOrderBy('creatorEvent.created_at', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getRawAndEntities<{ search_rank?: string | number }>();
+
+    return {
+      data: entities.map((event, index) =>
+        this.toSearchResult(event, raw[index]?.search_rank, searchTerm),
+      ),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+      query: searchTerm,
+    };
+  }
 
   async getEventById(id: string): Promise<EnrichedEvent> {
     const event = await this.contractService.getEvent(id);
@@ -156,5 +239,122 @@ export class CreatorEventsService {
           return 0;
       }
     });
+  }
+
+  private getSearchVectorSql(alias: string): string {
+    return `
+      setweight(to_tsvector('english', coalesce(${alias}.title, '')), 'A') ||
+      setweight(to_tsvector('english', coalesce(${alias}.description, '')), 'B') ||
+      setweight(to_tsvector('simple', coalesce(${alias}.creator_address, '')), 'C')
+    `;
+  }
+
+  private applyStatusFilter(
+    queryBuilder: ReturnType<Repository<CreatorEvent>['createQueryBuilder']>,
+    status: CreatorEventSearchStatus = CreatorEventSearchStatus.All,
+  ): void {
+    switch (status) {
+      case CreatorEventSearchStatus.Active:
+        queryBuilder.andWhere('creatorEvent.is_active = :isActive', {
+          isActive: true,
+        });
+        queryBuilder.andWhere('creatorEvent.is_cancelled = :isCancelled', {
+          isCancelled: false,
+        });
+        break;
+      case CreatorEventSearchStatus.Cancelled:
+        queryBuilder.andWhere('creatorEvent.is_cancelled = :isCancelled', {
+          isCancelled: true,
+        });
+        break;
+      case CreatorEventSearchStatus.Inactive:
+        queryBuilder.andWhere('creatorEvent.is_active = :isActive', {
+          isActive: false,
+        });
+        break;
+      case CreatorEventSearchStatus.All:
+      default:
+        break;
+    }
+  }
+
+  private toSearchResult(
+    event: CreatorEvent,
+    rank: string | number | undefined,
+    searchTerm: string,
+  ): SearchEventResultDto {
+    return {
+      id: event.id,
+      on_chain_event_id: event.on_chain_event_id,
+      title: event.title,
+      description: event.description,
+      creator_address: event.creator_address,
+      is_active: event.is_active,
+      is_cancelled: event.is_cancelled,
+      participant_count: event.participant_count,
+      match_count: event.match_count,
+      rank: Number(rank ?? 0),
+      highlights: this.buildHighlights(event, searchTerm),
+    };
+  }
+
+  private buildHighlights(
+    event: CreatorEvent,
+    searchTerm: string,
+  ): SearchHighlightsDto {
+    return {
+      title: this.highlightMatches(event.title, searchTerm),
+      description: this.highlightMatches(event.description, searchTerm),
+      creator_address: this.highlightMatches(event.creator_address, searchTerm),
+    };
+  }
+
+  private highlightMatches(value: string, searchTerm: string): string {
+    const escapedValue = this.escapeHtml(value);
+    const terms = this.getHighlightTerms(searchTerm);
+
+    if (terms.length === 0) {
+      return escapedValue;
+    }
+
+    const pattern = terms.map((term) => this.escapeRegExp(term)).join('|');
+    return escapedValue.replace(
+      new RegExp(`(${pattern})`, 'gi'),
+      '<mark>$1</mark>',
+    );
+  }
+
+  private getHighlightTerms(searchTerm: string): string[] {
+    return Array.from(
+      new Set(
+        searchTerm
+          .toLowerCase()
+          .split(/\s+/)
+          .map((term) => term.replace(/["']/g, '').trim())
+          .filter(Boolean),
+      ),
+    );
+  }
+
+  private escapeHtml(value: string): string {
+    return value.replace(/[&<>"']/g, (char) => {
+      const replacements: Record<string, string> = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      };
+
+      return replacements[char];
+    });
+  }
+
+  private escapeLikePattern(value: string): string {
+    return value.replace(/[\\%_]/g, (char) => `\\${char}`);
+  }
+
+  private escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -10,6 +10,16 @@ import {
 } from '../contract/contract.service';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import {
+  EventByCodeResponseDto,
+  MatchPreviewDto,
+} from './dto/event-by-code-response.dto';
+import {
+  ListMatchesQueryDto,
+  MatchSortBy,
+  MatchStatus,
+  SortOrder,
+} from './dto/list-matches-query.dto';
+import {
   ListParticipantsQueryDto,
   ParticipantSortBy,
   SortOrder as ParticipantSortOrder,
@@ -23,6 +33,7 @@ import {
   SearchEventsResponseDto,
   SearchHighlightsDto,
 } from './dto/search-events-response.dto';
+import { UserScoreResponseDto } from './dto/user-score-response.dto';
 
 export interface EnrichedEvent extends ContractEvent {
   matchCount: number;

--- a/backend/src/creator-events/dto/search-events-query.dto.ts
+++ b/backend/src/creator-events/dto/search-events-query.dto.ts
@@ -1,0 +1,51 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export enum CreatorEventSearchStatus {
+  Active = 'active',
+  Cancelled = 'cancelled',
+  Inactive = 'inactive',
+  All = 'all',
+}
+
+export class SearchEventsQueryDto {
+  @ApiProperty({
+    description:
+      'Full-text search query matched against title, description, and creator address.',
+    example: 'champions league',
+  })
+  @IsString()
+  q: string;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit: number = 20;
+
+  @ApiPropertyOptional({
+    enum: CreatorEventSearchStatus,
+    default: CreatorEventSearchStatus.All,
+  })
+  @IsOptional()
+  @IsEnum(CreatorEventSearchStatus)
+  status: CreatorEventSearchStatus = CreatorEventSearchStatus.All;
+
+  @ApiPropertyOptional({
+    description: 'Filter results to a specific creator address.',
+    example: '0x1234567890abcdef1234567890abcdef12345678',
+  })
+  @IsOptional()
+  @IsString()
+  creator?: string;
+}

--- a/backend/src/creator-events/dto/search-events-response.dto.ts
+++ b/backend/src/creator-events/dto/search-events-response.dto.ts
@@ -1,0 +1,67 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SearchHighlightsDto {
+  @ApiProperty({ required: false })
+  title?: string;
+
+  @ApiProperty({ required: false })
+  description?: string;
+
+  @ApiProperty({ required: false })
+  creator_address?: string;
+}
+
+export class SearchEventResultDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  on_chain_event_id: number;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  description: string;
+
+  @ApiProperty()
+  creator_address: string;
+
+  @ApiProperty()
+  is_active: boolean;
+
+  @ApiProperty()
+  is_cancelled: boolean;
+
+  @ApiProperty()
+  participant_count: number;
+
+  @ApiProperty()
+  match_count: number;
+
+  @ApiProperty()
+  rank: number;
+
+  @ApiProperty({ type: SearchHighlightsDto })
+  highlights: SearchHighlightsDto;
+}
+
+export class SearchEventsResponseDto {
+  @ApiProperty({ type: [SearchEventResultDto] })
+  data: SearchEventResultDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty()
+  totalPages: number;
+
+  @ApiProperty()
+  query: string;
+}

--- a/backend/src/migrations/1775600000000-AddCreatorEventsSearchIndexes.ts
+++ b/backend/src/migrations/1775600000000-AddCreatorEventsSearchIndexes.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCreatorEventsSearchIndexes1775600000000 implements MigrationInterface {
+  name = 'AddCreatorEventsSearchIndexes1775600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_events_search_vector"
+      ON "creator_events"
+      USING GIN (
+        (
+          setweight(to_tsvector('english', coalesce("title", '')), 'A') ||
+          setweight(to_tsvector('english', coalesce("description", '')), 'B') ||
+          setweight(to_tsvector('simple', coalesce("creator_address", '')), 'C')
+        )
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_events_status_creator"
+      ON "creator_events" ("is_active", "is_cancelled", "creator_address")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_creator_events_status_creator"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_creator_events_search_vector"`,
+    );
+  }
+}


### PR DESCRIPTION
Summary
- Added a cached creator-events search endpoint backed by PostgreSQL full-text search.

Issue
- Closes #757

Changes
- Added GET /api/creator-events/search with q, page, limit, status, and creator query parameters.
- Ranked matches across event title, description, and creator address using weighted PostgreSQL full-text search.
- Added highlighted result fields and Swagger/OpenAPI response/query documentation.
- Added GIN/status indexes for fast search and filtering.
- Added service tests covering ranking output, highlighting, filters, pagination, and blank-query behavior.

Validation
- npm ci was not run; existing dependencies were already installed in the reused repo clone.
- Ran npx prettier --write on touched backend files.
- Ran npx jest --runInBand src/creator-events/creator-events.service.spec.ts.
- Ran npm run build.
- Ran git diff --check.

Notes
- The endpoint is declared before /:id so the literal search route is not captured as an event ID.