### PR TITLE
Frontend] — Finalize event & claim prize flow + `PrizePoolSummary`

### DIFF
--- a/frontend/src/app/(authenticated)/competitions/page.tsx
+++ b/frontend/src/app/(authenticated)/competitions/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import PrizePoolSummary from "@/component/PrizePoolSummary";
+import { useWallet } from "@/context/WalletContext";
+import {
+  claimPayout,
+  finalizeEvent,
+  getUserPayout,
+  type UserPayout,
+} from "@/lib/eventRewards";
 
 export default function CompetitionsPage() {
   type CompetitionStatus = "Active" | "Upcoming" | "Ended" | "Cancelled";
@@ -18,6 +26,8 @@ export default function CompetitionsPage() {
     endDate: string;
     visibility: CompetitionVisibility;
     joined: boolean;
+    isFinalized: boolean;
+    rewardBreakdown: { label: string; amountXlm: number; percentage: number }[];
   };
 
   const [activeTab, setActiveTab] = useState<
@@ -26,6 +36,11 @@ export default function CompetitionsPage() {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const { address } = useWallet();
+  const [userPayouts, setUserPayouts] = useState<
+    Record<string, UserPayout | null>
+  >({});
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
 
   const [createForm, setCreateForm] = useState({
     title: "",
@@ -49,6 +64,12 @@ export default function CompetitionsPage() {
       endDate: "2026-04-30",
       visibility: "Public",
       joined: true,
+      isFinalized: false,
+      rewardBreakdown: [
+        { label: "1st place", amountXlm: 1250, percentage: 50 },
+        { label: "2nd place", amountXlm: 750, percentage: 30 },
+        { label: "3rd place", amountXlm: 500, percentage: 20 },
+      ],
     },
     {
       id: "comp-2",
@@ -63,6 +84,12 @@ export default function CompetitionsPage() {
       endDate: "2026-05-20",
       visibility: "Public",
       joined: false,
+      isFinalized: false,
+      rewardBreakdown: [
+        { label: "1st place", amountXlm: 600, percentage: 50 },
+        { label: "2nd place", amountXlm: 360, percentage: 30 },
+        { label: "3rd place", amountXlm: 240, percentage: 20 },
+      ],
     },
     {
       id: "comp-3",
@@ -77,6 +104,12 @@ export default function CompetitionsPage() {
       endDate: "2026-05-10",
       visibility: "Private",
       joined: false,
+      isFinalized: false,
+      rewardBreakdown: [
+        { label: "1st place", amountXlm: 2500, percentage: 50 },
+        { label: "2nd place", amountXlm: 1500, percentage: 30 },
+        { label: "3rd place", amountXlm: 1000, percentage: 20 },
+      ],
     },
     {
       id: "comp-4",
@@ -91,6 +124,12 @@ export default function CompetitionsPage() {
       endDate: "2026-03-31",
       visibility: "Public",
       joined: true,
+      isFinalized: false,
+      rewardBreakdown: [
+        { label: "1st place", amountXlm: 4000, percentage: 50 },
+        { label: "2nd place", amountXlm: 2400, percentage: 30 },
+        { label: "3rd place", amountXlm: 1600, percentage: 20 },
+      ],
     },
     {
       id: "comp-5",
@@ -105,6 +144,8 @@ export default function CompetitionsPage() {
       endDate: "2026-04-25",
       visibility: "Public",
       joined: false,
+      isFinalized: true,
+      rewardBreakdown: [],
     },
   ]);
 
@@ -190,11 +231,85 @@ export default function CompetitionsPage() {
       endDate,
       visibility: createForm.visibility,
       joined: true,
+      isFinalized: false,
+      rewardBreakdown: [
+        {
+          label: "1st place",
+          amountXlm: Math.round(
+            (Math.max(0, Number(createForm.prizePoolXlm) || 0) * 50) / 100,
+          ),
+          percentage: 50,
+        },
+        {
+          label: "2nd place",
+          amountXlm: Math.round(
+            (Math.max(0, Number(createForm.prizePoolXlm) || 0) * 30) / 100,
+          ),
+          percentage: 30,
+        },
+        {
+          label: "3rd place",
+          amountXlm: Math.round(
+            (Math.max(0, Number(createForm.prizePoolXlm) || 0) * 20) / 100,
+          ),
+          percentage: 20,
+        },
+      ],
     };
 
     setCompetitions((prev) => [newCompetition, ...prev]);
     setIsCreateOpen(false);
     setCreateForm((prev) => ({ ...prev, title: "", description: "" }));
+  };
+
+  useEffect(() => {
+    if (!address) {
+      setUserPayouts({});
+      return;
+    }
+
+    competitions
+      .filter((competition) => competition.isFinalized)
+      .forEach((competition) => {
+        getUserPayout(competition.id, address)
+          .then((payout) => {
+            setUserPayouts((prev) => ({ ...prev, [competition.id]: payout }));
+          })
+          .catch(() => {
+            setUserPayouts((prev) => ({ ...prev, [competition.id]: null }));
+          });
+      });
+  }, [address, competitions]);
+
+  const onFinalizeEvent = async (id: string) => {
+    setPendingAction(`finalize-${id}`);
+    try {
+      await finalizeEvent(id);
+      setCompetitions((prev) =>
+        prev.map((competition) =>
+          competition.id === id
+            ? { ...competition, isFinalized: true, status: "Ended" }
+            : competition,
+        ),
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const onClaimPrize = async (id: string) => {
+    if (!address) return;
+
+    setPendingAction(`claim-${id}`);
+    try {
+      const payout = await claimPayout(id, address);
+      setUserPayouts((prev) => ({
+        ...prev,
+        [id]: { ...payout, claimed: true },
+      }));
+    } finally {
+      setPendingAction(null);
+    }
   };
 
   const tabs = [
@@ -284,6 +399,15 @@ export default function CompetitionsPage() {
             {paged.map((competition) => {
               const isEnded = competition.status === "Ended";
               const isCancelled = competition.status === "Cancelled";
+              const endsAtHasPassed =
+                new Date(competition.endDate).getTime() <= Date.now();
+              const canFinalize =
+                !competition.isFinalized && endsAtHasPassed && !isCancelled;
+              const userPayout = userPayouts[competition.id];
+              const canClaimPrize =
+                competition.isFinalized &&
+                Boolean(userPayout) &&
+                !userPayout?.claimed;
               const canJoin = !competition.joined && !isEnded && !isCancelled;
               const canLeave = competition.joined && !isEnded && !isCancelled;
 
@@ -353,8 +477,39 @@ export default function CompetitionsPage() {
                     </div>
                   </dl>
 
-                  <div className="mt-5 flex items-center justify-between gap-3">
-                    {isEnded ? (
+                  <div className="mt-5">
+                    <PrizePoolSummary
+                      prizePoolXlm={competition.prizePoolXlm}
+                      rewardBreakdown={competition.rewardBreakdown}
+                    />
+                  </div>
+
+                  <div className="mt-5 flex flex-col items-center justify-between gap-3">
+                    {canFinalize ? (
+                      <button
+                        type="button"
+                        onClick={() => onFinalizeEvent(competition.id)}
+                        disabled={
+                          pendingAction === `finalize-${competition.id}`
+                        }
+                        className="w-full rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-orange-500/90 disabled:cursor-wait disabled:opacity-70"
+                      >
+                        {pendingAction === `finalize-${competition.id}`
+                          ? "Finalizing…"
+                          : "Finalize Event"}
+                      </button>
+                    ) : canClaimPrize ? (
+                      <button
+                        type="button"
+                        onClick={() => onClaimPrize(competition.id)}
+                        disabled={pendingAction === `claim-${competition.id}`}
+                        className="w-full rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500/90 disabled:cursor-wait disabled:opacity-70"
+                      >
+                        {pendingAction === `claim-${competition.id}`
+                          ? "Claiming…"
+                          : `Claim Prize${userPayout?.amountXlm ? ` · ${userPayout.amountXlm.toLocaleString()} XLM` : ""}`}
+                      </button>
+                    ) : isEnded ? (
                       <button
                         type="button"
                         className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-gray-200 transition hover:bg-white/10"

--- a/frontend/src/app/events/[id]/page.tsx
+++ b/frontend/src/app/events/[id]/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import PrizePoolSummary from "@/component/PrizePoolSummary";
+import { useWallet } from "@/context/WalletContext";
+import {
+  claimPayout,
+  finalizeEvent,
+  getUserPayout,
+  type UserPayout,
+} from "@/lib/eventRewards";
+
+type EventStatus = "Active" | "Upcoming" | "Ended" | "Cancelled";
+
+type EventDetails = {
+  id: string;
+  title: string;
+  description: string;
+  status: EventStatus;
+  prizePoolXlm: number;
+  participants: number;
+  maxParticipants: number;
+  startsAt: string;
+  endsAt: string;
+  isFinalized: boolean;
+  rewardBreakdown: { label: string; amountXlm: number; percentage: number }[];
+};
+
+const demoEvents: Record<string, EventDetails> = {
+  "season-1-finals": {
+    id: "season-1-finals",
+    title: "Season 1 Finals",
+    description:
+      "A leaderboard-based event for top predictors competing across the final Season 1 markets.",
+    status: "Ended",
+    prizePoolXlm: 8000,
+    participants: 256,
+    maxParticipants: 256,
+    startsAt: "2026-03-01T00:00:00.000Z",
+    endsAt: "2026-03-31T23:59:59.000Z",
+    isFinalized: false,
+    rewardBreakdown: [
+      { label: "1st place", amountXlm: 4000, percentage: 50 },
+      { label: "2nd place", amountXlm: 2400, percentage: 30 },
+      { label: "3rd place", amountXlm: 1600, percentage: 20 },
+    ],
+  },
+};
+
+function getFallbackEvent(id: string): EventDetails {
+  return {
+    id,
+    title: "Creator Event",
+    description:
+      "Make predictions, follow the leaderboard, and compete for XLM prizes in this creator-hosted event.",
+    status: "Active",
+    prizePoolXlm: 2500,
+    participants: 42,
+    maxParticipants: 200,
+    startsAt: "2026-04-01T00:00:00.000Z",
+    endsAt: "2026-04-30T23:59:59.000Z",
+    isFinalized: false,
+    rewardBreakdown: [
+      { label: "1st place", amountXlm: 1250, percentage: 50 },
+      { label: "2nd place", amountXlm: 750, percentage: 30 },
+      { label: "3rd place", amountXlm: 500, percentage: 20 },
+    ],
+  };
+}
+
+export default function EventDetailsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { address } = useWallet();
+  const [event, setEvent] = useState<EventDetails>(
+    demoEvents[params.id] ?? getFallbackEvent(params.id),
+  );
+  const [userPayout, setUserPayout] = useState<UserPayout | null>(null);
+  const [pendingAction, setPendingAction] = useState<"finalize" | "claim" | null>(
+    null,
+  );
+
+  const endsAtHasPassed = useMemo(
+    () => new Date(event.endsAt).getTime() <= Date.now(),
+    [event.endsAt],
+  );
+  const canFinalizeEvent =
+    !event.isFinalized && endsAtHasPassed && event.status !== "Cancelled";
+  const canClaimPrize =
+    event.isFinalized && Boolean(userPayout) && !userPayout?.claimed;
+
+  useEffect(() => {
+    if (!address || !event.isFinalized) {
+      setUserPayout(null);
+      return;
+    }
+
+    getUserPayout(event.id, address)
+      .then(setUserPayout)
+      .catch(() => setUserPayout(null));
+  }, [address, event.id, event.isFinalized]);
+
+  async function onFinalizeEvent() {
+    setPendingAction("finalize");
+    try {
+      await finalizeEvent(event.id);
+      setEvent((current) => ({
+        ...current,
+        isFinalized: true,
+        status: "Ended",
+      }));
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function onClaimPrize() {
+    if (!address) return;
+
+    setPendingAction("claim");
+    try {
+      const payout = await claimPayout(event.id, address);
+      setUserPayout({ ...payout, claimed: true });
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <main className="space-y-6 p-4 sm:p-6">
+      <section className="rounded-2xl border border-white/10 bg-white/5 p-6 text-white backdrop-blur">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-3">
+            <span className="inline-flex rounded-xl border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-orange-200">
+              {event.status}
+            </span>
+            <h1 className="text-3xl font-bold">{event.title}</h1>
+            <p className="max-w-3xl text-sm leading-6 text-gray-400">
+              {event.description}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-gray-300">
+            <p>
+              <span className="text-gray-500">Participants:</span>{" "}
+              {event.participants}/{event.maxParticipants}
+            </p>
+            <p className="mt-2">
+              <span className="text-gray-500">Ends:</span>{" "}
+              {new Date(event.endsAt).toLocaleString()}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem]">
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-6 text-white backdrop-blur">
+          <h2 className="text-xl font-semibold">Event Details</h2>
+          <p className="mt-2 text-sm text-gray-400">
+            Review the event timeline and use the action bar once the event is
+            ready to finalize or when a finalized event has a wallet payout to
+            claim.
+          </p>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+              <p className="text-xs uppercase tracking-wide text-gray-500">
+                Starts At
+              </p>
+              <p className="mt-1 font-medium">
+                {new Date(event.startsAt).toLocaleString()}
+              </p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+              <p className="text-xs uppercase tracking-wide text-gray-500">
+                Ends At
+              </p>
+              <p className="mt-1 font-medium">
+                {new Date(event.endsAt).toLocaleString()}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <PrizePoolSummary
+            prizePoolXlm={event.prizePoolXlm}
+            rewardBreakdown={event.rewardBreakdown}
+          />
+
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-300">
+              Actions
+            </h2>
+            <div className="mt-4 space-y-3">
+              <button
+                type="button"
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-gray-200 transition hover:bg-white/10"
+              >
+                Make Predictions
+              </button>
+
+              {canFinalizeEvent ? (
+                <button
+                  type="button"
+                  onClick={onFinalizeEvent}
+                  disabled={pendingAction === "finalize"}
+                  className="w-full rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-orange-500/90 disabled:cursor-wait disabled:opacity-70"
+                >
+                  {pendingAction === "finalize" ? "Finalizing…" : "Finalize Event"}
+                </button>
+              ) : null}
+
+              {canClaimPrize ? (
+                <button
+                  type="button"
+                  onClick={onClaimPrize}
+                  disabled={pendingAction === "claim"}
+                  className="w-full rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500/90 disabled:cursor-wait disabled:opacity-70"
+                >
+                  {pendingAction === "claim"
+                    ? "Claiming…"
+                    : `Claim Prize · ${userPayout?.amountXlm.toLocaleString()} XLM`}
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/component/PrizePoolSummary.tsx
+++ b/frontend/src/component/PrizePoolSummary.tsx
@@ -36,22 +36,28 @@ export default function PrizePoolSummary({
       </div>
 
       <div className="mt-4 space-y-2">
-        {rewardBreakdown.map((reward) => (
-          <div
-            key={reward.label}
-            className="flex items-center justify-between rounded-xl border border-white/10 bg-black/10 px-3 py-2 text-sm"
-          >
-            <span className="text-gray-300">
-              {reward.label}
-              {typeof reward.percentage === "number" ? (
-                <span className="text-gray-500"> · {reward.percentage}%</span>
-              ) : null}
-            </span>
-            <span className="font-semibold text-white">
-              {formatXlm(reward.amountXlm)}
-            </span>
-          </div>
-        ))}
+        {rewardBreakdown.length > 0 ? (
+          rewardBreakdown.map((reward) => (
+            <div
+              key={reward.label}
+              className="flex items-center justify-between rounded-xl border border-white/10 bg-black/10 px-3 py-2 text-sm"
+            >
+              <span className="text-gray-300">
+                {reward.label}
+                {typeof reward.percentage === "number" ? (
+                  <span className="text-gray-500"> · {reward.percentage}%</span>
+                ) : null}
+              </span>
+              <span className="font-semibold text-white">
+                {formatXlm(reward.amountXlm)}
+              </span>
+            </div>
+          ))
+        ) : (
+          <p className="rounded-xl border border-white/10 bg-black/10 px-3 py-2 text-sm text-gray-400">
+            Reward distribution will be available after prizes are configured.
+          </p>
+        )}
       </div>
     </section>
   );

--- a/frontend/src/component/PrizePoolSummary.tsx
+++ b/frontend/src/component/PrizePoolSummary.tsx
@@ -1,0 +1,58 @@
+type RewardBreakdownItem = {
+  label: string;
+  amountXlm: number;
+  percentage?: number;
+};
+
+type PrizePoolSummaryProps = {
+  prizePoolXlm: number;
+  rewardBreakdown: RewardBreakdownItem[];
+};
+
+function formatXlm(amount: number) {
+  return `${amount.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+  })} XLM`;
+}
+
+export default function PrizePoolSummary({
+  prizePoolXlm,
+  rewardBreakdown,
+}: PrizePoolSummaryProps) {
+  return (
+    <section className="rounded-2xl border border-orange-500/20 bg-orange-500/10 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-orange-200/80">
+            Prize Pool
+          </p>
+          <p className="mt-1 text-2xl font-bold text-white">
+            {formatXlm(prizePoolXlm)}
+          </p>
+        </div>
+        <div className="rounded-full border border-orange-400/30 bg-orange-400/10 px-3 py-1 text-xs font-semibold text-orange-100">
+          XLM Rewards
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {rewardBreakdown.map((reward) => (
+          <div
+            key={reward.label}
+            className="flex items-center justify-between rounded-xl border border-white/10 bg-black/10 px-3 py-2 text-sm"
+          >
+            <span className="text-gray-300">
+              {reward.label}
+              {typeof reward.percentage === "number" ? (
+                <span className="text-gray-500"> · {reward.percentage}%</span>
+              ) : null}
+            </span>
+            <span className="font-semibold text-white">
+              {formatXlm(reward.amountXlm)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/lib/eventRewards.ts
+++ b/frontend/src/lib/eventRewards.ts
@@ -1,0 +1,58 @@
+export type UserPayout = {
+  amountXlm: number;
+  claimed: boolean;
+  transactionHash?: string;
+};
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function finalizeEvent(eventId: string) {
+  const response = await fetch(
+    `${API_BASE_URL}/api/creator-events/${eventId}/finalize`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+
+  return parseJsonResponse(response);
+}
+
+export async function claimPayout(eventId: string, walletAddress: string) {
+  const response = await fetch(
+    `${API_BASE_URL}/api/creator-events/${eventId}/payouts/${walletAddress}/claim`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+
+  return parseJsonResponse<UserPayout>(response);
+}
+
+export async function getUserPayout(
+  eventId: string,
+  walletAddress: string,
+): Promise<UserPayout | null> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/creator-events/${eventId}/payouts/${walletAddress}`,
+    {
+      cache: "no-store",
+    },
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  return parseJsonResponse<UserPayout>(response);
+}


### PR DESCRIPTION
close #950 


Description
Add a new event detail page at frontend/src/app/events/[id]/page.tsx that renders event metadata, a PrizePoolSummary, and an action panel.
Implement onFinalizeEvent and onClaimPrize handlers that call the existing finalizeEvent and claimPayout helpers and update local UI state.
Use getUserPayout to fetch the connected wallet payout for finalized events and track UserPayout to show/hide the claim button.
Update frontend/src/component/PrizePoolSummary.tsx to render an empty-state message when rewardBreakdown is empty while retaining the XLM prize display.

Testing
Ran npm --prefix frontend run build and the frontend compiled successfully with TypeScript checks and Next.js page generation completed.
