### PR TITLE
Add optional entry fee that pools into the prize pool on join

### DIFF
--- a/contracts/creator-event-manager/src/event.rs
+++ b/contracts/creator-event-manager/src/event.rs
@@ -53,6 +53,8 @@ pub enum EventError {
     AlreadyFinalized = 18,
     /// Operation rejected because the event has been cancelled.
     EventCancelled = 19,
+    /// entry_fee < 0
+    InvalidEntryFee = 20,
 }
 
 impl From<InviteError> for EventError {
@@ -145,6 +147,7 @@ pub fn create_event(
     end_time: u64,
     prize_pool: i128,
     reward_distribution: Vec<u32>,
+    entry_fee: i128,
 ) -> Result<(u64, Symbol), EventError> {
     creator.require_auth();
 
@@ -184,6 +187,11 @@ pub fn create_event(
 
     // Validate the prize pool and its reward distribution.
     validate_prize_pool(prize_pool, &reward_distribution)?;
+
+    // A negative entry fee is nonsensical; `0` means free to join.
+    if entry_fee < 0 {
+        return Err(EventError::InvalidEntryFee);
+    }
 
     let fee = admin::get_creation_fee(env).unwrap_or_else(|| panic!("not_initialized"));
     let treasury = admin::get_treasury(env).unwrap_or_else(|| panic!("not_initialized"));
@@ -226,6 +234,7 @@ pub fn create_event(
         max_participants,
         prize_pool,
         reward_distribution.clone(),
+        entry_fee,
     );
 
     storage::set_event(env, event_id, &event);

--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -264,6 +264,7 @@ impl CreatorEventManagerContract {
     ///   non-empty distribution on an unfunded event).
     /// * `"insufficient_prize_pool_funds"` — creator cannot cover
     ///   `creation_fee + prize_pool`.
+    /// * `"invalid_entry_fee"` — `entry_fee` is negative.
     pub fn create_event(
         env: Env,
         creator: Address,
@@ -274,6 +275,7 @@ impl CreatorEventManagerContract {
         end_time: u64,
         prize_pool: i128,
         reward_distribution: Vec<u32>,
+        entry_fee: i128,
     ) -> (u64, Symbol) {
         match event::create_event(
             &env,
@@ -285,6 +287,7 @@ impl CreatorEventManagerContract {
             end_time,
             prize_pool,
             reward_distribution,
+            entry_fee,
         ) {
             Ok(result) => result,
             Err(EventError::Paused) => panic!("contract_paused"),
@@ -300,6 +303,7 @@ impl CreatorEventManagerContract {
             Err(EventError::InvalidPrizePool) => panic!("invalid_prize_pool"),
             Err(EventError::InvalidRewardDistribution) => panic!("invalid_reward_distribution"),
             Err(EventError::InsufficientPrizePoolFunds) => panic!("insufficient_prize_pool_funds"),
+            Err(EventError::InvalidEntryFee) => panic!("invalid_entry_fee"),
             Err(_) => panic!("unexpected_error"),
         }
     }
@@ -488,6 +492,9 @@ impl CreatorEventManagerContract {
             Err(prediction::PredictionError::EventCancelled) => panic!("event_cancelled"),
             Err(prediction::PredictionError::AlreadyJoined) => panic!("already_joined"),
             Err(prediction::PredictionError::EventFull) => panic!("event_full"),
+            Err(prediction::PredictionError::InsufficientEntryFeeBalance) => {
+                panic!("insufficient_entry_fee_balance")
+            }
             Err(_) => panic!("unexpected_error"),
         }
     }

--- a/contracts/creator-event-manager/src/prediction.rs
+++ b/contracts/creator-event-manager/src/prediction.rs
@@ -1,8 +1,9 @@
-use soroban_sdk::{Address, Env, Symbol, Vec};
+use soroban_sdk::{token::Client as TokenClient, Address, Env, Symbol, Vec};
 
 use crate::admin;
 use crate::storage::{self};
 use crate::storage_types::{DataKey, Event, Match, Prediction};
+use crate::token::TokenHelper;
 
 /// Errors returned by event joining and prediction operations.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -21,12 +22,13 @@ pub enum PredictionError {
     AlreadyPredicted = 11,
     PredictionNotFound = 12,
     Overflow = 13,
+    InsufficientEntryFeeBalance = 14,
 }
 
-fn emit_user_joined(env: &Env, event_id: u64, user: &Address) {
+fn emit_user_joined(env: &Env, event_id: u64, user: &Address, entry_fee_paid: i128) {
     env.events().publish(
         (Symbol::new(env, "event"), Symbol::new(env, "joined")),
-        (event_id, user.clone()),
+        (event_id, user.clone(), entry_fee_paid),
     );
 }
 
@@ -102,6 +104,33 @@ pub fn join_event(env: &Env, user: Address, invite_code: Symbol) -> Result<(), P
         return Err(PredictionError::EventFull);
     }
 
+    // Collect the entry fee (if any) before mutating any state, so a user who
+    // cannot cover the fee is rejected without a partial join.
+    let entry_fee = event.entry_fee;
+    if entry_fee > 0 {
+        let xlm_token = admin::get_xlm_token(env).unwrap_or_else(|| panic!("not_initialized"));
+
+        if !TokenHelper::has_sufficient_balance(env, &xlm_token, &user, entry_fee) {
+            return Err(PredictionError::InsufficientEntryFeeBalance);
+        }
+
+        // Compute the grown pool before moving funds so an (effectively
+        // unreachable) overflow aborts before any transfer occurs.
+        let new_prize_pool = event
+            .prize_pool
+            .checked_add(entry_fee)
+            .ok_or(PredictionError::Overflow)?;
+
+        // Escrow the fee from the user into the contract address.
+        TokenClient::new(env, &xlm_token).transfer(
+            &user,
+            &env.current_contract_address(),
+            &entry_fee,
+        );
+
+        event.prize_pool = new_prize_pool;
+    }
+
     storage::add_event_participant(env, event_id, &user);
     event.participant_count = event
         .participant_count
@@ -109,7 +138,7 @@ pub fn join_event(env: &Env, user: Address, invite_code: Symbol) -> Result<(), P
         .ok_or(PredictionError::Overflow)?;
     storage::set_event(env, event_id, &event);
 
-    emit_user_joined(env, event_id, &user);
+    emit_user_joined(env, event_id, &user, entry_fee);
 
     Ok(())
 }

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -235,8 +235,14 @@ pub struct Event {
     pub match_count: u32,
 
     /// XLM prize pool (in stroops) escrowed in the contract for winners.
-    /// `0` means this is a "fun event" with no payouts.
+    /// `0` means this is a "fun event" with no payouts. Grows as paid
+    /// participants join (see `entry_fee`).
     pub prize_pool: i128,
+
+    /// XLM fee (in stroops) each participant pays to join. `0` = free to join.
+    /// When non-zero, the fee is collected on `join_event` and added to
+    /// `prize_pool`.
+    pub entry_fee: i128,
 
     /// Percentage of the prize pool awarded to each leaderboard rank, in
     /// 1-based rank order (index 0 → rank 1). Each entry is 1–100 and the
@@ -264,6 +270,7 @@ impl Event {
         max_participants: u32,
         prize_pool: i128,
         reward_distribution: Vec<u32>,
+        entry_fee: i128,
     ) -> Self {
         Self {
             event_id,
@@ -281,6 +288,7 @@ impl Event {
             participant_count: 0,
             match_count: 0,
             prize_pool,
+            entry_fee,
             reward_distribution,
             is_finalized: false,
         }

--- a/contracts/creator-event-manager/tests/data_structures_test.rs
+++ b/contracts/creator-event-manager/tests/data_structures_test.rs
@@ -26,6 +26,7 @@ fn make_event(env: &Env, event_id: u64) -> Event {
         100u32,
         0i128,
         Vec::new(env),
+        0i128,
     )
 }
 
@@ -135,6 +136,7 @@ fn test_event_add_participant_rejects_when_full() {
         1u32,
         0i128,
         Vec::new(&env),
+        0i128,
     );
     assert!(event.add_participant().is_ok());
     assert_eq!(

--- a/contracts/creator-event-manager/tests/event_tests.rs
+++ b/contracts/creator-event-manager/tests/event_tests.rs
@@ -80,6 +80,7 @@ fn test_create_event_success() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     assert_eq!(event_id, 1);
 }
@@ -102,6 +103,7 @@ fn test_create_event_stores_correct_fields() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let event = client.get_event(&event_id);
@@ -136,6 +138,7 @@ fn test_create_event_fee_transferred_to_treasury() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     assert_eq!(token.balance(&treasury) - before, FEE);
 }
@@ -160,6 +163,7 @@ fn test_create_event_fails_when_paused() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -182,6 +186,7 @@ fn test_create_event_fails_empty_title() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -204,6 +209,7 @@ fn test_create_event_fails_empty_description() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -226,6 +232,7 @@ fn test_create_event_fails_zero_max_participants() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -248,6 +255,7 @@ fn test_create_event_fails_insufficient_balance() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -269,6 +277,7 @@ fn test_get_event_returns_correct_data() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     let event = client.get_event(&event_id);
     assert_eq!(event.event_id, event_id);
@@ -302,6 +311,7 @@ fn test_get_event_by_code_returns_correct_event() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     let event = client.get_event_by_code(&invite_code);
     assert_eq!(event.event_id, event_id);
@@ -337,6 +347,7 @@ fn test_create_event_with_valid_duration() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let event = client.get_event(&event_id);
@@ -364,6 +375,7 @@ fn test_create_event_end_before_start_rejected() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -387,6 +399,7 @@ fn test_create_event_end_equals_start_rejected() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -411,6 +424,7 @@ fn test_create_event_start_in_past_rejected() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -434,6 +448,7 @@ fn test_create_event_duration_too_long_rejected() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 }
 
@@ -455,6 +470,7 @@ fn test_event_has_ended_helper() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     let event = client.get_event(&event_id);
 
@@ -486,6 +502,7 @@ fn test_event_is_within_window_helper() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     let event = client.get_event(&event_id);
 
@@ -539,6 +556,7 @@ fn test_create_event_with_prize_pool_escrows_funds() {
         &end_time,
         &PRIZE_POOL,
         &distribution(&env),
+        &0i128,
     );
 
     // Contract escrows exactly the prize pool (the creation fee goes to treasury).
@@ -568,6 +586,7 @@ fn test_create_event_reward_distribution_must_sum_to_100() {
         &end_time,
         &PRIZE_POOL,
         &dist,
+        &0i128,
     );
 }
 
@@ -592,6 +611,7 @@ fn test_create_event_too_many_reward_ranks() {
         &end_time,
         &PRIZE_POOL,
         &dist,
+        &0i128,
     );
 }
 
@@ -616,6 +636,7 @@ fn test_create_event_zero_entry_in_distribution_rejected() {
         &end_time,
         &PRIZE_POOL,
         &dist,
+        &0i128,
     );
 }
 
@@ -639,6 +660,7 @@ fn test_create_event_insufficient_balance_for_prize_pool() {
         &end_time,
         &PRIZE_POOL,
         &distribution(&env),
+        &0i128,
     );
 }
 
@@ -663,6 +685,7 @@ fn test_create_event_zero_prize_pool_requires_empty_distribution() {
         &end_time,
         &0i128,
         &dist,
+        &0i128,
     );
 }
 
@@ -684,6 +707,7 @@ fn test_get_event_prize_pool_and_distribution_views() {
         &end_time,
         &PRIZE_POOL,
         &distribution(&env),
+        &0i128,
     );
 
     assert_eq!(client.get_event_prize_pool(&event_id), PRIZE_POOL);
@@ -714,6 +738,7 @@ fn test_get_event_prize_pool_zero_for_fun_event() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     assert_eq!(client.get_event_prize_pool(&event_id), 0);

--- a/contracts/creator-event-manager/tests/fee_views_tests.rs
+++ b/contracts/creator-event-manager/tests/fee_views_tests.rs
@@ -87,6 +87,7 @@ fn test_treasury_balance_and_withdraw_success() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     // Treasury address should now have the fee
@@ -142,6 +143,7 @@ fn test_withdraw_non_admin_rejected() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let non_admin = Address::generate(&env);

--- a/contracts/creator-event-manager/tests/finalize_tests.rs
+++ b/contracts/creator-event-manager/tests/finalize_tests.rs
@@ -87,6 +87,7 @@ fn create_funded_event(
         &end_time,
         &prize_pool,
         &reward_distribution,
+        &0i128,
     );
 
     let mut match_ids: Vec<u64> = Vec::new(env);

--- a/contracts/creator-event-manager/tests/get_match_predictions_tests.rs
+++ b/contracts/creator-event-manager/tests/get_match_predictions_tests.rs
@@ -77,6 +77,7 @@ fn create_event_with_match(
         &end_time,
         &0i128,
         &Vec::new(env),
+        &0i128,
     );
 
     let match_id = env.as_contract(contract_id, || {

--- a/contracts/creator-event-manager/tests/leaderboard_tests.rs
+++ b/contracts/creator-event-manager/tests/leaderboard_tests.rs
@@ -77,6 +77,7 @@ fn create_event_with_matches(
         &end_time,
         &0i128,
         &soroban_sdk::Vec::new(env),
+        &0i128,
     );
 
     let mut match_ids: Vec<u64> = Vec::new();

--- a/contracts/creator-event-manager/tests/match_tests.rs
+++ b/contracts/creator-event-manager/tests/match_tests.rs
@@ -69,6 +69,7 @@ fn create_event_default(
         &end_time,
         &0i128,
         &Vec::new(env),
+        &0i128,
     )
 }
 

--- a/contracts/creator-event-manager/tests/oracle_tests.rs
+++ b/contracts/creator-event-manager/tests/oracle_tests.rs
@@ -69,6 +69,7 @@ fn create_event_with_match(
         &end_time,
         &0i128,
         &Vec::new(env),
+        &0i128,
     );
 
     let match_id = env.as_contract(contract_id, || {
@@ -196,6 +197,7 @@ fn test_get_user_score_calculation_accurate() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -3,7 +3,7 @@ use creator_event_manager::storage;
 use creator_event_manager::CreatorEventManagerContractClient;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::testutils::Ledger as _;
-use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
 use soroban_sdk::{Address, Env, String, Symbol, Vec};
 
 const FEE: i128 = 1_000_000;
@@ -73,6 +73,7 @@ fn create_event_and_match(
         &end_time,
         &0i128,
         &Vec::new(env),
+        &0i128,
     );
 
     let match_id = env.as_contract(contract_id, || {
@@ -325,6 +326,7 @@ fn test_get_user_predictions_returns_all_for_event() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {
@@ -402,6 +404,7 @@ fn test_get_user_predictions_sorted_by_predicted_at() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {
@@ -570,6 +573,7 @@ fn test_get_prediction_distribution_multiple_matches_independent() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {
@@ -634,3 +638,146 @@ fn test_get_prediction_distribution_multiple_matches_independent() {
 // 2. test_submit_prediction_scores_are_valid
 //    - Verifies that any non-negative score pair is accepted (e.g., 0-0)
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Entry-fee join tests
+// ---------------------------------------------------------------------------
+
+/// Create an event with an optional `entry_fee` and seeded `prize_pool`.
+/// The creator is funded with `FEE + prize_pool` so creation succeeds.
+fn create_paid_event(
+    env: &Env,
+    client: &CreatorEventManagerContractClient<'static>,
+    creator: &Address,
+    xlm_token: &Address,
+    max_participants: u32,
+    entry_fee: i128,
+    prize_pool: i128,
+    reward_distribution: Vec<u32>,
+) -> (u64, Symbol) {
+    fund(env, xlm_token, creator, FEE + prize_pool);
+
+    let start_time = get_future_time(env, 3600);
+    let end_time = get_future_time(env, 7200);
+    client.create_event(
+        creator,
+        &title(env),
+        &desc(env),
+        &max_participants,
+        &start_time,
+        &end_time,
+        &prize_pool,
+        &reward_distribution,
+        &entry_fee,
+    )
+}
+
+#[test]
+fn test_join_event_free_when_entry_fee_zero() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    // entry_fee == 0 → identical to the original free-join behaviour.
+    let (event_id, invite_code, _) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    // The user is never funded; a free join must not require any XLM.
+    client.join_event(&user, &invite_code);
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.participant_count, 1);
+    assert_eq!(client.get_event_prize_pool(&event_id), 0);
+    assert_eq!(TokenClient::new(&env, &xlm_token).balance(&user), 0);
+}
+
+#[test]
+fn test_join_event_with_entry_fee_charges_user_and_grows_pool() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let entry_fee: i128 = 5_000_000;
+    let (event_id, invite_code) = create_paid_event(
+        &env,
+        &client,
+        &creator,
+        &xlm_token,
+        10,
+        entry_fee,
+        0,
+        Vec::new(&env),
+    );
+
+    // Fund the user with exactly the entry fee.
+    fund(&env, &xlm_token, &user, entry_fee);
+
+    client.join_event(&user, &invite_code);
+
+    // The fee left the user and grew the prize pool.
+    assert_eq!(TokenClient::new(&env, &xlm_token).balance(&user), 0);
+    assert_eq!(client.get_event_prize_pool(&event_id), entry_fee);
+    assert_eq!(client.get_event(&event_id).participant_count, 1);
+}
+
+#[test]
+#[should_panic(expected = "insufficient_entry_fee_balance")]
+fn test_join_event_insufficient_balance_for_entry_fee_rejected() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let entry_fee: i128 = 5_000_000;
+    let (_event_id, invite_code) = create_paid_event(
+        &env,
+        &client,
+        &creator,
+        &xlm_token,
+        10,
+        entry_fee,
+        0,
+        Vec::new(&env),
+    );
+
+    // Fund the user with less than the entry fee — the join must be rejected.
+    fund(&env, &xlm_token, &user, entry_fee - 1);
+
+    client.join_event(&user, &invite_code);
+}
+
+#[test]
+fn test_prize_pool_reflects_creator_seed_plus_entry_fees() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+
+    let seed: i128 = 10_000_000;
+    let entry_fee: i128 = 2_000_000;
+    let n: usize = 4;
+
+    let mut reward = Vec::new(&env);
+    reward.push_back(100u32);
+
+    let (event_id, invite_code) = create_paid_event(
+        &env,
+        &client,
+        &creator,
+        &xlm_token,
+        n as u32,
+        entry_fee,
+        seed,
+        reward,
+    );
+
+    // The seed is in the pool before anyone joins.
+    assert_eq!(client.get_event_prize_pool(&event_id), seed);
+
+    for _ in 0..n {
+        let user = Address::generate(&env);
+        fund(&env, &xlm_token, &user, entry_fee);
+        client.join_event(&user, &invite_code);
+    }
+
+    let expected = seed + (n as i128) * entry_fee;
+    assert_eq!(client.get_event_prize_pool(&event_id), expected);
+    assert_eq!(client.get_event(&event_id).participant_count, n as u32);
+}

--- a/contracts/creator-event-manager/tests/storage_types_tests.rs
+++ b/contracts/creator-event-manager/tests/storage_types_tests.rs
@@ -53,6 +53,7 @@ fn make_event(env: &Env, event_id: u64) -> Event {
         100u32,
         0i128,
         Vec::new(env),
+        0i128,
     )
 }
 
@@ -81,6 +82,7 @@ fn test_event_creation() {
         50u32,
         0i128,
         Vec::new(&env),
+        0i128,
     );
 
     assert_eq!(event.event_id, 1);
@@ -150,6 +152,7 @@ fn test_event_max_participants() {
         2u32,
         0i128,
         Vec::new(&env),
+        0i128,
     );
 
     assert!(event.add_participant().is_ok());
@@ -173,6 +176,7 @@ fn test_event_unlimited_participants() {
         0u32, // 0 = unlimited
         0i128,
         Vec::new(&env),
+        0i128,
     );
 
     for _ in 0..10 {

--- a/contracts/creator-event-manager/tests/submit_match_result_contract_tests.rs
+++ b/contracts/creator-event-manager/tests/submit_match_result_contract_tests.rs
@@ -83,6 +83,7 @@ fn create_event_with_match(
         &end_time,
         &0i128,
         &Vec::new(env),
+        &0i128,
     );
 
     let match_id = env.as_contract(contract_id, || {

--- a/contracts/creator-event-manager/tests/views_tests.rs
+++ b/contracts/creator-event-manager/tests/views_tests.rs
@@ -117,6 +117,7 @@ fn test_get_event_participants_returns_all_participants() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     client.join_event(&user_one, &invite_code);
     client.join_event(&user_two, &invite_code);
@@ -147,6 +148,7 @@ fn test_get_event_participants_empty_for_new_event() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let participants = client.get_event_participants(&event_id);
@@ -172,6 +174,7 @@ fn test_get_event_participants_updates_as_participants_join() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let initial_participants = client.get_event_participants(&event_id);
@@ -215,6 +218,7 @@ fn test_event_statistics_are_accurate() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     client.join_event(&user_one, &invite_code);
     client.join_event(&user_two, &invite_code);
@@ -253,6 +257,7 @@ fn test_event_statistics_completion_status() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     env.as_contract(&contract_id, || {
@@ -315,6 +320,7 @@ fn test_get_platform_statistics_all_statistics_accurate() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     client.join_event(&user1, &invite_code_1);
     client.join_event(&user2, &invite_code_1);
@@ -338,6 +344,7 @@ fn test_get_platform_statistics_all_statistics_accurate() {
         &end_time2,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     client.join_event(&user1, &invite_code_2);
 
@@ -379,6 +386,7 @@ fn test_get_platform_statistics_counters_increment_correctly() {
         &end_time,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let after_event = client.get_platform_statistics();
@@ -425,6 +433,7 @@ fn test_get_platform_statistics_unique_participants_calculated() {
         &end_time1,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     client.join_event(&user1, &invite_code_1);
     client.join_event(&user2, &invite_code_1);
@@ -442,6 +451,7 @@ fn test_get_platform_statistics_unique_participants_calculated() {
         &end_time2,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
     client.join_event(&user1, &invite_code_2);
 
@@ -481,6 +491,7 @@ fn test_get_platform_statistics_fees_accumulated() {
         &end_time1,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     fund(&env, &xlm_token, &creator2, FEE);
@@ -495,6 +506,7 @@ fn test_get_platform_statistics_fees_accumulated() {
         &end_time2,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     fund(&env, &xlm_token, &creator3, FEE);
@@ -509,6 +521,7 @@ fn test_get_platform_statistics_fees_accumulated() {
         &end_time3,
         &0i128,
         &Vec::new(&env),
+        &0i128,
     );
 
     let stats = client.get_platform_statistics();


### PR DESCRIPTION
`prediction::join_event` in the **creator-event-manager** contract was free for
everyone. Many prediction-campaign formats let the creator charge a small entry
fee that is pooled into the prize money, on top of whatever the creator seeded.

This PR lets creators set an optional `entry_fee`. If non-zero, joining costs
that much XLM, the fee is escrowed into the contract, and it grows
`event.prize_pool` so it is paid out at finalize time.

## Changes

### `storage_types.rs`
- `Event` gains `pub entry_fee: i128` (`0` = free to join, the default).
- `Event::new` takes and stores `entry_fee`.

### `event.rs`
- `create_event` gains an `entry_fee: i128` parameter.
- New `EventError::InvalidEntryFee` returned when `entry_fee < 0`.

### `prediction.rs`
- New `PredictionError::InsufficientEntryFeeBalance = 14`.
- `join_event`, when `event.entry_fee > 0`:
  1. Verifies `TokenHelper::has_sufficient_balance(...)`, otherwise returns
     `InsufficientEntryFeeBalance` — **before any state change**.
  2. Computes the grown pool with `checked_add` (→ `Overflow`), then transfers
     `entry_fee` from the user into `env.current_contract_address()` (escrow).
  3. Persists the event with the updated `prize_pool`.
  4. Emits `(event, joined)` with `(event_id, user, entry_fee_paid)`.
- When `entry_fee == 0`, joining behaves exactly as before (no funds required).

### `lib.rs`
- Threads `entry_fee` through the `create_event` entry point.
- Maps `InvalidEntryFee → "invalid_entry_fee"` and
  `InsufficientEntryFeeBalance → "insufficient_entry_fee_balance"`.

## Note on the error discriminant

The issue requested `InvalidEntryFee = 19`, but `19` is already taken by
`EventError::EventCancelled`. Duplicate fieldless-enum discriminants do not
compile, so `InvalidEntryFee` uses the next free value, `20`. Behavior is
unchanged: a negative entry fee is rejected.

`finalize_event` reads `event.prize_pool` live at finalize time
(`finalize.rs:113`), so it already reflects the creator seed **plus** all
collected entry fees. Likewise `views::get_event_prize_pool` returns the live
field. No caching of the creation-time value exists, so both issues operate on
the same `Event.prize_pool` and stay consistent.

## Acceptance criteria

- [x] `entry_fee == 0` → joining behaves exactly as before (free).
- [x] `entry_fee > 0` → joining charges the user and grows `event.prize_pool`.
- [x] Insufficient balance is rejected before any state change.
- [x] `get_event_prize_pool` reflects accumulated entry fees.

## Test plan

New tests in `tests/prediction_tests.rs`:

- [x] `test_join_event_free_when_entry_fee_zero`
- [x] `test_join_event_with_entry_fee_charges_user_and_grows_pool`
- [x] `test_join_event_insufficient_balance_for_entry_fee_rejected`
- [x] `test_prize_pool_reflects_creator_seed_plus_entry_fees` — N users join a
  paid event; asserts `get_event_prize_pool == seed + N * entry_fee`.

Existing call sites of `create_event` / `Event::new` across all test files were
updated for the new parameter. Full suite: **all suites pass, 0 failed.**




closes #970