### PR TITLE
feat(backend): implement user predictions, event stats, indexer health, and email notifications

### DIFF
--- a/backend/src/contract/contract.service.ts
+++ b/backend/src/contract/contract.service.ts
@@ -214,8 +214,16 @@ export class ContractService {
       return null;
     }
 
+    const eventIdRaw = result.eventId ?? result.event_id ?? eventId;
+    const eventIdString =
+      typeof eventIdRaw === 'string'
+        ? eventIdRaw
+        : typeof eventIdRaw === 'number'
+          ? String(eventIdRaw)
+          : eventId;
+
     return {
-      eventId: String(result.eventId ?? result.event_id ?? eventId),
+      eventId: eventIdString,
       participantCount: Number(
         result.participantCount ?? result.participant_count ?? 0,
       ),

--- a/backend/src/contract/contract.service.ts
+++ b/backend/src/contract/contract.service.ts
@@ -36,12 +36,39 @@ export interface ContractMatch {
 }
 
 export interface ContractPrediction {
-  predictionId: string;
-  matchId: string;
-  user: string;
-  chosenOutcome: string;
-  stakeAmount: string;
-  claimed: boolean;
+  predictionId?: string;
+  prediction_id?: string | number;
+  matchId?: string;
+  match_id?: string | number;
+  eventId?: string;
+  event_id?: string | number;
+  user?: string;
+  predictor?: string;
+  chosenOutcome?: string;
+  predictedOutcome?: string;
+  predicted_outcome?: string;
+  predictedAt?: number;
+  predicted_at?: number;
+  stakeAmount?: string;
+  claimed?: boolean;
+  isCorrect?: boolean | null;
+  is_correct?: boolean | null;
+}
+
+export interface ContractEventStatistics {
+  eventId: string;
+  participantCount: number;
+  matchCount: number;
+  totalPredictions: number;
+  allMatchesResolved: boolean;
+  winnersVerified: boolean;
+  winnerCount: number;
+}
+
+export interface ContractPredictionDistribution {
+  teamA: number;
+  teamB: number;
+  draw: number;
 }
 
 export interface ContractParticipant {
@@ -168,6 +195,66 @@ export class ContractService {
       new Address(address).toScVal(),
     ]);
     return result ?? false;
+  }
+
+  async getEventStatistics(
+    eventId: string,
+  ): Promise<ContractEventStatistics | null> {
+    const numericId = Number(eventId);
+    if (!Number.isFinite(numericId)) {
+      return null;
+    }
+
+    const result = await this.viewCall<Record<string, unknown>>(
+      'get_event_statistics',
+      [nativeToScVal(numericId, { type: 'u64' })],
+    );
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      eventId: String(result.eventId ?? result.event_id ?? eventId),
+      participantCount: Number(
+        result.participantCount ?? result.participant_count ?? 0,
+      ),
+      matchCount: Number(result.matchCount ?? result.match_count ?? 0),
+      totalPredictions: Number(
+        result.totalPredictions ?? result.total_predictions ?? 0,
+      ),
+      allMatchesResolved: Boolean(
+        result.allMatchesResolved ?? result.all_matches_resolved ?? false,
+      ),
+      winnersVerified: Boolean(
+        result.winnersVerified ?? result.winners_verified ?? false,
+      ),
+      winnerCount: Number(result.winnerCount ?? result.winner_count ?? 0),
+    };
+  }
+
+  async getPredictionDistribution(
+    matchId: string,
+  ): Promise<ContractPredictionDistribution> {
+    const numericId = Number(matchId);
+    if (!Number.isFinite(numericId)) {
+      return { teamA: 0, teamB: 0, draw: 0 };
+    }
+
+    const result = await this.viewCall<[number, number, number] | number[]>(
+      'get_prediction_distribution',
+      [nativeToScVal(numericId, { type: 'u64' })],
+    );
+
+    if (!result || !Array.isArray(result) || result.length < 3) {
+      return { teamA: 0, teamB: 0, draw: 0 };
+    }
+
+    return {
+      teamA: Number(result[0] ?? 0),
+      teamB: Number(result[1] ?? 0),
+      draw: Number(result[2] ?? 0),
+    };
   }
 
   private async viewCall<T>(fn: string, args: xdr.ScVal[]): Promise<T | null> {

--- a/backend/src/creator-events/creator-events-predictions-stats.spec.ts
+++ b/backend/src/creator-events/creator-events-predictions-stats.spec.ts
@@ -1,7 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { ContractService } from '../contract/contract.service';
+import {
+  ContractPrediction,
+  ContractService,
+} from '../contract/contract.service';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { CreatorEventsService } from './creator-events.service';
 
@@ -98,7 +101,7 @@ describe('CreatorEventsService predictions and stats', () => {
           predicted_at: 1_040_000,
           is_correct: true,
         },
-      ] as any);
+      ] as ContractPrediction[]);
 
       const result = await service.getUserPredictionsForEvent('1', 'GUSER');
 

--- a/backend/src/creator-events/creator-events-predictions-stats.spec.ts
+++ b/backend/src/creator-events/creator-events-predictions-stats.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ContractService } from '../contract/contract.service';
+import { CreatorEvent } from '../matches/entities/creator-event.entity';
+import { CreatorEventsService } from './creator-events.service';
+
+describe('CreatorEventsService predictions and stats', () => {
+  let service: CreatorEventsService;
+  let contractService: jest.Mocked<
+    Pick<
+      ContractService,
+      | 'getEvent'
+      | 'getEventMatches'
+      | 'getUserPredictions'
+      | 'getEventStatistics'
+      | 'getEventParticipants'
+      | 'getPredictionDistribution'
+    >
+  >;
+
+  const mockEvent = {
+    eventId: '1',
+    inviteCode: 'ABC',
+    creator: 'GCREATOR',
+    title: 'Test Event',
+    description: 'Desc',
+    startTime: 1_000_000,
+    endTime: 2_000_000,
+    maxParticipants: 100,
+    participantCount: 3,
+    isActive: true,
+  };
+
+  const mockMatches = [
+    {
+      matchId: '10',
+      eventId: '1',
+      homeTeam: 'Alpha',
+      awayTeam: 'Beta',
+      startTime: 1_100_000,
+      resolved: true,
+      outcome: 'TEAM_A',
+    },
+    {
+      matchId: '11',
+      eventId: '1',
+      homeTeam: 'Gamma',
+      awayTeam: 'Delta',
+      startTime: 1_200_000,
+      resolved: false,
+      outcome: null,
+    },
+  ];
+
+  beforeEach(async () => {
+    contractService = {
+      getEvent: jest.fn(),
+      getEventMatches: jest.fn(),
+      getUserPredictions: jest.fn(),
+      getEventStatistics: jest.fn(),
+      getEventParticipants: jest.fn(),
+      getPredictionDistribution: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CreatorEventsService,
+        { provide: ContractService, useValue: contractService },
+        {
+          provide: getRepositoryToken(CreatorEvent),
+          useValue: { createQueryBuilder: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CreatorEventsService>(CreatorEventsService);
+  });
+
+  describe('getUserPredictionsForEvent', () => {
+    beforeEach(() => {
+      contractService.getEvent.mockResolvedValue(mockEvent);
+      contractService.getEventMatches.mockResolvedValue(mockMatches);
+    });
+
+    it('returns enriched predictions sorted by match time', async () => {
+      contractService.getUserPredictions.mockResolvedValue([
+        {
+          prediction_id: 2,
+          match_id: 11,
+          predicted_outcome: 'DRAW',
+          predicted_at: 1_050_000,
+        },
+        {
+          prediction_id: 1,
+          match_id: 10,
+          predicted_outcome: 'TEAM_A',
+          predicted_at: 1_040_000,
+          is_correct: true,
+        },
+      ] as any);
+
+      const result = await service.getUserPredictionsForEvent('1', 'GUSER');
+
+      expect(result.address).toBe('GUSER');
+      expect(result.predictions).toHaveLength(2);
+      expect(result.predictions[0].matchId).toBe('10');
+      expect(result.predictions[1].matchId).toBe('11');
+      expect(result.predictions[0].isCorrect).toBe(true);
+      expect(result.predictions[0].actualResult).toBe('TEAM_A');
+      expect(result.predictions[1].isCorrect).toBeNull();
+      expect(result.score).toEqual({
+        totalPredictions: 2,
+        correctPredictions: 1,
+        accuracyPercentage: 100,
+        matchesRemaining: 0,
+      });
+    });
+
+    it('throws when event is not found', async () => {
+      contractService.getEvent.mockResolvedValue(null);
+
+      await expect(
+        service.getUserPredictionsForEvent('999', 'GUSER'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getEventStats', () => {
+    beforeEach(() => {
+      contractService.getEvent.mockResolvedValue(mockEvent);
+      contractService.getEventMatches.mockResolvedValue(mockMatches);
+      contractService.getEventStatistics.mockResolvedValue({
+        eventId: '1',
+        participantCount: 3,
+        matchCount: 2,
+        totalPredictions: 5,
+        allMatchesResolved: false,
+        winnersVerified: false,
+        winnerCount: 0,
+      });
+      contractService.getEventParticipants.mockResolvedValue([
+        { address: 'A', joinedAt: 1, predictionCount: 2 },
+        { address: 'B', joinedAt: 2, predictionCount: 2 },
+        { address: 'C', joinedAt: 3, predictionCount: 1 },
+      ]);
+      contractService.getPredictionDistribution
+        .mockResolvedValueOnce({ teamA: 2, teamB: 1, draw: 0 })
+        .mockResolvedValueOnce({ teamA: 0, teamB: 1, draw: 1 });
+    });
+
+    it('calculates event statistics with distribution and completion rate', async () => {
+      const result = await service.getEventStats('1');
+
+      expect(result.totalParticipants).toBe(3);
+      expect(result.totalMatches).toBe(2);
+      expect(result.matchesResolved).toBe(1);
+      expect(result.matchesPending).toBe(1);
+      expect(result.totalPredictions).toBe(5);
+      expect(result.predictionDistribution).toHaveLength(2);
+      expect(result.predictionDistribution[0].total).toBe(3);
+      expect(result.averagePredictionsPerUser).toBe(1.67);
+      expect(result.completionRate).toBe(67);
+      expect(result.winnersVerified).toBe(false);
+    });
+
+    it('throws when event is not found', async () => {
+      contractService.getEvent.mockResolvedValue(null);
+
+      await expect(service.getEventStats('999')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/creator-events/creator-events.controller.spec.ts
+++ b/backend/src/creator-events/creator-events.controller.spec.ts
@@ -13,6 +13,8 @@ import {
 } from './dto/list-matches-query.dto';
 import { EventByCodeResponseDto } from './dto/event-by-code-response.dto';
 import { UserScoreResponseDto } from './dto/user-score-response.dto';
+import { UserPredictionsResponseDto } from './dto/user-predictions-response.dto';
+import { EventStatsResponseDto } from './dto/event-stats-response.dto';
 
 describe('CreatorEventsController', () => {
   let controller: CreatorEventsController;
@@ -30,6 +32,8 @@ describe('CreatorEventsController', () => {
             getParticipants: jest.fn(),
             getEventMatches: jest.fn(),
             getUserScore: jest.fn(),
+            getUserPredictionsForEvent: jest.fn(),
+            getEventStats: jest.fn(),
             getContractConfig: jest.fn(),
           },
         },
@@ -80,6 +84,56 @@ describe('CreatorEventsController', () => {
       const result = await controller.getEventMatches('event-1', query);
 
       expect(result).toEqual(mockMatches);
+    });
+  });
+
+  describe('getUserPredictions', () => {
+    it('should call service with correct parameters', async () => {
+      const mockResponse: UserPredictionsResponseDto = {
+        address: 'GUSER1',
+        eventId: 'event-1',
+        score: {
+          totalPredictions: 2,
+          correctPredictions: 1,
+          accuracyPercentage: 50,
+          matchesRemaining: 0,
+        },
+        predictions: [],
+      };
+
+      service.getUserPredictionsForEvent.mockResolvedValue(mockResponse);
+
+      await controller.getUserPredictions('event-1', 'GUSER1');
+
+      expect(service.getUserPredictionsForEvent).toHaveBeenCalledWith(
+        'event-1',
+        'GUSER1',
+      );
+    });
+  });
+
+  describe('getEventStats', () => {
+    it('should return event stats from service', async () => {
+      const mockStats: EventStatsResponseDto = {
+        eventId: 'event-1',
+        totalParticipants: 10,
+        totalMatches: 5,
+        matchesResolved: 3,
+        matchesPending: 2,
+        totalPredictions: 40,
+        predictionDistribution: [],
+        winnersVerified: false,
+        winnerCount: 0,
+        averagePredictionsPerUser: 4,
+        completionRate: 60,
+      };
+
+      service.getEventStats.mockResolvedValue(mockStats);
+
+      const result = await controller.getEventStats('event-1');
+
+      expect(service.getEventStats).toHaveBeenCalledWith('event-1');
+      expect(result).toEqual(mockStats);
     });
   });
 

--- a/backend/src/creator-events/creator-events.controller.ts
+++ b/backend/src/creator-events/creator-events.controller.ts
@@ -27,7 +27,10 @@ import { ListParticipantsQueryDto } from './dto/list-participants-query.dto';
 import { SearchEventsQueryDto } from './dto/search-events-query.dto';
 import { SearchEventsResponseDto } from './dto/search-events-response.dto';
 import { UserScoreResponseDto } from './dto/user-score-response.dto';
+import { UserPredictionsResponseDto } from './dto/user-predictions-response.dto';
+import { EventStatsResponseDto } from './dto/event-stats-response.dto';
 
+@ApiTags('creator-events')
 @Controller('creator-events')
 export class CreatorEventsController {
   constructor(private readonly creatorEventsService: CreatorEventsService) {}
@@ -113,6 +116,45 @@ export class CreatorEventsController {
     @Query() query: ListMatchesQueryDto,
   ) {
     return this.creatorEventsService.getEventMatches(id, query);
+  }
+
+  /**
+   * GET /api/creator-events/:id/stats
+   * #727 — Fetch detailed statistics for a specific event.
+   */
+  @Get(':id/stats')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(120) // 2 minutes
+  @ApiOperation({ summary: 'Get event statistics' })
+  @ApiResponse({
+    status: 200,
+    description: 'Event statistics with prediction distribution',
+    type: EventStatsResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  getEventStats(@Param('id') id: string): Promise<EventStatsResponseDto> {
+    return this.creatorEventsService.getEventStats(id);
+  }
+
+  /**
+   * GET /api/creator-events/:id/predictions/:address
+   * #731 — Fetch all predictions a user has made for a specific event.
+   */
+  @Get(':id/predictions/:address')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(30) // 30 seconds
+  @ApiOperation({ summary: 'Get user predictions for an event' })
+  @ApiResponse({
+    status: 200,
+    description: 'User predictions with match details and score',
+    type: UserPredictionsResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  getUserPredictions(
+    @Param('id') id: string,
+    @Param('address') address: string,
+  ): Promise<UserPredictionsResponseDto> {
+    return this.creatorEventsService.getUserPredictionsForEvent(id, address);
   }
 
   /**

--- a/backend/src/creator-events/creator-events.module.ts
+++ b/backend/src/creator-events/creator-events.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { CacheModule } from '@nestjs/cache-manager';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContractModule } from '../contract/contract.module';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
@@ -10,7 +11,11 @@ import {
 import { CreatorEventsService } from './creator-events.service';
 
 @Module({
-  imports: [ContractModule, TypeOrmModule.forFeature([CreatorEvent])],
+  imports: [
+    ContractModule,
+    TypeOrmModule.forFeature([CreatorEvent]),
+    CacheModule.register(),
+  ],
   controllers: [
     CreatorEventsController,
     PublicCreatorEventsController,

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -413,9 +413,10 @@ export class CreatorEventsService {
 
     const distributionResults = await Promise.all(
       matches.map(async (match) => {
-        const distribution = await this.contractService.getPredictionDistribution(
-          String(match.matchId),
-        );
+        const distribution =
+          await this.contractService.getPredictionDistribution(
+            String(match.matchId),
+          );
         return {
           matchId: String(match.matchId),
           homeTeam: match.homeTeam,
@@ -490,7 +491,9 @@ export class CreatorEventsService {
 
     for (const prediction of userPredictions) {
       const normalized = normalizeContractPrediction(prediction);
-      const match = matches.find((m) => String(m.matchId) === normalized.matchId);
+      const match = matches.find(
+        (m) => String(m.matchId) === normalized.matchId,
+      );
       if (!match) continue;
 
       if (!match.resolved) {

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -34,6 +34,12 @@ import {
   SearchHighlightsDto,
 } from './dto/search-events-response.dto';
 import { UserScoreResponseDto } from './dto/user-score-response.dto';
+import { UserPredictionsResponseDto } from './dto/user-predictions-response.dto';
+import { EventStatsResponseDto } from './dto/event-stats-response.dto';
+import {
+  normalizeContractPrediction,
+  resolveCorrectness,
+} from './utils/prediction.util';
 
 // Type definitions - exported for use in controllers
 export interface ParticipantWithStats {
@@ -308,6 +314,156 @@ export class CreatorEventsService {
     };
   }
 
+  async getUserPredictionsForEvent(
+    eventId: string,
+    address: string,
+  ): Promise<UserPredictionsResponseDto> {
+    const event = await this.contractService.getEvent(eventId);
+    if (!event) {
+      throw new NotFoundException(`Event ${eventId} not found`);
+    }
+
+    const [matches, rawPredictions] = await Promise.all([
+      this.contractService.getEventMatches(eventId),
+      this.contractService.getUserPredictions(address, eventId),
+    ]);
+
+    const matchMap = new Map(matches.map((m) => [String(m.matchId), m]));
+    const predictedMatchIds = new Set<string>();
+
+    let correctPredictions = 0;
+    let resolvedPredictions = 0;
+
+    const predictions = rawPredictions
+      .map((raw) => {
+        const normalized = normalizeContractPrediction(raw);
+        const match = matchMap.get(normalized.matchId);
+        if (!match) {
+          return null;
+        }
+
+        predictedMatchIds.add(normalized.matchId);
+        const isCorrect = resolveCorrectness(
+          normalized,
+          match.resolved,
+          match.outcome,
+        );
+
+        if (match.resolved) {
+          resolvedPredictions++;
+          if (isCorrect) {
+            correctPredictions++;
+          }
+        }
+
+        return {
+          predictionId: normalized.predictionId,
+          matchId: normalized.matchId,
+          match: {
+            matchId: match.matchId,
+            homeTeam: match.homeTeam,
+            awayTeam: match.awayTeam,
+            matchTime: match.startTime,
+          },
+          predictedOutcome: normalized.predictedOutcome,
+          actualResult: match.resolved ? match.outcome : null,
+          isCorrect,
+          predictedAt: normalized.predictedAt,
+        };
+      })
+      .filter((item): item is NonNullable<typeof item> => item !== null)
+      .sort((a, b) => a.match.matchTime - b.match.matchTime);
+
+    const totalPredictions = predictions.length;
+    const matchesRemaining = matches.filter(
+      (m) => !predictedMatchIds.has(String(m.matchId)),
+    ).length;
+    const accuracyPercentage =
+      resolvedPredictions > 0
+        ? Math.round((correctPredictions / resolvedPredictions) * 100)
+        : 0;
+
+    return {
+      address,
+      eventId,
+      score: {
+        totalPredictions,
+        correctPredictions,
+        accuracyPercentage,
+        matchesRemaining,
+      },
+      predictions,
+    };
+  }
+
+  async getEventStats(eventId: string): Promise<EventStatsResponseDto> {
+    const event = await this.contractService.getEvent(eventId);
+    if (!event) {
+      throw new NotFoundException(`Event ${eventId} not found`);
+    }
+
+    const [statistics, matches, participants] = await Promise.all([
+      this.contractService.getEventStatistics(eventId),
+      this.contractService.getEventMatches(eventId),
+      this.contractService.getEventParticipants(eventId),
+    ]);
+
+    const matchesResolved = matches.filter((m) => m.resolved).length;
+    const matchesPending = matches.length - matchesResolved;
+
+    const distributionResults = await Promise.all(
+      matches.map(async (match) => {
+        const distribution = await this.contractService.getPredictionDistribution(
+          String(match.matchId),
+        );
+        return {
+          matchId: String(match.matchId),
+          homeTeam: match.homeTeam,
+          awayTeam: match.awayTeam,
+          teamA: distribution.teamA,
+          teamB: distribution.teamB,
+          draw: distribution.draw,
+          total: distribution.teamA + distribution.teamB + distribution.draw,
+        };
+      }),
+    );
+
+    const totalParticipants =
+      statistics?.participantCount ?? participants.length;
+    const totalMatches = statistics?.matchCount ?? matches.length;
+    const totalPredictions =
+      statistics?.totalPredictions ??
+      distributionResults.reduce((sum, item) => sum + item.total, 0);
+
+    const matchCount = matches.length;
+    const usersWithFullPredictions = participants.filter(
+      (p) => p.predictionCount >= matchCount && matchCount > 0,
+    ).length;
+    const completionRate =
+      totalParticipants > 0
+        ? Math.round((usersWithFullPredictions / totalParticipants) * 100)
+        : 0;
+
+    const averagePredictionsPerUser =
+      totalParticipants > 0
+        ? Math.round((totalPredictions / totalParticipants) * 100) / 100
+        : 0;
+
+    return {
+      eventId,
+      totalParticipants,
+      totalMatches,
+      matchesResolved,
+      matchesPending,
+      totalPredictions,
+      predictionDistribution: distributionResults,
+      winnersVerified: statistics?.winnersVerified ?? false,
+      winnerCount: statistics?.winnerCount ?? 0,
+      averagePredictionsPerUser,
+      completionRate,
+    };
+  }
+
   async getUserScore(
     eventId: string,
     address: string,
@@ -333,12 +489,15 @@ export class CreatorEventsService {
     let pendingPredictions = 0;
 
     for (const prediction of userPredictions) {
-      const match = matches.find((m) => m.matchId === prediction.matchId);
+      const normalized = normalizeContractPrediction(prediction);
+      const match = matches.find((m) => String(m.matchId) === normalized.matchId);
       if (!match) continue;
 
       if (!match.resolved) {
         pendingPredictions++;
-      } else if (match.outcome === prediction.chosenOutcome) {
+      } else if (
+        resolveCorrectness(normalized, match.resolved, match.outcome)
+      ) {
         correctPredictions++;
       } else {
         incorrectPredictions++;

--- a/backend/src/creator-events/dto/event-stats-response.dto.ts
+++ b/backend/src/creator-events/dto/event-stats-response.dto.ts
@@ -39,7 +39,9 @@ export class EventStatsResponseDto {
   @ApiProperty({ description: 'Number of pending (unresolved) matches' })
   matchesPending: number;
 
-  @ApiProperty({ description: 'Total predictions submitted across all matches' })
+  @ApiProperty({
+    description: 'Total predictions submitted across all matches',
+  })
   totalPredictions: number;
 
   @ApiProperty({
@@ -60,8 +62,7 @@ export class EventStatsResponseDto {
   averagePredictionsPerUser: number;
 
   @ApiProperty({
-    description:
-      'Percentage of participants who predicted all matches (0-100)',
+    description: 'Percentage of participants who predicted all matches (0-100)',
   })
   completionRate: number;
 }

--- a/backend/src/creator-events/dto/event-stats-response.dto.ts
+++ b/backend/src/creator-events/dto/event-stats-response.dto.ts
@@ -1,0 +1,67 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MatchPredictionDistributionDto {
+  @ApiProperty({ description: 'Match identifier' })
+  matchId: string;
+
+  @ApiProperty({ description: 'Home team name' })
+  homeTeam: string;
+
+  @ApiProperty({ description: 'Away team name' })
+  awayTeam: string;
+
+  @ApiProperty({ description: 'Predictions for TEAM_A' })
+  teamA: number;
+
+  @ApiProperty({ description: 'Predictions for TEAM_B' })
+  teamB: number;
+
+  @ApiProperty({ description: 'Predictions for DRAW' })
+  draw: number;
+
+  @ApiProperty({ description: 'Total predictions for this match' })
+  total: number;
+}
+
+export class EventStatsResponseDto {
+  @ApiProperty({ description: 'Event identifier' })
+  eventId: string;
+
+  @ApiProperty({ description: 'Total participants' })
+  totalParticipants: number;
+
+  @ApiProperty({ description: 'Total matches in the event' })
+  totalMatches: number;
+
+  @ApiProperty({ description: 'Number of resolved matches' })
+  matchesResolved: number;
+
+  @ApiProperty({ description: 'Number of pending (unresolved) matches' })
+  matchesPending: number;
+
+  @ApiProperty({ description: 'Total predictions submitted across all matches' })
+  totalPredictions: number;
+
+  @ApiProperty({
+    type: [MatchPredictionDistributionDto],
+    description: 'Prediction distribution per match',
+  })
+  predictionDistribution: MatchPredictionDistributionDto[];
+
+  @ApiProperty({ description: 'Whether event winners have been verified' })
+  winnersVerified: boolean;
+
+  @ApiProperty({ description: 'Number of verified winners' })
+  winnerCount: number;
+
+  @ApiProperty({
+    description: 'Average predictions per participant',
+  })
+  averagePredictionsPerUser: number;
+
+  @ApiProperty({
+    description:
+      'Percentage of participants who predicted all matches (0-100)',
+  })
+  completionRate: number;
+}

--- a/backend/src/creator-events/dto/user-predictions-response.dto.ts
+++ b/backend/src/creator-events/dto/user-predictions-response.dto.ts
@@ -1,0 +1,78 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UserPredictionMatchDto {
+  @ApiProperty({ description: 'Match identifier' })
+  matchId: string;
+
+  @ApiProperty({ description: 'Home team name' })
+  homeTeam: string;
+
+  @ApiProperty({ description: 'Away team name' })
+  awayTeam: string;
+
+  @ApiProperty({ description: 'Match start time (Unix timestamp)' })
+  matchTime: number;
+}
+
+export class UserPredictionItemDto {
+  @ApiProperty({ description: 'Prediction identifier' })
+  predictionId: string;
+
+  @ApiProperty({ description: 'Match identifier' })
+  matchId: string;
+
+  @ApiProperty({ type: UserPredictionMatchDto })
+  match: UserPredictionMatchDto;
+
+  @ApiProperty({
+    description: 'Predicted outcome (TEAM_A, TEAM_B, or DRAW)',
+  })
+  predictedOutcome: string;
+
+  @ApiPropertyOptional({
+    description: 'Actual match result if resolved',
+    nullable: true,
+  })
+  actualResult: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Whether prediction was correct (null if unresolved)',
+    nullable: true,
+  })
+  isCorrect: boolean | null;
+
+  @ApiProperty({ description: 'Prediction submission timestamp (Unix)' })
+  predictedAt: number;
+}
+
+export class UserPredictionsScoreDto {
+  @ApiProperty({ description: 'Total predictions made by user' })
+  totalPredictions: number;
+
+  @ApiProperty({
+    description: 'Correct predictions (resolved matches only)',
+  })
+  correctPredictions: number;
+
+  @ApiProperty({ description: 'Accuracy percentage (0-100)' })
+  accuracyPercentage: number;
+
+  @ApiProperty({
+    description: 'Matches remaining without a user prediction',
+  })
+  matchesRemaining: number;
+}
+
+export class UserPredictionsResponseDto {
+  @ApiProperty({ description: 'User wallet address' })
+  address: string;
+
+  @ApiProperty({ description: 'Event identifier' })
+  eventId: string;
+
+  @ApiProperty({ type: UserPredictionsScoreDto })
+  score: UserPredictionsScoreDto;
+
+  @ApiProperty({ type: [UserPredictionItemDto] })
+  predictions: UserPredictionItemDto[];
+}

--- a/backend/src/creator-events/utils/prediction.util.spec.ts
+++ b/backend/src/creator-events/utils/prediction.util.spec.ts
@@ -1,0 +1,73 @@
+import {
+  normalizeContractPrediction,
+  resolveCorrectness,
+} from './prediction.util';
+import { ContractPrediction } from '../../contract/contract.service';
+
+describe('prediction.util', () => {
+  describe('normalizeContractPrediction', () => {
+    it('normalizes snake_case contract fields', () => {
+      const result = normalizeContractPrediction({
+        prediction_id: 42,
+        match_id: 7,
+        predicted_outcome: 'TEAM_A',
+        predicted_at: 1_700_000_000,
+        is_correct: true,
+      } as ContractPrediction);
+
+      expect(result).toEqual({
+        predictionId: '42',
+        matchId: '7',
+        predictedOutcome: 'TEAM_A',
+        predictedAt: 1_700_000_000,
+        isCorrect: true,
+      });
+    });
+
+    it('normalizes camelCase contract fields', () => {
+      const result = normalizeContractPrediction({
+        predictionId: 'pred-1',
+        matchId: 'match-1',
+        chosenOutcome: 'DRAW',
+        predictedAt: 1_800_000_000,
+      });
+
+      expect(result.predictedOutcome).toBe('DRAW');
+      expect(result.isCorrect).toBeNull();
+    });
+  });
+
+  describe('resolveCorrectness', () => {
+    it('returns stored isCorrect when available', () => {
+      const normalized = normalizeContractPrediction({
+        is_correct: false,
+        predicted_outcome: 'TEAM_A',
+        match_id: 1,
+        prediction_id: 1,
+      } as ContractPrediction);
+
+      expect(resolveCorrectness(normalized, true, 'TEAM_B')).toBe(false);
+    });
+
+    it('returns null for unresolved matches', () => {
+      const normalized = normalizeContractPrediction({
+        predicted_outcome: 'TEAM_A',
+        match_id: 1,
+        prediction_id: 1,
+      } as ContractPrediction);
+
+      expect(resolveCorrectness(normalized, false, null)).toBeNull();
+    });
+
+    it('compares outcome for resolved matches', () => {
+      const normalized = normalizeContractPrediction({
+        predicted_outcome: 'TEAM_B',
+        match_id: 1,
+        prediction_id: 1,
+      } as ContractPrediction);
+
+      expect(resolveCorrectness(normalized, true, 'TEAM_B')).toBe(true);
+      expect(resolveCorrectness(normalized, true, 'TEAM_A')).toBe(false);
+    });
+  });
+});

--- a/backend/src/creator-events/utils/prediction.util.ts
+++ b/backend/src/creator-events/utils/prediction.util.ts
@@ -13,15 +13,22 @@ export function normalizeContractPrediction(
 ): NormalizedPrediction {
   const raw = prediction as ContractPrediction & Record<string, unknown>;
 
-  const predictionId = String(
-    raw.predictionId ?? raw.prediction_id ?? raw.id ?? '',
+  const normalizeString = (value: unknown, fallback = ''): string => {
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      return String(value);
+    }
+    return fallback;
+  };
+
+  const predictionId = normalizeString(
+    raw.predictionId ?? raw.prediction_id ?? raw.id,
   );
-  const matchId = String(raw.matchId ?? raw.match_id ?? '');
-  const predictedOutcome = String(
-    raw.chosenOutcome ??
-      raw.predictedOutcome ??
-      raw.predicted_outcome ??
-      '',
+  const matchId = normalizeString(raw.matchId ?? raw.match_id);
+  const predictedOutcome = normalizeString(
+    raw.chosenOutcome ?? raw.predictedOutcome ?? raw.predicted_outcome,
   );
   const predictedAt = Number(raw.predictedAt ?? raw.predicted_at ?? 0);
   const isCorrectRaw = raw.isCorrect ?? raw.is_correct;

--- a/backend/src/creator-events/utils/prediction.util.ts
+++ b/backend/src/creator-events/utils/prediction.util.ts
@@ -1,0 +1,57 @@
+import { ContractPrediction } from '../../contract/contract.service';
+
+export interface NormalizedPrediction {
+  predictionId: string;
+  matchId: string;
+  predictedOutcome: string;
+  predictedAt: number;
+  isCorrect: boolean | null;
+}
+
+export function normalizeContractPrediction(
+  prediction: ContractPrediction,
+): NormalizedPrediction {
+  const raw = prediction as ContractPrediction & Record<string, unknown>;
+
+  const predictionId = String(
+    raw.predictionId ?? raw.prediction_id ?? raw.id ?? '',
+  );
+  const matchId = String(raw.matchId ?? raw.match_id ?? '');
+  const predictedOutcome = String(
+    raw.chosenOutcome ??
+      raw.predictedOutcome ??
+      raw.predicted_outcome ??
+      '',
+  );
+  const predictedAt = Number(raw.predictedAt ?? raw.predicted_at ?? 0);
+  const isCorrectRaw = raw.isCorrect ?? raw.is_correct;
+
+  let isCorrect: boolean | null = null;
+  if (isCorrectRaw === true || isCorrectRaw === false) {
+    isCorrect = isCorrectRaw;
+  }
+
+  return {
+    predictionId,
+    matchId,
+    predictedOutcome,
+    predictedAt,
+    isCorrect,
+  };
+}
+
+export function resolveCorrectness(
+  normalized: NormalizedPrediction,
+  matchResolved: boolean,
+  matchOutcome: string | null,
+): boolean | null {
+  if (normalized.isCorrect !== null) {
+    return normalized.isCorrect;
+  }
+
+  if (!matchResolved || !matchOutcome) {
+    return null;
+  }
+
+  return matchOutcome === normalized.predictedOutcome;
+}

--- a/backend/src/indexer/dto/indexer-health.dto.ts
+++ b/backend/src/indexer/dto/indexer-health.dto.ts
@@ -1,0 +1,80 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum IndexerAlertSeverity {
+  Warning = 'warning',
+  Critical = 'critical',
+}
+
+export class IndexerAlertDto {
+  @ApiProperty({ enum: IndexerAlertSeverity })
+  severity: IndexerAlertSeverity;
+
+  @ApiProperty()
+  code: string;
+
+  @ApiProperty()
+  message: string;
+
+  @ApiProperty()
+  triggered_at: string;
+}
+
+export class IndexerHealthMetricsDto {
+  @ApiProperty()
+  last_processed_ledger: number;
+
+  @ApiProperty()
+  current_stellar_ledger: number;
+
+  @ApiProperty()
+  lag_in_ledgers: number;
+
+  @ApiProperty()
+  events_processed_per_minute: number;
+
+  @ApiProperty()
+  failed_event_count: number;
+
+  @ApiProperty()
+  error_rate_percent: number;
+
+  @ApiProperty()
+  last_successful_sync_at: string;
+
+  @ApiProperty()
+  is_running: boolean;
+
+  @ApiProperty()
+  uptime_seconds: number;
+
+  @ApiProperty()
+  total_events_processed: number;
+
+  @ApiProperty()
+  pending_events: number;
+
+  @ApiProperty()
+  dlq_events: number;
+}
+
+export class IndexerHealthResponseDto {
+  @ApiProperty()
+  status: 'healthy' | 'degraded' | 'unhealthy';
+
+  @ApiProperty({ type: IndexerHealthMetricsDto })
+  metrics: IndexerHealthMetricsDto;
+
+  @ApiProperty({ type: [IndexerAlertDto] })
+  alerts: IndexerAlertDto[];
+}
+
+export class IndexerDashboardDto extends IndexerHealthResponseDto {
+  @ApiProperty()
+  events_per_second: number;
+
+  @ApiProperty()
+  sync_interval_seconds: number;
+
+  @ApiProperty()
+  contract_configured: boolean;
+}

--- a/backend/src/indexer/health.service.spec.ts
+++ b/backend/src/indexer/health.service.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { IndexerHealthService } from './health.service';
+import { IndexerService } from './indexer.service';
+import { IndexerAlertSeverity } from './dto/indexer-health.dto';
+
+describe('IndexerHealthService', () => {
+  let service: IndexerHealthService;
+  let indexerService: jest.Mocked<
+    Pick<
+      IndexerService,
+      | 'getMetrics'
+      | 'getEventsProcessedPerMinute'
+      | 'getLastSuccessfulSyncTimestamp'
+      | 'triggerManualSync'
+    >
+  >;
+
+  beforeEach(async () => {
+    indexerService = {
+      getMetrics: jest.fn(),
+      getEventsProcessedPerMinute: jest.fn(),
+      getLastSuccessfulSyncTimestamp: jest.fn(),
+      triggerManualSync: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IndexerHealthService,
+        { provide: IndexerService, useValue: indexerService },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'SOROBAN_CONTRACT_ID') return 'contract-123';
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<IndexerHealthService>(IndexerHealthService);
+  });
+
+  const mockHealthyMetrics = () => {
+    indexerService.getMetrics.mockResolvedValue({
+      events_per_second: 1.5,
+      lag_in_ledgers: 10,
+      total_events_processed: 950,
+      pending_events: 5,
+      failed_events: 2,
+      dlq_events: 1,
+      last_processed_ledger: 500,
+      latest_contract_ledger: 510,
+      is_running: false,
+      uptime_seconds: 3600,
+    });
+    indexerService.getEventsProcessedPerMinute.mockReturnValue(12);
+    indexerService.getLastSuccessfulSyncTimestamp.mockReturnValue(new Date());
+  };
+
+  it('returns healthy status when all metrics are within thresholds', async () => {
+    mockHealthyMetrics();
+
+    const health = await service.getHealth();
+
+    expect(health.status).toBe('healthy');
+    expect(health.alerts).toHaveLength(0);
+    expect(health.metrics.lag_in_ledgers).toBe(10);
+    expect(health.metrics.events_processed_per_minute).toBe(12);
+  });
+
+  it('triggers lag alert when lag exceeds 100 ledgers', async () => {
+    mockHealthyMetrics();
+    indexerService.getMetrics.mockResolvedValue({
+      events_per_second: 0,
+      lag_in_ledgers: 150,
+      total_events_processed: 100,
+      pending_events: 0,
+      failed_events: 0,
+      dlq_events: 0,
+      last_processed_ledger: 100,
+      latest_contract_ledger: 250,
+      is_running: false,
+      uptime_seconds: 60,
+    });
+
+    const health = await service.getHealth();
+
+    expect(health.status).toBe('unhealthy');
+    expect(health.alerts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'INDEXER_LAG_HIGH',
+          severity: IndexerAlertSeverity.Critical,
+        }),
+      ]),
+    );
+  });
+
+  it('triggers stale sync alert when no events processed recently', async () => {
+    mockHealthyMetrics();
+    indexerService.getEventsProcessedPerMinute.mockReturnValue(0);
+    indexerService.getLastSuccessfulSyncTimestamp.mockReturnValue(
+      new Date(Date.now() - 10 * 60_000),
+    );
+
+    const health = await service.getHealth();
+
+    expect(health.status).toBe('degraded');
+    expect(health.alerts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'INDEXER_STALE' }),
+      ]),
+    );
+  });
+
+  it('exports prometheus metrics in text format', async () => {
+    mockHealthyMetrics();
+
+    const output = await service.getPrometheusMetrics();
+
+    expect(output).toContain('indexer_lag_in_ledgers 10');
+    expect(output).toContain('# TYPE indexer_is_running gauge');
+    expect(output).toContain('indexer_total_events_processed 950');
+  });
+
+  it('triggers manual sync via indexer service', async () => {
+    indexerService.triggerManualSync.mockResolvedValue(undefined);
+
+    const result = await service.triggerManualSync();
+
+    expect(indexerService.triggerManualSync).toHaveBeenCalled();
+    expect(result.message).toContain('triggered');
+  });
+});

--- a/backend/src/indexer/health.service.ts
+++ b/backend/src/indexer/health.service.ts
@@ -1,0 +1,189 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IndexerService } from './indexer.service';
+import {
+  IndexerAlertDto,
+  IndexerAlertSeverity,
+  IndexerDashboardDto,
+  IndexerHealthMetricsDto,
+  IndexerHealthResponseDto,
+} from './dto/indexer-health.dto';
+
+const LAG_ALERT_THRESHOLD = 100;
+const STALE_SYNC_MINUTES = 5;
+const ERROR_RATE_THRESHOLD = 5;
+
+@Injectable()
+export class IndexerHealthService {
+  private readonly logger = new Logger(IndexerHealthService.name);
+
+  constructor(
+    private readonly indexerService: IndexerService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async getHealth(): Promise<IndexerHealthResponseDto> {
+    const metrics = await this.buildMetrics();
+    const alerts = this.evaluateAlerts(metrics);
+
+    return {
+      status: this.resolveStatus(alerts),
+      metrics,
+      alerts,
+    };
+  }
+
+  async getDashboard(): Promise<IndexerDashboardDto> {
+    const health = await this.getHealth();
+    const baseMetrics = await this.indexerService.getMetrics();
+    const contractId = this.configService.get<string>('SOROBAN_CONTRACT_ID');
+
+    return {
+      ...health,
+      events_per_second: baseMetrics.events_per_second,
+      sync_interval_seconds: 30,
+      contract_configured: Boolean(
+        contractId && contractId !== 'your-contract-id-here',
+      ),
+    };
+  }
+
+  async getPrometheusMetrics(): Promise<string> {
+    const metrics = await this.buildMetrics();
+    const lines = [
+      '# HELP indexer_last_processed_ledger Last ledger processed by the indexer',
+      '# TYPE indexer_last_processed_ledger gauge',
+      `indexer_last_processed_ledger ${metrics.last_processed_ledger}`,
+      '# HELP indexer_current_stellar_ledger Current Stellar network ledger',
+      '# TYPE indexer_current_stellar_ledger gauge',
+      `indexer_current_stellar_ledger ${metrics.current_stellar_ledger}`,
+      '# HELP indexer_lag_in_ledgers Ledger lag behind the network',
+      '# TYPE indexer_lag_in_ledgers gauge',
+      `indexer_lag_in_ledgers ${metrics.lag_in_ledgers}`,
+      '# HELP indexer_events_processed_per_minute Events processed in the last minute',
+      '# TYPE indexer_events_processed_per_minute gauge',
+      `indexer_events_processed_per_minute ${metrics.events_processed_per_minute}`,
+      '# HELP indexer_failed_event_count Total failed contract events',
+      '# TYPE indexer_failed_event_count gauge',
+      `indexer_failed_event_count ${metrics.failed_event_count}`,
+      '# HELP indexer_error_rate_percent Failed events as a percentage of total',
+      '# TYPE indexer_error_rate_percent gauge',
+      `indexer_error_rate_percent ${metrics.error_rate_percent}`,
+      '# HELP indexer_is_running Whether the indexer poll is currently running',
+      '# TYPE indexer_is_running gauge',
+      `indexer_is_running ${metrics.is_running ? 1 : 0}`,
+      '# HELP indexer_uptime_seconds Indexer process uptime in seconds',
+      '# TYPE indexer_uptime_seconds counter',
+      `indexer_uptime_seconds ${metrics.uptime_seconds}`,
+      '# HELP indexer_total_events_processed Total successfully processed events',
+      '# TYPE indexer_total_events_processed counter',
+      `indexer_total_events_processed ${metrics.total_events_processed}`,
+      '# HELP indexer_pending_events Pending events awaiting processing',
+      '# TYPE indexer_pending_events gauge',
+      `indexer_pending_events ${metrics.pending_events}`,
+      '# HELP indexer_dlq_events Events in the dead-letter queue',
+      '# TYPE indexer_dlq_events gauge',
+      `indexer_dlq_events ${metrics.dlq_events}`,
+    ];
+
+    return `${lines.join('\n')}\n`;
+  }
+
+  async triggerManualSync(): Promise<{ message: string }> {
+    this.logger.log('Manual indexer sync triggered');
+    await this.indexerService.triggerManualSync();
+    return { message: 'Indexer sync triggered successfully' };
+  }
+
+  private async buildMetrics(): Promise<IndexerHealthMetricsDto> {
+    const baseMetrics = await this.indexerService.getMetrics();
+    const eventsProcessedPerMinute =
+      this.indexerService.getEventsProcessedPerMinute();
+    const lastSyncAt = this.indexerService.getLastSuccessfulSyncTimestamp();
+
+    const totalAttempts =
+      baseMetrics.total_events_processed +
+      baseMetrics.failed_events +
+      baseMetrics.dlq_events;
+    const errorRate =
+      totalAttempts > 0
+        ? Math.round(
+            ((baseMetrics.failed_events + baseMetrics.dlq_events) /
+              totalAttempts) *
+              10000,
+          ) / 100
+        : 0;
+
+    return {
+      last_processed_ledger: baseMetrics.last_processed_ledger,
+      current_stellar_ledger: baseMetrics.latest_contract_ledger,
+      lag_in_ledgers: baseMetrics.lag_in_ledgers,
+      events_processed_per_minute: eventsProcessedPerMinute,
+      failed_event_count: baseMetrics.failed_events + baseMetrics.dlq_events,
+      error_rate_percent: errorRate,
+      last_successful_sync_at: lastSyncAt.toISOString(),
+      is_running: baseMetrics.is_running,
+      uptime_seconds: baseMetrics.uptime_seconds,
+      total_events_processed: baseMetrics.total_events_processed,
+      pending_events: baseMetrics.pending_events,
+      dlq_events: baseMetrics.dlq_events,
+    };
+  }
+
+  private evaluateAlerts(metrics: IndexerHealthMetricsDto): IndexerAlertDto[] {
+    const alerts: IndexerAlertDto[] = [];
+    const now = new Date().toISOString();
+
+    if (metrics.lag_in_ledgers > LAG_ALERT_THRESHOLD) {
+      alerts.push({
+        severity: IndexerAlertSeverity.Critical,
+        code: 'INDEXER_LAG_HIGH',
+        message: `Indexer lag is ${metrics.lag_in_ledgers} ledgers (threshold: ${LAG_ALERT_THRESHOLD})`,
+        triggered_at: now,
+      });
+    }
+
+    const minutesSinceSync =
+      (Date.now() - new Date(metrics.last_successful_sync_at).getTime()) /
+      60000;
+
+    if (
+      metrics.events_processed_per_minute === 0 &&
+      minutesSinceSync >= STALE_SYNC_MINUTES
+    ) {
+      alerts.push({
+        severity: IndexerAlertSeverity.Warning,
+        code: 'INDEXER_STALE',
+        message: `No events processed in the last ${STALE_SYNC_MINUTES} minutes`,
+        triggered_at: now,
+      });
+    }
+
+    if (metrics.error_rate_percent > ERROR_RATE_THRESHOLD) {
+      alerts.push({
+        severity: IndexerAlertSeverity.Critical,
+        code: 'INDEXER_ERROR_RATE_HIGH',
+        message: `Indexer error rate is ${metrics.error_rate_percent}% (threshold: ${ERROR_RATE_THRESHOLD}%)`,
+        triggered_at: now,
+      });
+    }
+
+    return alerts;
+  }
+
+  private resolveStatus(
+    alerts: IndexerAlertDto[],
+  ): 'healthy' | 'degraded' | 'unhealthy' {
+    if (
+      alerts.some((alert) => alert.severity === IndexerAlertSeverity.Critical)
+    ) {
+      return 'unhealthy';
+    }
+
+    if (alerts.length > 0) {
+      return 'degraded';
+    }
+
+    return 'healthy';
+  }
+}

--- a/backend/src/indexer/indexer-health.controller.spec.ts
+++ b/backend/src/indexer/indexer-health.controller.spec.ts
@@ -7,7 +7,10 @@ describe('IndexerHealthController', () => {
   let healthService: jest.Mocked<
     Pick<
       IndexerHealthService,
-      'getHealth' | 'getDashboard' | 'getPrometheusMetrics' | 'triggerManualSync'
+      | 'getHealth'
+      | 'getDashboard'
+      | 'getPrometheusMetrics'
+      | 'triggerManualSync'
     >
   >;
 

--- a/backend/src/indexer/indexer-health.controller.spec.ts
+++ b/backend/src/indexer/indexer-health.controller.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IndexerHealthController } from './indexer-health.controller';
+import { IndexerHealthService } from './health.service';
+
+describe('IndexerHealthController', () => {
+  let controller: IndexerHealthController;
+  let healthService: jest.Mocked<
+    Pick<
+      IndexerHealthService,
+      'getHealth' | 'getDashboard' | 'getPrometheusMetrics' | 'triggerManualSync'
+    >
+  >;
+
+  beforeEach(async () => {
+    healthService = {
+      getHealth: jest.fn(),
+      getDashboard: jest.fn(),
+      getPrometheusMetrics: jest.fn(),
+      triggerManualSync: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [IndexerHealthController],
+      providers: [{ provide: IndexerHealthService, useValue: healthService }],
+    }).compile();
+
+    controller = module.get<IndexerHealthController>(IndexerHealthController);
+  });
+
+  it('returns health status', async () => {
+    healthService.getHealth.mockResolvedValue({
+      status: 'healthy',
+      metrics: {} as any,
+      alerts: [],
+    });
+
+    const result = await controller.getHealth();
+    expect(result.status).toBe('healthy');
+  });
+
+  it('returns prometheus metrics as plain text', async () => {
+    healthService.getPrometheusMetrics.mockResolvedValue(
+      'indexer_lag_in_ledgers 0\n',
+    );
+
+    const result = await controller.getPrometheusMetrics();
+    expect(result).toContain('indexer_lag_in_ledgers');
+  });
+});

--- a/backend/src/indexer/indexer-health.controller.ts
+++ b/backend/src/indexer/indexer-health.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Header,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiProduces,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Public } from '../common/decorators/public.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '../common/enums/role.enum';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { IndexerHealthService } from './health.service';
+import {
+  IndexerDashboardDto,
+  IndexerHealthResponseDto,
+} from './dto/indexer-health.dto';
+
+@ApiTags('Indexer')
+@Controller('indexer')
+export class IndexerHealthController {
+  constructor(private readonly healthService: IndexerHealthService) {}
+
+  /**
+   * GET /api/indexer/health
+   * #722 — Indexer health metrics and alerting status.
+   */
+  @Get('health')
+  @Public()
+  @ApiOperation({ summary: 'Get indexer health status and metrics' })
+  @ApiResponse({
+    status: 200,
+    description: 'Indexer health with alerts',
+    type: IndexerHealthResponseDto,
+  })
+  getHealth(): Promise<IndexerHealthResponseDto> {
+    return this.healthService.getHealth();
+  }
+
+  /**
+   * GET /api/indexer/health/dashboard
+   * #722 — Real-time indexer dashboard stats.
+   */
+  @Get('health/dashboard')
+  @Public()
+  @ApiOperation({ summary: 'Get indexer dashboard statistics' })
+  @ApiResponse({
+    status: 200,
+    description: 'Extended indexer dashboard data',
+    type: IndexerDashboardDto,
+  })
+  getDashboard(): Promise<IndexerDashboardDto> {
+    return this.healthService.getDashboard();
+  }
+
+  /**
+   * GET /api/indexer/health/prometheus
+   * #722 — Prometheus metrics export for the indexer.
+   */
+  @Get('health/prometheus')
+  @Public()
+  @Header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+  @ApiProduces('text/plain')
+  @ApiOperation({ summary: 'Export indexer metrics in Prometheus format' })
+  @ApiResponse({
+    status: 200,
+    description: 'Prometheus text exposition format',
+  })
+  getPrometheusMetrics(): Promise<string> {
+    return this.healthService.getPrometheusMetrics();
+  }
+
+  /**
+   * POST /api/indexer/health/sync
+   * #722 — Manually trigger an indexer sync (admin only).
+   */
+  @Post('health/sync')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.Admin)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Manually trigger indexer sync (admin only)' })
+  @ApiResponse({ status: 200, description: 'Sync triggered' })
+  triggerSync(): Promise<{ message: string }> {
+    return this.healthService.triggerManualSync();
+  }
+}

--- a/backend/src/indexer/indexer-health.controller.ts
+++ b/backend/src/indexer/indexer-health.controller.ts
@@ -1,10 +1,4 @@
-import {
-  Controller,
-  Get,
-  Header,
-  Post,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Header, Post, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -6,6 +6,8 @@ import { FeeHistory } from './entities/fee-history.entity';
 import { IndexerCheckpoint } from './entities/indexer-checkpoint.entity';
 import { IndexerService } from './indexer.service';
 import { IndexerController } from './indexer.controller';
+import { IndexerHealthController } from './indexer-health.controller';
+import { IndexerHealthService } from './health.service';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { Match } from '../matches/entities/match.entity';
 import { MatchPrediction } from '../matches/entities/match-prediction.entity';
@@ -24,8 +26,8 @@ import { User } from '../users/entities/user.entity';
     ]),
     CacheModule.register(),
   ],
-  controllers: [IndexerController],
-  providers: [IndexerService],
-  exports: [IndexerService],
+  controllers: [IndexerController, IndexerHealthController],
+  providers: [IndexerService, IndexerHealthService],
+  exports: [IndexerService, IndexerHealthService],
 })
 export class IndexerModule {}

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -187,6 +187,20 @@ describe('IndexerService', () => {
     });
   });
 
+  describe('health helpers', () => {
+    it('tracks events processed per minute', () => {
+      (service as any).recordProcessedEvent();
+      (service as any).recordProcessedEvent();
+
+      expect(service.getEventsProcessedPerMinute()).toBe(2);
+    });
+
+    it('returns last successful sync timestamp', () => {
+      const timestamp = service.getLastSuccessfulSyncTimestamp();
+      expect(timestamp).toBeInstanceOf(Date);
+    });
+  });
+
   describe('retryFailedEvents', () => {
     it('should retry failed events', async () => {
       const failedEvent = {

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -1,7 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import {
+  DeleteResult,
+  InsertResult,
+  Repository,
+  SelectQueryBuilder,
+} from 'typeorm';
 import { IndexerService } from './indexer.service';
 import {
   ContractEvent,
@@ -142,7 +147,7 @@ describe('IndexerService', () => {
 
   describe('reindex', () => {
     it('should reset checkpoint and trigger reindex', async () => {
-      checkpointRepository.upsert.mockResolvedValue({} as any);
+      checkpointRepository.upsert.mockResolvedValue({} as InsertResult);
 
       await service.reindex(100);
 
@@ -223,8 +228,8 @@ describe('IndexerService', () => {
 
       const origCreate = creatorEventRepository.findOne;
       creatorEventRepository.findOne.mockResolvedValue(null);
-      creatorEventRepository.create.mockReturnValue({} as any);
-      creatorEventRepository.save.mockResolvedValue({} as any);
+      creatorEventRepository.create.mockReturnValue({} as CreatorEvent);
+      creatorEventRepository.save.mockResolvedValue({} as CreatorEvent);
 
       const count = await service.retryFailedEvents();
 
@@ -253,7 +258,7 @@ describe('IndexerService', () => {
       };
 
       contractEventRepository.createQueryBuilder.mockReturnValue(
-        mockQueryBuilder as any,
+        mockQueryBuilder as unknown as SelectQueryBuilder<ContractEvent>,
       );
 
       const result = await service.getEventsPaginated(undefined, 10);
@@ -283,11 +288,9 @@ describe('IndexerService', () => {
 
       mockQueryBuilder.getMany.mockResolvedValue(events);
       contractEventRepository.createQueryBuilder.mockReturnValue(
-        mockQueryBuilder as any,
+        mockQueryBuilder as unknown as SelectQueryBuilder<ContractEvent>,
       );
-
       const result = await service.getEventsPaginated(undefined, 5);
-
       expect(result.data).toHaveLength(5);
       expect(result.meta.has_more).toBe(true);
       expect(result.meta.next_cursor).toBeTruthy();
@@ -302,7 +305,9 @@ describe('IndexerService', () => {
 
   describe('cleanupOldEvents', () => {
     it('should delete old processed events', async () => {
-      contractEventRepository.delete.mockResolvedValue({ affected: 10 } as any);
+      contractEventRepository.delete.mockResolvedValue({
+        affected: 10,
+      } as DeleteResult);
 
       const count = await service.cleanupOldEvents(30);
 

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -32,6 +32,7 @@ export class IndexerService implements OnModuleInit {
   private eventsProcessed = 0;
   private lastProcessedAt = Date.now();
   private processingRate = 0;
+  private eventTimestamps: number[] = [];
 
   constructor(
     private readonly configService: ConfigService,
@@ -127,6 +128,7 @@ export class IndexerService implements OnModuleInit {
         try {
           await this.storeAndProcessEvent(rawEvent);
           this.eventsProcessed++;
+          this.recordProcessedEvent();
           if (rawEvent.ledger > maxProcessedLedger) {
             maxProcessedLedger = rawEvent.ledger;
           }
@@ -833,6 +835,26 @@ export class IndexerService implements OnModuleInit {
       CHECKPOINT_LEDGER_KEY,
       Math.max(0, fromLedger - 1),
     );
+  }
+
+  async triggerManualSync(): Promise<void> {
+    await this.pollContractEvents();
+  }
+
+  getEventsProcessedPerMinute(): number {
+    const cutoff = Date.now() - 60_000;
+    this.eventTimestamps = this.eventTimestamps.filter((t) => t >= cutoff);
+    return this.eventTimestamps.length;
+  }
+
+  getLastSuccessfulSyncTimestamp(): Date {
+    return new Date(this.lastProcessedAt);
+  }
+
+  private recordProcessedEvent(): void {
+    this.eventTimestamps.push(Date.now());
+    const cutoff = Date.now() - 60_000;
+    this.eventTimestamps = this.eventTimestamps.filter((t) => t >= cutoff);
   }
 
   async getEventsPaginated(cursor?: string, limit = 50) {

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -1,0 +1,106 @@
+export type EmailTemplateType =
+  | 'event_created'
+  | 'match_result_available'
+  | 'event_won'
+  | 'event_cancelled';
+
+export interface EmailTemplateContext {
+  eventTitle?: string;
+  eventId?: string;
+  matchHomeTeam?: string;
+  matchAwayTeam?: string;
+  matchResult?: string;
+  userAddress?: string;
+  inviteCode?: string;
+}
+
+const baseStyles = `
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1a1a2e; line-height: 1.6; }
+  .container { max-width: 560px; margin: 0 auto; padding: 32px 24px; }
+  .header { background: #6366f1; color: #fff; padding: 24px; border-radius: 8px 8px 0 0; }
+  .content { background: #f8fafc; padding: 24px; border-radius: 0 0 8px 8px; border: 1px solid #e2e8f0; border-top: none; }
+  .cta { display: inline-block; background: #6366f1; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; margin-top: 16px; }
+  .footer { color: #64748b; font-size: 12px; margin-top: 24px; text-align: center; }
+`;
+
+export function renderEmailTemplate(
+  type: EmailTemplateType,
+  context: EmailTemplateContext,
+): { subject: string; html: string; text: string } {
+  switch (type) {
+    case 'event_created':
+      return {
+        subject: `Your event "${context.eventTitle ?? 'New Event'}" is live on InsightArena`,
+        html: wrapHtml(
+          'Event Created',
+          `<p>Your creator event <strong>${escapeHtml(context.eventTitle ?? 'New Event')}</strong> has been created successfully.</p>
+           <p>Share your invite code <strong>${escapeHtml(context.inviteCode ?? '')}</strong> with participants to get started.</p>`,
+        ),
+        text: `Your event "${context.eventTitle ?? 'New Event'}" is live on InsightArena. Invite code: ${context.inviteCode ?? ''}`,
+      };
+
+    case 'match_result_available':
+      return {
+        subject: `Match result: ${context.matchHomeTeam ?? 'Team A'} vs ${context.matchAwayTeam ?? 'Team B'}`,
+        html: wrapHtml(
+          'Match Result Available',
+          `<p>The match <strong>${escapeHtml(context.matchHomeTeam ?? 'Team A')}</strong> vs <strong>${escapeHtml(context.matchAwayTeam ?? 'Team B')}</strong> in event <strong>${escapeHtml(context.eventTitle ?? '')}</strong> has been resolved.</p>
+           <p>Result: <strong>${escapeHtml(context.matchResult ?? 'Pending')}</strong></p>`,
+        ),
+        text: `Match result available for ${context.matchHomeTeam} vs ${context.matchAwayTeam}. Result: ${context.matchResult}`,
+      };
+
+    case 'event_won':
+      return {
+        subject: `Congratulations! You won "${context.eventTitle ?? 'the event'}"`,
+        html: wrapHtml(
+          'You Won!',
+          `<p>Congratulations! You are a verified winner of <strong>${escapeHtml(context.eventTitle ?? 'the event')}</strong>.</p>
+           <p>Log in to InsightArena to claim your payout.</p>`,
+        ),
+        text: `Congratulations! You won the event "${context.eventTitle ?? 'the event'}".`,
+      };
+
+    case 'event_cancelled':
+      return {
+        subject: `Event cancelled: ${context.eventTitle ?? 'Event'}`,
+        html: wrapHtml(
+          'Event Cancelled',
+          `<p>The event <strong>${escapeHtml(context.eventTitle ?? 'Event')}</strong> has been cancelled by the creator.</p>
+           <p>Any stakes will be refunded according to the event rules.</p>`,
+        ),
+        text: `The event "${context.eventTitle ?? 'Event'}" has been cancelled.`,
+      };
+
+    default:
+      return {
+        subject: 'InsightArena Notification',
+        html: wrapHtml('Notification', '<p>You have a new notification from InsightArena.</p>'),
+        text: 'You have a new notification from InsightArena.',
+      };
+  }
+}
+
+function wrapHtml(title: string, body: string): string {
+  return `<!DOCTYPE html><html><head><style>${baseStyles}</style></head>
+    <body><div class="container">
+      <div class="header"><h1 style="margin:0;font-size:20px;">${escapeHtml(title)}</h1></div>
+      <div class="content">${body}
+        <a class="cta" href="https://insightarena.app">View on InsightArena</a>
+      </div>
+      <div class="footer">You received this email because of your InsightArena notification preferences.</div>
+    </div></body></html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    const map: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    };
+    return map[char];
+  });
+}

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -75,7 +75,10 @@ export function renderEmailTemplate(
     default:
       return {
         subject: 'InsightArena Notification',
-        html: wrapHtml('Notification', '<p>You have a new notification from InsightArena.</p>'),
+        html: wrapHtml(
+          'Notification',
+          '<p>You have a new notification from InsightArena.</p>',
+        ),
         text: 'You have a new notification from InsightArena.',
       };
   }

--- a/backend/src/notifications/email.service.spec.ts
+++ b/backend/src/notifications/email.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EmailService } from './email.service';
+import { User } from '../users/entities/user.entity';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
+
+describe('EmailService', () => {
+  let service: EmailService;
+  let userRepository: jest.Mocked<Pick<import('typeorm').Repository<User>, 'findOne'>>;
+  let preferencesRepository: jest.Mocked<
+    Pick<import('typeorm').Repository<UserPreferences>, 'findOne'>
+  >;
+
+  beforeEach(async () => {
+    userRepository = { findOne: jest.fn() };
+    preferencesRepository = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(() => undefined),
+          },
+        },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        {
+          provide: getRepositoryToken(UserPreferences),
+          useValue: preferencesRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+    service.onModuleInit();
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
+  it('queues templated emails when preferences allow', async () => {
+    userRepository.findOne.mockResolvedValue(null);
+
+    const result = await service.sendTemplatedEmail(
+      'user@example.com',
+      'event_created',
+      { eventTitle: 'World Cup', inviteCode: 'WC2026' },
+    );
+
+    expect(result.queued).toBe(true);
+    expect(service.getQueueLength()).toBe(1);
+  });
+
+  it('respects email opt-out preferences', async () => {
+    userRepository.findOne.mockResolvedValue({ id: 'user-1' } as User);
+    preferencesRepository.findOne.mockResolvedValue({
+      email_notifications: false,
+    } as UserPreferences);
+
+    const result = await service.sendTemplatedEmail(
+      'user@example.com',
+      'match_result_available',
+      { eventTitle: 'World Cup' },
+      'GSTELLAR123',
+    );
+
+    expect(result.queued).toBe(false);
+    expect(result.reason).toContain('opted out');
+  });
+
+  it('renders all template types without throwing', async () => {
+    userRepository.findOne.mockResolvedValue(null);
+
+    const templates = [
+      'event_created',
+      'match_result_available',
+      'event_won',
+      'event_cancelled',
+    ] as const;
+
+    for (const template of templates) {
+      const result = await service.sendTemplatedEmail(
+        'user@example.com',
+        template,
+        { eventTitle: 'Test Event' },
+      );
+      expect(result.queued).toBe(true);
+    }
+
+    expect(service.getQueueLength()).toBe(4);
+  });
+});

--- a/backend/src/notifications/email.service.spec.ts
+++ b/backend/src/notifications/email.service.spec.ts
@@ -7,7 +7,9 @@ import { UserPreferences } from '../users/entities/user-preferences.entity';
 
 describe('EmailService', () => {
   let service: EmailService;
-  let userRepository: jest.Mocked<Pick<import('typeorm').Repository<User>, 'findOne'>>;
+  let userRepository: jest.Mocked<
+    Pick<import('typeorm').Repository<User>, 'findOne'>
+  >;
   let preferencesRepository: jest.Mocked<
     Pick<import('typeorm').Repository<UserPreferences>, 'findOne'>
   >;

--- a/backend/src/notifications/email.service.ts
+++ b/backend/src/notifications/email.service.ts
@@ -1,0 +1,227 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
+import { User } from '../users/entities/user.entity';
+import {
+  EmailTemplateContext,
+  EmailTemplateType,
+  renderEmailTemplate,
+} from './email-templates';
+
+export interface QueuedEmail {
+  id: string;
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+  userAddress?: string;
+  queuedAt: number;
+}
+
+const DEFAULT_RATE_LIMIT = 30;
+const QUEUE_PROCESS_INTERVAL_MS = 2000;
+
+@Injectable()
+export class EmailService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(EmailService.name);
+  private readonly queue: QueuedEmail[] = [];
+  private readonly sentTimestamps: number[] = [];
+  private processTimer: ReturnType<typeof setInterval> | null = null;
+  private isProcessing = false;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(UserPreferences)
+    private readonly preferencesRepository: Repository<UserPreferences>,
+  ) {}
+
+  onModuleInit(): void {
+    this.processTimer = setInterval(() => {
+      void this.processQueue();
+    }, QUEUE_PROCESS_INTERVAL_MS);
+  }
+
+  onModuleDestroy(): void {
+    if (this.processTimer) {
+      clearInterval(this.processTimer);
+    }
+  }
+
+  async sendTemplatedEmail(
+    to: string,
+    template: EmailTemplateType,
+    context: EmailTemplateContext,
+    userAddress?: string,
+  ): Promise<{ queued: boolean; reason?: string }> {
+    if (userAddress) {
+      const allowed = await this.isEmailAllowed(userAddress, template);
+      if (!allowed) {
+        return { queued: false, reason: 'User has opted out of email notifications' };
+      }
+    }
+
+    const { subject, html, text } = renderEmailTemplate(template, context);
+
+    return this.queueEmail({ to, subject, html, text, userAddress });
+  }
+
+  async queueEmail(params: {
+    to: string;
+    subject: string;
+    html: string;
+    text: string;
+    userAddress?: string;
+  }): Promise<{ queued: boolean; reason?: string }> {
+    if (!params.to?.trim()) {
+      return { queued: false, reason: 'Recipient email is required' };
+    }
+
+    if (params.userAddress) {
+      const allowed = await this.isEmailAllowed(params.userAddress);
+      if (!allowed) {
+        return { queued: false, reason: 'User has opted out of email notifications' };
+      }
+    }
+
+    this.queue.push({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      to: params.to.trim(),
+      subject: params.subject,
+      html: params.html,
+      text: params.text,
+      userAddress: params.userAddress,
+      queuedAt: Date.now(),
+    });
+
+    return { queued: true };
+  }
+
+  getQueueLength(): number {
+    return this.queue.length;
+  }
+
+  private async isEmailAllowed(
+    userAddress: string,
+    template?: EmailTemplateType,
+  ): Promise<boolean> {
+    const user = await this.userRepository.findOne({
+      where: { stellar_address: userAddress },
+    });
+
+    if (!user) {
+      return true;
+    }
+
+    const prefs = await this.preferencesRepository.findOne({
+      where: { userId: user.id },
+    });
+
+    if (!prefs) {
+      return true;
+    }
+
+    if (!prefs.email_notifications) {
+      return false;
+    }
+
+    if (template === 'event_cancelled' || template === 'event_created') {
+      return prefs.competition_notifications;
+    }
+
+    if (template === 'match_result_available') {
+      return prefs.market_resolution_notifications;
+    }
+
+    if (template === 'event_won') {
+      return prefs.leaderboard_notifications;
+    }
+
+    return true;
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.isProcessing || this.queue.length === 0) {
+      return;
+    }
+
+    if (!this.canSendMore()) {
+      return;
+    }
+
+    this.isProcessing = true;
+
+    try {
+      const email = this.queue.shift();
+      if (!email) {
+        return;
+      }
+
+      await this.deliverEmail(email);
+      this.sentTimestamps.push(Date.now());
+    } catch (error) {
+      this.logger.error(
+        `Failed to process email queue: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
+  private canSendMore(): boolean {
+    const limit = Number(
+      this.configService.get<string>('EMAIL_RATE_LIMIT_PER_MINUTE') ??
+        DEFAULT_RATE_LIMIT,
+    );
+    const cutoff = Date.now() - 60_000;
+    const recent = this.sentTimestamps.filter((t) => t >= cutoff);
+    this.sentTimestamps.splice(0, this.sentTimestamps.length, ...recent);
+    return recent.length < limit;
+  }
+
+  private async deliverEmail(email: QueuedEmail): Promise<void> {
+    const apiKey = this.configService.get<string>('SENDGRID_API_KEY');
+    const fromEmail =
+      this.configService.get<string>('EMAIL_FROM') ??
+      'notifications@insightarena.app';
+
+    if (apiKey) {
+      const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          personalizations: [{ to: [{ email: email.to }] }],
+          from: { email: fromEmail, name: 'InsightArena' },
+          subject: email.subject,
+          content: [
+            { type: 'text/plain', value: email.text },
+            { type: 'text/html', value: email.html },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`SendGrid error (${response.status}): ${body}`);
+      }
+
+      this.logger.log(`Email sent to ${email.to}: ${email.subject}`);
+      return;
+    }
+
+    this.logger.log(
+      `[DEV] Email queued for ${email.to}: ${email.subject}\n${email.text}`,
+    );
+  }
+}

--- a/backend/src/notifications/email.service.ts
+++ b/backend/src/notifications/email.service.ts
@@ -65,7 +65,10 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
     if (userAddress) {
       const allowed = await this.isEmailAllowed(userAddress, template);
       if (!allowed) {
-        return { queued: false, reason: 'User has opted out of email notifications' };
+        return {
+          queued: false,
+          reason: 'User has opted out of email notifications',
+        };
       }
     }
 
@@ -88,7 +91,10 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
     if (params.userAddress) {
       const allowed = await this.isEmailAllowed(params.userAddress);
       if (!allowed) {
-        return { queued: false, reason: 'User has opted out of email notifications' };
+        return {
+          queued: false,
+          reason: 'User has opted out of email notifications',
+        };
       }
     }
 

--- a/backend/src/notifications/notifications.controller.spec.ts
+++ b/backend/src/notifications/notifications.controller.spec.ts
@@ -51,7 +51,9 @@ describe('NotificationsController', () => {
 
   describe('getNotifications', () => {
     it('should return paginated notifications for the user address', async () => {
-      const paginated = {
+      const paginated: Awaited<
+        ReturnType<NotificationsService['findAllForUser']>
+      > = {
         data: [mockNotification],
         total: 1,
         page: 1,
@@ -60,7 +62,7 @@ describe('NotificationsController', () => {
       };
       const spy = jest
         .spyOn(service, 'findAllForUser')
-        .mockResolvedValue(paginated as any);
+        .mockResolvedValue(paginated);
 
       const result = await controller.getNotifications(
         'GBRPYHIL2CI3WHZDTOOQFC6EB4RRJC3XNRBF7XN',

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -3,12 +3,18 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Notification } from './entities/notification.entity';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
+import { EmailService } from './email.service';
 import { UsersModule } from '../users/users.module';
+import { User } from '../users/entities/user.entity';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notification]), UsersModule],
+  imports: [
+    TypeOrmModule.forFeature([Notification, User, UserPreferences]),
+    UsersModule,
+  ],
   controllers: [NotificationsController],
-  providers: [NotificationsService],
-  exports: [NotificationsService],
+  providers: [NotificationsService, EmailService],
+  exports: [NotificationsService, EmailService],
 })
 export class NotificationsModule {}

--- a/backend/src/oracle/oracle.service.spec.ts
+++ b/backend/src/oracle/oracle.service.spec.ts
@@ -91,6 +91,7 @@ describe('OracleService', () => {
     }).compile();
 
     service = module.get<OracleService>(OracleService);
+    eventRepo.find.mockResolvedValue([mockEvent]);
   });
 
   describe('getPendingMatches', () => {

--- a/backend/src/oracle/oracle.service.spec.ts
+++ b/backend/src/oracle/oracle.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { OracleService } from './oracle.service';
 import { CreatorEventMatch } from '../creator-events/entities/creator-event-match.entity';
 import { CreatorEvent } from '../creator-events/entities/creator-event.entity';
@@ -10,7 +10,9 @@ type MockRepo = jest.Mocked<
   Pick<Repository<any>, 'findOne' | 'createQueryBuilder' | 'find' | 'findByIds'>
 >;
 
-function createMockQueryBuilder(returnValue: any): any {
+function createMockQueryBuilder<T>(
+  returnValue: any,
+): Partial<SelectQueryBuilder<T>> {
   return {
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
@@ -25,7 +27,7 @@ function createMockQueryBuilder(returnValue: any): any {
     groupBy: jest.fn().mockReturnThis(),
     having: jest.fn().mockReturnThis(),
     getOne: jest.fn().mockResolvedValue(null),
-  };
+  } as unknown as Partial<SelectQueryBuilder<T>>;
 }
 
 describe('OracleService', () => {
@@ -93,9 +95,10 @@ describe('OracleService', () => {
 
   describe('getPendingMatches', () => {
     it('should return only matches that have started and not been resolved', async () => {
-      const qb = createMockQueryBuilder([mockMatches, 2]);
-      matchRepo.createQueryBuilder.mockReturnValue(qb);
-      eventRepo.find.mockResolvedValue([mockEvent]);
+      const qb = createMockQueryBuilder<CreatorEvent>([mockMatches, 2]);
+      matchRepo.createQueryBuilder.mockReturnValue(
+        qb as unknown as SelectQueryBuilder<CreatorEvent>,
+      );
 
       const result = await service.getPendingMatches(
         new ListPendingMatchesQueryDto(),
@@ -114,8 +117,10 @@ describe('OracleService', () => {
     });
 
     it('should return empty array when no pending matches', async () => {
-      const qb = createMockQueryBuilder([[], 0]);
-      matchRepo.createQueryBuilder.mockReturnValue(qb);
+      const qb = createMockQueryBuilder<CreatorEvent>([[], 0]);
+      matchRepo.createQueryBuilder.mockReturnValue(
+        qb as unknown as SelectQueryBuilder<CreatorEvent>,
+      );
 
       const result = await service.getPendingMatches(
         new ListPendingMatchesQueryDto(),
@@ -126,9 +131,10 @@ describe('OracleService', () => {
     });
 
     it('should sort matches by match_time ascending (oldest first)', async () => {
-      const qb = createMockQueryBuilder([mockMatches, 2]);
-      matchRepo.createQueryBuilder.mockReturnValue(qb);
-      eventRepo.find.mockResolvedValue([mockEvent]);
+      const qb = createMockQueryBuilder<CreatorEvent>([mockMatches, 2]);
+      matchRepo.createQueryBuilder.mockReturnValue(
+        qb as unknown as SelectQueryBuilder<CreatorEvent>,
+      );
 
       await service.getPendingMatches(new ListPendingMatchesQueryDto());
 
@@ -136,9 +142,10 @@ describe('OracleService', () => {
     });
 
     it('should include event details in response', async () => {
-      const qb = createMockQueryBuilder([mockMatches, 2]);
-      matchRepo.createQueryBuilder.mockReturnValue(qb);
-      eventRepo.find.mockResolvedValue([mockEvent]);
+      const qb = createMockQueryBuilder<CreatorEvent>([mockMatches, 2]);
+      matchRepo.createQueryBuilder.mockReturnValue(
+        qb as unknown as SelectQueryBuilder<CreatorEvent>,
+      );
 
       const result = await service.getPendingMatches(
         new ListPendingMatchesQueryDto(),
@@ -151,9 +158,10 @@ describe('OracleService', () => {
     });
 
     it('should include time_since_match_started_seconds', async () => {
-      const qb = createMockQueryBuilder([mockMatches, 2]);
-      matchRepo.createQueryBuilder.mockReturnValue(qb);
-      eventRepo.find.mockResolvedValue([mockEvent]);
+      const qb = createMockQueryBuilder<CreatorEvent>([mockMatches, 2]);
+      matchRepo.createQueryBuilder.mockReturnValue(
+        qb as unknown as SelectQueryBuilder<CreatorEvent>,
+      );
 
       const result = await service.getPendingMatches(
         new ListPendingMatchesQueryDto(),
@@ -165,9 +173,10 @@ describe('OracleService', () => {
     });
 
     it('should handle pagination', async () => {
-      const qb = createMockQueryBuilder([mockMatches, 2]);
-      matchRepo.createQueryBuilder.mockReturnValue(qb);
-      eventRepo.find.mockResolvedValue([mockEvent]);
+      const qb = createMockQueryBuilder<CreatorEvent>([mockMatches, 2]);
+      matchRepo.createQueryBuilder.mockReturnValue(
+        qb as unknown as SelectQueryBuilder<CreatorEvent>,
+      );
 
       const result = await service.getPendingMatches({ page: 1, limit: 5 });
 

--- a/backend/src/oracle/oracle.service.ts
+++ b/backend/src/oracle/oracle.service.ts
@@ -41,7 +41,9 @@ export class OracleService {
     const eventIds = [...new Set(matches.map((m) => m.event_id))];
     const events =
       eventIds.length > 0
-        ? await this.eventRepository.find({ where: { id: In(eventIds) } })
+        ? ((await this.eventRepository.find({
+            where: { id: In(eventIds) },
+          })) ?? [])
         : [];
     const eventMap = new Map(events.map((e) => [e.id, e]));
 


### PR DESCRIPTION
## Summary

Implements four backend features for creator events, indexer monitoring, and optional email notifications:

- **#731** — `GET /api/v1/creator-events/:id/predictions/:address` returns all user predictions for an event with enriched match details, correctness scoring, and 30-second response caching.
- **#727** — `GET /api/v1/creator-events/:id/stats` returns comprehensive event statistics including per-match prediction distribution, completion rate, and winner status with 2-minute caching.
- **#722** — Indexer health monitoring with public health/dashboard endpoints, Prometheus metrics export, configurable alerting thresholds, and admin-only manual sync trigger.
- **#749** — Optional async email notification service with HTML templates, user preference opt-in/opt-out, rate limiting, and SendGrid integration.

## Changes

### Creator Events (#731, #727)
- Added `getUserPredictionsForEvent()` and `getEventStats()` to `CreatorEventsService`
- Added `getEventStatistics()` and `getPredictionDistribution()` wrappers to `ContractService`
- Added prediction normalization utility for snake_case/camelCase contract field compatibility
- Extended `ContractPrediction` interface with on-chain fields (`predicted_at`, `is_correct`, etc.)
- Registered `CacheModule` in `CreatorEventsModule`
- OpenAPI DTOs: `UserPredictionsResponseDto`, `EventStatsResponseDto`

### Indexer Health (#722)
- New `IndexerHealthService` with metrics aggregation and alert evaluation
- New `IndexerHealthController` at `/indexer/health/*`
- Extended `IndexerService` with events-per-minute tracking, manual sync trigger, and last-sync timestamp
- Prometheus exposition format at `/indexer/health/prometheus`

### Email Notifications (#749)
- New `EmailService` with in-memory async queue and per-minute rate limiting
- HTML email templates for event lifecycle notifications
- Preference-aware sending via existing `user_preferences` table
- SendGrid delivery when `SENDGRID_API_KEY` is configured; console fallback in dev

## New Endpoints

| Method | Route | Auth | Cache |
|--------|-------|------|-------|
| GET | `/api/v1/creator-events/:id/predictions/:address` | JWT | 30s |
| GET | `/api/v1/creator-events/:id/stats` | JWT | 120s |
| GET | `/api/v1/indexer/health` | Public | — |
| GET | `/api/v1/indexer/health/dashboard` | Public | — |
| GET | `/api/v1/indexer/health/prometheus` | Public | — |
| POST | `/api/v1/indexer/health/sync` | Admin | — |

## Environment Variables (optional)

| Variable | Purpose |
|----------|---------|
| `SENDGRID_API_KEY` | Enable SendGrid email delivery |
| `EMAIL_FROM` | Sender address (default: `notifications@insightarena.app`) |
| `EMAIL_RATE_LIMIT_PER_MINUTE` | Max emails per minute (default: 30) |

## Test plan

- [x] Unit tests for prediction normalization and correctness resolution
- [x] Service tests for user predictions enrichment and score calculation
- [x] Service tests for event statistics aggregation and completion rate
- [x] Controller tests for new creator-events endpoints
- [x] Indexer health service tests (healthy, lag alert, stale sync alert, Prometheus export)
- [x] Indexer health controller tests
- [x] Email service tests (queue, opt-out, all template types)
- [x] `pnpm build` passes
- [ ] Manual: `GET /api/v1/creator-events/:id/predictions/:address` against testnet contract
- [ ] Manual: `GET /api/v1/creator-events/:id/stats` returns expected distribution
- [ ] Manual: `GET /api/v1/indexer/health` shows accurate lag and alerts
- [ ] Manual: `GET /api/v1/indexer/health/prometheus` scrapable by Prometheus
- [ ] Manual: `POST /api/v1/indexer/health/sync` triggers poll (admin JWT)
- [ ] Manual: Email delivery with `SENDGRID_API_KEY` configured

## Closes

- Closes #731
- Closes #722
- Closes #727
- Closes #749