### PR TITLE
feat: GDPR-style user data export & account deletion

### DIFF
--- a/backend/src/account/account.controller.ts
+++ b/backend/src/account/account.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Res,
+  StreamableFile,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { createReadStream } from 'fs';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+import { AccountService } from './account.service';
+
+@Controller('account')
+export class AccountController {
+  constructor(private readonly accountService: AccountService) {}
+
+  @Post('export')
+  requestExport(@CurrentUser() user: User) {
+    return this.accountService.requestExport(user.id);
+  }
+
+  @Get('export/:jobId')
+  getExportStatus(@CurrentUser() user: User, @Param('jobId') jobId: string) {
+    return this.accountService.getExportStatus(user.id, jobId);
+  }
+
+  @Get('export/:jobId/download')
+  async downloadExport(
+    @CurrentUser() user: User,
+    @Param('jobId') jobId: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<StreamableFile> {
+    const filePath = await this.accountService.downloadExport(user.id, jobId);
+    res.set({
+      'Content-Type': 'application/json',
+      'Content-Disposition': `attachment; filename="export-${jobId}.json"`,
+    });
+    return new StreamableFile(createReadStream(filePath));
+  }
+
+  @Delete()
+  @HttpCode(204)
+  async deleteAccount(@CurrentUser() user: User): Promise<void> {
+    await this.accountService.deleteAccount(user.id);
+  }
+}

--- a/backend/src/account/account.module.ts
+++ b/backend/src/account/account.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AccountController } from './account.controller';
+import { AccountService } from './account.service';
+import { DataExportJob } from './entities/data-export-job.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DataExportJob])],
+  controllers: [AccountController],
+  providers: [AccountService],
+})
+export class AccountModule {}

--- a/backend/src/account/account.service.ts
+++ b/backend/src/account/account.service.ts
@@ -1,0 +1,230 @@
+import {
+  BadRequestException,
+  GoneException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DataSource, LessThan, Repository } from 'typeorm';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { DataExportJob } from './entities/data-export-job.entity';
+
+@Injectable()
+export class AccountService {
+  constructor(
+    @InjectRepository(DataExportJob)
+    private readonly jobRepo: Repository<DataExportJob>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async requestExport(userId: string): Promise<{ jobId: string; status: string }> {
+    const existing = await this.jobRepo.findOne({
+      where: [
+        { user_id: userId, status: 'pending' },
+        { user_id: userId, status: 'processing' },
+      ],
+    });
+    if (existing) {
+      return { jobId: existing.id, status: existing.status };
+    }
+
+    const job = this.jobRepo.create({ user_id: userId });
+    await this.jobRepo.save(job);
+    return { jobId: job.id, status: job.status };
+  }
+
+  async getExportStatus(
+    userId: string,
+    jobId: string,
+  ): Promise<{ jobId: string; status: string; expires_at: Date | null }> {
+    const job = await this.jobRepo.findOne({ where: { id: jobId } });
+    if (!job || job.user_id !== userId) {
+      throw new NotFoundException('Export job not found');
+    }
+    return { jobId: job.id, status: job.status, expires_at: job.expires_at };
+  }
+
+  async downloadExport(userId: string, jobId: string): Promise<string> {
+    const job = await this.jobRepo.findOne({ where: { id: jobId } });
+    if (!job || job.user_id !== userId) {
+      throw new NotFoundException('Export job not found');
+    }
+    if (job.status !== 'ready' || !job.file_path) {
+      throw new BadRequestException('Export is not ready yet');
+    }
+    if (job.expires_at && job.expires_at < new Date()) {
+      throw new GoneException('Export has expired');
+    }
+    try {
+      await fs.access(job.file_path);
+    } catch {
+      throw new GoneException('Export file is no longer available');
+    }
+    return job.file_path;
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async processExports(): Promise<void> {
+    const jobs = await this.jobRepo.find({ where: { status: 'pending' }, take: 5 });
+    for (const job of jobs) {
+      await this.runExport(job).catch(() => {});
+    }
+  }
+
+  private async runExport(job: DataExportJob): Promise<void> {
+    await this.jobRepo.update(job.id, { status: 'processing' });
+    try {
+      const data = await this.gatherUserData(job.user_id);
+      const dir = this.configService.get<string>('EXPORT_DIR', './exports');
+      await fs.mkdir(dir, { recursive: true });
+      const filePath = path.join(dir, `${job.id}.json`);
+      await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
+      const ttl = this.configService.get<number>('EXPORT_TTL_HOURS', 48);
+      const expiresAt = new Date(Date.now() + ttl * 3_600_000);
+      await this.jobRepo.update(job.id, {
+        status: 'ready',
+        file_path: filePath,
+        expires_at: expiresAt,
+      });
+    } catch {
+      await this.jobRepo.update(job.id, { status: 'failed' });
+    }
+  }
+
+  private async gatherUserData(userId: string): Promise<Record<string, unknown>> {
+    const [profile] = await this.dataSource.query(
+      `SELECT id, stellar_address, username, avatar_url, email, role,
+              total_predictions, correct_predictions, reputation_score,
+              season_points, created_at
+       FROM users WHERE id = $1`,
+      [userId],
+    );
+    if (!profile) throw new NotFoundException('User not found');
+
+    const [
+      predictions,
+      markets,
+      achievements,
+      bookmarks,
+      follows,
+      competitions,
+      leaderboard,
+      notifications,
+    ] = await Promise.all([
+      this.dataSource.query(
+        `SELECT * FROM predictions WHERE "userId" = $1`,
+        [userId],
+      ),
+      this.dataSource.query(
+        `SELECT * FROM markets WHERE "creatorId" = $1`,
+        [userId],
+      ),
+      this.dataSource.query(
+        `SELECT * FROM user_achievements WHERE "userId" = $1`,
+        [userId],
+      ),
+      this.dataSource.query(
+        `SELECT * FROM user_bookmarks WHERE user_id = $1`,
+        [userId],
+      ),
+      this.dataSource.query(
+        `SELECT * FROM user_follows WHERE follower_id = $1 OR following_id = $1`,
+        [userId],
+      ),
+      this.dataSource.query(
+        `SELECT * FROM competition_participants WHERE user_id = $1`,
+        [userId],
+      ),
+      this.dataSource.query(
+        `SELECT * FROM leaderboard_history WHERE user_id = $1 ORDER BY created_at DESC LIMIT 100`,
+        [userId],
+      ),
+      this.dataSource.query(
+        `SELECT id, type, title, message, data, read, created_at
+         FROM notifications WHERE user_address = $1 ORDER BY created_at DESC LIMIT 1000`,
+        [profile.stellar_address],
+      ),
+    ]);
+
+    return {
+      exported_at: new Date().toISOString(),
+      profile,
+      predictions,
+      markets_created: markets,
+      notifications,
+      achievements,
+      bookmarks,
+      follows,
+      competitions,
+      leaderboard_history: leaderboard,
+    };
+  }
+
+  async deleteAccount(userId: string): Promise<void> {
+    const filePaths: string[] = [];
+
+    await this.dataSource.transaction(async (manager) => {
+      const [user] = await manager.query(
+        `SELECT stellar_address FROM users WHERE id = $1`,
+        [userId],
+      );
+      if (!user) throw new NotFoundException('User not found');
+
+      // Collect export file paths before deleting job rows
+      const jobs: { file_path: string | null }[] = await manager.query(
+        `SELECT file_path FROM data_export_jobs WHERE user_id = $1`,
+        [userId],
+      );
+      for (const j of jobs) {
+        if (j.file_path) filePaths.push(j.file_path);
+      }
+
+      // Delete address-indexed personal data
+      await manager.query(
+        `DELETE FROM notifications WHERE user_address = $1`,
+        [user.stellar_address],
+      );
+      await manager.query(
+        `DELETE FROM notification_digest_state WHERE user_id = $1`,
+        [userId],
+      );
+
+      // Remove pending export records
+      await manager.query(
+        `DELETE FROM data_export_jobs WHERE user_id = $1`,
+        [userId],
+      );
+
+      // Anonymize PII and soft-delete (sets deleted_at so JWT validate returns null)
+      await manager.query(
+        `UPDATE users
+         SET email = NULL, username = NULL, avatar_url = NULL,
+             ban_reason = NULL, banned_at = NULL, banned_by = NULL,
+             deleted_at = NOW()
+         WHERE id = $1`,
+        [userId],
+      );
+    });
+
+    // Remove export files from disk after the transaction commits
+    for (const fp of filePaths) {
+      await fs.unlink(fp).catch(() => {});
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async cleanupExports(): Promise<void> {
+    const expired = await this.jobRepo.find({
+      where: { status: 'ready', expires_at: LessThan(new Date()) },
+    });
+    for (const job of expired) {
+      if (job.file_path) await fs.unlink(job.file_path).catch(() => {});
+      await this.jobRepo.delete(job.id);
+    }
+  }
+}

--- a/backend/src/account/entities/data-export-job.entity.ts
+++ b/backend/src/account/entities/data-export-job.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export type ExportStatus = 'pending' | 'processing' | 'ready' | 'failed';
+
+@Entity('data_export_jobs')
+@Index(['user_id'])
+@Index(['expires_at'])
+export class DataExportJob {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  user_id: string;
+
+  @Column({ type: 'varchar', default: 'pending' })
+  status: ExportStatus;
+
+  @Column({ type: 'varchar', nullable: true })
+  file_path: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expires_at: Date | null;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -36,6 +36,7 @@ import { ContractModule } from './contract/contract.module';
 import { CacheWarmingModule } from './cache/cache-warming.module';
 import { WebsocketModule } from './websocket/websocket.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
+import { AccountModule } from './account/account.module';
 
 @Module({
   imports: [
@@ -102,6 +103,7 @@ import { WebhooksModule } from './webhooks/webhooks.module';
     CacheWarmingModule,
     WebsocketModule,
     WebhooksModule,
+    AccountModule,
   ],
 
   controllers: [AppController],

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -65,6 +65,12 @@ class EnvironmentVariables {
   @IsOptional()
   @IsNumber()
   RECONCILE_WINDOW?: number;
+
+  @IsString()
+  EXPORT_DIR: string = './exports';
+
+  @IsNumber()
+  EXPORT_TTL_HOURS: number = 48;
 }
 
 export function validate(config: Record<string, unknown>) {

--- a/backend/src/migrations/1776300000000-AddDataExportJobAndUserSoftDelete.ts
+++ b/backend/src/migrations/1776300000000-AddDataExportJobAndUserSoftDelete.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDataExportJobAndUserSoftDelete1776300000000
+  implements MigrationInterface
+{
+  name = 'AddDataExportJobAndUserSoftDelete1776300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "deleted_at" TIMESTAMP`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "data_export_jobs" (
+        "id"         uuid                        NOT NULL DEFAULT uuid_generate_v4(),
+        "user_id"    uuid                        NOT NULL,
+        "status"     character varying           NOT NULL DEFAULT 'pending',
+        "file_path"  character varying,
+        "expires_at" TIMESTAMP,
+        "created_at" TIMESTAMP                   NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP                   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_data_export_jobs" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_data_export_jobs_user_id" ON "data_export_jobs" ("user_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_data_export_jobs_status" ON "data_export_jobs" ("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_data_export_jobs_expires_at" ON "data_export_jobs" ("expires_at")
+       WHERE expires_at IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_data_export_jobs_expires_at"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_data_export_jobs_status"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_data_export_jobs_user_id"`,
+    );
+    await queryRunner.query(`DROP TABLE "data_export_jobs"`);
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN "deleted_at"`,
+    );
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -3,6 +3,7 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   UpdateDateColumn,
   Index,
   OneToOne,
@@ -93,4 +94,7 @@ export class User {
 
   @UpdateDateColumn()
   updated_at: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deleted_at: Date | null;
 }


### PR DESCRIPTION

Implements a self-contained `AccountModule` that gives users the ability to (1) export all of their personal data as a downloadable JSON bundle and (2) permanently delete their account, anonymizing PII while preserving on-chain data integrity.

## Motivation

Users generate data across predictions, markets, competitions, notifications, leaderboard, and achievements with no way to retrieve or erase it. This is a standard legal/compliance requirement (GDPR Art. 15 & 17, CCPA) and was previously impossible.

## Changes

### New files

| File | Purpose |
|------|---------|
| `src/account/entities/data-export-job.entity.ts` | Tracks async export jobs (`pending → processing → ready \| failed`) with file path and expiry timestamp |
| `src/account/account.service.ts` | Core business logic — export queuing, async processing cron, account deletion transaction, expiry cleanup cron |
| `src/account/account.controller.ts` | JWT-protected REST endpoints for export and deletion |
| `src/account/account.module.ts` | NestJS module wiring |
| `src/migrations/1776300000000-AddDataExportJobAndUserSoftDelete.ts` | Adds `deleted_at` to `users`, creates `data_export_jobs` table with indexes |

### Modified files

| File | Change |
|------|--------|
| `src/users/entities/user.entity.ts` | Added `@DeleteDateColumn() deleted_at` — TypeORM automatically excludes soft-deleted users from all queries, invalidating their JWT immediately |
| `src/config/env.validation.ts` | Added optional `EXPORT_DIR` (default `./exports`) and `EXPORT_TTL_HOURS` (default `48`) |
| `src/app.module.ts` | Registered `AccountModule` |

## API Endpoints

All endpoints require a valid JWT (global `JwtAuthGuard` applies).

```
POST   /account/export                  → { jobId, status: "pending" }
GET    /account/export/:jobId           → { jobId, status, expires_at }
GET    /account/export/:jobId/download  → JSON file download (StreamableFile)
DELETE /account                         → 204 No Content
```

## How it works

### Data export (async)

1. `POST /account/export` creates a `DataExportJob` row and returns the job ID. If a pending or processing job already exists for the user it is returned instead (idempotent).
2. A `@Cron(EVERY_MINUTE)` worker picks up pending jobs in batches of 5. For each job it:
   - Gathers data in parallel from `predictions`, `markets`, `user_achievements`, `user_bookmarks`, `user_follows`, `competition_participants`, `leaderboard_history`, and `notifications`
   - Writes a `<jobId>.json` file to `EXPORT_DIR`
   - Updates the job to `ready` with an expiry timestamp (`now + EXPORT_TTL_HOURS`)
3. The client polls `GET /account/export/:jobId` until `status === "ready"`, then calls the download endpoint.
4. Ownership is enforced: `job.user_id !== userId` → 404. Expired files → 410 Gone.
5. A `@Cron(EVERY_DAY_AT_MIDNIGHT)` cleanup job deletes expired files from disk and removes their DB rows.

### Account deletion

`DELETE /account` runs a single database transaction that:

1. Reads the user's `stellar_address` (needed for address-indexed tables).
2. Collects export file paths for later disk cleanup.
3. Deletes `notifications` rows by `user_address`.
4. Deletes `notification_digest_state` rows by `user_id`.
5. Deletes all `data_export_jobs` for the user.
6. **Anonymizes** the user row: nulls `email`, `username`, `avatar_url`, `ban_reason`, `banned_at`, `banned_by` and sets `deleted_at = NOW()`.

After the transaction commits, export files are removed from disk.

`stellar_address` is intentionally preserved to maintain on-chain data integrity (predictions, market settlements). Setting `deleted_at` causes TypeORM's soft-delete filter to exclude the row from all subsequent queries, so the user's JWT immediately stops working — they cannot log in again.

## Environment variables

| Variable | Default | Description |
|----------|---------|-------------|
| `EXPORT_DIR` | `./exports` | Directory where JSON export files are written |
| `EXPORT_TTL_HOURS` | `48` | Hours before an export file expires and is cleaned up |

Both variables are optional; the service works out of the box without them.

## Acceptance criteria

- [x] `POST /account/export` returns a job ID; polling shows `pending → ready`
- [x] Export JSON bundle contains profile, predictions, markets, notifications, achievements, bookmarks, follows, competitions, leaderboard history
- [x] Export files expire after TTL; expired download returns **410 Gone**
- [x] `DELETE /account` anonymizes user, removes PII tables, user can no longer log in
- [x] A user cannot download another user's export — returns **404**
- [x] Cleanup cron deletes expired export files and DB rows daily
- [x] Migration adds `deleted_at` to `users` and creates `data_export_jobs` table


closes #1005 


