### PR TITLE
feat: add the setup test files for contracts

### DIFF
--- a/contracts/creator-event-manager/README.md
+++ b/contracts/creator-event-manager/README.md
@@ -137,6 +137,15 @@ Get match statistics: `(has_started, result_submitted, time_until_start, time_si
 #### `get_match_count()` / `validate_match(match_id)`
 Get total match count and validate match data consistency.
 
+#### `join_event(user, invite_code)`
+Join an event using its invite code before submitting predictions.
+
+#### `submit_prediction(predictor, match_id, predicted_outcome)`
+Submit a TEAM_A, TEAM_B, or DRAW prediction for a match.
+
+#### `get_prediction(prediction_id)`
+Fetch a stored prediction by ID for display or verification.
+
 #### Legacy Functions (Backward Compatibility)
 #### `create_event()` (Legacy)
 Create a new prediction event with the following parameters:

--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -4,6 +4,8 @@ pub mod admin;
 pub mod storage;
 pub mod storage_types;
 pub mod verification;
+pub mod prediction;
+pub mod r#match;
 mod event;
 mod invite;
 mod token;
@@ -12,7 +14,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 
 use admin::AdminError;
 use event::EventError;
-use storage_types::Event;
+use storage_types::{Event, Prediction};
 use verification::VerificationError;
 
 // ---------------------------------------------------------------------------
@@ -290,6 +292,62 @@ impl CreatorEventManagerContract {
             Ok(e) => e,
             Err(EventError::InvalidInviteCode) => panic!("invalid_invite_code"),
             Err(EventError::EventNotFound) => panic!("event_not_found"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
+    /// Return the number of matches currently stored for an event.
+    ///
+    /// This is a lightweight read that loads only the event record, not the
+    /// full match list.
+    pub fn get_match_count(env: Env, event_id: u64) -> u32 {
+        match r#match::get_match_count(&env, event_id) {
+            Ok(count) => count,
+            Err(EventError::EventNotFound) => panic!("event_not_found"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
+    /// Join an event using its invite code.
+    pub fn join_event(env: Env, user: Address, invite_code: Symbol) {
+        match prediction::join_event(&env, user, invite_code) {
+            Ok(()) => {}
+            Err(prediction::PredictionError::Paused) => panic!("paused"),
+            Err(prediction::PredictionError::InvalidInviteCode) => panic!("invalid_invite_code"),
+            Err(prediction::PredictionError::EventNotFound) => panic!("event_not_found"),
+            Err(prediction::PredictionError::EventCancelled) => panic!("event_cancelled"),
+            Err(prediction::PredictionError::AlreadyJoined) => panic!("already_joined"),
+            Err(prediction::PredictionError::EventFull) => panic!("event_full"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
+    /// Submit a prediction for a match in an event.
+    pub fn submit_prediction(
+        env: Env,
+        predictor: Address,
+        match_id: u64,
+        predicted_outcome: Symbol,
+    ) -> u64 {
+        match prediction::submit_prediction(&env, predictor, match_id, predicted_outcome) {
+            Ok(prediction_id) => prediction_id,
+            Err(prediction::PredictionError::Paused) => panic!("paused"),
+            Err(prediction::PredictionError::MatchNotFound) => panic!("match_not_found"),
+            Err(prediction::PredictionError::EventNotFound) => panic!("event_not_found"),
+            Err(prediction::PredictionError::EventCancelled) => panic!("event_cancelled"),
+            Err(prediction::PredictionError::NotJoined) => panic!("not_joined"),
+            Err(prediction::PredictionError::MatchStarted) => panic!("match_started"),
+            Err(prediction::PredictionError::InvalidOutcome) => panic!("invalid_outcome"),
+            Err(prediction::PredictionError::AlreadyPredicted) => panic!("already_predicted"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
+    /// Return a stored prediction by ID.
+    pub fn get_prediction(env: Env, prediction_id: u64) -> Prediction {
+        match prediction::get_prediction(&env, prediction_id) {
+            Ok(prediction) => prediction,
+            Err(prediction::PredictionError::PredictionNotFound) => panic!("prediction_not_found"),
             Err(_) => panic!("unexpected_error"),
         }
     }

--- a/contracts/creator-event-manager/src/match.rs
+++ b/contracts/creator-event-manager/src/match.rs
@@ -1,0 +1,12 @@
+use soroban_sdk::Env;
+
+use crate::event::{self, EventError};
+
+/// Return the number of matches currently stored for an event.
+///
+/// This reads only the event record, so it avoids loading the full match list.
+/// Returns [`EventError::EventNotFound`] if the event ID does not exist.
+pub fn get_match_count(env: &Env, event_id: u64) -> Result<u32, EventError> {
+    let event = event::get_event(env, event_id)?;
+    Ok(event.match_count)
+}

--- a/contracts/creator-event-manager/src/prediction.rs
+++ b/contracts/creator-event-manager/src/prediction.rs
@@ -1,0 +1,188 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+use crate::admin;
+use crate::storage::{self};
+use crate::storage_types::{DataKey, Event, Match, Prediction};
+
+/// Errors returned by event joining and prediction operations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum PredictionError {
+    Paused = 1,
+    InvalidInviteCode = 2,
+    EventNotFound = 3,
+    EventCancelled = 4,
+    AlreadyJoined = 5,
+    EventFull = 6,
+    MatchNotFound = 7,
+    NotJoined = 8,
+    MatchStarted = 9,
+    InvalidOutcome = 10,
+    AlreadyPredicted = 11,
+    PredictionNotFound = 12,
+    Overflow = 13,
+}
+
+fn emit_user_joined(env: &Env, event_id: u64, user: &Address) {
+    env.events().publish(
+        (Symbol::new(env, "event"), Symbol::new(env, "joined")),
+        (event_id, user.clone()),
+    );
+}
+
+fn emit_prediction_submitted(
+    env: &Env,
+    prediction_id: u64,
+    match_id: u64,
+    event_id: u64,
+    predictor: &Address,
+    predicted_outcome: &Symbol,
+) {
+    env.events().publish(
+        (Symbol::new(env, "prediction"), Symbol::new(env, "submitted")),
+        (
+            prediction_id,
+            match_id,
+            event_id,
+            predictor.clone(),
+            predicted_outcome.clone(),
+        ),
+    );
+}
+
+fn is_valid_outcome(env: &Env, predicted_outcome: &Symbol) -> bool {
+    let team_a = Symbol::new(env, crate::storage_types::OUTCOME_TEAM_A);
+    let team_b = Symbol::new(env, crate::storage_types::OUTCOME_TEAM_B);
+    let draw = Symbol::new(env, crate::storage_types::OUTCOME_DRAW);
+    *predicted_outcome == team_a || *predicted_outcome == team_b || *predicted_outcome == draw
+}
+
+fn user_already_predicted_match(
+    env: &Env,
+    predictor: &Address,
+    event_id: u64,
+    match_id: u64,
+) -> bool {
+    let prediction_ids = storage::get_user_predictions(env, predictor, event_id);
+    for prediction_id in prediction_ids.iter() {
+        if let Ok(prediction) = storage::get_prediction(env, prediction_id) {
+            if prediction.match_id == match_id {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Join an event with an invite code.
+pub fn join_event(env: &Env, user: Address, invite_code: Symbol) -> Result<(), PredictionError> {
+    user.require_auth();
+
+    if admin::is_paused(env) {
+        return Err(PredictionError::Paused);
+    }
+
+    let invite_key = DataKey::InviteCode(invite_code.clone());
+    let event_id: u64 = env
+        .storage()
+        .persistent()
+        .get(&invite_key)
+        .ok_or(PredictionError::InvalidInviteCode)?;
+
+    let mut event: Event = storage::get_event(env, event_id).map_err(|_| PredictionError::EventNotFound)?;
+
+    if !event.is_active || event.is_cancelled {
+        return Err(PredictionError::EventCancelled);
+    }
+
+    let participants = storage::get_event_participants(env, event_id);
+    if participants.iter().any(|participant| participant == user) {
+        return Err(PredictionError::AlreadyJoined);
+    }
+
+    if event.max_participants > 0 && event.participant_count >= event.max_participants {
+        return Err(PredictionError::EventFull);
+    }
+
+    storage::add_event_participant(env, event_id, &user);
+    event.participant_count = event
+        .participant_count
+        .checked_add(1)
+        .ok_or(PredictionError::Overflow)?;
+    storage::set_event(env, event_id, &event);
+
+    emit_user_joined(env, event_id, &user);
+
+    Ok(())
+}
+
+/// Submit a prediction for a match inside a joined event.
+pub fn submit_prediction(
+    env: &Env,
+    predictor: Address,
+    match_id: u64,
+    predicted_outcome: Symbol,
+) -> Result<u64, PredictionError> {
+    predictor.require_auth();
+
+    if admin::is_paused(env) {
+        return Err(PredictionError::Paused);
+    }
+
+    let match_record: Match = storage::get_match(env, match_id).map_err(|_| PredictionError::MatchNotFound)?;
+    let event: Event = storage::get_event(env, match_record.event_id)
+        .map_err(|_| PredictionError::EventNotFound)?;
+
+    if !event.is_active || event.is_cancelled {
+        return Err(PredictionError::EventCancelled);
+    }
+
+    let participants = storage::get_event_participants(env, event.event_id);
+    if !participants.iter().any(|participant| participant == predictor) {
+        return Err(PredictionError::NotJoined);
+    }
+
+    let now = env.ledger().timestamp();
+    if now >= match_record.match_time {
+        return Err(PredictionError::MatchStarted);
+    }
+
+    if !is_valid_outcome(env, &predicted_outcome) {
+        return Err(PredictionError::InvalidOutcome);
+    }
+
+    if user_already_predicted_match(env, &predictor, event.event_id, match_id) {
+        return Err(PredictionError::AlreadyPredicted);
+    }
+
+    let prediction_id = storage::next_prediction_id(env);
+    let prediction = Prediction::new(
+        prediction_id,
+        match_id,
+        event.event_id,
+        predictor.clone(),
+        predicted_outcome.clone(),
+        now,
+    );
+
+    storage::set_prediction(env, prediction_id, &prediction);
+    storage::add_match_prediction(env, match_id, prediction_id);
+    storage::add_user_prediction(env, &predictor, event.event_id, prediction_id);
+
+    emit_prediction_submitted(
+        env,
+        prediction_id,
+        match_id,
+        event.event_id,
+        &predictor,
+        &predicted_outcome,
+    );
+
+    Ok(prediction_id)
+}
+
+/// Fetch a prediction by ID and extend its TTL on read.
+pub fn get_prediction(env: &Env, prediction_id: u64) -> Result<Prediction, PredictionError> {
+    storage::get_prediction(env, prediction_id).map_err(|_| PredictionError::PredictionNotFound)
+}

--- a/contracts/creator-event-manager/tests/match_tests.rs
+++ b/contracts/creator-event-manager/tests/match_tests.rs
@@ -1,0 +1,92 @@
+/// Tests for event match counting.
+use creator_event_manager::storage;
+use creator_event_manager::CreatorEventManagerContractClient;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env, String};
+
+const FEE: i128 = 1_000_000;
+
+fn setup() -> (
+    Env,
+    CreatorEventManagerContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id =
+        env.register_contract(None, creator_event_manager::CreatorEventManagerContract);
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> = unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env.register_stellar_asset_contract_v2(token_admin).address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+    (env, client, contract_id, admin, xlm_token)
+}
+
+fn fund(env: &Env, token: &Address, user: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(user, &amount);
+}
+
+fn title(env: &Env) -> String {
+    String::from_str(env, "World Cup 2026 Predictions")
+}
+
+fn desc(env: &Env) -> String {
+    String::from_str(env, "Predict the matches of the 2026 World Cup.")
+}
+
+#[test]
+fn test_get_match_count_returns_zero_for_new_event() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = client.create_event(&creator, &title(&env), &desc(&env), &5u32);
+
+    assert_eq!(client.get_match_count(&event_id), 0);
+}
+
+#[test]
+fn test_get_match_count_returns_correct_count() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = client.create_event(&creator, &title(&env), &desc(&env), &5u32);
+
+    let _match_id = env.as_contract(&contract_id, || {
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.add_match();
+        storage::set_event(&env, event_id, &event);
+
+        let match_id = storage::next_match_id(&env);
+        let match_record = creator_event_manager::storage_types::Match::new(
+            match_id,
+            event_id,
+            String::from_str(&env, "Team A"),
+            String::from_str(&env, "Team B"),
+            env.ledger().timestamp() + 10_000,
+        );
+        storage::set_match(&env, match_id, &match_record);
+        storage::add_event_match(&env, event_id, match_id);
+        match_id
+    });
+
+    assert_eq!(client.get_match_count(&event_id), 1);
+}
+
+#[test]
+#[should_panic(expected = "event_not_found")]
+fn test_get_match_count_missing_event_panics() {
+    let (_env, client, _contract_id, _admin, _xlm_token) = setup();
+    client.get_match_count(&999u64);
+}

--- a/contracts/creator-event-manager/tests/mod.rs
+++ b/contracts/creator-event-manager/tests/mod.rs
@@ -1,4 +1,6 @@
 mod admin_tests;
 mod event_tests;
+mod match_tests;
+mod prediction_tests;
 mod storage_types_tests;
 mod verification_tests;

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -1,0 +1,291 @@
+/// Tests for joining events and submitting predictions.
+use creator_event_manager::storage;
+use creator_event_manager::CreatorEventManagerContractClient;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env, String, Symbol};
+
+const FEE: i128 = 1_000_000;
+
+fn setup() -> (
+    Env,
+    CreatorEventManagerContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id =
+        env.register_contract(None, creator_event_manager::CreatorEventManagerContract);
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> = unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env.register_stellar_asset_contract_v2(token_admin).address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+    (env, client, contract_id, admin, xlm_token)
+}
+
+fn fund(env: &Env, token: &Address, user: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(user, &amount);
+}
+
+fn title(env: &Env) -> String {
+    String::from_str(env, "World Cup 2026 Predictions")
+}
+
+fn desc(env: &Env) -> String {
+    String::from_str(env, "Predict the matches of the 2026 World Cup.")
+}
+
+fn create_event_and_match(
+    env: &Env,
+    contract_id: &Address,
+    client: &CreatorEventManagerContractClient<'static>,
+    creator: &Address,
+    xlm_token: &Address,
+    max_participants: u32,
+    match_time_offset: u64,
+) -> (u64, Symbol, u64) {
+    fund(env, xlm_token, creator, FEE);
+
+    let (event_id, invite_code) = client.create_event(creator, &title(env), &desc(env), &max_participants);
+
+    let match_id = env.as_contract(contract_id, || {
+        let match_id = storage::next_match_id(env);
+        let match_record = creator_event_manager::storage_types::Match::new(
+            match_id,
+            event_id,
+            String::from_str(env, "Team A"),
+            String::from_str(env, "Team B"),
+            env.ledger().timestamp() + match_time_offset,
+        );
+        storage::set_match(env, match_id, &match_record);
+        storage::add_event_match(env, event_id, match_id);
+
+        let mut event = storage::get_event(env, event_id).expect("event exists");
+        event.add_match();
+        storage::set_event(env, event_id, &event);
+        match_id
+    });
+
+    (event_id, invite_code, match_id)
+}
+
+#[test]
+fn test_join_event_valid_code_succeeds() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+    let (event_id, invite_code, _) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&user, &invite_code);
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.participant_count, 1);
+    let participants = env.as_contract(&contract_id, || storage::get_event_participants(&env, event_id));
+    assert_eq!(participants.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid_invite_code")]
+fn test_join_event_invalid_code_rejected() {
+    let (env, client, _contract_id, _admin, _xlm_token) = setup();
+    let user = Address::generate(&env);
+
+    client.join_event(&user, &Symbol::new(&env, "ZZZZZZZZ"));
+}
+
+#[test]
+#[should_panic(expected = "already_joined")]
+fn test_join_event_already_joined_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+    let (_event_id, invite_code, _) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&user, &invite_code);
+    client.join_event(&user, &invite_code);
+}
+
+#[test]
+#[should_panic(expected = "event_full")]
+fn test_join_event_full_event_blocks_joining() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let (_event_id, invite_code, _) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 1, 10_000);
+
+    client.join_event(&user1, &invite_code);
+    client.join_event(&user2, &invite_code);
+}
+
+#[test]
+#[should_panic(expected = "event_cancelled")]
+fn test_join_event_cancelled_event_blocks_joining() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+    let (event_id, invite_code, _) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    env.as_contract(&contract_id, || {
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.cancel();
+        storage::set_event(&env, event_id, &event);
+    });
+
+    client.join_event(&user, &invite_code);
+}
+
+#[test]
+fn test_join_event_increments_participant_count() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+    let (event_id, invite_code, _) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&user, &invite_code);
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.participant_count, 1);
+}
+
+#[test]
+fn test_submit_prediction_valid_succeeds() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (_event_id, invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&predictor, &invite_code);
+
+    let prediction_id = client.submit_prediction(
+        &predictor,
+        &match_id,
+        &Symbol::new(&env, "TEAM_A"),
+    );
+
+    assert_eq!(prediction_id, 1);
+
+    let prediction = client.get_prediction(&prediction_id);
+    assert_eq!(prediction.prediction_id, prediction_id);
+    assert_eq!(prediction.match_id, match_id);
+    assert_eq!(prediction.predictor, predictor);
+    assert_eq!(prediction.predicted_outcome, Symbol::new(&env, "TEAM_A"));
+}
+
+#[test]
+#[should_panic(expected = "not_joined")]
+fn test_submit_prediction_non_participant_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (_event_id, _invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "TEAM_A"));
+}
+
+#[test]
+#[should_panic(expected = "match_started")]
+fn test_submit_prediction_late_prediction_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (_event_id, invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 1);
+
+    client.join_event(&predictor, &invite_code);
+    env.ledger().with_mut(|ledger| ledger.timestamp += 10);
+
+    client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "TEAM_A"));
+}
+
+#[test]
+#[should_panic(expected = "invalid_outcome")]
+fn test_submit_prediction_invalid_outcome_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (_event_id, invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&predictor, &invite_code);
+    client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "INVALID"));
+}
+
+#[test]
+#[should_panic(expected = "already_predicted")]
+fn test_submit_prediction_duplicate_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (_event_id, invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&predictor, &invite_code);
+    client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "TEAM_A"));
+    client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "TEAM_A"));
+}
+
+#[test]
+#[should_panic(expected = "event_cancelled")]
+fn test_submit_prediction_cancelled_event_blocks_prediction() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (event_id, invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&predictor, &invite_code);
+
+    env.as_contract(&contract_id, || {
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.cancel();
+        storage::set_event(&env, event_id, &event);
+    });
+
+    client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "TEAM_A"));
+}
+
+#[test]
+fn test_get_prediction_returns_existing_prediction() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (_event_id, invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&predictor, &invite_code);
+    let prediction_id = client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "TEAM_A"));
+
+    let prediction = client.get_prediction(&prediction_id);
+    assert_eq!(prediction.prediction_id, prediction_id);
+    assert_eq!(prediction.match_id, match_id);
+}
+
+#[test]
+#[should_panic(expected = "prediction_not_found")]
+fn test_get_prediction_non_existent_prediction_rejected() {
+    let (_env, client, _contract_id, _admin, _xlm_token) = setup();
+    client.get_prediction(&999u64);
+}
+
+#[test]
+fn test_get_prediction_extends_ttl() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let (_event_id, invite_code, match_id) = create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&predictor, &invite_code);
+    let prediction_id = client.submit_prediction(&predictor, &match_id, &Symbol::new(&env, "TEAM_A"));
+
+    let current_ledger = env.ledger().get().sequence_number;
+    env.ledger().set_sequence_number(current_ledger + 1);
+
+    let prediction = client.get_prediction(&prediction_id);
+    assert_eq!(prediction.prediction_id, prediction_id);
+}


### PR DESCRIPTION
## Summary
Implements the creator-event-manager contract features for issues #803, #804, #805, and #806.

### What changed
- Added `get_match_count` to return the number of matches for an event.
- Added `join_event` to let users join via invite code.
- Added `submit_prediction` to allow joined users to submit match predictions.
- Added `get_prediction` to fetch stored predictions.
- Added integration tests for match counting, event joining, and prediction flows.
- Updated the contract README with the new public usage notes.

### Validation
- `cargo test`
- `cargo test --test match_tests --test prediction_tests`

## Checklist
- [x] Implemented match count lookup
- [x] Implemented event joining flow
- [x] Implemented prediction submission flow
- [x] Implemented prediction retrieval
- [x] Added integration tests
- [x] Updated documentation
- [x] Verified tests pass locally

Closes #803
Closes #804
Closes #805
Closes #806

