### PR TITLE
feat: add category badge, bannerUrl, and category filter (issue #952)

### DIFF
--- a/frontend/src/app/(authenticated)/creator-events/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/[id]/page.tsx
@@ -378,6 +378,8 @@ export default function CreatorEventDetailPage() {
           maxParticipants={event.maxParticipants}
           createdAt={event.createdAt}
           inviteCode={isCreator ? event.inviteCode : undefined}
+          category={event.category}
+          bannerUrl={event.bannerUrl}
         />
 
         <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-5">

--- a/frontend/src/app/(authenticated)/creator-events/page.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/page.tsx
@@ -18,6 +18,8 @@ interface CreatorEvent {
   endsAt: string;
   joined: boolean;
   createdAt: string;
+  category?: string;
+  bannerUrl?: string;
 }
 
 const eventData: CreatorEvent[] = [
@@ -33,6 +35,8 @@ const eventData: CreatorEvent[] = [
     endsAt: "Jun 4, 2026",
     joined: true,
     createdAt: "2026-05-18",
+    category: "Football",
+    bannerUrl: "/creator-events/apollo-banner.jpg",
   },
   {
     id: "event-002",
@@ -46,6 +50,8 @@ const eventData: CreatorEvent[] = [
     endsAt: "May 12, 2026",
     joined: false,
     createdAt: "2026-05-06",
+    category: "Crypto",
+    bannerUrl: "/creator-events/finals-banner.jpg",
   },
   {
     id: "event-003",
@@ -59,6 +65,8 @@ const eventData: CreatorEvent[] = [
     endsAt: "Jun 14, 2026",
     joined: false,
     createdAt: "2026-05-22",
+    category: "Football",
+    bannerUrl: "/creator-events/rising-stars-banner.jpg",
   },
   {
     id: "event-004",
@@ -72,6 +80,7 @@ const eventData: CreatorEvent[] = [
     endsAt: "May 29, 2026",
     joined: false,
     createdAt: "2026-05-09",
+    category: "Esports",
   },
 ];
 
@@ -88,17 +97,32 @@ const sortOptions = [
   { label: "Ending Soon", value: "ending" },
 ] as const;
 
+const ALL_CATEGORIES = "All";
+
+function deriveCategories(events: CreatorEvent[]): string[] {
+  const seen = new Set<string>();
+  for (const event of events) {
+    if (event.category) seen.add(event.category);
+  }
+  return Array.from(seen).sort();
+}
+
 export default function CreatorEventsPage() {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState<CreatorEventStatus | "All">("All");
+  const [categoryFilter, setCategoryFilter] = useState<string>(ALL_CATEGORIES);
   const [sortKey, setSortKey] = useState<typeof sortOptions[number]["value"]>("newest");
+
+  const categories = useMemo(() => deriveCategories(eventData), []);
 
   const visibleEvents = useMemo(() => {
     const filtered = eventData.filter((event) => {
       const matchesTitle = event.title.toLowerCase().includes(searchTerm.toLowerCase());
       const matchesStatus = statusFilter === "All" || event.status === statusFilter;
-      return matchesTitle && matchesStatus;
+      const matchesCategory =
+        categoryFilter === ALL_CATEGORIES || event.category === categoryFilter;
+      return matchesTitle && matchesStatus && matchesCategory;
     });
 
     return [...filtered].sort((a, b) => {
@@ -110,7 +134,7 @@ export default function CreatorEventsPage() {
       }
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
-  }, [searchTerm, statusFilter, sortKey]);
+  }, [searchTerm, statusFilter, categoryFilter, sortKey]);
 
   const totalActiveEvents = eventData.filter((event) => event.status === "Active").length;
   const totalParticipants = eventData.reduce((sum, event) => sum + event.participants, 0);
@@ -190,6 +214,33 @@ export default function CreatorEventsPage() {
             </div>
           </div>
 
+          {/* Category filter row */}
+          {categories.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 rounded-3xl border border-white/10 bg-slate-900/80 px-6 py-4 shadow-xl shadow-black/20">
+              <span className="mr-1 text-xs uppercase tracking-[0.22em] text-slate-500">Category</span>
+              <Button
+                key={ALL_CATEGORIES}
+                variant={categoryFilter === ALL_CATEGORIES ? "default" : "outline"}
+                size="sm"
+                onClick={() => setCategoryFilter(ALL_CATEGORIES)}
+                className="rounded-full border-white/10 px-4 text-xs font-semibold uppercase tracking-[0.18em]"
+              >
+                All
+              </Button>
+              {categories.map((cat) => (
+                <Button
+                  key={cat}
+                  variant={categoryFilter === cat ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setCategoryFilter(cat)}
+                  className="rounded-full border-white/10 px-4 text-xs font-semibold uppercase tracking-[0.18em]"
+                >
+                  {cat}
+                </Button>
+              ))}
+            </div>
+          )}
+
           {visibleEvents.length > 0 ? (
             <div className="grid gap-6 xl:grid-cols-2">
               {visibleEvents.map((event) => (
@@ -204,6 +255,8 @@ export default function CreatorEventsPage() {
                   status={event.status}
                   endsAt={event.endsAt}
                   joined={event.joined}
+                  category={event.category}
+                  bannerUrl={event.bannerUrl}
                   onViewDetails={() => router.push(`/creator-events/${event.id}`)}
                 />
               ))}

--- a/frontend/src/component/creator-events/EventCard.tsx
+++ b/frontend/src/component/creator-events/EventCard.tsx
@@ -1,4 +1,7 @@
-import { ArrowRight, Calendar, Users, XCircle, CheckCircle, ShieldCheck } from "lucide-react";
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Calendar, Users, XCircle, CheckCircle, ShieldCheck, Tag } from "lucide-react";
 import { Button } from "@/component/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -14,6 +17,8 @@ export interface CreatorEventCardProps {
   status: CreatorEventStatus;
   endsAt: string;
   joined?: boolean;
+  category?: string;
+  bannerUrl?: string;
   onViewDetails?: () => void;
 }
 
@@ -39,66 +44,91 @@ export default function EventCard({
   status,
   endsAt,
   joined,
+  category,
+  bannerUrl,
   onViewDetails,
 }: CreatorEventCardProps) {
   const StatusIcon = statusIcons[status];
+  const [bannerError, setBannerError] = useState(false);
+  const showBanner = Boolean(bannerUrl) && !bannerError;
 
   return (
-    <div className="rounded-3xl border border-white/10 bg-slate-950/80 p-6 shadow-xl shadow-black/20 transition hover:border-white/20 hover:shadow-white/5">
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-3">
-          <div className="flex flex-wrap gap-2">
-            <span className={cn("inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide", statusColors[status])}>
-              <StatusIcon className="h-3.5 w-3.5" />
-              {status}
-            </span>
-            {joined ? (
-              <span className="inline-flex items-center gap-2 rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-200">
-                <Users className="h-3.5 w-3.5" />
-                Joined
+    <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950/80 shadow-xl shadow-black/20 transition hover:border-white/20 hover:shadow-white/5">
+      {showBanner && (
+        <div className="relative h-36 w-full">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={bannerUrl}
+            alt={`${title} banner`}
+            onError={() => setBannerError(true)}
+            className="h-full w-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent to-slate-950/70" />
+        </div>
+      )}
+
+      <div className="p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <span className={cn("inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide", statusColors[status])}>
+                <StatusIcon className="h-3.5 w-3.5" />
+                {status}
               </span>
-            ) : null}
+              {category && (
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/20 bg-violet-500/10 px-3 py-1 text-xs font-semibold text-violet-300">
+                  <Tag className="h-3 w-3" />
+                  {category}
+                </span>
+              )}
+              {joined ? (
+                <span className="inline-flex items-center gap-2 rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-200">
+                  <Users className="h-3.5 w-3.5" />
+                  Joined
+                </span>
+              ) : null}
+            </div>
+            <h3 className="text-xl font-semibold text-white">{title}</h3>
+            <p className="text-sm leading-6 text-slate-400">{description}</p>
           </div>
-          <h3 className="text-xl font-semibold text-white">{title}</h3>
-          <p className="text-sm leading-6 text-slate-400">{description}</p>
         </div>
-      </div>
 
-      <div className="mt-6 grid gap-3 sm:grid-cols-2">
-        <div className="rounded-2xl bg-white/5 p-4 border border-white/10">
-          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Creator</p>
-          <p className="mt-2 text-sm font-semibold text-white">{creator}</p>
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          <div className="rounded-2xl bg-white/5 p-4 border border-white/10">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Creator</p>
+            <p className="mt-2 text-sm font-semibold text-white">{creator}</p>
+          </div>
+          <div className="rounded-2xl bg-white/5 p-4 border border-white/10">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Ends</p>
+            <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-white">
+              <Calendar className="h-4 w-4 text-slate-400" />
+              {endsAt}
+            </p>
+          </div>
         </div>
-        <div className="rounded-2xl bg-white/5 p-4 border border-white/10">
-          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Ends</p>
-          <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-white">
-            <Calendar className="h-4 w-4 text-slate-400" />
-            {endsAt}
-          </p>
-        </div>
-      </div>
 
-      <div className="mt-6 grid grid-cols-2 gap-3 text-sm text-slate-300">
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Matches</p>
-          <p className="mt-2 text-lg font-semibold text-white">{matchesCount}</p>
+        <div className="mt-6 grid grid-cols-2 gap-3 text-sm text-slate-300">
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Matches</p>
+            <p className="mt-2 text-lg font-semibold text-white">{matchesCount}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Participants</p>
+            <p className="mt-2 text-lg font-semibold text-white">{participants}/{maxParticipants}</p>
+          </div>
         </div>
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Participants</p>
-          <p className="mt-2 text-lg font-semibold text-white">{participants}/{maxParticipants}</p>
-        </div>
-      </div>
 
-      <div className="mt-6 flex items-center justify-between gap-4">
-        <Button
-          type="button"
-          variant="outline"
-          className="min-w-[150px] border-white/10 text-white hover:border-white hover:bg-white/5"
-          onClick={onViewDetails}
-        >
-          View Details
-          <ArrowRight className="h-4 w-4" />
-        </Button>
+        <div className="mt-6 flex items-center justify-between gap-4">
+          <Button
+            type="button"
+            variant="outline"
+            className="min-w-[150px] border-white/10 text-white hover:border-white hover:bg-white/5"
+            onClick={onViewDetails}
+          >
+            View Details
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/component/creator-events/EventHeader.tsx
+++ b/frontend/src/component/creator-events/EventHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CalendarDays, Check, Copy, KeyRound, Users } from "lucide-react";
+import { CalendarDays, Check, Copy, KeyRound, Tag, Users } from "lucide-react";
 
 import { Badge } from "@/component/ui/badge";
 import { Button } from "@/component/ui/button";
@@ -17,6 +17,8 @@ interface EventHeaderProps {
   maxParticipants: number;
   createdAt: string;
   inviteCode?: string;
+  category?: string;
+  bannerUrl?: string;
 }
 
 const statusClasses: Record<EventStatus, string> = {
@@ -34,8 +36,12 @@ export default function EventHeader({
   maxParticipants,
   createdAt,
   inviteCode,
+  category,
+  bannerUrl,
 }: EventHeaderProps) {
   const [copied, setCopied] = useState(false);
+  const [bannerError, setBannerError] = useState(false);
+  const showBanner = Boolean(bannerUrl) && !bannerError;
 
   const handleCopyCreator = async () => {
     try {
@@ -48,65 +54,86 @@ export default function EventHeader({
   };
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-900/90 p-6 shadow-2xl shadow-black/30 sm:p-8">
-      <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-        <div className="max-w-3xl space-y-4">
-          <div className="flex flex-wrap items-center gap-3">
-            <Badge
-              variant="outline"
-              className={cn("rounded-full px-3 py-1 uppercase tracking-[0.18em]", statusClasses[status])}
-            >
-              {status}
-            </Badge>
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
-              <Users className="h-3.5 w-3.5" />
-              {participants} / {maxParticipants}
-            </span>
-          </div>
-
-          <div>
-            <h1 className="text-3xl font-semibold text-white sm:text-5xl">{title}</h1>
-            <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300 sm:text-base">
-              {description}
-            </p>
-          </div>
+    <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/90 shadow-2xl shadow-black/30">
+      {showBanner && (
+        <div className="relative h-48 w-full sm:h-56">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={bannerUrl}
+            alt={`${title} banner`}
+            onError={() => setBannerError(true)}
+            className="h-full w-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent to-slate-900/80" />
         </div>
+      )}
 
-        <div className="grid gap-3 sm:grid-cols-2 lg:min-w-[360px] lg:grid-cols-1">
-          <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
-            <p className="text-xs uppercase tracking-[0.22em] text-slate-500">Creator</p>
-            <div className="mt-2 flex items-center justify-between gap-3">
-              <p className="truncate text-sm font-semibold text-white">{creator}</p>
-              <Button
-                type="button"
-                size="icon"
+      <div className="p-6 sm:p-8">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl space-y-4">
+            <div className="flex flex-wrap items-center gap-3">
+              <Badge
                 variant="outline"
-                className="h-8 w-8 border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
-                onClick={handleCopyCreator}
-                aria-label="Copy creator address"
+                className={cn("rounded-full px-3 py-1 uppercase tracking-[0.18em]", statusClasses[status])}
               >
-                {copied ? <Check className="h-4 w-4 text-emerald-300" /> : <Copy className="h-4 w-4" />}
-              </Button>
+                {status}
+              </Badge>
+              {category && (
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/20 bg-violet-500/10 px-3 py-1 text-xs font-semibold text-violet-300">
+                  <Tag className="h-3 w-3" />
+                  {category}
+                </span>
+              )}
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
+                <Users className="h-3.5 w-3.5" />
+                {participants} / {maxParticipants}
+              </span>
             </div>
-          </div>
 
-          <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
-            <p className="text-xs uppercase tracking-[0.22em] text-slate-500">Created</p>
-            <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-white">
-              <CalendarDays className="h-4 w-4 text-amber-300" />
-              {createdAt}
-            </p>
-          </div>
-
-          {inviteCode ? (
-            <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 p-4 sm:col-span-2 lg:col-span-1">
-              <p className="text-xs uppercase tracking-[0.22em] text-amber-200/80">Invite code</p>
-              <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-amber-100">
-                <KeyRound className="h-4 w-4" />
-                {inviteCode}
+            <div>
+              <h1 className="text-3xl font-semibold text-white sm:text-5xl">{title}</h1>
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300 sm:text-base">
+                {description}
               </p>
             </div>
-          ) : null}
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:min-w-[360px] lg:grid-cols-1">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-slate-500">Creator</p>
+              <div className="mt-2 flex items-center justify-between gap-3">
+                <p className="truncate text-sm font-semibold text-white">{creator}</p>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  className="h-8 w-8 border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
+                  onClick={handleCopyCreator}
+                  aria-label="Copy creator address"
+                >
+                  {copied ? <Check className="h-4 w-4 text-emerald-300" /> : <Copy className="h-4 w-4" />}
+                </Button>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
+              <p className="text-xs uppercase tracking-[0.22em] text-slate-500">Created</p>
+              <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-white">
+                <CalendarDays className="h-4 w-4 text-amber-300" />
+                {createdAt}
+              </p>
+            </div>
+
+            {inviteCode ? (
+              <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 p-4 sm:col-span-2 lg:col-span-1">
+                <p className="text-xs uppercase tracking-[0.22em] text-amber-200/80">Invite code</p>
+                <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-amber-100">
+                  <KeyRound className="h-4 w-4" />
+                  {inviteCode}
+                </p>
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
- EventCard: accept category/bannerUrl props; render violet Tag badge for category and a top banner image with onError graceful fallback so a broken URL never shows a broken-image icon
- EventHeader: same category badge and optional full-width banner with gradient overlay and onError fallback; wrapped in overflow-hidden container
- Listing page (creator-events/page.tsx): add category/bannerUrl to local CreatorEvent interface; populate category and bannerUrl in eventData; add deriveCategories() helper; add stateful categoryFilter; render a category filter row of buttons above the event grid; pass category/bannerUrl through to EventCard
- Detail page ([id]/page.tsx): forward event.category and event.bannerUrl to EventHeader

Closes #952 