### PR TITLE
 [Contract] — Implement Get Event Participants Function

### DIFF
--- a/contracts/creator-event-manager/README.md
+++ b/contracts/creator-event-manager/README.md
@@ -137,6 +137,9 @@ Get match statistics: `(has_started, result_submitted, time_until_start, time_si
 #### `get_match_count()` / `validate_match(match_id)`
 Get total match count and validate match data consistency.
 
+#### `get_event_participants(event_id)`
+Return the full `Vec<Address>` of users who have joined an event. Newly created events return an empty vector, and unknown event IDs fail with `event_not_found`.
+
 #### `join_event(user, invite_code)`
 Join an event using its invite code before submitting predictions.
 

--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -300,6 +300,21 @@ impl CreatorEventManagerContract {
         }
     }
 
+    /// Return all participant addresses for an event.
+    ///
+    /// Reads the `EventParticipants(event_id)` storage index after validating
+    /// that the event exists. A newly created event returns an empty vector.
+    ///
+    /// # Panics
+    /// * `"event_not_found"` — no event exists with the given ID.
+    pub fn get_event_participants(env: Env, event_id: u64) -> Vec<Address> {
+        match views::get_event_participants(&env, event_id) {
+            Ok(participants) => participants,
+            Err(EventError::EventNotFound) => panic!("event_not_found"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
     /// Return aggregate statistics for an event.
     ///
     /// The returned [`EventStatistics`] summarizes participant count, match

--- a/contracts/creator-event-manager/src/views.rs
+++ b/contracts/creator-event-manager/src/views.rs
@@ -4,10 +4,10 @@
 //! paths so callers can inspect an event's participation, prediction volume,
 //! and completion state in a single contract view.
 
-use soroban_sdk::{contracttype, Env, Vec, Address};
 use crate::event::{self, EventError};
 use crate::storage;
 use crate::storage_types::DataKey;
+use soroban_sdk::{contracttype, Address, Env, Vec};
 
 /// Aggregate statistics for one creator event.
 ///
@@ -44,6 +44,16 @@ pub struct Config {
     pub xlm_token: Address,
     pub creation_fee: i128,
     pub paused: bool,
+}
+
+/// Return all participant addresses for an existing event.
+///
+/// This view validates that `event_id` points to a stored event, then returns
+/// the `EventParticipants(event_id)` storage index. Newly created events return
+/// an empty `Vec` until users join through `join_event`.
+pub fn get_event_participants(env: &Env, event_id: u64) -> Result<Vec<Address>, EventError> {
+    event::get_event(env, event_id)?;
+    Ok(storage::get_event_participants(env, event_id))
 }
 
 /// Build aggregate statistics for an existing event.
@@ -125,7 +135,9 @@ pub fn get_config(env: &Env) -> Result<Config, &'static str> {
 pub fn get_user_events(env: &Env, user: Address) -> Vec<u64> {
     // Read the current event counter (instance storage)
     let instance = env.storage().instance();
-    let max_id: u64 = instance.get::<DataKey, u64>(&DataKey::EventCounter(0)).unwrap_or(0);
+    let max_id: u64 = instance
+        .get::<DataKey, u64>(&DataKey::EventCounter(0))
+        .unwrap_or(0);
 
     let mut out = Vec::new(env);
     for id in 1..=max_id {

--- a/contracts/creator-event-manager/tests/views_tests.rs
+++ b/contracts/creator-event-manager/tests/views_tests.rs
@@ -93,6 +93,72 @@ fn add_prediction(env: &Env, event_id: u64, match_id: u64, predictor: &Address) 
 }
 
 #[test]
+fn test_get_event_participants_returns_all_participants() {
+    let (env, client, _contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_one = Address::generate(&env);
+    let user_two = Address::generate(&env);
+    let user_three = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, invite_code) = client.create_event(&creator, &title(&env), &desc(&env), &5u32);
+    client.join_event(&user_one, &invite_code);
+    client.join_event(&user_two, &invite_code);
+    client.join_event(&user_three, &invite_code);
+
+    let participants = client.get_event_participants(&event_id);
+
+    assert_eq!(participants.len(), 3);
+    assert_eq!(participants.get(0).unwrap(), user_one);
+    assert_eq!(participants.get(1).unwrap(), user_two);
+    assert_eq!(participants.get(2).unwrap(), user_three);
+}
+
+#[test]
+fn test_get_event_participants_empty_for_new_event() {
+    let (env, client, _contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = client.create_event(&creator, &title(&env), &desc(&env), &5u32);
+
+    let participants = client.get_event_participants(&event_id);
+    assert_eq!(participants.len(), 0);
+}
+
+#[test]
+fn test_get_event_participants_updates_as_participants_join() {
+    let (env, client, _contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_one = Address::generate(&env);
+    let user_two = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, invite_code) = client.create_event(&creator, &title(&env), &desc(&env), &5u32);
+
+    let initial_participants = client.get_event_participants(&event_id);
+    assert_eq!(initial_participants.len(), 0);
+
+    client.join_event(&user_one, &invite_code);
+    let one_participant = client.get_event_participants(&event_id);
+    assert_eq!(one_participant.len(), 1);
+    assert_eq!(one_participant.get(0).unwrap(), user_one);
+
+    client.join_event(&user_two, &invite_code);
+    let two_participants = client.get_event_participants(&event_id);
+    assert_eq!(two_participants.len(), 2);
+    assert_eq!(two_participants.get(0).unwrap(), user_one);
+    assert_eq!(two_participants.get(1).unwrap(), user_two);
+}
+
+#[test]
+#[should_panic(expected = "event_not_found")]
+fn test_get_event_participants_missing_event_panics() {
+    let (_env, client, _contract_id, _xlm_token) = setup();
+    client.get_event_participants(&999u64);
+}
+
+#[test]
 fn test_event_statistics_are_accurate() {
     let (env, client, contract_id, xlm_token) = setup();
     let creator = Address::generate(&env);


### PR DESCRIPTION
close #817 

Description
Added get_event_participants(env: &Env, event_id: u64) -> Result<Vec<Address>, EventError> in src/views.rs which validates the event exists and returns the EventParticipants(event_id) storage index.
Exposed a public contract method get_event_participants(env: Env, event_id: u64) -> Vec<Address> in src/lib.rs that maps EventError::EventNotFound to the existing "event_not_found" panic path.
Added unit tests in tests/views_tests.rs covering: returning all participants, empty list for a newly created event, updates as participants join, and missing-event panic behavior.
Documented the new view in README.md and applied minor formatting tweaks to affected files.

Testing
Ran cargo test --manifest-path contracts/creator-event-manager/Cargo.toml --test views_tests -- --nocapture; the new and existing view tests passed (7 passed, 0 failed).