### PR TITLE
feat: replace ILIKE search with Postgres full-text search (tsvector + GIN + ts_rank)

### DIFF
--- a/backend/src/migrations/1776200000000-AddSearchVectors.ts
+++ b/backend/src/migrations/1776200000000-AddSearchVectors.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSearchVectors1776200000000 implements MigrationInterface {
+  name = 'AddSearchVectors1776200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // markets: weight title A, description B
+    await queryRunner.query(`
+      ALTER TABLE "markets"
+        ADD COLUMN IF NOT EXISTS "search_vector" tsvector
+          GENERATED ALWAYS AS (
+            setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(description, '')), 'B')
+          ) STORED
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_markets_search_vector"
+        ON "markets" USING GIN("search_vector")
+    `);
+
+    // users: weight username A, stellar_address B (simple dict — addresses aren't English)
+    await queryRunner.query(`
+      ALTER TABLE "users"
+        ADD COLUMN IF NOT EXISTS "search_vector" tsvector
+          GENERATED ALWAYS AS (
+            setweight(to_tsvector('simple', coalesce(username, '')), 'A') ||
+            setweight(to_tsvector('simple', coalesce(stellar_address, '')), 'B')
+          ) STORED
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_users_search_vector"
+        ON "users" USING GIN("search_vector")
+    `);
+
+    // competitions: weight title A, description B
+    await queryRunner.query(`
+      ALTER TABLE "competitions"
+        ADD COLUMN IF NOT EXISTS "search_vector" tsvector
+          GENERATED ALWAYS AS (
+            setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('english', coalesce(description, '')), 'B')
+          ) STORED
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_competitions_search_vector"
+        ON "competitions" USING GIN("search_vector")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // markets
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_markets_search_vector"`);
+    await queryRunner.query(`ALTER TABLE "markets" DROP COLUMN IF EXISTS "search_vector"`);
+
+    // users
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_users_search_vector"`);
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "search_vector"`);
+
+    // competitions
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_competitions_search_vector"`);
+    await queryRunner.query(`ALTER TABLE "competitions" DROP COLUMN IF EXISTS "search_vector"`);
+  }
+}

--- a/backend/src/search/search.service.spec.ts
+++ b/backend/src/search/search.service.spec.ts
@@ -1,0 +1,229 @@
+// backend/src/search/search.service.spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SelectQueryBuilder } from 'typeorm';
+import { Market } from '../markets/entities/market.entity';
+import { User } from '../users/entities/user.entity';
+import { Competition, CompetitionVisibility } from '../competitions/entities/competition.entity';
+import { SearchService } from './search.service';
+import { GlobalSearchDto, SearchType } from './dto/global-search.dto';
+
+type MockQb<T> = jest.Mocked<
+  Pick<
+    SelectQueryBuilder<T>,
+    | 'addSelect'
+    | 'select'
+    | 'where'
+    | 'andWhere'
+    | 'setParameter'
+    | 'orderBy'
+    | 'skip'
+    | 'take'
+    | 'getMany'
+  >
+>;
+
+function makeQb<T>(results: T[]): MockQb<T> {
+  const qb = {
+    addSelect: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue(results),
+  } as MockQb<T>;
+  return qb;
+}
+
+describe('SearchService', () => {
+  let service: SearchService;
+  let marketQb: MockQb<Market>;
+  let userQb: MockQb<User>;
+  let competitionQb: MockQb<Competition>;
+
+  const mockMarket = {
+    id: 'market-1',
+    title: 'Bitcoin price prediction',
+    description: 'Will BTC hit 100k?',
+    category: 'crypto',
+    is_resolved: false,
+    is_public: true,
+    participant_count: 10,
+    created_at: new Date('2026-01-01'),
+  } as Market;
+
+  const mockUser = {
+    id: 'user-1',
+    username: 'alice',
+    stellar_address: 'GABC123',
+    avatar_url: null,
+    reputation_score: 42,
+    total_predictions: 7,
+  } as User;
+
+  const mockCompetition = {
+    id: 'comp-1',
+    title: 'Crypto League',
+    description: 'Monthly crypto competition',
+    start_time: new Date('2026-02-01'),
+    end_time: new Date('2026-02-28'),
+    participant_count: 5,
+    visibility: CompetitionVisibility.Public,
+  } as unknown as Competition;
+
+  beforeEach(async () => {
+    marketQb = makeQb([mockMarket]);
+    userQb = makeQb([mockUser]);
+    competitionQb = makeQb([mockCompetition]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchService,
+        {
+          provide: getRepositoryToken(Market),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(marketQb) },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(userQb) },
+        },
+        {
+          provide: getRepositoryToken(Competition),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SearchService>(SearchService);
+  });
+
+  describe('search()', () => {
+    it('returns all three entity types for SearchType.All', async () => {
+      const dto: GlobalSearchDto = { query: 'bitcoin', type: SearchType.All, page: 1, limit: 20 };
+      const result = await service.search(dto);
+
+      expect(result.markets).toEqual([mockMarket]);
+      expect(result.users).toEqual([mockUser]);
+      expect(result.competitions).toEqual([mockCompetition]);
+      expect(result.total).toBe(3);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+
+    it('returns only markets when type is Markets', async () => {
+      const dto: GlobalSearchDto = { query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 };
+      const result = await service.search(dto);
+
+      expect(result.markets).toEqual([mockMarket]);
+      expect(result.users).toEqual([]);
+      expect(result.competitions).toEqual([]);
+    });
+
+    it('caps limit at 50', async () => {
+      const dto: GlobalSearchDto = { query: 'test', type: SearchType.Markets, page: 1, limit: 999 };
+      await service.search(dto);
+
+      expect(marketQb.take).toHaveBeenCalledWith(50);
+    });
+
+    it('computes correct skip for page 3 limit 10', async () => {
+      const dto: GlobalSearchDto = { query: 'test', type: SearchType.Markets, page: 3, limit: 10 };
+      await service.search(dto);
+
+      expect(marketQb.skip).toHaveBeenCalledWith(20);
+      expect(marketQb.take).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('searchMarkets FTS', () => {
+    it('filters by is_public = true', async () => {
+      await service.search({ query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 });
+
+      expect(marketQb.where).toHaveBeenCalledWith(
+        'market.is_public = :isPublic',
+        { isPublic: true },
+      );
+    });
+
+    it('matches via search_vector @@ plainto_tsquery', async () => {
+      await service.search({ query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 });
+
+      expect(marketQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('search_vector @@'),
+        expect.objectContaining({ query: 'bitcoin' }),
+      );
+    });
+
+    it('orders by ts_rank DESC', async () => {
+      await service.search({ query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 });
+
+      expect(marketQb.orderBy).toHaveBeenCalledWith(
+        expect.stringContaining('ts_rank'),
+        'DESC',
+      );
+    });
+  });
+
+  describe('searchUsers FTS', () => {
+    it('filters out banned users', async () => {
+      await service.search({ query: 'alice', type: SearchType.Users, page: 1, limit: 20 });
+
+      expect(userQb.where).toHaveBeenCalledWith(
+        'user.is_banned = :banned',
+        { banned: false },
+      );
+    });
+
+    it('matches via search_vector @@ plainto_tsquery', async () => {
+      await service.search({ query: 'alice', type: SearchType.Users, page: 1, limit: 20 });
+
+      expect(userQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('search_vector @@'),
+        expect.objectContaining({ query: 'alice' }),
+      );
+    });
+
+    it('orders by ts_rank DESC', async () => {
+      await service.search({ query: 'alice', type: SearchType.Users, page: 1, limit: 20 });
+
+      expect(userQb.orderBy).toHaveBeenCalledWith(
+        expect.stringContaining('ts_rank'),
+        'DESC',
+      );
+    });
+  });
+
+  describe('searchCompetitions FTS', () => {
+    it('filters by visibility = public', async () => {
+      await service.search({ query: 'league', type: SearchType.Competitions, page: 1, limit: 20 });
+
+      expect(competitionQb.where).toHaveBeenCalledWith(
+        'competition.visibility = :visibility',
+        { visibility: CompetitionVisibility.Public },
+      );
+    });
+
+    it('matches via search_vector @@ plainto_tsquery', async () => {
+      await service.search({ query: 'league', type: SearchType.Competitions, page: 1, limit: 20 });
+
+      expect(competitionQb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('search_vector @@'),
+        expect.objectContaining({ query: 'league' }),
+      );
+    });
+
+    it('orders by ts_rank DESC', async () => {
+      await service.search({ query: 'league', type: SearchType.Competitions, page: 1, limit: 20 });
+
+      expect(competitionQb.orderBy).toHaveBeenCalledWith(
+        expect.stringContaining('ts_rank'),
+        'DESC',
+      );
+    });
+  });
+});

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -29,17 +29,17 @@ export class SearchService {
     const limit = Math.min(dto.limit ?? 20, 50);
     const skip = (page - 1) * limit;
     const searchType = dto.type ?? SearchType.All;
-    const searchPattern = `%${dto.query}%`;
+    const query = dto.query;
 
     const [markets, users, competitions] = await Promise.all([
       searchType === SearchType.All || searchType === SearchType.Markets
-        ? this.searchMarkets(searchPattern, skip, limit)
+        ? this.searchMarkets(query, skip, limit)
         : Promise.resolve([]),
       searchType === SearchType.All || searchType === SearchType.Users
-        ? this.searchUsers(searchPattern, skip, limit)
+        ? this.searchUsers(query, skip, limit)
         : Promise.resolve([]),
       searchType === SearchType.All || searchType === SearchType.Competitions
-        ? this.searchCompetitions(searchPattern, skip, limit)
+        ? this.searchCompetitions(query, skip, limit)
         : Promise.resolve([]),
     ]);
 
@@ -49,7 +49,7 @@ export class SearchService {
   }
 
   private async searchMarkets(
-    pattern: string,
+    query: string,
     skip: number,
     limit: number,
   ): Promise<Market[]> {
@@ -67,17 +67,20 @@ export class SearchService {
       ])
       .where('market.is_public = :isPublic', { isPublic: true })
       .andWhere(
-        '(market.title ILIKE :pattern OR market.description ILIKE :pattern)',
-        { pattern },
+        `market.search_vector @@ plainto_tsquery('english', :query)`,
+        { query },
       )
-      .orderBy('market.created_at', 'DESC')
+      .orderBy(
+        `ts_rank(market.search_vector, plainto_tsquery('english', :query))`,
+        'DESC',
+      )
       .skip(skip)
       .take(limit)
       .getMany();
   }
 
   private async searchUsers(
-    pattern: string,
+    query: string,
     skip: number,
     limit: number,
   ): Promise<User[]> {
@@ -93,17 +96,20 @@ export class SearchService {
       ])
       .where('user.is_banned = :banned', { banned: false })
       .andWhere(
-        '(user.username ILIKE :pattern OR user.stellar_address ILIKE :pattern)',
-        { pattern },
+        `user.search_vector @@ plainto_tsquery('simple', :query)`,
+        { query },
       )
-      .orderBy('user.reputation_score', 'DESC')
+      .orderBy(
+        `ts_rank(user.search_vector, plainto_tsquery('simple', :query))`,
+        'DESC',
+      )
       .skip(skip)
       .take(limit)
       .getMany();
   }
 
   private async searchCompetitions(
-    pattern: string,
+    query: string,
     skip: number,
     limit: number,
   ): Promise<Competition[]> {
@@ -122,10 +128,13 @@ export class SearchService {
         visibility: CompetitionVisibility.Public,
       })
       .andWhere(
-        '(competition.title ILIKE :pattern OR competition.description ILIKE :pattern)',
-        { pattern },
+        `competition.search_vector @@ plainto_tsquery('english', :query)`,
+        { query },
       )
-      .orderBy('competition.created_at', 'DESC')
+      .orderBy(
+        `ts_rank(competition.search_vector, plainto_tsquery('english', :query))`,
+        'DESC',
+      )
       .skip(skip)
       .take(limit)
       .getMany();


### PR DESCRIPTION
## Summary
closes #1001 

- Replaces `%term%` ILIKE sequential scans in `SearchService` with Postgres full-text search using `tsvector GENERATED ALWAYS AS STORED` columns, GIN indexes, and `ts_rank` relevance ordering
- Adds migration `1776200000000-AddSearchVectors` that adds `search_vector` generated columns to `markets`, `users`, and `competitions` tables — fully reversible with `down()`
- Rewrites `searchMarkets`, `searchUsers`, `searchCompetitions` helpers to use `@@ plainto_tsquery()` matching and `ts_rank()` ordering; pagination and `GlobalSearchResponseDto` shape are unchanged

## Why

`%term%` patterns cannot use a B-tree index, causing a full sequential scan per table on every search request. With GIN indexes on the stored tsvector columns, Postgres can use a Bitmap Index Scan and scale with data growth. Results are now ordered by relevance (exact/title hits rank above partial description matches) rather than by `created_at` or `reputation_score`.

## Dictionary choices

| Table | Dictionary | Reason |
|---|---|---|
| `markets`, `competitions` | `english` | Natural language — benefits from stemming and stop-words |
| `users` | `simple` | Stellar addresses aren't English words; no stemming needed |

## Test plan

- [ ] Run migration `up` on a populated DB and verify `EXPLAIN (ANALYZE) SELECT ...` shows `Bitmap Index Scan on idx_markets_search_vector` (not `Seq Scan`)
- [ ] Run migration `down` — indexes and columns drop cleanly
- [ ] `GET /search?query=bitcoin` returns relevance-ordered results
- [ ] `GET /search?query=bitcoin&type=markets` returns only markets
- [ ] Pagination (`page`, `limit`) behaves identically to before
- [ ] Unit tests: `npx jest src/search/search.service.spec.ts` — 13/13 pass
