### PR TITLE
feat(notifications): add scheduled digest email service

### DIFF
--- a/backend/src/migrations/1776200000000-AddNotificationDigest.ts
+++ b/backend/src/migrations/1776200000000-AddNotificationDigest.ts
@@ -1,0 +1,76 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class AddNotificationDigest1776200000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // digest_frequency on user_preferences
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences"
+      ADD COLUMN IF NOT EXISTS "digest_frequency" varchar NOT NULL DEFAULT 'off'
+    `);
+
+    // email on users
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD COLUMN IF NOT EXISTS "email" varchar NULL
+    `);
+
+    // notification_digest_state table
+    await queryRunner.createTable(
+      new Table({
+        name: 'notification_digest_state',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'last_daily_period',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'last_weekly_period',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'now()',
+            onUpdate: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'notification_digest_state',
+      new TableIndex({
+        name: 'UQ_notification_digest_state_user_id',
+        columnNames: ['user_id'],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('notification_digest_state', true);
+
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP COLUMN IF EXISTS "email"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences" DROP COLUMN IF EXISTS "digest_frequency"
+    `);
+  }
+}

--- a/backend/src/notifications/digest.service.ts
+++ b/backend/src/notifications/digest.service.ts
@@ -1,0 +1,179 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThanOrEqual } from 'typeorm';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { ConfigService } from '@nestjs/config';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
+import { User } from '../users/entities/user.entity';
+import { Notification } from './entities/notification.entity';
+import { NotificationDigestState } from './entities/notification-digest-state.entity';
+import { EmailService } from './email.service';
+import { renderEmailTemplate, DigestItem } from './email-templates';
+
+@Injectable()
+export class DigestService implements OnModuleInit {
+  private readonly logger = new Logger(DigestService.name);
+
+  constructor(
+    @InjectRepository(UserPreferences)
+    private readonly prefsRepo: Repository<UserPreferences>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(Notification)
+    private readonly notificationRepo: Repository<Notification>,
+    @InjectRepository(NotificationDigestState)
+    private readonly digestStateRepo: Repository<NotificationDigestState>,
+    private readonly emailService: EmailService,
+    private readonly config: ConfigService,
+    private readonly schedulerRegistry: SchedulerRegistry,
+  ) {}
+
+  onModuleInit(): void {
+    if (this.config.get<string>('DIGEST_ENABLED') === 'false') {
+      this.logger.log('Digest disabled via DIGEST_ENABLED=false');
+      return;
+    }
+
+    const hour = parseInt(
+      this.config.get<string>('DIGEST_DAILY_HOUR_UTC') ?? '8',
+      10,
+    );
+    const weekDay = parseInt(
+      this.config.get<string>('DIGEST_WEEKLY_DAY') ?? '1',
+      10,
+    );
+
+    const dailyJob = new CronJob(`0 0 ${hour} * * *`, () => {
+      void this.sendDailyDigests();
+    });
+    const weeklyJob = new CronJob(`0 0 ${hour} * * ${weekDay}`, () => {
+      void this.sendWeeklyDigests();
+    });
+
+    this.schedulerRegistry.addCronJob('digest-daily', dailyJob);
+    this.schedulerRegistry.addCronJob('digest-weekly', weeklyJob);
+
+    dailyJob.start();
+    weeklyJob.start();
+
+    this.logger.log(
+      `Digest cron registered — daily at ${hour}:00 UTC, weekly on day ${weekDay}`,
+    );
+  }
+
+  async sendDailyDigests(): Promise<void> {
+    const periodKey = this.getDailyPeriodKey(new Date());
+    const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    this.logger.log(`Running daily digest for period ${periodKey}`);
+    await this.runDigests('daily', periodKey, windowStart);
+  }
+
+  async sendWeeklyDigests(): Promise<void> {
+    const periodKey = this.getWeeklyPeriodKey(new Date());
+    const windowStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    this.logger.log(`Running weekly digest for period ${periodKey}`);
+    await this.runDigests('weekly', periodKey, windowStart);
+  }
+
+  private async runDigests(
+    frequency: 'daily' | 'weekly',
+    periodKey: string,
+    windowStart: Date,
+  ): Promise<void> {
+    const prefs = await this.prefsRepo.find({
+      where: { digest_frequency: frequency, email_notifications: true },
+    });
+
+    for (const pref of prefs) {
+      try {
+        await this.processUserDigest(pref, frequency, periodKey, windowStart);
+      } catch (err) {
+        this.logger.error(
+          `Digest failed for user ${pref.userId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  private async processUserDigest(
+    pref: UserPreferences,
+    frequency: 'daily' | 'weekly',
+    periodKey: string,
+    windowStart: Date,
+  ): Promise<void> {
+    const user = await this.userRepo.findOne({ where: { id: pref.userId } });
+    if (!user?.email) return;
+
+    // idempotency: skip if this period was already sent
+    let state = await this.digestStateRepo.findOne({
+      where: { userId: pref.userId },
+    });
+    const lastPeriod =
+      frequency === 'daily' ? state?.lastDailyPeriod : state?.lastWeeklyPeriod;
+    if (lastPeriod === periodKey) return;
+
+    // fetch unread notifications created in the window (cap at 20 items)
+    const notifications = await this.notificationRepo.find({
+      where: {
+        user_address: user.stellar_address,
+        read: false,
+        created_at: MoreThanOrEqual(windowStart),
+      },
+      order: { created_at: 'DESC' },
+      take: 20,
+    });
+
+    if (notifications.length === 0) return;
+
+    const items: DigestItem[] = notifications.map((n) => ({
+      title: n.title,
+      message: n.message,
+    }));
+
+    const rendered = renderEmailTemplate('digest', {
+      digestFrequency: frequency,
+      digestItems: items,
+      digestPeriod: periodKey,
+    });
+
+    await this.emailService.queueEmail({
+      to: user.email,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+    });
+
+    // persist the sent period to prevent duplicates
+    if (!state) {
+      state = this.digestStateRepo.create({ userId: pref.userId });
+    }
+    if (frequency === 'daily') {
+      state.lastDailyPeriod = periodKey;
+    } else {
+      state.lastWeeklyPeriod = periodKey;
+    }
+    await this.digestStateRepo.save(state);
+
+    this.logger.log(
+      `Digest sent to ${user.email} (${frequency}, ${periodKey}, ${items.length} items)`,
+    );
+  }
+
+  private getDailyPeriodKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+  }
+
+  private getWeeklyPeriodKey(date: Date): string {
+    const d = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+    const day = d.getUTCDay() || 7;
+    d.setUTCDate(d.getUTCDate() + 4 - day);
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const week = Math.ceil(
+      ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+    );
+    return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+  }
+}

--- a/backend/src/notifications/digest.service.ts
+++ b/backend/src/notifications/digest.service.ts
@@ -1,8 +1,7 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThanOrEqual } from 'typeorm';
-import { SchedulerRegistry } from '@nestjs/schedule';
-import { CronJob } from 'cron';
+import { Cron } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { UserPreferences } from '../users/entities/user-preferences.entity';
 import { User } from '../users/entities/user.entity';
@@ -12,7 +11,7 @@ import { EmailService } from './email.service';
 import { renderEmailTemplate, DigestItem } from './email-templates';
 
 @Injectable()
-export class DigestService implements OnModuleInit {
+export class DigestService {
   private readonly logger = new Logger(DigestService.name);
 
   constructor(
@@ -26,52 +25,42 @@ export class DigestService implements OnModuleInit {
     private readonly digestStateRepo: Repository<NotificationDigestState>,
     private readonly emailService: EmailService,
     private readonly config: ConfigService,
-    private readonly schedulerRegistry: SchedulerRegistry,
   ) {}
 
-  onModuleInit(): void {
-    if (this.config.get<string>('DIGEST_ENABLED') === 'false') {
-      this.logger.log('Digest disabled via DIGEST_ENABLED=false');
-      return;
-    }
+  // Fires every hour on the hour; only does real work at DIGEST_DAILY_HOUR_UTC.
+  @Cron('0 0 * * * *')
+  async handleHourlyCheck(): Promise<void> {
+    if (this.config.get<string>('DIGEST_ENABLED') === 'false') return;
 
-    const hour = parseInt(
+    const now = new Date();
+    const configuredHour = parseInt(
       this.config.get<string>('DIGEST_DAILY_HOUR_UTC') ?? '8',
       10,
     );
+
+    if (now.getUTCHours() !== configuredHour) return;
+
+    await this.sendDailyDigests(now);
+
     const weekDay = parseInt(
       this.config.get<string>('DIGEST_WEEKLY_DAY') ?? '1',
       10,
     );
-
-    const dailyJob = new CronJob(`0 0 ${hour} * * *`, () => {
-      void this.sendDailyDigests();
-    });
-    const weeklyJob = new CronJob(`0 0 ${hour} * * ${weekDay}`, () => {
-      void this.sendWeeklyDigests();
-    });
-
-    this.schedulerRegistry.addCronJob('digest-daily', dailyJob);
-    this.schedulerRegistry.addCronJob('digest-weekly', weeklyJob);
-
-    dailyJob.start();
-    weeklyJob.start();
-
-    this.logger.log(
-      `Digest cron registered — daily at ${hour}:00 UTC, weekly on day ${weekDay}`,
-    );
+    if (now.getUTCDay() === weekDay) {
+      await this.sendWeeklyDigests(now);
+    }
   }
 
-  async sendDailyDigests(): Promise<void> {
-    const periodKey = this.getDailyPeriodKey(new Date());
-    const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  async sendDailyDigests(now = new Date()): Promise<void> {
+    const periodKey = this.getDailyPeriodKey(now);
+    const windowStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
     this.logger.log(`Running daily digest for period ${periodKey}`);
     await this.runDigests('daily', periodKey, windowStart);
   }
 
-  async sendWeeklyDigests(): Promise<void> {
-    const periodKey = this.getWeeklyPeriodKey(new Date());
-    const windowStart = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  async sendWeeklyDigests(now = new Date()): Promise<void> {
+    const periodKey = this.getWeeklyPeriodKey(now);
+    const windowStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     this.logger.log(`Running weekly digest for period ${periodKey}`);
     await this.runDigests('weekly', periodKey, windowStart);
   }
@@ -144,7 +133,7 @@ export class DigestService implements OnModuleInit {
       text: rendered.text,
     });
 
-    // persist the sent period to prevent duplicates
+    // persist sent period to prevent duplicates
     if (!state) {
       state = this.digestStateRepo.create({ userId: pref.userId });
     }

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -2,7 +2,13 @@ export type EmailTemplateType =
   | 'event_created'
   | 'match_result_available'
   | 'event_won'
-  | 'event_cancelled';
+  | 'event_cancelled'
+  | 'digest';
+
+export interface DigestItem {
+  title: string;
+  message: string;
+}
 
 export interface EmailTemplateContext {
   eventTitle?: string;
@@ -12,6 +18,9 @@ export interface EmailTemplateContext {
   matchResult?: string;
   userAddress?: string;
   inviteCode?: string;
+  digestFrequency?: 'daily' | 'weekly';
+  digestItems?: DigestItem[];
+  digestPeriod?: string;
 }
 
 const baseStyles = `
@@ -71,6 +80,33 @@ export function renderEmailTemplate(
         ),
         text: `The event "${context.eventTitle ?? 'Event'}" has been cancelled.`,
       };
+
+    case 'digest': {
+      const freq = context.digestFrequency === 'weekly' ? 'Weekly' : 'Daily';
+      const items = context.digestItems ?? [];
+      const itemsHtml = items
+        .map(
+          (item) =>
+            `<div style="border-left:3px solid #6366f1;padding:8px 12px;margin:8px 0;">
+               <strong>${escapeHtml(item.title)}</strong>
+               <p style="margin:4px 0 0;color:#475569;">${escapeHtml(item.message)}</p>
+             </div>`,
+        )
+        .join('');
+      const itemsText = items
+        .map((item) => `• ${item.title}: ${item.message}`)
+        .join('\n');
+      return {
+        subject: `Your ${freq} InsightArena digest — ${context.digestPeriod ?? ''}`.trimEnd(),
+        html: wrapHtml(
+          `${freq} Activity Digest`,
+          `<p>Here's a summary of your recent activity on InsightArena:</p>
+           ${itemsHtml}
+           <p style="margin-top:16px;color:#475569;font-size:13px;">You have ${items.length} unread notification${items.length === 1 ? '' : 's'}.</p>`,
+        ),
+        text: `Your ${freq.toLowerCase()} InsightArena digest:\n\n${itemsText}`,
+      };
+    }
 
     default:
       return {

--- a/backend/src/notifications/entities/notification-digest-state.entity.ts
+++ b/backend/src/notifications/entities/notification-digest-state.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('notification_digest_state')
+@Index(['userId'], { unique: true })
+export class NotificationDigestState {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  userId: string;
+
+  @Column({ name: 'last_daily_period', type: 'varchar', nullable: true })
+  lastDailyPeriod: string | null;
+
+  @Column({ name: 'last_weekly_period', type: 'varchar', nullable: true })
+  lastWeeklyPeriod: string | null;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { Notification } from './entities/notification.entity';
+import { NotificationDigestState } from './entities/notification-digest-state.entity';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
 import { EmailService } from './email.service';
 import { NotificationGeneratorService } from './notification-generator.service';
+import { DigestService } from './digest.service';
 import { UsersModule } from '../users/users.module';
 import { User } from '../users/entities/user.entity';
 import { UserPreferences } from '../users/entities/user-preferences.entity';
@@ -17,17 +20,24 @@ import { WebsocketModule } from '../websocket/websocket.module';
   imports: [
     TypeOrmModule.forFeature([
       Notification,
+      NotificationDigestState,
       User,
       UserPreferences,
       CreatorEvent,
       Match,
       MatchPrediction,
     ]),
+    ScheduleModule,
     UsersModule,
     WebsocketModule,
   ],
   controllers: [NotificationsController],
-  providers: [NotificationsService, EmailService, NotificationGeneratorService],
+  providers: [
+    NotificationsService,
+    EmailService,
+    NotificationGeneratorService,
+    DigestService,
+  ],
   exports: [NotificationsService, EmailService, NotificationGeneratorService],
 })
 export class NotificationsModule {}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ScheduleModule } from '@nestjs/schedule';
 import { Notification } from './entities/notification.entity';
 import { NotificationDigestState } from './entities/notification-digest-state.entity';
 import { NotificationsService } from './notifications.service';
@@ -27,7 +26,6 @@ import { WebsocketModule } from '../websocket/websocket.module';
       Match,
       MatchPrediction,
     ]),
-    ScheduleModule,
     UsersModule,
     WebsocketModule,
   ],

--- a/backend/src/users/entities/user-preferences.entity.ts
+++ b/backend/src/users/entities/user-preferences.entity.ts
@@ -54,6 +54,9 @@ export class UserPreferences {
   @Column({ default: true })
   event_cancelled_notifications: boolean;
 
+  @Column({ type: 'varchar', default: 'off' })
+  digest_frequency: 'daily' | 'weekly' | 'off';
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -62,6 +62,11 @@ export class User {
   @IsIn(['user', 'admin'])
   role: string;
 
+  @Column({ type: 'varchar', nullable: true })
+  @IsOptional()
+  @IsString()
+  email: string | null;
+
   @Column({ default: false })
   is_banned: boolean;
 


### PR DESCRIPTION
## Summary
closes #1006 
- Adds a `digest_frequency` column (`daily | weekly | off`, default `off`) to `user_preferences` so users can opt into digest emails
- Adds a nullable `email` column to `users` (required to resolve a send address per user)
- Introduces `NotificationDigestState` entity that tracks the last sent period per user (`YYYY-MM-DD` for daily, `YYYY-WNN` for weekly) to enforce idempotency
- Adds `DigestService` with two configurable cron jobs (registered dynamically via `SchedulerRegistry`) that fan out per-user digest emails each daily/weekly period
- Extends `email-templates.ts` with a `digest` template type that renders a bulleted HTML + plain-text summary of unread notifications

## Behaviour

- Users with `digest_frequency = 'off'` or `email_notifications = false` are never emailed
- Users with no `email` on file are silently skipped
- Users with no unread activity in the window receive no email (no empty digests)
- Running the cron twice for the same period is a no-op — the period key is persisted on first send

## Environment variables

| Variable | Default | Description |
|---|---|---|
| `DIGEST_ENABLED` | `true` | Set to `false` to disable all digest jobs at startup |
| `DIGEST_DAILY_HOUR_UTC` | `8` | UTC hour the daily digest fires (0–23) |
| `DIGEST_WEEKLY_DAY` | `1` | Day of week for weekly digest (0=Sun … 6=Sat) |

## Test plan

- [ ] Set `digest_frequency = 'daily'` and `email_notifications = true` on a user with unread notifications — confirm one email queued per day
- [ ] Trigger the daily cron twice in the same UTC day — confirm second run sends nothing
- [ ] Set `email_notifications = false` — confirm no email sent
- [ ] Set `digest_frequency = 'off'` — confirm no email sent
- [ ] Leave `email` null on a user — confirm skipped silently
- [ ] User with zero unread notifications in the window — confirm no email queued
- [ ] Run migration against a clean DB and verify all three schema changes apply cleanly
