### PR TITLE
Fix wallet connect redirect behavior

### DIFF
--- a/frontend/src/component/ConnectWalletModal.tsx
+++ b/frontend/src/component/ConnectWalletModal.tsx
@@ -254,7 +254,7 @@ export default function ConnectWalletModal({
                 {connectedAddress.slice(0, 6)}...{connectedAddress.slice(-4)}
               </p>
               <p className="mt-4 text-xs text-[#9aa4bc]">
-                Redirecting to dashboard...
+                You can continue from this page or open the dashboard from the header.
               </p>
             </div>
           </div>

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -149,7 +149,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     setAuthError(null);
     setIsConnectModalOpen(false);
     router.push("/");
-  }, []);
+  }, [router]);
 
   const handleModalSuccess = useCallback(
     (walletAddress: string, _jwt: string) => {
@@ -158,9 +158,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       setUser({ username: "Alex" });
       setAuthError(null);
       setIsConnectModalOpen(false);
-      router.push("/dashboard");
     },
-    [router],
+    [],
   );
 
   const value = useMemo<WalletContextValue>(


### PR DESCRIPTION
## Summary
- Keep users on the current page after a successful wallet connection instead of forcing a `/dashboard` redirect.
- Update the wallet success copy so it no longer says the app is redirecting to the dashboard.
- Include `router` in the `logout` callback dependency array.

Closes #849
Closes #850
Closes #851

## Verification
- `node` source guard for wallet redirect behavior, logout dependencies, and success copy
- `git diff --check`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm build`

## Notes
- `corepack pnpm exec tsc --noEmit --pretty false` currently fails on existing SVG module declaration errors in `src/component/coursenav.tsx`.
- `corepack pnpm lint` currently fails because the script runs `next lint`, which Next 16 treats as an invalid project directory argument (`frontend/lint`).

This PR was prepared with OpenAI GPT-5 Codex.
