### PR TITLE
feat: extend Match entity with scoreline and points multiplier (#954)

### DIFF
--- a/backend/src/contract/contract.service.ts
+++ b/backend/src/contract/contract.service.ts
@@ -30,6 +30,8 @@ export interface ContractMatch {
   eventId: string;
   homeTeam: string;
   awayTeam: string;
+  homeScore: number | null;
+  awayScore: number | null;
   startTime: number;
   resolved: boolean;
   outcome: string | null;

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -361,6 +361,7 @@ export class IndexerService implements OnModuleInit {
           team_a: this.readStr(base, 'team_a'),
           team_b: this.readStr(base, 'team_b'),
           match_time: this.readNum(base, 'match_time'),
+          points_multiplier: this.readNum(base, 'points_multiplier'),
         };
       case 'UserJoinedEvent':
         return {
@@ -384,6 +385,8 @@ export class IndexerService implements OnModuleInit {
           winning_team: this.readNum(base, 'winning_team'),
           submitted_by: this.readStr(base, 'submitted_by'),
           submitted_at: this.readNum(base, 'submitted_at'),
+          home_score: this.readNum(base, 'home_score'),
+          away_score: this.readNum(base, 'away_score'),
         };
       case 'WinnersVerified':
         return {
@@ -576,6 +579,12 @@ export class IndexerService implements OnModuleInit {
       return;
     }
 
+    let pointsMultiplier =
+      data.points_multiplier !== undefined ? Number(data.points_multiplier) : 1;
+    if (pointsMultiplier < 1 || pointsMultiplier > 3 || isNaN(pointsMultiplier)) {
+      pointsMultiplier = 1;
+    }
+
     const match = this.matchRepository.create({
       on_chain_match_id: onChainMatchId,
       event,
@@ -584,10 +593,13 @@ export class IndexerService implements OnModuleInit {
       match_time: data.match_time
         ? new Date(Number(data.match_time) * 1000)
         : new Date(),
+      points_multiplier: pointsMultiplier,
       result_submitted: false,
       winning_team: null,
       submitted_by: null,
       submitted_at: null,
+      home_score: null,
+      away_score: null,
     });
 
     await this.matchRepository.save(match);
@@ -743,6 +755,10 @@ export class IndexerService implements OnModuleInit {
     match.submitted_at = data.submitted_at
       ? new Date(Number(data.submitted_at) * 1000)
       : new Date();
+    match.home_score =
+      data.home_score !== undefined ? Number(data.home_score) : null;
+    match.away_score =
+      data.away_score !== undefined ? Number(data.away_score) : null;
 
     await this.matchRepository.save(match);
 

--- a/backend/src/matches/dto/match-detail.dto.ts
+++ b/backend/src/matches/dto/match-detail.dto.ts
@@ -53,6 +53,15 @@ export class MatchDetailDto {
   @ApiPropertyOptional({ nullable: true })
   winning_team: string | null;
 
+  @ApiPropertyOptional({ nullable: true })
+  home_score: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  away_score: number | null;
+
+  @ApiProperty()
+  points_multiplier: number;
+
   @ApiProperty()
   total_predictions: number;
 

--- a/backend/src/matches/entities/match.entity.ts
+++ b/backend/src/matches/entities/match.entity.ts
@@ -49,6 +49,15 @@ export class Match {
   @Column({ default: false })
   result_submitted: boolean;
 
+  @Column({ type: 'int', nullable: true })
+  home_score: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  away_score: number | null;
+
+  @Column({ type: 'int', default: 1 })
+  points_multiplier: number;
+
   @Column({
     type: 'enum',
     enum: WinningTeam,

--- a/backend/src/matches/matches.service.ts
+++ b/backend/src/matches/matches.service.ts
@@ -50,6 +50,9 @@ export class MatchesService {
       match_time: match.match_time,
       result_submitted: match.result_submitted,
       winning_team: match.winning_team,
+      home_score: match.home_score,
+      away_score: match.away_score,
+      points_multiplier: match.points_multiplier,
       total_predictions: totalPredictions,
       prediction_distribution: distribution,
       event_info: {

--- a/backend/src/migrations/1775800000000-AddScoreAndMultiplierToMatch.ts
+++ b/backend/src/migrations/1775800000000-AddScoreAndMultiplierToMatch.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddScoreAndMultiplierToMatch1775800000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('event_matches', [
+      new TableColumn({
+        name: 'home_score',
+        type: 'int',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'away_score',
+        type: 'int',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'points_multiplier',
+        type: 'int',
+        default: 1,
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('event_matches', 'points_multiplier');
+    await queryRunner.dropColumn('event_matches', 'away_score');
+    await queryRunner.dropColumn('event_matches', 'home_score');
+  }
+}


### PR DESCRIPTION
Description:
This PR extends the Match entity to capture and persist the final scoreline. I Added home_score, away_score, and points_multiplier to the Match entity along with a database migration. Updates the indexer to capture and persist these fields from Soroban events, handling out-of-bounds multiplier values. Ensures the new match details are correctly mapped and returned by the matches API.

Closes #954 