### PR TITLE
Add reusable filtering service

### DIFF
--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { FilteringService } from './filtering.service';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { PassportModule } from '@nestjs/passport';
       }),
     }),
   ],
-  exports: [JwtModule],
+  providers: [FilteringService],
+  exports: [JwtModule, FilteringService],
 })
 export class CommonModule {}

--- a/backend/src/common/filtering.service.spec.ts
+++ b/backend/src/common/filtering.service.spec.ts
@@ -1,0 +1,293 @@
+import { BadRequestException } from '@nestjs/common';
+import { Brackets, ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+import {
+  creatorEventFilterConfig,
+  FilterCombination,
+  FilteringService,
+  matchFilterConfig,
+  predictionFilterConfig,
+} from './filtering.service';
+
+describe('FilteringService', () => {
+  let service: FilteringService;
+
+  beforeEach(() => {
+    service = new FilteringService();
+  });
+
+  it('builds date, status, numeric, address, boolean, and sort filters', () => {
+    const plan = service.buildFilterPlan(creatorEventFilterConfig, {
+      dateRanges: {
+        created_at: {
+          from: '2026-01-01T00:00:00.000Z',
+          to: '2026-01-31T23:59:59.000Z',
+        },
+      },
+      statuses: 'active',
+      numericRanges: {
+        participant_count: {
+          min: '10',
+          max: 50,
+        },
+      },
+      addresses: {
+        creator: '0xABCDEF',
+      },
+      booleans: {
+        is_active: 'true',
+      },
+      sort: {
+        field: 'created_at',
+        direction: 'ASC',
+      },
+    });
+
+    expect(plan.combination).toBe(FilterCombination.And);
+    expect(plan.sort).toEqual({
+      column: 'creatorEvent.created_at',
+      direction: 'ASC',
+    });
+    expect(plan.clauses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sql: 'creatorEvent.created_at >= :filter_0',
+        }),
+        expect.objectContaining({
+          sql: 'creatorEvent.created_at <= :filter_1',
+        }),
+        expect.objectContaining({
+          sql: 'creatorEvent.participant_count >= :filter_4',
+        }),
+        expect.objectContaining({
+          sql: 'creatorEvent.participant_count <= :filter_5',
+        }),
+        expect.objectContaining({
+          sql: 'LOWER(creatorEvent.creator_address) IN (:...filter_6)',
+          parameters: { filter_6: ['0xabcdef'] },
+        }),
+        expect.objectContaining({
+          sql: 'creatorEvent.is_active = :filter_7',
+          parameters: { filter_7: true },
+        }),
+      ]),
+    );
+    expect(plan.clauses[2]).toEqual({
+      sql: '((creatorEvent.is_active = :filter_2 AND creatorEvent.is_cancelled = :filter_3))',
+      parameters: {
+        filter_2: true,
+        filter_3: false,
+      },
+    });
+  });
+
+  it('supports OR combinations and multiple statuses', () => {
+    const plan = service.buildFilterPlan(creatorEventFilterConfig, {
+      statuses: ['active', 'cancelled'],
+      booleans: {
+        is_active: false,
+      },
+      combination: FilterCombination.Or,
+    });
+
+    expect(plan.combination).toBe(FilterCombination.Or);
+    expect(plan.clauses[0].sql).toBe(
+      '((creatorEvent.is_active = :filter_0 AND creatorEvent.is_cancelled = :filter_1) OR (creatorEvent.is_cancelled = :filter_2))',
+    );
+    expect(plan.clauses[1]).toEqual({
+      sql: 'creatorEvent.is_active = :filter_3',
+      parameters: { filter_3: false },
+    });
+  });
+
+  it('builds match filters for match time, completion status, and submitter', () => {
+    const plan = service.buildFilterPlan(matchFilterConfig, {
+      dateRanges: {
+        match_time: {
+          from: '2026-05-01T00:00:00.000Z',
+        },
+      },
+      statuses: 'completed',
+      addresses: {
+        submitted_by: 'GCREATOR',
+      },
+      booleans: {
+        result_submitted: true,
+      },
+      sort: {
+        field: 'match_time',
+      },
+    });
+
+    expect(plan.sort).toEqual({
+      column: 'match.match_time',
+      direction: 'DESC',
+    });
+    expect(plan.clauses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sql: 'match.match_time >= :filter_0' }),
+        {
+          sql: '((match.result_submitted = :filter_1))',
+          parameters: { filter_1: true },
+        },
+        {
+          sql: 'LOWER(match.submitted_by) IN (:...filter_2)',
+          parameters: { filter_2: ['gcreator'] },
+        },
+        {
+          sql: 'match.result_submitted = :filter_3',
+          parameters: { filter_3: true },
+        },
+      ]),
+    );
+  });
+
+  it('builds prediction filters for participant, amount, submitted date, and payout status', () => {
+    const plan = service.buildFilterPlan(predictionFilterConfig, {
+      dateRanges: {
+        submitted_at: {
+          to: '2026-06-01T00:00:00.000Z',
+        },
+      },
+      statuses: 'active',
+      numericRanges: {
+        stake_amount_stroops: {
+          min: 100,
+        },
+      },
+      addresses: {
+        participant: ['GONE', 'GTWO'],
+      },
+      booleans: {
+        payout_claimed: 'false',
+      },
+    });
+
+    expect(plan.clauses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sql: 'prediction.submitted_at <= :filter_0',
+        }),
+        {
+          sql: '((prediction.payout_claimed = :filter_1))',
+          parameters: { filter_1: false },
+        },
+        {
+          sql: 'prediction.stake_amount_stroops >= :filter_2',
+          parameters: { filter_2: 100 },
+        },
+        {
+          sql: 'LOWER(user.stellar_address) IN (:...filter_3)',
+          parameters: { filter_3: ['gone', 'gtwo'] },
+        },
+        {
+          sql: 'prediction.payout_claimed = :filter_4',
+          parameters: { filter_4: false },
+        },
+      ]),
+    );
+  });
+
+  it('applies filter brackets and sorting to a TypeORM query builder', () => {
+    const queryBuilder = {
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+    } as unknown as SelectQueryBuilder<ObjectLiteral>;
+
+    const result = service.applyFilters(
+      queryBuilder,
+      creatorEventFilterConfig,
+      {
+        booleans: {
+          is_cancelled: false,
+        },
+        sort: {
+          field: 'participant_count',
+          direction: 'DESC',
+        },
+      },
+    );
+
+    expect(result).toBe(queryBuilder);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+    expect(queryBuilder.orderBy).toHaveBeenCalledWith(
+      'creatorEvent.participant_count',
+      'DESC',
+    );
+  });
+
+  it('rejects invalid filter values', () => {
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        dateRanges: {
+          created_at: {
+            from: 'bad-date',
+          },
+        },
+      }),
+    ).toThrow(BadRequestException);
+
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        numericRanges: {
+          participant_count: {
+            min: 'many',
+          },
+        },
+      }),
+    ).toThrow(BadRequestException);
+
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        statuses: 'archived',
+      }),
+    ).toThrow(BadRequestException);
+
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        booleans: {
+          is_active: 'yes',
+        },
+      }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects invalid ranges, unsupported fields, and unsupported sorting', () => {
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        dateRanges: {
+          created_at: {
+            from: '2026-02-01T00:00:00.000Z',
+            to: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }),
+    ).toThrow(BadRequestException);
+
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        numericRanges: {
+          participant_count: {
+            min: 100,
+            max: 50,
+          },
+        },
+      }),
+    ).toThrow(BadRequestException);
+
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        addresses: {
+          participant: 'GABC',
+        },
+      }),
+    ).toThrow(BadRequestException);
+
+    expect(() =>
+      service.buildFilterPlan(creatorEventFilterConfig, {
+        sort: {
+          field: 'creator',
+        },
+      }),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/backend/src/common/filtering.service.ts
+++ b/backend/src/common/filtering.service.ts
@@ -1,0 +1,467 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Brackets, ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+
+export enum FilterCombination {
+  And = 'AND',
+  Or = 'OR',
+}
+
+export enum FilterFieldType {
+  Address = 'address',
+  Boolean = 'boolean',
+  Date = 'date',
+  Number = 'number',
+}
+
+export type SortDirection = 'ASC' | 'DESC';
+
+export interface DateRangeFilter {
+  from?: Date | string;
+  to?: Date | string;
+}
+
+export interface NumericRangeFilter {
+  min?: number | string;
+  max?: number | string;
+}
+
+export interface FilterFieldConfig {
+  column: string;
+  type: FilterFieldType;
+  sortable?: boolean;
+}
+
+export interface StatusFilterCondition {
+  field: string;
+  value: boolean | number | string | null;
+  operator?: '=' | '!=' | 'IS' | 'IS NOT';
+}
+
+export interface EntityFilterConfig {
+  fields: Record<string, FilterFieldConfig>;
+  statuses?: Record<string, StatusFilterCondition[]>;
+}
+
+export interface FilteringRequest {
+  dateRanges?: Record<string, DateRangeFilter>;
+  statuses?: string | string[];
+  numericRanges?: Record<string, NumericRangeFilter>;
+  addresses?: Record<string, string | string[]>;
+  booleans?: Record<string, boolean | string>;
+  combination?: FilterCombination;
+  sort?: {
+    field: string;
+    direction?: string;
+  };
+}
+
+export interface FilterClause {
+  sql: string;
+  parameters: Record<
+    string,
+    boolean | Date | number | string | string[] | null
+  >;
+}
+
+export interface FilterPlan {
+  clauses: FilterClause[];
+  combination: FilterCombination;
+  sort?: {
+    column: string;
+    direction: SortDirection;
+  };
+}
+
+const PARAM_PREFIX = 'filter';
+
+@Injectable()
+export class FilteringService {
+  buildFilterPlan(
+    config: EntityFilterConfig,
+    request: FilteringRequest,
+  ): FilterPlan {
+    const clauses: FilterClause[] = [];
+    const combination = request.combination ?? FilterCombination.And;
+    let parameterIndex = 0;
+
+    this.assertCombination(combination);
+
+    for (const [field, range] of Object.entries(request.dateRanges ?? {})) {
+      const fieldConfig = this.getField(config, field, FilterFieldType.Date);
+      const from = this.parseOptionalDate(range.from, `${field}.from`);
+      const to = this.parseOptionalDate(range.to, `${field}.to`);
+
+      if (from && to && from > to) {
+        throw new BadRequestException(
+          `${field}.from must be before ${field}.to`,
+        );
+      }
+
+      if (from) {
+        const parameterName = `${PARAM_PREFIX}_${parameterIndex++}`;
+        clauses.push({
+          sql: `${fieldConfig.column} >= :${parameterName}`,
+          parameters: { [parameterName]: from },
+        });
+      }
+
+      if (to) {
+        const parameterName = `${PARAM_PREFIX}_${parameterIndex++}`;
+        clauses.push({
+          sql: `${fieldConfig.column} <= :${parameterName}`,
+          parameters: { [parameterName]: to },
+        });
+      }
+    }
+
+    const statuses = this.normalizeArray(request.statuses);
+    if (statuses.length > 0) {
+      clauses.push(this.buildStatusClause(config, statuses, parameterIndex));
+      parameterIndex += statuses.reduce(
+        (count, status) => count + (config.statuses?.[status]?.length ?? 0),
+        0,
+      );
+    }
+
+    for (const [field, range] of Object.entries(request.numericRanges ?? {})) {
+      const fieldConfig = this.getField(config, field, FilterFieldType.Number);
+      const min = this.parseOptionalNumber(range.min, `${field}.min`);
+      const max = this.parseOptionalNumber(range.max, `${field}.max`);
+
+      if (min !== undefined && max !== undefined && min > max) {
+        throw new BadRequestException(
+          `${field}.min must be less than ${field}.max`,
+        );
+      }
+
+      if (min !== undefined) {
+        const parameterName = `${PARAM_PREFIX}_${parameterIndex++}`;
+        clauses.push({
+          sql: `${fieldConfig.column} >= :${parameterName}`,
+          parameters: { [parameterName]: min },
+        });
+      }
+
+      if (max !== undefined) {
+        const parameterName = `${PARAM_PREFIX}_${parameterIndex++}`;
+        clauses.push({
+          sql: `${fieldConfig.column} <= :${parameterName}`,
+          parameters: { [parameterName]: max },
+        });
+      }
+    }
+
+    for (const [field, value] of Object.entries(request.addresses ?? {})) {
+      const fieldConfig = this.getField(config, field, FilterFieldType.Address);
+      const addresses = this.normalizeArray(value).map((address) =>
+        address.trim().toLowerCase(),
+      );
+
+      if (addresses.length === 0 || addresses.some((address) => !address)) {
+        throw new BadRequestException(`${field} must include a valid address`);
+      }
+
+      const parameterName = `${PARAM_PREFIX}_${parameterIndex++}`;
+      clauses.push({
+        sql: `LOWER(${fieldConfig.column}) IN (:...${parameterName})`,
+        parameters: { [parameterName]: addresses },
+      });
+    }
+
+    for (const [field, value] of Object.entries(request.booleans ?? {})) {
+      const fieldConfig = this.getField(config, field, FilterFieldType.Boolean);
+      const parameterName = `${PARAM_PREFIX}_${parameterIndex++}`;
+      clauses.push({
+        sql: `${fieldConfig.column} = :${parameterName}`,
+        parameters: {
+          [parameterName]: this.parseBoolean(value, field),
+        },
+      });
+    }
+
+    return {
+      clauses,
+      combination,
+      sort: this.buildSort(config, request.sort),
+    };
+  }
+
+  applyFilters<T extends ObjectLiteral>(
+    queryBuilder: SelectQueryBuilder<T>,
+    config: EntityFilterConfig,
+    request: FilteringRequest,
+  ): SelectQueryBuilder<T> {
+    const plan = this.buildFilterPlan(config, request);
+
+    if (plan.clauses.length > 0) {
+      queryBuilder.andWhere(
+        new Brackets((qb) => {
+          plan.clauses.forEach((clause, index) => {
+            if (index === 0) {
+              qb.where(clause.sql, clause.parameters);
+              return;
+            }
+
+            if (plan.combination === FilterCombination.Or) {
+              qb.orWhere(clause.sql, clause.parameters);
+              return;
+            }
+
+            qb.andWhere(clause.sql, clause.parameters);
+          });
+        }),
+      );
+    }
+
+    if (plan.sort) {
+      queryBuilder.orderBy(plan.sort.column, plan.sort.direction);
+    }
+
+    return queryBuilder;
+  }
+
+  private buildStatusClause(
+    config: EntityFilterConfig,
+    statuses: string[],
+    startParameterIndex: number,
+  ): FilterClause {
+    const statusMap = config.statuses ?? {};
+    const parameters: FilterClause['parameters'] = {};
+    let parameterIndex = startParameterIndex;
+
+    const groups = statuses.map((status) => {
+      const conditions = statusMap[status];
+
+      if (!conditions) {
+        throw new BadRequestException(`Unsupported status filter: ${status}`);
+      }
+
+      const conditionSql = conditions.map((condition) => {
+        const operator = condition.operator ?? '=';
+        const parameterName = `${PARAM_PREFIX}_${parameterIndex++}`;
+        parameters[parameterName] = condition.value;
+        return `${condition.field} ${operator} :${parameterName}`;
+      });
+
+      return `(${conditionSql.join(' AND ')})`;
+    });
+
+    return {
+      sql: `(${groups.join(' OR ')})`,
+      parameters,
+    };
+  }
+
+  private buildSort(
+    config: EntityFilterConfig,
+    sort: FilteringRequest['sort'],
+  ): FilterPlan['sort'] {
+    if (!sort) {
+      return undefined;
+    }
+
+    const fieldConfig = config.fields[sort.field];
+    if (!fieldConfig || fieldConfig.sortable === false) {
+      throw new BadRequestException(`Unsupported sort field: ${sort.field}`);
+    }
+
+    const direction = (sort.direction ?? 'DESC').toUpperCase();
+    if (direction !== 'ASC' && direction !== 'DESC') {
+      throw new BadRequestException(
+        `Unsupported sort direction: ${sort.direction}`,
+      );
+    }
+
+    return {
+      column: fieldConfig.column,
+      direction,
+    };
+  }
+
+  private getField(
+    config: EntityFilterConfig,
+    field: string,
+    expectedType: FilterFieldType,
+  ): FilterFieldConfig {
+    const fieldConfig = config.fields[field];
+
+    if (!fieldConfig || fieldConfig.type !== expectedType) {
+      throw new BadRequestException(
+        `Unsupported ${expectedType} filter: ${field}`,
+      );
+    }
+
+    return fieldConfig;
+  }
+
+  private normalizeArray(value: string | string[] | undefined): string[] {
+    if (value === undefined) {
+      return [];
+    }
+
+    const values = Array.isArray(value) ? value : [value];
+    return values.flatMap((item) =>
+      item
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean),
+    );
+  }
+
+  private parseOptionalDate(
+    value: Date | string | undefined,
+    label: string,
+  ): Date | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      throw new BadRequestException(`${label} must be a valid date`);
+    }
+
+    return date;
+  }
+
+  private parseOptionalNumber(
+    value: number | string | undefined,
+    label: string,
+  ): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const numberValue = Number(value);
+    if (!Number.isFinite(numberValue)) {
+      throw new BadRequestException(`${label} must be a valid number`);
+    }
+
+    return numberValue;
+  }
+
+  private parseBoolean(value: boolean | string, label: string): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (value === 'true') {
+      return true;
+    }
+
+    if (value === 'false') {
+      return false;
+    }
+
+    throw new BadRequestException(`${label} must be true or false`);
+  }
+
+  private assertCombination(combination: FilterCombination): void {
+    if (!Object.values(FilterCombination).includes(combination)) {
+      throw new BadRequestException(
+        `Unsupported filter combination: ${combination}`,
+      );
+    }
+  }
+}
+
+export const creatorEventFilterConfig: EntityFilterConfig = {
+  fields: {
+    created_at: {
+      column: 'creatorEvent.created_at',
+      type: FilterFieldType.Date,
+    },
+    on_chain_created_at: {
+      column: 'creatorEvent.on_chain_created_at',
+      type: FilterFieldType.Date,
+    },
+    participant_count: {
+      column: 'creatorEvent.participant_count',
+      type: FilterFieldType.Number,
+    },
+    match_count: {
+      column: 'creatorEvent.match_count',
+      type: FilterFieldType.Number,
+    },
+    creator: {
+      column: 'creatorEvent.creator_address',
+      type: FilterFieldType.Address,
+      sortable: false,
+    },
+    is_active: {
+      column: 'creatorEvent.is_active',
+      type: FilterFieldType.Boolean,
+    },
+    is_cancelled: {
+      column: 'creatorEvent.is_cancelled',
+      type: FilterFieldType.Boolean,
+    },
+  },
+  statuses: {
+    active: [
+      { field: 'creatorEvent.is_active', value: true },
+      { field: 'creatorEvent.is_cancelled', value: false },
+    ],
+    completed: [
+      { field: 'creatorEvent.is_active', value: false },
+      { field: 'creatorEvent.is_cancelled', value: false },
+    ],
+    cancelled: [{ field: 'creatorEvent.is_cancelled', value: true }],
+  },
+};
+
+export const matchFilterConfig: EntityFilterConfig = {
+  fields: {
+    created_at: {
+      column: 'match.created_at',
+      type: FilterFieldType.Date,
+    },
+    match_time: {
+      column: 'match.match_time',
+      type: FilterFieldType.Date,
+    },
+    submitted_at: {
+      column: 'match.submitted_at',
+      type: FilterFieldType.Date,
+    },
+    submitted_by: {
+      column: 'match.submitted_by',
+      type: FilterFieldType.Address,
+      sortable: false,
+    },
+    result_submitted: {
+      column: 'match.result_submitted',
+      type: FilterFieldType.Boolean,
+    },
+  },
+  statuses: {
+    active: [{ field: 'match.result_submitted', value: false }],
+    completed: [{ field: 'match.result_submitted', value: true }],
+  },
+};
+
+export const predictionFilterConfig: EntityFilterConfig = {
+  fields: {
+    submitted_at: {
+      column: 'prediction.submitted_at',
+      type: FilterFieldType.Date,
+    },
+    stake_amount_stroops: {
+      column: 'prediction.stake_amount_stroops',
+      type: FilterFieldType.Number,
+    },
+    participant: {
+      column: 'user.stellar_address',
+      type: FilterFieldType.Address,
+      sortable: false,
+    },
+    payout_claimed: {
+      column: 'prediction.payout_claimed',
+      type: FilterFieldType.Boolean,
+    },
+  },
+  statuses: {
+    active: [{ field: 'prediction.payout_claimed', value: false }],
+    completed: [{ field: 'prediction.payout_claimed', value: true }],
+  },
+};

--- a/backend/src/matches/entities/creator-event.entity.ts
+++ b/backend/src/matches/entities/creator-event.entity.ts
@@ -12,6 +12,10 @@ import { Match } from './match.entity';
 @Index(['on_chain_event_id'], { unique: true })
 @Index(['creator_address'])
 @Index(['is_active'])
+@Index(['is_active', 'is_cancelled', 'created_at'])
+@Index(['creator_address', 'created_at'])
+@Index(['participant_count'])
+@Index(['match_count'])
 export class CreatorEvent {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/backend/src/matches/entities/match.entity.ts
+++ b/backend/src/matches/entities/match.entity.ts
@@ -21,6 +21,9 @@ export enum WinningTeam {
 @Index(['on_chain_match_id'], { unique: true })
 @Index(['event'])
 @Index(['result_submitted'])
+@Index(['result_submitted', 'match_time'])
+@Index(['match_time'])
+@Index(['submitted_by'])
 export class Match {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/backend/src/migrations/1775700000000-AddFilteringIndexes.ts
+++ b/backend/src/migrations/1775700000000-AddFilteringIndexes.ts
@@ -1,0 +1,74 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFilteringIndexes1775700000000 implements MigrationInterface {
+  name = 'AddFilteringIndexes1775700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_events_status_created"
+      ON "creator_events" ("is_active", "is_cancelled", "created_at")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_events_creator_created"
+      ON "creator_events" ("creator_address", "created_at")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_events_participant_count"
+      ON "creator_events" ("participant_count")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_creator_events_match_count"
+      ON "creator_events" ("match_count")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_event_matches_result_match_time"
+      ON "event_matches" ("result_submitted", "match_time")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_event_matches_match_time"
+      ON "event_matches" ("match_time")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_event_matches_submitted_by"
+      ON "event_matches" ("submitted_by")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_predictions_submitted_at"
+      ON "predictions" ("submitted_at")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_predictions_payout_submitted"
+      ON "predictions" ("payout_claimed", "submitted_at")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_predictions_payout_submitted"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_predictions_submitted_at"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_event_matches_submitted_by"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_event_matches_match_time"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_event_matches_result_match_time"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_creator_events_match_count"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_creator_events_participant_count"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_creator_events_creator_created"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_creator_events_status_created"`,
+    );
+  }
+}

--- a/backend/src/predictions/entities/prediction.entity.ts
+++ b/backend/src/predictions/entities/prediction.entity.ts
@@ -15,6 +15,8 @@ import { Market } from '../../markets/entities/market.entity';
 @Unique('UQ_prediction_user_market', ['user', 'market'])
 @Index(['user'])
 @Index(['market'])
+@Index(['submitted_at'])
+@Index(['payout_claimed', 'submitted_at'])
 export class Prediction {
   @PrimaryGeneratedColumn('uuid')
   id: string;


### PR DESCRIPTION
Summary
- Added a reusable TypeORM filtering service for complex event, match, and prediction queries.

Issue
- Closes #758

Changes
- Added `FilteringService` with validation and filter-plan generation for date ranges, statuses, numeric ranges, address filters, boolean filters, AND/OR combinations, and sorting.
- Exported reusable configs for creator events, event matches, and predictions.
- Registered `FilteringService` through `CommonModule` for reuse across backend modules.
- Added entity index decorators and a migration for common filtering/sorting fields.
- Added focused tests covering all filter types, combinations, sorting, TypeORM application, and invalid input handling.

Validation
- npm ci was not run; existing dependencies were already installed in the reused repo clone.
- Ran npx prettier --write on touched backend files.
- Ran npx eslint src/common/filtering.service.ts src/common/filtering.service.spec.ts.
- Ran npx jest --runInBand src/common/filtering.service.spec.ts.
- Ran npm run build.
- Ran git diff --check.

Notes
- Prediction participant filtering uses the `user.stellar_address` alias, so callers should join the prediction user relation with alias `user` before applying that filter.