### PR TITLE
feat: Update creator event manager contract

### DIFF
--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -351,4 +351,21 @@ impl CreatorEventManagerContract {
             Err(_) => panic!("unexpected_error"),
         }
     }
+
+    /// Retrieve all predictions a user has made for a specific event.
+    ///
+    /// Returns a `Vec<Prediction>` sorted by `predicted_at` ascending
+    /// (earliest prediction first).  Returns an empty `Vec` when the user has
+    /// made no predictions for the event.
+    pub fn get_user_predictions(env: Env, user: Address, event_id: u64) -> Vec<Prediction> {
+        prediction::get_user_predictions(&env, user, event_id)
+    }
+
+    /// Calculate how many users predicted each outcome for a match.
+    ///
+    /// Returns `(team_a_count, team_b_count, draw_count)`.  All three counts
+    /// are always present; outcomes with no predictions return `0`.
+    pub fn get_prediction_distribution(env: Env, match_id: u64) -> (u32, u32, u32) {
+        prediction::get_prediction_distribution(&env, match_id)
+    }
 }

--- a/contracts/creator-event-manager/src/prediction.rs
+++ b/contracts/creator-event-manager/src/prediction.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Symbol};
+use soroban_sdk::{Address, Env, Symbol, Vec};
 
 use crate::admin;
 use crate::storage::{self};
@@ -185,4 +185,88 @@ pub fn submit_prediction(
 /// Fetch a prediction by ID and extend its TTL on read.
 pub fn get_prediction(env: &Env, prediction_id: u64) -> Result<Prediction, PredictionError> {
     storage::get_prediction(env, prediction_id).map_err(|_| PredictionError::PredictionNotFound)
+}
+
+/// Retrieve all predictions a user has made for a specific event, sorted by
+/// `predicted_at` timestamp in ascending order (earliest first).
+///
+/// Returns an empty `Vec` when the user has made no predictions for the event.
+/// Predictions from other events are never included.
+///
+/// # Sorting behaviour
+/// The returned `Vec` is sorted by `predicted_at` ascending.  Because
+/// predictions are appended in submission order and each ledger timestamp is
+/// monotonically non-decreasing, the list is almost always already sorted;
+/// the explicit sort guarantees correctness even if two predictions share the
+/// same timestamp.
+pub fn get_user_predictions(
+    env: &Env,
+    user: Address,
+    event_id: u64,
+) -> Vec<Prediction> {
+    let prediction_ids = storage::get_user_predictions(env, &user, event_id);
+
+    let mut predictions: Vec<Prediction> = Vec::new(env);
+    for prediction_id in prediction_ids.iter() {
+        if let Ok(prediction) = storage::get_prediction(env, prediction_id) {
+            predictions.push_back(prediction);
+        }
+    }
+
+    // Sort by predicted_at ascending (insertion-sort — list is typically small
+    // and already nearly sorted, so O(n²) worst-case is acceptable here).
+    let len = predictions.len();
+    for i in 1..len {
+        let mut j = i;
+        while j > 0 {
+            let prev = predictions.get(j - 1).unwrap();
+            let curr = predictions.get(j).unwrap();
+            if prev.predicted_at > curr.predicted_at {
+                predictions.set(j - 1, curr);
+                predictions.set(j, prev);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    predictions
+}
+
+/// Calculate how many users predicted each outcome for a match.
+///
+/// Returns a tuple `(team_a_count, team_b_count, draw_count)` where each
+/// element is the number of predictions for that outcome.  All three counts
+/// are always present; outcomes with no predictions return `0`.
+///
+/// # Return format
+/// `(team_a_count: u32, team_b_count: u32, draw_count: u32)`
+pub fn get_prediction_distribution(
+    env: &Env,
+    match_id: u64,
+) -> (u32, u32, u32) {
+    let prediction_ids = storage::get_match_predictions(env, match_id);
+
+    let team_a_sym = Symbol::new(env, crate::storage_types::OUTCOME_TEAM_A);
+    let team_b_sym = Symbol::new(env, crate::storage_types::OUTCOME_TEAM_B);
+    let draw_sym = Symbol::new(env, crate::storage_types::OUTCOME_DRAW);
+
+    let mut team_a_count: u32 = 0;
+    let mut team_b_count: u32 = 0;
+    let mut draw_count: u32 = 0;
+
+    for prediction_id in prediction_ids.iter() {
+        if let Ok(prediction) = storage::get_prediction(env, prediction_id) {
+            if prediction.predicted_outcome == team_a_sym {
+                team_a_count += 1;
+            } else if prediction.predicted_outcome == team_b_sym {
+                team_b_count += 1;
+            } else if prediction.predicted_outcome == draw_sym {
+                draw_count += 1;
+            }
+        }
+    }
+
+    (team_a_count, team_b_count, draw_count)
 }

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -289,3 +289,299 @@ fn test_get_prediction_extends_ttl() {
     let prediction = client.get_prediction(&prediction_id);
     assert_eq!(prediction.prediction_id, prediction_id);
 }
+
+// ---------------------------------------------------------------------------
+// get_user_predictions tests (#807)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_user_predictions_returns_all_for_event() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    // Create event with two matches
+    fund(&env, &xlm_token, &creator, FEE);
+    let (event_id, invite_code) = client.create_event(&creator, &title(&env), &desc(&env), &2u32);
+
+    let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {
+        let m1 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m1,
+            &creator_event_manager::storage_types::Match::new(
+                m1,
+                event_id,
+                String::from_str(&env, "Team A"),
+                String::from_str(&env, "Team B"),
+                env.ledger().timestamp() + 10_000,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m1);
+
+        let m2 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m2,
+            &creator_event_manager::storage_types::Match::new(
+                m2,
+                event_id,
+                String::from_str(&env, "Team C"),
+                String::from_str(&env, "Team D"),
+                env.ledger().timestamp() + 20_000,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m2);
+
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.add_match();
+        event.add_match();
+        storage::set_event(&env, event_id, &event);
+
+        (m1, m2)
+    });
+
+    client.join_event(&predictor, &invite_code);
+    client.submit_prediction(&predictor, &match_id_1, &Symbol::new(&env, "TEAM_A"));
+    client.submit_prediction(&predictor, &match_id_2, &Symbol::new(&env, "DRAW"));
+
+    let predictions = client.get_user_predictions(&predictor, &event_id);
+    assert_eq!(predictions.len(), 2);
+}
+
+#[test]
+fn test_get_user_predictions_empty_for_non_participant() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let non_participant = Address::generate(&env);
+    let (event_id, _invite_code, _match_id) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    let predictions = client.get_user_predictions(&non_participant, &event_id);
+    assert_eq!(predictions.len(), 0);
+}
+
+#[test]
+fn test_get_user_predictions_sorted_by_predicted_at() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    fund(&env, &xlm_token, &creator, FEE);
+    let (event_id, invite_code) = client.create_event(&creator, &title(&env), &desc(&env), &2u32);
+
+    // Create two matches with different future times
+    let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {
+        let m1 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m1,
+            &creator_event_manager::storage_types::Match::new(
+                m1,
+                event_id,
+                String::from_str(&env, "Team A"),
+                String::from_str(&env, "Team B"),
+                env.ledger().timestamp() + 50_000,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m1);
+
+        let m2 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m2,
+            &creator_event_manager::storage_types::Match::new(
+                m2,
+                event_id,
+                String::from_str(&env, "Team C"),
+                String::from_str(&env, "Team D"),
+                env.ledger().timestamp() + 60_000,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m2);
+
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.add_match();
+        event.add_match();
+        storage::set_event(&env, event_id, &event);
+
+        (m1, m2)
+    });
+
+    client.join_event(&predictor, &invite_code);
+
+    // Submit first prediction at timestamp T
+    client.submit_prediction(&predictor, &match_id_1, &Symbol::new(&env, "TEAM_A"));
+
+    // Advance ledger time so second prediction has a later timestamp
+    env.ledger().with_mut(|l| l.timestamp += 100);
+
+    client.submit_prediction(&predictor, &match_id_2, &Symbol::new(&env, "TEAM_B"));
+
+    let predictions = client.get_user_predictions(&predictor, &event_id);
+    assert_eq!(predictions.len(), 2);
+
+    // Verify ascending order
+    let first = predictions.get(0).unwrap();
+    let second = predictions.get(1).unwrap();
+    assert!(
+        first.predicted_at <= second.predicted_at,
+        "predictions must be sorted by predicted_at ascending"
+    );
+    assert_eq!(first.match_id, match_id_1);
+    assert_eq!(second.match_id, match_id_2);
+}
+
+#[test]
+fn test_get_user_predictions_multiple_events_dont_mix() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    // Event 1
+    let (event_id_1, invite_code_1, match_id_1) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    // Event 2
+    let (event_id_2, invite_code_2, match_id_2) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&predictor, &invite_code_1);
+    client.join_event(&predictor, &invite_code_2);
+
+    client.submit_prediction(&predictor, &match_id_1, &Symbol::new(&env, "TEAM_A"));
+    client.submit_prediction(&predictor, &match_id_2, &Symbol::new(&env, "TEAM_B"));
+
+    // Each event should only contain its own prediction
+    let preds_event_1 = client.get_user_predictions(&predictor, &event_id_1);
+    let preds_event_2 = client.get_user_predictions(&predictor, &event_id_2);
+
+    assert_eq!(preds_event_1.len(), 1);
+    assert_eq!(preds_event_2.len(), 1);
+    assert_eq!(preds_event_1.get(0).unwrap().match_id, match_id_1);
+    assert_eq!(preds_event_2.get(0).unwrap().match_id, match_id_2);
+}
+
+// ---------------------------------------------------------------------------
+// get_prediction_distribution tests (#809)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_prediction_distribution_correct_counts() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let user_draw = Address::generate(&env);
+
+    let (_event_id, invite_code, match_id) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 5, 10_000);
+
+    client.join_event(&user_a, &invite_code);
+    client.join_event(&user_b, &invite_code);
+    client.join_event(&user_draw, &invite_code);
+
+    client.submit_prediction(&user_a, &match_id, &Symbol::new(&env, "TEAM_A"));
+    client.submit_prediction(&user_b, &match_id, &Symbol::new(&env, "TEAM_B"));
+    client.submit_prediction(&user_draw, &match_id, &Symbol::new(&env, "DRAW"));
+
+    let (team_a, team_b, draw) = client.get_prediction_distribution(&match_id);
+    assert_eq!(team_a, 1);
+    assert_eq!(team_b, 1);
+    assert_eq!(draw, 1);
+}
+
+#[test]
+fn test_get_prediction_distribution_zero_counts_for_no_predictions() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let (_event_id, _invite_code, match_id) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    let (team_a, team_b, draw) = client.get_prediction_distribution(&match_id);
+    assert_eq!(team_a, 0);
+    assert_eq!(team_b, 0);
+    assert_eq!(draw, 0);
+}
+
+#[test]
+fn test_get_prediction_distribution_all_same_outcome() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+
+    let (_event_id, invite_code, match_id) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 5, 10_000);
+
+    client.join_event(&user1, &invite_code);
+    client.join_event(&user2, &invite_code);
+    client.join_event(&user3, &invite_code);
+
+    client.submit_prediction(&user1, &match_id, &Symbol::new(&env, "TEAM_A"));
+    client.submit_prediction(&user2, &match_id, &Symbol::new(&env, "TEAM_A"));
+    client.submit_prediction(&user3, &match_id, &Symbol::new(&env, "TEAM_A"));
+
+    let (team_a, team_b, draw) = client.get_prediction_distribution(&match_id);
+    assert_eq!(team_a, 3);
+    assert_eq!(team_b, 0);
+    assert_eq!(draw, 0);
+}
+
+#[test]
+fn test_get_prediction_distribution_multiple_matches_independent() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    fund(&env, &xlm_token, &creator, FEE);
+    let (event_id, invite_code) = client.create_event(&creator, &title(&env), &desc(&env), &2u32);
+
+    let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {
+        let m1 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m1,
+            &creator_event_manager::storage_types::Match::new(
+                m1,
+                event_id,
+                String::from_str(&env, "Team A"),
+                String::from_str(&env, "Team B"),
+                env.ledger().timestamp() + 10_000,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m1);
+
+        let m2 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m2,
+            &creator_event_manager::storage_types::Match::new(
+                m2,
+                event_id,
+                String::from_str(&env, "Team C"),
+                String::from_str(&env, "Team D"),
+                env.ledger().timestamp() + 20_000,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m2);
+
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.add_match();
+        event.add_match();
+        storage::set_event(&env, event_id, &event);
+
+        (m1, m2)
+    });
+
+    client.join_event(&user, &invite_code);
+    client.submit_prediction(&user, &match_id_1, &Symbol::new(&env, "TEAM_A"));
+    client.submit_prediction(&user, &match_id_2, &Symbol::new(&env, "DRAW"));
+
+    let (a1, b1, d1) = client.get_prediction_distribution(&match_id_1);
+    let (a2, b2, d2) = client.get_prediction_distribution(&match_id_2);
+
+    assert_eq!((a1, b1, d1), (1, 0, 0));
+    assert_eq!((a2, b2, d2), (0, 0, 1));
+}


### PR DESCRIPTION

**`get_user_predictions(user, event_id)`** — returns all `Prediction` structs a user has placed in a specific event, sorted by `predicted_at` ascending. Returns an empty list when the user has no predictions for that event.

**`get_prediction_distribution(match_id)`** — returns a `(team_a_count, team_b_count, draw_count)` tuple counting how many users predicted each outcome for a match. All three counts are always present; outcomes with zero predictions return `0`.

---

## Checklist

- [x] Add `get_user_predictions` function to `prediction.rs` accepting `user: Address` and `event_id: u64`
- [x] Retrieve `UserPredictions(user, event_id)` list, loop through prediction IDs, retrieve each `Prediction` struct, and return sorted `Vec<Prediction>`
- [x] Sort predictions by `predicted_at` timestamp ascending
- [x] Add `get_prediction_distribution` function to `prediction.rs` accepting `match_id: u64`
- [x] Count predictions for `TEAM_A`, `TEAM_B`, `DRAW` and return `(u32, u32, u32)` tuple
- [x] Expose both functions in `lib.rs` contract interface
- [x] Unit test: returns all user predictions for event
- [x] Unit test: empty list for user with no predictions
- [x] Unit test: predictions are sorted by time
- [x] Unit test: multiple events don't mix
- [x] Unit test: correct counts for each outcome
- [x] Unit test: zero counts for no predictions
- [x] Unit test: all outcomes represented independently per match
- [x] All 127 tests passing

---
Closes #807 
Closes #809 