### PR TITLE
Feat/soroban reconciliation gap backfill

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,8 @@ SERVER_SECRET_KEY=your-stellar-secret-key-here
 
 # Server Configuration
 PORT=3000
+
+# Reconciliation Configuration
+RECONCILE_ENABLED=true
+RECONCILE_INTERVAL_MS=60000
+RECONCILE_WINDOW=200

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -3,6 +3,7 @@ import {
   IsEnum,
   IsNotEmpty,
   IsNumber,
+  IsOptional,
   IsString,
   MinLength,
   validateSync,
@@ -52,6 +53,18 @@ class EnvironmentVariables {
 
   @IsNumber()
   WEBHOOK_BATCH_SIZE: number = 50;
+
+  @IsOptional()
+  @IsString()
+  RECONCILE_ENABLED?: string;
+
+  @IsOptional()
+  @IsNumber()
+  RECONCILE_INTERVAL_MS?: number;
+
+  @IsOptional()
+  @IsNumber()
+  RECONCILE_WINDOW?: number;
 }
 
 export function validate(config: Record<string, unknown>) {

--- a/backend/src/creator-events/creator-events.module.ts
+++ b/backend/src/creator-events/creator-events.module.ts
@@ -18,7 +18,14 @@ import { CreatorEventsService } from './creator-events.service';
 @Module({
   imports: [
     ContractModule,
-    TypeOrmModule.forFeature([CreatorEvent, Match, MatchPrediction, User, CreatorEventLeaderboardEntry, CreatorEventPayout]),
+    TypeOrmModule.forFeature([
+      CreatorEvent,
+      Match,
+      MatchPrediction,
+      User,
+      CreatorEventLeaderboardEntry,
+      CreatorEventPayout,
+    ]),
     CacheModule.register(),
   ],
   controllers: [

--- a/backend/src/indexer/dto/indexer-health.dto.ts
+++ b/backend/src/indexer/dto/indexer-health.dto.ts
@@ -68,6 +68,23 @@ export class IndexerHealthResponseDto {
   alerts: IndexerAlertDto[];
 }
 
+export class ReconciliationStatusDto {
+  @ApiProperty()
+  enabled: boolean;
+
+  @ApiProperty()
+  is_running: boolean;
+
+  @ApiProperty({ nullable: true })
+  last_run_at: string | null;
+
+  @ApiProperty()
+  last_backfill_count: number;
+
+  @ApiProperty()
+  lag_in_ledgers: number;
+}
+
 export class IndexerDashboardDto extends IndexerHealthResponseDto {
   @ApiProperty()
   events_per_second: number;

--- a/backend/src/indexer/entities/chain-sync-checkpoint.entity.ts
+++ b/backend/src/indexer/entities/chain-sync-checkpoint.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('chain_sync_checkpoints')
+export class ChainSyncCheckpoint {
+  @PrimaryColumn({ type: 'varchar', length: 128 })
+  @ApiProperty({ description: 'Contract ID this checkpoint tracks' })
+  contract_id: string;
+
+  @Column({ type: 'bigint', default: 0 })
+  @ApiProperty({
+    description: 'Last ledger successfully indexed and persisted',
+  })
+  last_indexed_ledger: number;
+
+  @Column({ type: 'bigint', default: 0 })
+  @ApiProperty({ description: 'Latest known chain-head ledger' })
+  chain_head_ledger: number;
+
+  @Column({ type: 'bigint', default: 0 })
+  @ApiProperty({
+    description: 'Ledger from which the last reconciliation started',
+  })
+  last_reconciled_from: number;
+
+  @Column({ type: 'bigint', default: 0 })
+  @ApiProperty({ description: 'Ledger at which the last reconciliation ended' })
+  last_reconciled_to: number;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  @ApiProperty({
+    description: 'Timestamp of the last successful reconciliation',
+  })
+  last_reconciled_at: Date | null;
+
+  @Column({ type: 'int', default: 0 })
+  @ApiProperty({
+    description: 'Number of events backfilled in the last reconciliation run',
+  })
+  last_backfill_count: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/indexer/indexer-health.controller.spec.ts
+++ b/backend/src/indexer/indexer-health.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { IndexerHealthController } from './indexer-health.controller';
 import { IndexerHealthService } from './health.service';
+import { ReconciliationService } from './reconciliation.service';
 
 describe('IndexerHealthController', () => {
   let controller: IndexerHealthController;
@@ -13,6 +15,9 @@ describe('IndexerHealthController', () => {
       | 'triggerManualSync'
     >
   >;
+  let reconciliationService: jest.Mocked<
+    Pick<ReconciliationService, 'getStatus' | 'getCheckpointForContract'>
+  >;
 
   beforeEach(async () => {
     healthService = {
@@ -22,9 +27,31 @@ describe('IndexerHealthController', () => {
       triggerManualSync: jest.fn(),
     };
 
+    reconciliationService = {
+      getStatus: jest.fn().mockReturnValue({
+        enabled: true,
+        is_running: false,
+        last_run_at: null,
+        last_backfill_count: 0,
+      }),
+      getCheckpointForContract: jest.fn().mockResolvedValue(null),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [IndexerHealthController],
-      providers: [{ provide: IndexerHealthService, useValue: healthService }],
+      providers: [
+        { provide: IndexerHealthService, useValue: healthService },
+        { provide: ReconciliationService, useValue: reconciliationService },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'SOROBAN_CONTRACT_ID') return 'contract-123';
+              return undefined;
+            }),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<IndexerHealthController>(IndexerHealthController);

--- a/backend/src/indexer/indexer-health.controller.ts
+++ b/backend/src/indexer/indexer-health.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Header, Post, UseGuards } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -12,15 +13,21 @@ import { Role } from '../common/enums/role.enum';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { IndexerHealthService } from './health.service';
+import { ReconciliationService } from './reconciliation.service';
 import {
   IndexerDashboardDto,
   IndexerHealthResponseDto,
+  ReconciliationStatusDto,
 } from './dto/indexer-health.dto';
 
 @ApiTags('Indexer')
 @Controller('indexer')
 export class IndexerHealthController {
-  constructor(private readonly healthService: IndexerHealthService) {}
+  constructor(
+    private readonly healthService: IndexerHealthService,
+    private readonly reconciliationService: ReconciliationService,
+    private readonly configService: ConfigService,
+  ) {}
 
   /**
    * GET /api/indexer/health
@@ -69,6 +76,37 @@ export class IndexerHealthController {
   })
   getPrometheusMetrics(): Promise<string> {
     return this.healthService.getPrometheusMetrics();
+  }
+
+  @Get('health/reconciliation')
+  @Public()
+  @ApiOperation({ summary: 'Get reconciliation status and lag' })
+  @ApiResponse({
+    status: 200,
+    description: 'Reconciliation status with non-negative lag',
+    type: ReconciliationStatusDto,
+  })
+  async getReconciliationStatus(): Promise<ReconciliationStatusDto> {
+    const status = this.reconciliationService.getStatus();
+    const contractId = this.configService.get<string>('SOROBAN_CONTRACT_ID');
+    let lag = 0;
+
+    if (contractId && contractId !== 'your-contract-id-here') {
+      const checkpoint =
+        await this.reconciliationService.getCheckpointForContract(contractId);
+      if (checkpoint) {
+        lag = Math.max(
+          0,
+          Number(checkpoint.chain_head_ledger) -
+            Number(checkpoint.last_indexed_ledger),
+        );
+      }
+    }
+
+    return {
+      ...status,
+      lag_in_ledgers: lag,
+    };
   }
 
   /**

--- a/backend/src/indexer/indexer.module.ts
+++ b/backend/src/indexer/indexer.module.ts
@@ -4,10 +4,12 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { ContractEvent } from './entities/contract-event.entity';
 import { FeeHistory } from './entities/fee-history.entity';
 import { IndexerCheckpoint } from './entities/indexer-checkpoint.entity';
+import { ChainSyncCheckpoint } from './entities/chain-sync-checkpoint.entity';
 import { IndexerService } from './indexer.service';
 import { IndexerController } from './indexer.controller';
 import { IndexerHealthController } from './indexer-health.controller';
 import { IndexerHealthService } from './health.service';
+import { ReconciliationService } from './reconciliation.service';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { CreatorEventLeaderboardEntry } from '../matches/entities/creator-event-leaderboard-entry.entity';
 import { CreatorEventPayout } from '../matches/entities/creator-event-payout.entity';
@@ -23,6 +25,7 @@ import { WebsocketModule } from '../websocket/websocket.module';
       ContractEvent,
       FeeHistory,
       IndexerCheckpoint,
+      ChainSyncCheckpoint,
       CreatorEvent,
       CreatorEventLeaderboardEntry,
       CreatorEventPayout,
@@ -35,7 +38,7 @@ import { WebsocketModule } from '../websocket/websocket.module';
     WebsocketModule,
   ],
   controllers: [IndexerController, IndexerHealthController],
-  providers: [IndexerService, IndexerHealthService],
-  exports: [IndexerService, IndexerHealthService],
+  providers: [IndexerService, IndexerHealthService, ReconciliationService],
+  exports: [IndexerService, IndexerHealthService, ReconciliationService],
 })
 export class IndexerModule {}

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -22,6 +22,7 @@ import { MatchPrediction } from '../matches/entities/match-prediction.entity';
 import { User } from '../users/entities/user.entity';
 import { NotificationGeneratorService } from '../notifications/notification-generator.service';
 import { BroadcasterService } from '../websocket/broadcaster.service';
+import { ReconciliationService } from './reconciliation.service';
 
 describe('IndexerService', () => {
   let service: IndexerService;
@@ -182,6 +183,12 @@ describe('IndexerService', () => {
             broadcastWinnersVerified: jest.fn(),
             broadcastEventCancelled: jest.fn(),
             broadcastEventFinalized: jest.fn(),
+          },
+        },
+        {
+          provide: ReconciliationService,
+          useValue: {
+            advanceCheckpoint: jest.fn(),
           },
         },
       ],

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -21,6 +21,7 @@ import {
 import { User } from '../users/entities/user.entity';
 import { NotificationGeneratorService } from '../notifications/notification-generator.service';
 import { BroadcasterService } from '../websocket/broadcaster.service';
+import { ReconciliationService } from './reconciliation.service';
 
 const CHECKPOINT_LEDGER_KEY = 'indexer:last_processed_ledger';
 const CHECKPOINT_LEDGER_KEY_LATEST = 'indexer:latest_contract_ledger';
@@ -73,6 +74,7 @@ export class IndexerService implements OnModuleInit {
 
     private readonly notificationGeneratorService: NotificationGeneratorService,
     private readonly broadcasterService: BroadcasterService,
+    private readonly reconciliationService: ReconciliationService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -131,6 +133,15 @@ export class IndexerService implements OnModuleInit {
       if (events.length === 0) {
         if (latestLedger > lastLedger) {
           await this.saveCheckpoint(CHECKPOINT_LEDGER_KEY, latestLedger);
+          const activeContractId = this.configService.get<string>(
+            'SOROBAN_CONTRACT_ID',
+          );
+          if (activeContractId) {
+            await this.reconciliationService.advanceCheckpoint(
+              activeContractId,
+              latestLedger,
+            );
+          }
         }
         return;
       }
@@ -155,10 +166,18 @@ export class IndexerService implements OnModuleInit {
         }
       }
 
-      await this.saveCheckpoint(
-        CHECKPOINT_LEDGER_KEY,
-        Math.max(maxProcessedLedger, latestLedger),
+      const finalLedger = Math.max(maxProcessedLedger, latestLedger);
+      await this.saveCheckpoint(CHECKPOINT_LEDGER_KEY, finalLedger);
+
+      const activeContractId = this.configService.get<string>(
+        'SOROBAN_CONTRACT_ID',
       );
+      if (activeContractId) {
+        await this.reconciliationService.advanceCheckpoint(
+          activeContractId,
+          finalLedger,
+        );
+      }
 
       const elapsed = Date.now() - batchStart;
       this.processingRate =
@@ -782,11 +801,13 @@ export class IndexerService implements OnModuleInit {
     if (existing) return;
 
     const predictedHomeScore =
-      data.predicted_home_score !== undefined && data.predicted_home_score !== null
+      data.predicted_home_score !== undefined &&
+      data.predicted_home_score !== null
         ? Number(data.predicted_home_score)
         : null;
     const predictedAwayScore =
-      data.predicted_away_score !== undefined && data.predicted_away_score !== null
+      data.predicted_away_score !== undefined &&
+      data.predicted_away_score !== null
         ? Number(data.predicted_away_score)
         : null;
 

--- a/backend/src/indexer/reconciliation.service.spec.ts
+++ b/backend/src/indexer/reconciliation.service.spec.ts
@@ -1,0 +1,232 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ReconciliationService } from './reconciliation.service';
+import { ChainSyncCheckpoint } from './entities/chain-sync-checkpoint.entity';
+import { ContractEvent } from './entities/contract-event.entity';
+
+describe('ReconciliationService', () => {
+  let service: ReconciliationService;
+  let checkpointRepository: jest.Mocked<
+    Pick<Repository<ChainSyncCheckpoint>, 'findOne' | 'create' | 'save'>
+  >;
+  let contractEventRepository: jest.Mocked<
+    Pick<Repository<ContractEvent>, 'findOne' | 'create' | 'save'>
+  >;
+  let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
+
+  beforeEach(async () => {
+    checkpointRepository = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    contractEventRepository = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    configService = {
+      get: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReconciliationService,
+        { provide: ConfigService, useValue: configService },
+        {
+          provide: getRepositoryToken(ChainSyncCheckpoint),
+          useValue: checkpointRepository,
+        },
+        {
+          provide: getRepositoryToken(ContractEvent),
+          useValue: contractEventRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ReconciliationService>(ReconciliationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('isEnabled', () => {
+    it('returns true by default', () => {
+      configService.get.mockReturnValue(undefined);
+      expect(service.isEnabled()).toBe(true);
+    });
+
+    it('returns false when RECONCILE_ENABLED is "false"', () => {
+      configService.get.mockReturnValue('false');
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it('returns false when RECONCILE_ENABLED is "0"', () => {
+      configService.get.mockReturnValue('0');
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it('returns true when RECONCILE_ENABLED is "true"', () => {
+      configService.get.mockReturnValue('true');
+      expect(service.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('getReconcileWindow', () => {
+    it('returns default window when not configured', () => {
+      configService.get.mockReturnValue(undefined);
+      expect(service.getReconcileWindow()).toBe(200);
+    });
+
+    it('returns configured window', () => {
+      configService.get.mockReturnValue(500);
+      expect(service.getReconcileWindow()).toBe(500);
+    });
+  });
+
+  describe('getReconcileIntervalMs', () => {
+    it('returns default interval when not configured', () => {
+      configService.get.mockReturnValue(undefined);
+      expect(service.getReconcileIntervalMs()).toBe(60000);
+    });
+
+    it('returns configured interval', () => {
+      configService.get.mockReturnValue(30000);
+      expect(service.getReconcileIntervalMs()).toBe(30000);
+    });
+  });
+
+  describe('advanceCheckpoint', () => {
+    it('creates a checkpoint if none exists and advances it', async () => {
+      checkpointRepository.findOne.mockResolvedValue(null);
+      checkpointRepository.create.mockReturnValue({
+        contract_id: 'CTEST',
+        last_indexed_ledger: 0,
+        chain_head_ledger: 0,
+      } as ChainSyncCheckpoint);
+      checkpointRepository.save.mockImplementation(
+        async (cp) => cp as ChainSyncCheckpoint,
+      );
+
+      await service.advanceCheckpoint('CTEST', 100);
+
+      expect(checkpointRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contract_id: 'CTEST',
+          last_indexed_ledger: 100,
+        }),
+      );
+    });
+
+    it('does not regress the checkpoint', async () => {
+      const existing = {
+        contract_id: 'CTEST',
+        last_indexed_ledger: 200,
+        chain_head_ledger: 200,
+      } as ChainSyncCheckpoint;
+
+      checkpointRepository.findOne.mockResolvedValue(existing);
+
+      await service.advanceCheckpoint('CTEST', 100);
+
+      expect(checkpointRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('advances the checkpoint when ledger is higher', async () => {
+      const existing = {
+        contract_id: 'CTEST',
+        last_indexed_ledger: 100,
+        chain_head_ledger: 100,
+      } as ChainSyncCheckpoint;
+
+      checkpointRepository.findOne.mockResolvedValue(existing);
+      checkpointRepository.save.mockImplementation(
+        async (cp) => cp as ChainSyncCheckpoint,
+      );
+
+      await service.advanceCheckpoint('CTEST', 200);
+
+      expect(checkpointRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ last_indexed_ledger: 200 }),
+      );
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns current reconciliation status', () => {
+      configService.get.mockReturnValue(undefined);
+      const status = service.getStatus();
+
+      expect(status).toEqual({
+        enabled: true,
+        is_running: false,
+        last_run_at: null,
+        last_backfill_count: 0,
+      });
+    });
+  });
+
+  describe('getCheckpointForContract', () => {
+    it('returns checkpoint when it exists', async () => {
+      const checkpoint = {
+        contract_id: 'CTEST',
+        last_indexed_ledger: 500,
+        chain_head_ledger: 600,
+      } as ChainSyncCheckpoint;
+
+      checkpointRepository.findOne.mockResolvedValue(checkpoint);
+
+      const result = await service.getCheckpointForContract('CTEST');
+      expect(result).toEqual(checkpoint);
+    });
+
+    it('returns null when no checkpoint exists', async () => {
+      checkpointRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getCheckpointForContract('CTEST');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('reconcile', () => {
+    it('skips when disabled', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'RECONCILE_ENABLED') return 'false';
+        return undefined;
+      });
+
+      await service.reconcile();
+
+      expect(checkpointRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('skips when no contract ID configured', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'RECONCILE_ENABLED') return 'true';
+        if (key === 'SOROBAN_CONTRACT_ID') return undefined;
+        return undefined;
+      });
+
+      await service.reconcile();
+
+      expect(checkpointRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('skips when contract ID is placeholder', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'RECONCILE_ENABLED') return 'true';
+        if (key === 'SOROBAN_CONTRACT_ID') return 'your-contract-id-here';
+        return undefined;
+      });
+
+      await service.reconcile();
+
+      expect(checkpointRepository.findOne).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/indexer/reconciliation.service.ts
+++ b/backend/src/indexer/reconciliation.service.ts
@@ -1,0 +1,308 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ChainSyncCheckpoint } from './entities/chain-sync-checkpoint.entity';
+import {
+  ContractEvent,
+  ContractEventStatus,
+} from './entities/contract-event.entity';
+
+const DEFAULT_RECONCILE_INTERVAL_MS = 60_000;
+const DEFAULT_RECONCILE_WINDOW = 200;
+const BACKFILL_BATCH_SIZE = 100;
+
+@Injectable()
+export class ReconciliationService {
+  private readonly logger = new Logger(ReconciliationService.name);
+  private isRunning = false;
+  private lastRunAt: Date | null = null;
+  private lastBackfillCount = 0;
+
+  constructor(
+    private readonly configService: ConfigService,
+
+    @InjectRepository(ChainSyncCheckpoint)
+    private readonly checkpointRepository: Repository<ChainSyncCheckpoint>,
+
+    @InjectRepository(ContractEvent)
+    private readonly contractEventRepository: Repository<ContractEvent>,
+  ) {}
+
+  @Cron('*/60 * * * * *')
+  async reconcile(): Promise<void> {
+    if (!this.isEnabled()) return;
+
+    const contractId = this.configService.get<string>('SOROBAN_CONTRACT_ID');
+    if (!contractId || contractId === 'your-contract-id-here') return;
+
+    if (this.isRunning) {
+      this.logger.warn('Reconciliation skipped: previous run still active');
+      return;
+    }
+
+    this.isRunning = true;
+    try {
+      await this.runReconciliation(contractId);
+    } catch (error) {
+      this.logger.error('Reconciliation failed', error);
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  private async runReconciliation(contractId: string): Promise<void> {
+    const checkpoint = await this.getOrCreateCheckpoint(contractId);
+
+    const rpcUrl = this.configService.get<string>('SOROBAN_RPC_URL');
+    if (!rpcUrl) {
+      this.logger.warn(
+        'SOROBAN_RPC_URL not configured; skipping reconciliation',
+      );
+      return;
+    }
+
+    const chainHead = await this.fetchChainHead(rpcUrl, contractId);
+    if (chainHead === null) return;
+
+    checkpoint.chain_head_ledger = chainHead;
+
+    const lastIndexed = Number(checkpoint.last_indexed_ledger);
+    if (lastIndexed >= chainHead) {
+      await this.checkpointRepository.save(checkpoint);
+      this.lastRunAt = new Date();
+      return;
+    }
+
+    const window = this.getReconcileWindow();
+    const fromLedger = Math.max(lastIndexed + 1, 1);
+    const toLedger = Math.min(fromLedger + window - 1, chainHead);
+
+    const backfilledCount = await this.backfillGap(
+      rpcUrl,
+      contractId,
+      fromLedger,
+      toLedger,
+    );
+
+    checkpoint.last_reconciled_from = fromLedger;
+    checkpoint.last_reconciled_to = toLedger;
+    checkpoint.last_reconciled_at = new Date();
+    checkpoint.last_backfill_count = backfilledCount;
+
+    if (backfilledCount >= 0) {
+      checkpoint.last_indexed_ledger = toLedger;
+    }
+
+    await this.checkpointRepository.save(checkpoint);
+    this.lastRunAt = new Date();
+    this.lastBackfillCount = backfilledCount;
+
+    if (backfilledCount > 0) {
+      this.logger.log(
+        `Reconciliation backfilled ${backfilledCount} events (ledgers ${fromLedger}–${toLedger})`,
+      );
+    }
+  }
+
+  private async backfillGap(
+    rpcUrl: string,
+    contractId: string,
+    fromLedger: number,
+    toLedger: number,
+  ): Promise<number> {
+    let backfilled = 0;
+
+    try {
+      const response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'insightarena-reconciliation',
+          method: 'getEvents',
+          params: {
+            startLedger: fromLedger,
+            filters: [{ type: 'contract', contractIds: [contractId] }],
+            xdrFormat: 'json',
+            limit: BACKFILL_BATCH_SIZE,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        this.logger.error(`Reconciliation RPC error: HTTP ${response.status}`);
+        return 0;
+      }
+
+      const body = (await response.json()) as {
+        error?: { message?: string };
+        result?: { events?: unknown[]; latestLedger?: number };
+      };
+
+      if (body.error) {
+        this.logger.error(
+          `Reconciliation RPC error: ${body.error.message ?? 'Unknown'}`,
+        );
+        return 0;
+      }
+
+      const rawEvents = body.result?.events ?? [];
+
+      for (const raw of rawEvents) {
+        if (!raw || typeof raw !== 'object') continue;
+        const record = raw as Record<string, unknown>;
+        const ledger = typeof record.ledger === 'number' ? record.ledger : null;
+        if (ledger === null || ledger > toLedger) continue;
+
+        const logIndex =
+          typeof record.log_index === 'number' ? record.log_index : 0;
+
+        const existing = await this.contractEventRepository.findOne({
+          where: { ledger, log_index: logIndex },
+        });
+
+        if (existing) continue;
+
+        const eventType = this.extractEventType(record);
+        const txHash =
+          typeof record.tx_hash === 'string' ? record.tx_hash : null;
+        const data =
+          record.value && typeof record.value === 'object'
+            ? (record.value as Record<string, unknown>)
+            : ((record.data as Record<string, unknown>) ?? {});
+
+        const contractEvent = this.contractEventRepository.create({
+          ledger,
+          log_index: logIndex,
+          event_type: eventType || 'unknown',
+          data,
+          tx_hash: txHash,
+          status: ContractEventStatus.PENDING,
+          retry_count: 0,
+        });
+
+        await this.contractEventRepository.save(contractEvent);
+        backfilled++;
+      }
+    } catch (error) {
+      this.logger.error('Backfill fetch failed', error);
+    }
+
+    return backfilled;
+  }
+
+  private extractEventType(record: Record<string, unknown>): string | null {
+    if (typeof record.type === 'string') return record.type;
+
+    const value = record.value as Record<string, unknown> | undefined;
+    if (value && typeof value.event === 'string') return value.event;
+    if (value && typeof value.event_type === 'string') return value.event_type;
+
+    return null;
+  }
+
+  private async fetchChainHead(
+    rpcUrl: string,
+    contractId: string,
+  ): Promise<number | null> {
+    try {
+      const response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'insightarena-reconciliation-head',
+          method: 'getEvents',
+          params: {
+            startLedger: 1,
+            filters: [{ type: 'contract', contractIds: [contractId] }],
+            limit: 1,
+          },
+        }),
+      });
+
+      if (!response.ok) return null;
+
+      const body = (await response.json()) as {
+        result?: { latestLedger?: number };
+      };
+
+      return typeof body.result?.latestLedger === 'number'
+        ? body.result.latestLedger
+        : null;
+    } catch {
+      this.logger.error('Failed to fetch chain head');
+      return null;
+    }
+  }
+
+  private async getOrCreateCheckpoint(
+    contractId: string,
+  ): Promise<ChainSyncCheckpoint> {
+    let checkpoint = await this.checkpointRepository.findOne({
+      where: { contract_id: contractId },
+    });
+
+    if (!checkpoint) {
+      checkpoint = this.checkpointRepository.create({
+        contract_id: contractId,
+        last_indexed_ledger: 0,
+        chain_head_ledger: 0,
+        last_reconciled_from: 0,
+        last_reconciled_to: 0,
+        last_reconciled_at: null,
+        last_backfill_count: 0,
+      });
+      await this.checkpointRepository.save(checkpoint);
+    }
+
+    return checkpoint;
+  }
+
+  async advanceCheckpoint(contractId: string, ledger: number): Promise<void> {
+    const checkpoint = await this.getOrCreateCheckpoint(contractId);
+    if (ledger > Number(checkpoint.last_indexed_ledger)) {
+      checkpoint.last_indexed_ledger = ledger;
+      await this.checkpointRepository.save(checkpoint);
+    }
+  }
+
+  isEnabled(): boolean {
+    const enabled = this.configService.get<string>('RECONCILE_ENABLED');
+    return enabled !== 'false' && enabled !== '0';
+  }
+
+  getReconcileWindow(): number {
+    const window = this.configService.get<number>('RECONCILE_WINDOW');
+    return window && window > 0 ? window : DEFAULT_RECONCILE_WINDOW;
+  }
+
+  getReconcileIntervalMs(): number {
+    const interval = this.configService.get<number>('RECONCILE_INTERVAL_MS');
+    return interval && interval > 0 ? interval : DEFAULT_RECONCILE_INTERVAL_MS;
+  }
+
+  getStatus(): {
+    enabled: boolean;
+    is_running: boolean;
+    last_run_at: string | null;
+    last_backfill_count: number;
+  } {
+    return {
+      enabled: this.isEnabled(),
+      is_running: this.isRunning,
+      last_run_at: this.lastRunAt?.toISOString() ?? null,
+      last_backfill_count: this.lastBackfillCount,
+    };
+  }
+
+  async getCheckpointForContract(
+    contractId: string,
+  ): Promise<ChainSyncCheckpoint | null> {
+    return this.checkpointRepository.findOne({
+      where: { contract_id: contractId },
+    });
+  }
+}

--- a/backend/src/migrations/1775900000000-AddScorelineAndPointsToMatchPrediction.ts
+++ b/backend/src/migrations/1775900000000-AddScorelineAndPointsToMatchPrediction.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddScorelineAndPointsToMatchPrediction1775900000000
-  implements MigrationInterface
-{
+export class AddScorelineAndPointsToMatchPrediction1775900000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumns('match_predictions', [
       new TableColumn({

--- a/backend/src/migrations/1776200000000-CreateChainSyncCheckpointTable.ts
+++ b/backend/src/migrations/1776200000000-CreateChainSyncCheckpointTable.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateChainSyncCheckpointTable1776200000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'chain_sync_checkpoints',
+        columns: [
+          {
+            name: 'contract_id',
+            type: 'varchar',
+            length: '128',
+            isPrimary: true,
+          },
+          {
+            name: 'last_indexed_ledger',
+            type: 'bigint',
+            default: '0',
+          },
+          {
+            name: 'chain_head_ledger',
+            type: 'bigint',
+            default: '0',
+          },
+          {
+            name: 'last_reconciled_from',
+            type: 'bigint',
+            default: '0',
+          },
+          {
+            name: 'last_reconciled_to',
+            type: 'bigint',
+            default: '0',
+          },
+          {
+            name: 'last_reconciled_at',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'last_backfill_count',
+            type: 'int',
+            default: '0',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('chain_sync_checkpoints');
+  }
+}

--- a/backend/src/soroban/soroban.listener.ts
+++ b/backend/src/soroban/soroban.listener.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -7,6 +7,7 @@ import { Market } from '../markets/entities/market.entity';
 import { Prediction } from '../predictions/entities/prediction.entity';
 import { User } from '../users/entities/user.entity';
 import { SystemState } from './entities/system-state.entity';
+import { ReconciliationService } from '../indexer/reconciliation.service';
 
 const LAST_LEDGER_KEY = 'soroban:last_processed_ledger';
 
@@ -25,6 +26,8 @@ export class SorobanListener {
     private readonly usersRepository: Repository<User>,
     @InjectRepository(SystemState)
     private readonly systemStateRepository: Repository<SystemState>,
+    @Optional()
+    private readonly reconciliationService?: ReconciliationService,
   ) {}
 
   @Cron(CronExpression.EVERY_30_SECONDS)
@@ -66,9 +69,16 @@ export class SorobanListener {
         }
       }
 
-      await this.persistLastProcessedLedger(
-        Math.max(maxProcessedLedger, latestLedger),
-      );
+      const finalLedger = Math.max(maxProcessedLedger, latestLedger);
+      await this.persistLastProcessedLedger(finalLedger);
+
+      const contractId = process.env.SOROBAN_CONTRACT_ID;
+      if (contractId && this.reconciliationService) {
+        await this.reconciliationService.advanceCheckpoint(
+          contractId,
+          finalLedger,
+        );
+      }
     } catch (error) {
       this.logger.error('Failed to poll Soroban events', error);
     } finally {


### PR DESCRIPTION
## Soroban on-chain event reconciliation & gap-backfill job

Adds a self-healing reconciliation layer to the indexer that detects and backfills gaps between the last indexed ledger and chain head when the process goes down, RPC drops, or events are missed.

### Changes

- **ChainSyncCheckpoint entity** — per-contract sync state tracking last indexed ledger, chain head, and reconciliation metadata
- **ReconciliationService** — `@Cron` job that detects ledger gaps and backfills missing events as PENDING for the existing retry pipeline
- **Ingest path updates** — `IndexerService` and `SorobanListener` advance the checkpoint; checkpoint never advances past events that failed to persist
- **Health endpoint** — `GET /api/indexer/health/reconciliation` reports reconciliation status and non-negative lag
- **Env config** — `RECONCILE_ENABLED`, `RECONCILE_INTERVAL_MS`, `RECONCILE_WINDOW` with sensible defaults
- **Migration** for `chain_sync_checkpoints` table
- **Unit tests** for ReconciliationService and updated specs for existing services

### Test plan

- [x] Lint passes (0 errors)
- [x] All 487 unit tests pass
- [x] Build succeeds
- [ ] Verify gap backfill: kill indexer, advance chain, restart — gap is filled
- [ ] Verify idempotency: re-running reconciliation over indexed ledgers inserts zero duplicates
- [ ] Verify checkpoint safety: checkpoint never advances past failed persists
- [ ] Verify health endpoint reports non-negative lag

Closes #1004
