### PR TITLE
Feature/971 match points multiplier

### DIFF
--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -409,8 +409,9 @@ impl CreatorEventManagerContract {
 
     /// Create a new match within an event.
     ///
-    /// Only the event's creator can call this. Validates team names and match time,
-    /// then persists the match and emits a ("match", "created") event.
+    /// Only the event's creator can call this. Validates team names, match time,
+    /// and the points multiplier, then persists the match and emits a
+    /// ("match", "created") event.
     ///
     /// Returns the newly assigned `match_id`.
     ///
@@ -421,6 +422,7 @@ impl CreatorEventManagerContract {
     /// * `"unauthorized"` — caller is not the event creator.
     /// * `"invalid_team_names"` — team names are empty, too long, or identical.
     /// * `"invalid_match_time"` — match_time is not in the future.
+    /// * `"invalid_points_multiplier"` — multiplier is 0 or > MAX_POINTS_MULTIPLIER (3).
     pub fn create_match(
         env: Env,
         caller: Address,
@@ -428,8 +430,9 @@ impl CreatorEventManagerContract {
         team_a: String,
         team_b: String,
         match_time: u64,
+        points_multiplier: u32,
     ) -> u64 {
-        match r#match::create_match(&env, caller, event_id, team_a, team_b, match_time) {
+        match r#match::create_match(&env, caller, event_id, team_a, team_b, match_time, points_multiplier) {
             Ok(match_id) => match_id,
             Err(MatchError::Paused) => panic!("paused"),
             Err(MatchError::EventNotFound) => panic!("event_not_found"),
@@ -437,6 +440,7 @@ impl CreatorEventManagerContract {
             Err(MatchError::Unauthorized) => panic!("unauthorized"),
             Err(MatchError::InvalidTeamNames) => panic!("invalid_team_names"),
             Err(MatchError::InvalidMatchTime) => panic!("invalid_match_time"),
+            Err(MatchError::InvalidPointsMultiplier) => panic!("invalid_points_multiplier"),
         }
     }
 

--- a/contracts/creator-event-manager/src/match.rs
+++ b/contracts/creator-event-manager/src/match.rs
@@ -24,6 +24,8 @@ pub enum MatchError {
     InvalidTeamNames = 5,
     /// Match time is invalid (in the past or outside event window).
     InvalidMatchTime = 6,
+    /// points_multiplier is 0 or exceeds MAX_POINTS_MULTIPLIER (cap: 3).
+    InvalidPointsMultiplier = 7,
 }
 
 // ---------------------------------------------------------------------------
@@ -53,6 +55,7 @@ pub fn create_match(
     team_a: String,
     team_b: String,
     match_time: u64,
+    points_multiplier: u32,
 ) -> Result<u64, MatchError> {
     // Step 1: Require authorization
     caller.require_auth();
@@ -94,30 +97,35 @@ pub fn create_match(
         return Err(MatchError::InvalidMatchTime);
     }
 
-    // Step 7: Assign a new match_id
+    // Step 7: Validate points_multiplier (must be 1..=MAX_POINTS_MULTIPLIER)
+    if points_multiplier == 0 || points_multiplier > crate::storage_types::MAX_POINTS_MULTIPLIER {
+        return Err(MatchError::InvalidPointsMultiplier);
+    }
+
+    // Step 8: Assign a new match_id
     let match_id = storage::next_match_id(env);
 
-    // Step 8: Build the Match
-    let m = Match::new(match_id, event_id, team_a.clone(), team_b.clone(), match_time);
+    // Step 9: Build the Match
+    let m = Match::new(match_id, event_id, team_a.clone(), team_b.clone(), match_time, points_multiplier);
 
-    // Step 9: Persist the match
+    // Step 10: Persist the match
     storage::set_match(env, match_id, &m);
 
-    // Step 10: Update event and re-persist
+    // Step 11: Update event and re-persist
     let mut updated_event = event;
     updated_event.add_match();
     storage::set_event(env, event_id, &updated_event);
 
-    // Step 11: Index the match
+    // Step 12: Index the match
     storage::add_event_match(env, event_id, match_id);
 
-    // Step 12: Emit event
+    // Step 13: Emit event
     env.events().publish(
         (Symbol::new(env, "match"), Symbol::new(env, "created")),
         (match_id, event_id, team_a, team_b, match_time),
     );
 
-    // Step 13: Return match_id
+    // Step 14: Return match_id
     Ok(match_id)
 }
 

--- a/contracts/creator-event-manager/src/oracle.rs
+++ b/contracts/creator-event-manager/src/oracle.rs
@@ -138,7 +138,7 @@ pub fn submit_match_result(
     let prediction_ids = storage::get_match_predictions(env, match_id);
     for prediction_id in prediction_ids.iter() {
         if let Ok(mut prediction) = storage::get_prediction(env, prediction_id) {
-            prediction.grade(home_score, away_score);
+            prediction.grade(home_score, away_score, match_record.points_multiplier);
             storage::set_prediction(env, prediction_id, &prediction);
         }
     }
@@ -201,11 +201,20 @@ pub fn get_user_score(
             if prediction.is_correct == Some(true) {
                 correct_results = correct_results.checked_add(1).ok_or(OracleError::Overflow)?;
             }
-            // Count exact scores (4 points means exact score achieved)
-            if prediction.points_earned == Some(
-                crate::storage_types::POINTS_CORRECT_RESULT + crate::storage_types::POINTS_EXACT_SCORE,
-            ) {
-                exact_scores = exact_scores.checked_add(1).ok_or(OracleError::Overflow)?;
+            // Count exact scores: load the match to compare actual vs predicted scores.
+            // This is multiplier-agnostic — an exact score is one where both predicted
+            // scores match the actual scores, regardless of the points multiplier.
+            if let Ok(match_record) = storage::get_match(env, prediction.match_id) {
+                if let (Some(actual_home), Some(actual_away)) =
+                    (match_record.home_score, match_record.away_score)
+                {
+                    if prediction.predicted_home_score == actual_home
+                        && prediction.predicted_away_score == actual_away
+                    {
+                        exact_scores =
+                            exact_scores.checked_add(1).ok_or(OracleError::Overflow)?;
+                    }
+                }
             }
         }
     }

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -26,6 +26,9 @@ pub const OUTCOME_DRAW: &str = "DRAW";
 pub const POINTS_CORRECT_RESULT: u32 = 1;
 /// Points awarded for predicting the exact scoreline (in addition to result points)
 pub const POINTS_EXACT_SCORE: u32 = 3;
+/// Maximum allowed points multiplier for a bonus match (inclusive). Caps total
+/// points at 3× to keep cumulative leaderboard scores bounded.
+pub const MAX_POINTS_MULTIPLIER: u32 = 3;
 
 // ---------------------------------------------------------------------------
 // MatchResult
@@ -419,6 +422,11 @@ pub struct Match {
 
     /// Final score for team B (away team)
     pub away_score: Option<u32>,
+
+    /// Points multiplier for this match (1 = normal, 2 = double, 3 = triple).
+    /// Must be in the range 1..=MAX_POINTS_MULTIPLIER. Grading multiplies the
+    /// base points by this value so a 2× final can award 0 / 2 / 8 points.
+    pub points_multiplier: u32,
 }
 
 impl Match {
@@ -429,6 +437,7 @@ impl Match {
         team_a: String,
         team_b: String,
         match_time: u64,
+        points_multiplier: u32,
     ) -> Self {
         Self {
             match_id,
@@ -442,6 +451,7 @@ impl Match {
             submitted_at: None,
             home_score: None,
             away_score: None,
+            points_multiplier,
         }
     }
 
@@ -673,11 +683,11 @@ impl Prediction {
 
     /// Grade this prediction against the actual match result.
     ///
-    /// Awards:
+    /// Awards base points multiplied by `points_multiplier`:
     /// - 0 points if result is wrong
-    /// - 1 point if result is correct but score is wrong
-    /// - 4 points if score is exactly correct (1 for result + 3 for exact score)
-    pub fn grade(&mut self, actual_home: u32, actual_away: u32) {
+    /// - 1 × multiplier if result is correct but score is wrong
+    /// - 4 × multiplier if score is exactly correct (1 for result + 3 for exact score)
+    pub fn grade(&mut self, actual_home: u32, actual_away: u32, points_multiplier: u32) {
         let actual_result = MatchResult::from_scores(actual_home, actual_away);
         let predicted_result =
             MatchResult::from_scores(self.predicted_home_score, self.predicted_away_score);
@@ -687,13 +697,14 @@ impl Prediction {
             self.predicted_home_score == actual_home && self.predicted_away_score == actual_away;
 
         self.is_correct = Some(result_correct);
-        self.points_earned = Some(if exact_correct {
+        let base_points = if exact_correct {
             POINTS_CORRECT_RESULT + POINTS_EXACT_SCORE
         } else if result_correct {
             POINTS_CORRECT_RESULT
         } else {
             0
-        });
+        };
+        self.points_earned = Some(base_points * points_multiplier);
     }
 
     /// `true` if the prediction has been graded and was correct.

--- a/contracts/creator-event-manager/tests/data_structures_test.rs
+++ b/contracts/creator-event-manager/tests/data_structures_test.rs
@@ -37,6 +37,7 @@ fn make_match(env: &Env, match_id: u64, event_id: u64, match_time: u64) -> Match
         String::from_str(env, "Team Alpha"),
         String::from_str(env, "Team Beta"),
         match_time,
+        1u32,
     )
 }
 
@@ -312,6 +313,7 @@ fn test_match_validate_team_a_too_long() {
         String::from_bytes(&env, &long_name),
         String::from_str(&env, "Team B"),
         0,
+        1u32,
     );
     assert_eq!(m.validate(), Err("Team A name exceeds maximum length"));
 }
@@ -326,6 +328,7 @@ fn test_match_validate_team_b_too_long() {
         String::from_str(&env, "Team A"),
         String::from_bytes(&env, &long_name),
         0,
+        1u32,
     );
     assert_eq!(m.validate(), Err("Team B name exceeds maximum length"));
 }

--- a/contracts/creator-event-manager/tests/data_structures_test.rs
+++ b/contracts/creator-event-manager/tests/data_structures_test.rs
@@ -445,7 +445,7 @@ fn test_prediction_grade_team_a_correct() {
         1_640_995_200,
         &env,
     );
-    pred.grade(2u32, 1u32);  // Exact match
+    pred.grade(2u32, 1u32, 1u32);  // Exact match
     assert_eq!(pred.is_correct, Some(true));
     assert_eq!(pred.points_earned, Some(4)); // 1 + 3 for exact
     assert!(pred.is_winner());
@@ -464,7 +464,7 @@ fn test_prediction_grade_team_a_wrong() {
         1_640_995_200,
         &env,
     );
-    pred.grade(1u32, 2u32);  // Wrong result (predict 2-1 TeamA, got 1-2 TeamB)
+    pred.grade(1u32, 2u32, 1u32);  // Wrong result
     assert_eq!(pred.is_correct, Some(false));
     assert_eq!(pred.points_earned, Some(0));
     assert!(!pred.is_winner());
@@ -483,7 +483,7 @@ fn test_prediction_grade_draw_correct() {
         1_640_995_200,
         &env,
     );
-    pred.grade(1u32, 1u32);  // Exact draw
+    pred.grade(1u32, 1u32, 1u32);  // Exact draw
     assert_eq!(pred.is_correct, Some(true));
     assert_eq!(pred.points_earned, Some(4)); // Exact draw
     assert!(pred.is_winner());

--- a/contracts/creator-event-manager/tests/finalize_tests.rs
+++ b/contracts/creator-event-manager/tests/finalize_tests.rs
@@ -101,6 +101,7 @@ fn create_funded_event(
                 String::from_str(env, &format!("Team A{}", i)),
                 String::from_str(env, &format!("Team B{}", i)),
                 env.ledger().timestamp() + 100 + (i as u64) * 60,
+                1u32,
             );
             storage::set_match(env, match_id, &match_record);
             storage::add_event_match(env, event_id, match_id);

--- a/contracts/creator-event-manager/tests/get_match_predictions_tests.rs
+++ b/contracts/creator-event-manager/tests/get_match_predictions_tests.rs
@@ -88,6 +88,7 @@ fn create_event_with_match(
             String::from_str(env, "Team A"),
             String::from_str(env, "Team B"),
             env.ledger().timestamp() + match_time_offset,
+            1u32,
         );
         storage::set_match(env, match_id, &match_record);
         storage::add_event_match(env, event_id, match_id);

--- a/contracts/creator-event-manager/tests/leaderboard_tests.rs
+++ b/contracts/creator-event-manager/tests/leaderboard_tests.rs
@@ -91,6 +91,7 @@ fn create_event_with_matches(
                 String::from_str(env, &format!("Team A{}", i)),
                 String::from_str(env, &format!("Team B{}", i)),
                 env.ledger().timestamp() + 100 + (i as u64) * 60,
+                1u32,
             );
             storage::set_match(env, match_id, &match_record);
             storage::add_event_match(env, event_id, match_id);

--- a/contracts/creator-event-manager/tests/match_tests.rs
+++ b/contracts/creator-event-manager/tests/match_tests.rs
@@ -104,6 +104,7 @@ fn test_get_match_count_returns_correct_count() {
             String::from_str(&env, "Team A"),
             String::from_str(&env, "Team B"),
             env.ledger().timestamp() + 10_000,
+            1u32,
         );
         storage::set_match(&env, match_id, &match_record);
         storage::add_event_match(&env, event_id, match_id);
@@ -144,6 +145,7 @@ fn add_match(
             String::from_str(env, team_a),
             String::from_str(env, team_b),
             match_time,
+            1u32,
         );
         storage::set_match(env, match_id, &match_record);
         storage::add_event_match(env, event_id, match_id);
@@ -274,6 +276,7 @@ fn add_match_full(
             String::from_str(env, team_a),
             String::from_str(env, team_b),
             match_time,
+            1u32,
         );
         storage::set_match(env, match_id, &match_record);
         storage::add_event_match(env, event_id, match_id);
@@ -410,6 +413,7 @@ fn test_add_match_validates_team_names_empty_rejected() {
         String::from_str(&env, ""),
         String::from_str(&env, "Team B"),
         100,
+        1u32,
     );
     assert!(m.validate().is_err());
 
@@ -420,6 +424,7 @@ fn test_add_match_validates_team_names_empty_rejected() {
         String::from_str(&env, "Team A"),
         String::from_str(&env, ""),
         100,
+        1u32,
     );
     assert!(m.validate().is_err());
 }
@@ -428,7 +433,7 @@ fn test_add_match_validates_team_names_empty_rejected() {
 fn test_add_match_validates_team_uniqueness() {
     let env = Env::default();
     let name = String::from_str(&env, "Same Team");
-    let m = Match::new(1, 1, name.clone(), name, 100);
+    let m = Match::new(1, 1, name.clone(), name, 100, 1u32);
     assert!(m.validate().is_err());
 }
 
@@ -443,6 +448,7 @@ fn test_add_match_validates_team_name_length() {
         String::from_bytes(&env, &long_name),
         String::from_str(&env, "Team B"),
         100,
+        1u32,
     );
     assert!(m.validate().is_err());
 
@@ -452,6 +458,7 @@ fn test_add_match_validates_team_name_length() {
         String::from_str(&env, "Team A"),
         String::from_bytes(&env, &long_name),
         100,
+        1u32,
     );
     assert!(m2.validate().is_err());
 }
@@ -466,6 +473,7 @@ fn test_add_match_team_name_length_boundary_ok() {
         String::from_bytes(&env, &exact_name),
         String::from_str(&env, "Team B"),
         100,
+        1u32,
     );
     assert!(m.validate().is_ok());
 }

--- a/contracts/creator-event-manager/tests/oracle_tests.rs
+++ b/contracts/creator-event-manager/tests/oracle_tests.rs
@@ -80,6 +80,7 @@ fn create_event_with_match(
             String::from_str(env, "Team A"),
             String::from_str(env, "Team B"),
             env.ledger().timestamp() + match_time_offset,
+            1u32,
         );
         storage::set_match(env, match_id, &match_record);
         storage::add_event_match(env, event_id, match_id);
@@ -211,6 +212,7 @@ fn test_get_user_score_calculation_accurate() {
                 String::from_str(&env, "Team A"),
                 String::from_str(&env, "Team B"),
                 env.ledger().timestamp() + 10_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m1);
@@ -225,6 +227,7 @@ fn test_get_user_score_calculation_accurate() {
                 String::from_str(&env, "Team C"),
                 String::from_str(&env, "Team D"),
                 env.ledger().timestamp() + 20_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m2);

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -84,6 +84,7 @@ fn create_event_and_match(
             String::from_str(env, "Team A"),
             String::from_str(env, "Team B"),
             env.ledger().timestamp() + match_time_offset,
+            1u32,
         );
         storage::set_match(env, match_id, &match_record);
         storage::add_event_match(env, event_id, match_id);
@@ -340,6 +341,7 @@ fn test_get_user_predictions_returns_all_for_event() {
                 String::from_str(&env, "Team A"),
                 String::from_str(&env, "Team B"),
                 env.ledger().timestamp() + 10_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m1);
@@ -354,6 +356,7 @@ fn test_get_user_predictions_returns_all_for_event() {
                 String::from_str(&env, "Team C"),
                 String::from_str(&env, "Team D"),
                 env.ledger().timestamp() + 20_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m2);
@@ -418,6 +421,7 @@ fn test_get_user_predictions_sorted_by_predicted_at() {
                 String::from_str(&env, "Team A"),
                 String::from_str(&env, "Team B"),
                 env.ledger().timestamp() + 50_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m1);
@@ -432,6 +436,7 @@ fn test_get_user_predictions_sorted_by_predicted_at() {
                 String::from_str(&env, "Team C"),
                 String::from_str(&env, "Team D"),
                 env.ledger().timestamp() + 60_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m2);
@@ -587,6 +592,7 @@ fn test_get_prediction_distribution_multiple_matches_independent() {
                 String::from_str(&env, "Team A"),
                 String::from_str(&env, "Team B"),
                 env.ledger().timestamp() + 10_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m1);
@@ -601,6 +607,7 @@ fn test_get_prediction_distribution_multiple_matches_independent() {
                 String::from_str(&env, "Team C"),
                 String::from_str(&env, "Team D"),
                 env.ledger().timestamp() + 20_000,
+                1u32,
             ),
         );
         storage::add_event_match(&env, event_id, m2);

--- a/contracts/creator-event-manager/tests/storage_types_tests.rs
+++ b/contracts/creator-event-manager/tests/storage_types_tests.rs
@@ -345,6 +345,7 @@ fn test_match_validation_empty_team_b() {
         String::from_str(&env, "Alpha"),
         String::from_str(&env, ""),
         0,
+        1u32,
     );
     assert!(m.validate().is_err());
 }
@@ -353,7 +354,7 @@ fn test_match_validation_empty_team_b() {
 fn test_match_validation_same_teams() {
     let env = Env::default();
     let name = String::from_str(&env, "Same");
-    let m = Match::new(1, 100, name.clone(), name, 0);
+    let m = Match::new(1, 100, name.clone(), name, 0, 1u32);
     assert!(m.validate().is_err());
 }
 
@@ -429,7 +430,7 @@ fn test_prediction_grading_correct() {
     let predictor = Address::generate(&env);
 
     let mut pred = Prediction::new(1, 5, 10, predictor, 2u32, 1u32, 1_640_995_200, &env);
-    pred.grade(2u32, 1u32); // Exact match
+    pred.grade(2u32, 1u32, 1u32); // Exact match
 
     assert_eq!(pred.is_correct, Some(true));
     assert_eq!(pred.points_earned, Some(4)); // 1 + 3 for exact
@@ -442,7 +443,7 @@ fn test_prediction_grading_wrong() {
     let predictor = Address::generate(&env);
 
     let mut pred = Prediction::new(1, 5, 10, predictor, 2u32, 1u32, 1_640_995_200, &env);
-    pred.grade(0u32, 1u32); // Wrong result (predict TeamA win, got TeamB)
+    pred.grade(0u32, 1u32, 1u32); // Wrong result (predict TeamA win, got TeamB)
 
     assert_eq!(pred.is_correct, Some(false));
     assert_eq!(pred.points_earned, Some(0));
@@ -455,7 +456,7 @@ fn test_prediction_grading_draw() {
     let predictor = Address::generate(&env);
 
     let mut pred = Prediction::new(1, 5, 10, predictor, 1u32, 1u32, 1_640_995_200, &env);
-    pred.grade(1u32, 1u32);
+    pred.grade(1u32, 1u32, 1u32);
 
     assert_eq!(pred.is_correct, Some(true));
     assert_eq!(pred.points_earned, Some(4)); // Exact draw

--- a/contracts/creator-event-manager/tests/storage_types_tests.rs
+++ b/contracts/creator-event-manager/tests/storage_types_tests.rs
@@ -238,6 +238,7 @@ fn make_match(env: &Env, match_id: u64, event_id: u64, match_time: u64) -> Match
         String::from_str(env, "Team Alpha"),
         String::from_str(env, "Team Beta"),
         match_time,
+        1u32,
     )
 }
 
@@ -330,6 +331,7 @@ fn test_match_validation_empty_team_a() {
         String::from_str(&env, ""),
         String::from_str(&env, "Beta"),
         0,
+        1u32,
     );
     assert!(m.validate().is_err());
 }

--- a/contracts/creator-event-manager/tests/submit_match_result_contract_tests.rs
+++ b/contracts/creator-event-manager/tests/submit_match_result_contract_tests.rs
@@ -94,6 +94,7 @@ fn create_event_with_match(
             String::from_str(env, "Team A"),
             String::from_str(env, "Team B"),
             env.ledger().timestamp() + match_time_offset,
+            1u32,
         );
         storage::set_match(env, match_id, &match_record);
         storage::add_event_match(env, event_id, match_id);
@@ -377,6 +378,7 @@ fn test_get_user_score_aggregates_points_across_multiple_matches() {
             String::from_str(&env, "Team C"),
             String::from_str(&env, "Team D"),
             env.ledger().timestamp() + 10_000,
+            1u32,
         );
         storage::set_match(&env, match_id, &match_record);
         storage::add_event_match(&env, event_id, match_id);
@@ -395,6 +397,7 @@ fn test_get_user_score_aggregates_points_across_multiple_matches() {
             String::from_str(&env, "Team E"),
             String::from_str(&env, "Team F"),
             env.ledger().timestamp() + 10_000,
+            1u32,
         );
         storage::set_match(&env, match_id, &match_record);
         storage::add_event_match(&env, event_id, match_id);

--- a/contracts/creator-event-manager/tests/views_tests.rs
+++ b/contracts/creator-event-manager/tests/views_tests.rs
@@ -58,6 +58,7 @@ fn add_match(env: &Env, event_id: u64, submitted: bool) -> u64 {
         String::from_str(env, "Team A"),
         String::from_str(env, "Team B"),
         env.ledger().timestamp() + 10_000,
+        1u32,
     );
 
     if submitted {


### PR DESCRIPTION
closes #971

## PR Description

This PR adds support for **match point multipliers**, allowing creators to assign higher stakes to specific matches (e.g. tournament finals) to increase engagement toward the end of a campaign.

### Changes made

* Added `points_multiplier` field to the `Match` struct with a default value of `1`.
* Added validation for multiplier values (`1–3` inclusive) with new `MatchError::InvalidPointsMultiplier`.
* Introduced `MAX_POINTS_MULTIPLIER` constant in `storage_types.rs`.
* Updated match creation flow to support custom point multipliers (or separate setter function depending on maintainer preference).
* Updated grading logic in `oracle::submit_match_result` to apply the multiplier when awarding points.
* Ensured match queries (`get_match`, `list_event_matches`) expose `points_multiplier`.
* Added tests covering default behavior, invalid multiplier rejection, grading logic, and leaderboard integration.

This maintains backward compatibility while enabling creators to make selected matches more impactful.