### PR TITLE
test: add named unit tests for oracle and conditional market modules

### DIFF
--- a/contracts/open-market/tests/conditional_tests.rs
+++ b/contracts/open-market/tests/conditional_tests.rs
@@ -1897,6 +1897,92 @@ fn test_calculate_depth_first_level_is_one() {
     assert_eq!(client.calculate_conditional_depth(&child_id), 1);
 }
 
+// ── Issue #581: three named creation tests ────────────────────────────────────
+
+#[test]
+fn test_create_conditional_market_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &conditional_params(&env, &client, parent_id),
+    );
+
+    // Market is accessible via get_market.
+    let child_market = client.get_market(&child_id);
+    assert_eq!(child_market.market_id, child_id);
+
+    // ConditionalMarket metadata is stored correctly.
+    let cond = read_conditional(&env, &client, child_id);
+    assert_eq!(cond.parent_market_id, parent_id);
+    assert_eq!(cond.required_outcome, symbol_short!("yes"));
+    assert!(!cond.is_activated);
+    assert_eq!(cond.activation_time, None);
+}
+
+#[test]
+fn test_create_conditional_market_depth_limit_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    // Build a chain at maximum depth (5 levels deep from root).
+    let mut parent = client.create_market(&creator, &default_params(&env));
+    for _ in 0..5 {
+        parent = client.create_conditional_market(
+            &creator,
+            &parent,
+            &symbol_short!("yes"),
+            &conditional_params(&env, &client, parent),
+        );
+    }
+
+    // Depth is now 5; any further nesting must be rejected.
+    let result = client.try_create_conditional_market(
+        &creator,
+        &parent,
+        &symbol_short!("yes"),
+        &conditional_params(&env, &client, parent),
+    );
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::ConditionalDepthExceeded))
+    ));
+}
+
+#[test]
+fn test_create_conditional_market_stores_parent_reference() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let parent_id = client.create_market(&creator, &default_params(&env));
+    let child_id = client.create_conditional_market(
+        &creator,
+        &parent_id,
+        &symbol_short!("yes"),
+        &conditional_params(&env, &client, parent_id),
+    );
+
+    // The ConditionalParent storage key must point back to the parent.
+    let contract_id = client.address.clone();
+    let stored_parent: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ConditionalParent(child_id))
+            .unwrap()
+    });
+    assert_eq!(stored_parent, parent_id);
+}
+
 #[test]
 fn test_calculate_depth_nested_three_levels() {
     let env = Env::default();

--- a/contracts/open-market/tests/oracle_tests.rs
+++ b/contracts/open-market/tests/oracle_tests.rs
@@ -165,6 +165,61 @@ fn update_oracle_unauthorized() {
     assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
 }
 
+// ── Issue #534: three additional named tests ──────────────────────────────────
+
+#[test]
+fn test_resolve_market_invalid_outcome() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle) = deploy(&env);
+    let creator = Address::generate(&env);
+
+    // default_params has outcomes ["yes", "no"]
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 2000);
+
+    let result = client.try_resolve_market(&oracle, &id, &symbol_short!("maybe"));
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidOutcome))));
+}
+
+#[test]
+fn test_resolve_already_resolved_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle) = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 2000);
+
+    // First resolution succeeds.
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+
+    // Second attempt on the same market must fail.
+    let result = client.try_resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyResolved))
+    ));
+}
+
+#[test]
+fn test_resolve_market_too_early() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle) = deploy(&env);
+    let creator = Address::generate(&env);
+
+    // resolution_time = now + 2000; do not advance time at all.
+    let id = client.create_market(&creator, &default_params(&env));
+
+    let result = client.try_resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketStillOpen))
+    ));
+}
+
 // New test: ensure oracle cannot resolve before resolution_time
 #[test]
 fn test_resolve_market_before_resolution_time() {


### PR DESCRIPTION
[Contract] — Unit Tests for Admin Functions
Fixes #823

[Contract] — Unit Tests for Event Management Functions Fixes #825

[Contract] — Create Mock XLM Token for Testing
Fixes #834

[contract] Add `create_conditional_market` Tests to `tests/conditional_tests.rs` Fixes #581