### PR TITLE
feat(auth): add API key authentication for third-party access

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -245,7 +245,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2102,7 +2101,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
       "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -2172,7 +2170,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2343,7 +2340,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2403,7 +2399,6 @@
       "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2467,7 +2462,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
       "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2489,7 +2483,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.27.tgz",
       "integrity": "sha512-xgpLzaIDGOCC6xOAtHnRAz8sqieFgGxxu3MN5ID026Jt6oeL3efp29N5QHhPr7UlqBfy/Jd02uj0POkZq6Au3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -2782,7 +2775,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
       "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -2796,7 +2788,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.27.tgz",
       "integrity": "sha512-X3OgJt9KgYTvt9D7sNz9SOj3A1daAHy7DZrYhM1pky8Fh+erlKQH5IQ/tKm+GaJKA5M0srBUr1CMqjak/qNxOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3158,7 +3149,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3293,7 +3283,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3473,7 +3462,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4181,7 +4169,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4231,7 +4218,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4467,7 +4453,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4821,7 +4806,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4919,7 +4903,6 @@
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
-      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -5061,7 +5044,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5109,15 +5091,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5939,7 +5919,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6000,7 +5979,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6242,7 +6220,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7406,7 +7383,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8333,7 +8309,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -9150,7 +9125,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9268,7 +9242,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9378,7 +9351,6 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -9410,7 +9382,6 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -9615,7 +9586,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9842,8 +9812,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9939,7 +9908,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10723,7 +10691,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11083,7 +11050,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11244,7 +11210,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -11427,7 +11392,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11801,6 +11765,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -11819,6 +11784,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -11832,6 +11798,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -11846,6 +11813,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11855,7 +11823,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -11863,6 +11832,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11873,6 +11843,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -11886,6 +11857,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/backend/src/account/account.service.ts
+++ b/backend/src/account/account.service.ts
@@ -22,7 +22,9 @@ export class AccountService {
     private readonly configService: ConfigService,
   ) {}
 
-  async requestExport(userId: string): Promise<{ jobId: string; status: string }> {
+  async requestExport(
+    userId: string,
+  ): Promise<{ jobId: string; status: string }> {
     const existing = await this.jobRepo.findOne({
       where: [
         { user_id: userId, status: 'pending' },
@@ -70,7 +72,10 @@ export class AccountService {
 
   @Cron(CronExpression.EVERY_MINUTE)
   async processExports(): Promise<void> {
-    const jobs = await this.jobRepo.find({ where: { status: 'pending' }, take: 5 });
+    const jobs = await this.jobRepo.find({
+      where: { status: 'pending' },
+      take: 5,
+    });
     for (const job of jobs) {
       await this.runExport(job).catch(() => {});
     }
@@ -96,7 +101,9 @@ export class AccountService {
     }
   }
 
-  private async gatherUserData(userId: string): Promise<Record<string, unknown>> {
+  private async gatherUserData(
+    userId: string,
+  ): Promise<Record<string, unknown>> {
     const [profile] = await this.dataSource.query(
       `SELECT id, stellar_address, username, avatar_url, email, role,
               total_predictions, correct_predictions, reputation_score,
@@ -116,22 +123,19 @@ export class AccountService {
       leaderboard,
       notifications,
     ] = await Promise.all([
-      this.dataSource.query(
-        `SELECT * FROM predictions WHERE "userId" = $1`,
-        [userId],
-      ),
-      this.dataSource.query(
-        `SELECT * FROM markets WHERE "creatorId" = $1`,
-        [userId],
-      ),
+      this.dataSource.query(`SELECT * FROM predictions WHERE "userId" = $1`, [
+        userId,
+      ]),
+      this.dataSource.query(`SELECT * FROM markets WHERE "creatorId" = $1`, [
+        userId,
+      ]),
       this.dataSource.query(
         `SELECT * FROM user_achievements WHERE "userId" = $1`,
         [userId],
       ),
-      this.dataSource.query(
-        `SELECT * FROM user_bookmarks WHERE user_id = $1`,
-        [userId],
-      ),
+      this.dataSource.query(`SELECT * FROM user_bookmarks WHERE user_id = $1`, [
+        userId,
+      ]),
       this.dataSource.query(
         `SELECT * FROM user_follows WHERE follower_id = $1 OR following_id = $1`,
         [userId],
@@ -185,20 +189,18 @@ export class AccountService {
       }
 
       // Delete address-indexed personal data
-      await manager.query(
-        `DELETE FROM notifications WHERE user_address = $1`,
-        [user.stellar_address],
-      );
+      await manager.query(`DELETE FROM notifications WHERE user_address = $1`, [
+        user.stellar_address,
+      ]);
       await manager.query(
         `DELETE FROM notification_digest_state WHERE user_id = $1`,
         [userId],
       );
 
       // Remove pending export records
-      await manager.query(
-        `DELETE FROM data_export_jobs WHERE user_id = $1`,
-        [userId],
-      );
+      await manager.query(`DELETE FROM data_export_jobs WHERE user_id = $1`, [
+        userId,
+      ]);
 
       // Anonymize PII and soft-delete (sets deleted_at so JWT validate returns null)
       await manager.query(

--- a/backend/src/auth/api-key.controller.ts
+++ b/backend/src/auth/api-key.controller.ts
@@ -1,0 +1,95 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ApiKeyService } from './api-key.service';
+import { CreateApiKeyDto } from './dto/create-api-key.dto';
+import {
+  ApiKeyCreatedResponseDto,
+  ApiKeyListItemDto,
+} from './dto/api-key-response.dto';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+
+@ApiTags('API Keys')
+@ApiBearerAuth()
+@Controller('auth/api-keys')
+export class ApiKeyController {
+  constructor(private readonly apiKeyService: ApiKeyService) {}
+
+  /**
+   * Create a new API key.
+   * The raw key is returned exactly once — store it securely, it cannot be retrieved again.
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create an API key',
+    description:
+      'Issues a new scoped API key. The raw key is shown once and cannot be retrieved again.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Key created — raw key shown once',
+    type: ApiKeyCreatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  create(
+    @CurrentUser() user: User,
+    @Body() dto: CreateApiKeyDto,
+  ): Promise<ApiKeyCreatedResponseDto> {
+    return this.apiKeyService.create(user.id, dto);
+  }
+
+  /**
+   * List all API keys belonging to the authenticated user.
+   * Never includes hashes or raw keys.
+   */
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "List the caller's API keys" })
+  @ApiResponse({
+    status: 200,
+    description: 'Array of API key summaries (no secrets)',
+    type: [ApiKeyListItemDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  list(@CurrentUser() user: User): Promise<ApiKeyListItemDto[]> {
+    return this.apiKeyService.listForUser(user.id);
+  }
+
+  /**
+   * Revoke an API key by ID.
+   * Only the key's owner may revoke it.
+   */
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Revoke an API key' })
+  @ApiResponse({
+    status: 200,
+    description: 'Key successfully revoked',
+    type: ApiKeyListItemDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Key already revoked' })
+  @ApiResponse({ status: 404, description: 'Key not found' })
+  revoke(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ApiKeyListItemDto> {
+    return this.apiKeyService.revoke(id, user.id);
+  }
+}

--- a/backend/src/auth/api-key.service.ts
+++ b/backend/src/auth/api-key.service.ts
@@ -1,0 +1,196 @@
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+  ForbiddenException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { randomBytes } from 'crypto';
+import * as bcrypt from 'bcrypt';
+import { ApiKey } from './entities/api-key.entity';
+import { CreateApiKeyDto } from './dto/create-api-key.dto';
+import {
+  ApiKeyCreatedResponseDto,
+  ApiKeyListItemDto,
+} from './dto/api-key-response.dto';
+
+/** Throttle window for last_used_at writes (60 seconds) */
+const LAST_USED_THROTTLE_MS = 60_000;
+
+/** bcrypt cost factor */
+const BCRYPT_ROUNDS = 10;
+
+/** Raw key prefix — makes keys identifiable in logs */
+const KEY_PREFIX = 'ia_';
+
+@Injectable()
+export class ApiKeyService {
+  private readonly logger = new Logger(ApiKeyService.name);
+
+  constructor(
+    @InjectRepository(ApiKey)
+    private readonly apiKeyRepository: Repository<ApiKey>,
+  ) {}
+
+  /**
+   * Create a new API key for the given user.
+   * The raw key is returned ONCE and never stored — only its bcrypt hash is persisted.
+   */
+  async create(
+    userId: string,
+    dto: CreateApiKeyDto,
+  ): Promise<ApiKeyCreatedResponseDto> {
+    const rawKey = `${KEY_PREFIX}${randomBytes(32).toString('hex')}`;
+    const key_prefix = rawKey.slice(0, 10); // 'ia_' + first 7 hex chars
+    const key_hash = await bcrypt.hash(rawKey, BCRYPT_ROUNDS);
+
+    const apiKey = this.apiKeyRepository.create({
+      userId,
+      name: dto.name,
+      key_prefix,
+      key_hash,
+      scopes: dto.scopes,
+      expires_at: dto.expires_at ? new Date(dto.expires_at) : null,
+      revoked_at: null,
+      last_used_at: null,
+    });
+
+    const saved = await this.apiKeyRepository.save(apiKey);
+
+    this.logger.log(`API key created: id=${saved.id} userId=${userId}`);
+
+    return {
+      id: saved.id,
+      name: saved.name,
+      key: rawKey,
+      key_prefix: saved.key_prefix,
+      scopes: saved.scopes,
+      expires_at: saved.expires_at,
+      created_at: saved.created_at,
+    };
+  }
+
+  /** List all (non-deleted) keys belonging to a user — never includes hashes. */
+  async listForUser(userId: string): Promise<ApiKeyListItemDto[]> {
+    const keys = await this.apiKeyRepository.find({
+      where: { userId },
+      order: { created_at: 'DESC' },
+    });
+
+    return keys.map((k) => this.toListItem(k));
+  }
+
+  /**
+   * Revoke a key owned by userId.
+   * Throws NotFoundException if the key doesn't exist or doesn't belong to the user.
+   * Throws ForbiddenException if the key is already revoked.
+   */
+  async revoke(id: string, userId: string): Promise<ApiKeyListItemDto> {
+    const apiKey = await this.apiKeyRepository.findOne({
+      where: { id, userId },
+    });
+
+    if (!apiKey) {
+      throw new NotFoundException('API key not found');
+    }
+
+    if (apiKey.revoked_at) {
+      throw new ForbiddenException('API key is already revoked');
+    }
+
+    apiKey.revoked_at = new Date();
+    const saved = await this.apiKeyRepository.save(apiKey);
+
+    this.logger.log(`API key revoked: id=${id} userId=${userId}`);
+
+    return this.toListItem(saved);
+  }
+
+  /**
+   * Validate a raw key sent via X-API-Key header.
+   * Returns the matching ApiKey entity (with user relation) if valid.
+   * Throws UnauthorizedException for all failure cases (to avoid leaking info).
+   */
+  async validateKey(rawKey: string): Promise<ApiKey> {
+    if (!rawKey?.startsWith(KEY_PREFIX)) {
+      throw new UnauthorizedException('Invalid API key format');
+    }
+
+    const prefix = rawKey.slice(0, 10);
+
+    // Narrow the candidate set by prefix before the expensive bcrypt compare
+    const candidates = await this.apiKeyRepository.find({
+      where: { key_prefix: prefix },
+      relations: ['user'],
+    });
+
+    if (!candidates.length) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    let matched: ApiKey | null = null;
+    for (const candidate of candidates) {
+      const valid = await bcrypt.compare(rawKey, candidate.key_hash);
+      if (valid) {
+        matched = candidate;
+        break;
+      }
+    }
+
+    if (!matched) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    if (matched.revoked_at) {
+      throw new UnauthorizedException('API key has been revoked');
+    }
+
+    if (matched.expires_at && matched.expires_at < new Date()) {
+      throw new UnauthorizedException('API key has expired');
+    }
+
+    return matched;
+  }
+
+  /**
+   * Throttled update of last_used_at.
+   * Only writes to the DB if more than LAST_USED_THROTTLE_MS has elapsed
+   * since the last recorded use — avoids a DB write on every single request.
+   * Fire-and-forget: errors are logged but not propagated.
+   */
+  touchLastUsed(apiKey: ApiKey): void {
+    const now = Date.now();
+    const last = apiKey.last_used_at?.getTime() ?? 0;
+
+    if (now - last < LAST_USED_THROTTLE_MS) {
+      return; // skip — within throttle window
+    }
+
+    this.apiKeyRepository
+      .update(apiKey.id, { last_used_at: new Date() })
+      .catch((err: unknown) =>
+        this.logger.error(
+          `Failed to update last_used_at for key ${apiKey.id}: ${String(err)}`,
+        ),
+      );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private toListItem(k: ApiKey): ApiKeyListItemDto {
+    return {
+      id: k.id,
+      name: k.name,
+      key_prefix: k.key_prefix,
+      scopes: k.scopes,
+      expires_at: k.expires_at,
+      last_used_at: k.last_used_at,
+      revoked_at: k.revoked_at,
+      created_at: k.created_at,
+    };
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,12 +8,15 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { RateLimitService } from './rate-limit.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { ApiKey } from './entities/api-key.entity';
+import { ApiKeyService } from './api-key.service';
+import { ApiKeyController } from './api-key.controller';
 
 @Module({
   imports: [
     PassportModule,
     ConfigModule,
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([User, ApiKey]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -25,8 +28,8 @@ import { JwtStrategy } from './strategies/jwt.strategy';
       }),
     }),
   ],
-  controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, RateLimitService],
-  exports: [AuthService, JwtModule],
+  controllers: [AuthController, ApiKeyController],
+  providers: [AuthService, ApiKeyService, JwtStrategy, RateLimitService],
+  exports: [AuthService, ApiKeyService, JwtModule],
 })
 export class AuthModule {}

--- a/backend/src/auth/dto/api-key-response.dto.ts
+++ b/backend/src/auth/dto/api-key-response.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Returned only at creation time — includes the raw key (shown once).
+ */
+export class ApiKeyCreatedResponseDto {
+  @ApiProperty({ example: 'a1b2c3d4-...' })
+  id: string;
+
+  @ApiProperty({ example: 'My Bot Key' })
+  name: string;
+
+  @ApiProperty({
+    example:
+      'ia_4f9a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f',
+    description:
+      'Full raw key — shown ONCE at creation, never retrievable again',
+  })
+  key: string;
+
+  @ApiProperty({
+    example: 'ia_4f9a1b',
+    description: 'First 8-char prefix for display',
+  })
+  key_prefix: string;
+
+  @ApiProperty({ example: ['predictions:read'] })
+  scopes: string[];
+
+  @ApiPropertyOptional({ example: '2027-01-01T00:00:00.000Z', nullable: true })
+  expires_at: Date | null;
+
+  @ApiProperty()
+  created_at: Date;
+}
+
+/**
+ * Returned by list / revoke — never includes the raw key or hash.
+ */
+export class ApiKeyListItemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ example: 'ia_4f9a1b' })
+  key_prefix: string;
+
+  @ApiProperty({ example: ['predictions:read'] })
+  scopes: string[];
+
+  @ApiPropertyOptional({ nullable: true })
+  expires_at: Date | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  last_used_at: Date | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  revoked_at: Date | null;
+
+  @ApiProperty()
+  created_at: Date;
+}

--- a/backend/src/auth/dto/create-api-key.dto.ts
+++ b/backend/src/auth/dto/create-api-key.dto.ts
@@ -1,0 +1,34 @@
+import {
+  IsArray,
+  IsDateString,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateApiKeyDto {
+  @ApiProperty({ example: 'My Bot Key', maxLength: 100 })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    example: ['predictions:read', 'markets:read'],
+    description: 'List of scopes this key is permitted to use',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  scopes: string[];
+
+  @ApiPropertyOptional({
+    example: '2027-01-01T00:00:00.000Z',
+    description: 'Optional ISO-8601 expiry date; omit for a non-expiring key',
+  })
+  @IsOptional()
+  @IsDateString()
+  expires_at?: string;
+}

--- a/backend/src/auth/entities/api-key.entity.ts
+++ b/backend/src/auth/entities/api-key.entity.ts
@@ -1,0 +1,77 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('api_keys')
+export class ApiKey {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  /** Human-readable label set by the owner */
+  @Column({ type: 'varchar', length: 100 })
+  name: string;
+
+  /** First 8 chars of the raw key — safe to display, not secret */
+  @Index()
+  @Column({ name: 'key_prefix', type: 'varchar', length: 12 })
+  key_prefix: string;
+
+  /** bcrypt hash of the full raw key — never exposed via API */
+  @Column({ name: 'key_hash', type: 'varchar' })
+  key_hash: string;
+
+  /**
+   * Scopes this key is authorised to access.
+   * Stored as a Postgres text[] column.
+   * Example values: 'predictions:read', 'markets:read', 'webhooks:write'
+   */
+  @Column({ type: 'text', array: true, default: () => "'{}'::text[]" })
+  scopes: string[];
+
+  /** Optional expiry date — null means the key never expires */
+  @Column({ name: 'expires_at', type: 'timestamptz', nullable: true })
+  expires_at: Date | null;
+
+  /**
+   * Set when the owner explicitly revokes the key.
+   * A non-null value means the key is revoked.
+   */
+  @Column({ name: 'revoked_at', type: 'timestamptz', nullable: true })
+  revoked_at: Date | null;
+
+  /**
+   * Throttled write — updated at most once every 60 s per guard request.
+   * Avoids a DB write on every single authenticated request.
+   */
+  @Column({ name: 'last_used_at', type: 'timestamptz', nullable: true })
+  last_used_at: Date | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updated_at: Date;
+
+  /** Convenience getter: true when the key is currently usable */
+  get isActive(): boolean {
+    if (this.revoked_at) return false;
+    if (this.expires_at && this.expires_at < new Date()) return false;
+    return true;
+  }
+}

--- a/backend/src/common/decorators/scopes.decorator.ts
+++ b/backend/src/common/decorators/scopes.decorator.ts
@@ -1,0 +1,22 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Metadata key used by ApiKeyGuard to read required scopes.
+ * Usage:  @Scopes('predictions:read', 'markets:write')
+ */
+export const SCOPES_KEY = 'scopes';
+
+/**
+ * Decorator that declares which API-key scopes are required to access
+ * a route or controller. Mirrors the pattern of @Roles().
+ *
+ * When applied, ApiKeyGuard will return 403 if the presenting key does
+ * not include every listed scope.
+ *
+ * @example
+ * @UseGuards(ApiKeyGuard)
+ * @Scopes('predictions:read')
+ * @Get()
+ * findAll() { ... }
+ */
+export const Scopes = (...scopes: string[]) => SetMetadata(SCOPES_KEY, scopes);

--- a/backend/src/common/guards/api-key.guard.ts
+++ b/backend/src/common/guards/api-key.guard.ts
@@ -1,0 +1,66 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { Request } from 'express';
+import { ApiKey } from '../../auth/entities/api-key.entity';
+import { ApiKeyService } from '../../auth/api-key.service';
+import { SCOPES_KEY } from '../decorators/scopes.decorator';
+
+interface ApiKeyRequest extends Request {
+  // other guards (JwtAuthGuard) populate request.user.
+  // Keep it permissive to satisfy TS Request typing.
+  user?: any;
+  apiKey?: ApiKey;
+}
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(
+    private readonly apiKeyService: ApiKeyService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<ApiKeyRequest>();
+
+    const rawKey = request.headers['x-api-key'];
+
+    if (!rawKey || typeof rawKey !== 'string') {
+      throw new UnauthorizedException('X-API-Key header is required');
+    }
+
+    // Throws 401 if key is invalid, revoked, or expired
+    const apiKey = await this.apiKeyService.validateKey(rawKey);
+
+    // Populate request.user from the key's owner (mirrors JWT guard behaviour)
+    request.user = apiKey.user;
+    request.apiKey = apiKey;
+
+    // Scope enforcement — returns 403 when key lacks a required scope
+    const requiredScopes = this.reflector.getAllAndOverride<string[]>(
+      SCOPES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (requiredScopes && requiredScopes.length > 0) {
+      const missing = requiredScopes.filter(
+        (scope) => !apiKey.scopes.includes(scope),
+      );
+      if (missing.length > 0) {
+        throw new ForbiddenException(
+          `API key missing required scope(s): ${missing.join(', ')}`,
+        );
+      }
+    }
+
+    // Throttled last_used_at update — fire-and-forget, never blocks the request
+    this.apiKeyService.touchLastUsed(apiKey);
+
+    return true;
+  }
+}

--- a/backend/src/migrations/1776200000000-AddSearchVectors.ts
+++ b/backend/src/migrations/1776200000000-AddSearchVectors.ts
@@ -50,14 +50,22 @@ export class AddSearchVectors1776200000000 implements MigrationInterface {
   public async down(queryRunner: QueryRunner): Promise<void> {
     // markets
     await queryRunner.query(`DROP INDEX IF EXISTS "IDX_markets_search_vector"`);
-    await queryRunner.query(`ALTER TABLE "markets" DROP COLUMN IF EXISTS "search_vector"`);
+    await queryRunner.query(
+      `ALTER TABLE "markets" DROP COLUMN IF EXISTS "search_vector"`,
+    );
 
     // users
     await queryRunner.query(`DROP INDEX IF EXISTS "IDX_users_search_vector"`);
-    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "search_vector"`);
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN IF EXISTS "search_vector"`,
+    );
 
     // competitions
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_competitions_search_vector"`);
-    await queryRunner.query(`ALTER TABLE "competitions" DROP COLUMN IF EXISTS "search_vector"`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_competitions_search_vector"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "competitions" DROP COLUMN IF EXISTS "search_vector"`,
+    );
   }
 }

--- a/backend/src/migrations/1776300000000-AddDataExportJobAndUserSoftDelete.ts
+++ b/backend/src/migrations/1776300000000-AddDataExportJobAndUserSoftDelete.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddDataExportJobAndUserSoftDelete1776300000000
-  implements MigrationInterface
-{
+export class AddDataExportJobAndUserSoftDelete1776300000000 implements MigrationInterface {
   name = 'AddDataExportJobAndUserSoftDelete1776300000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
@@ -46,8 +44,6 @@ export class AddDataExportJobAndUserSoftDelete1776300000000
       `DROP INDEX IF EXISTS "public"."IDX_data_export_jobs_user_id"`,
     );
     await queryRunner.query(`DROP TABLE "data_export_jobs"`);
-    await queryRunner.query(
-      `ALTER TABLE "users" DROP COLUMN "deleted_at"`,
-    );
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "deleted_at"`);
   }
 }

--- a/backend/src/migrations/1776400000000-CreateApiKeys.ts
+++ b/backend/src/migrations/1776400000000-CreateApiKeys.ts
@@ -1,0 +1,152 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateApiKeys1776400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'api_keys',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'userId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '100',
+            isNullable: false,
+          },
+          {
+            // First 10 chars of the raw key (e.g. 'ia_4f9a1b')
+            // — safe to store and display, not a secret
+            name: 'key_prefix',
+            type: 'varchar',
+            length: '12',
+            isNullable: false,
+          },
+          {
+            // bcrypt hash of the full raw key — never exposed via API
+            name: 'key_hash',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            // Postgres text[] — e.g. {'predictions:read','markets:read'}
+            name: 'scopes',
+            type: 'text',
+            isArray: true,
+            default: "'{}'",
+            isNullable: false,
+          },
+          {
+            name: 'expires_at',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'revoked_at',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'last_used_at',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // --- Indexes -----------------------------------------------------------
+
+    // Look up all keys belonging to a user
+    await queryRunner.createIndex(
+      'api_keys',
+      new TableIndex({
+        name: 'IDX_ak_user_id',
+        columnNames: ['userId'],
+      }),
+    );
+
+    // Narrow bcrypt candidates by prefix (guard hot path)
+    await queryRunner.createIndex(
+      'api_keys',
+      new TableIndex({
+        name: 'IDX_ak_key_prefix',
+        columnNames: ['key_prefix'],
+      }),
+    );
+
+    // Filter active (non-revoked) keys
+    await queryRunner.createIndex(
+      'api_keys',
+      new TableIndex({
+        name: 'IDX_ak_revoked_at',
+        columnNames: ['revoked_at'],
+      }),
+    );
+
+    // Filter non-expired keys
+    await queryRunner.createIndex(
+      'api_keys',
+      new TableIndex({
+        name: 'IDX_ak_expires_at',
+        columnNames: ['expires_at'],
+      }),
+    );
+
+    // Composite: user's active keys (list endpoint)
+    await queryRunner.createIndex(
+      'api_keys',
+      new TableIndex({
+        name: 'IDX_ak_user_revoked',
+        columnNames: ['userId', 'revoked_at'],
+      }),
+    );
+
+    // --- Foreign key -------------------------------------------------------
+
+    await queryRunner.createForeignKey(
+      'api_keys',
+      new TableForeignKey({
+        name: 'FK_ak_user',
+        columnNames: ['userId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('api_keys', 'FK_ak_user');
+    await queryRunner.dropTable('api_keys');
+  }
+}

--- a/backend/src/notifications/email-templates.ts
+++ b/backend/src/notifications/email-templates.ts
@@ -97,7 +97,8 @@ export function renderEmailTemplate(
         .map((item) => `• ${item.title}: ${item.message}`)
         .join('\n');
       return {
-        subject: `Your ${freq} InsightArena digest — ${context.digestPeriod ?? ''}`.trimEnd(),
+        subject:
+          `Your ${freq} InsightArena digest — ${context.digestPeriod ?? ''}`.trimEnd(),
         html: wrapHtml(
           `${freq} Activity Digest`,
           `<p>Here's a summary of your recent activity on InsightArena:</p>

--- a/backend/src/search/search.service.spec.ts
+++ b/backend/src/search/search.service.spec.ts
@@ -4,7 +4,10 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { SelectQueryBuilder } from 'typeorm';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
-import { Competition, CompetitionVisibility } from '../competitions/entities/competition.entity';
+import {
+  Competition,
+  CompetitionVisibility,
+} from '../competitions/entities/competition.entity';
 import { SearchService } from './search.service';
 import { GlobalSearchDto, SearchType } from './dto/global-search.dto';
 
@@ -104,7 +107,12 @@ describe('SearchService', () => {
 
   describe('search()', () => {
     it('returns all three entity types for SearchType.All', async () => {
-      const dto: GlobalSearchDto = { query: 'bitcoin', type: SearchType.All, page: 1, limit: 20 };
+      const dto: GlobalSearchDto = {
+        query: 'bitcoin',
+        type: SearchType.All,
+        page: 1,
+        limit: 20,
+      };
       const result = await service.search(dto);
 
       expect(result.markets).toEqual([mockMarket]);
@@ -116,7 +124,12 @@ describe('SearchService', () => {
     });
 
     it('returns only markets when type is Markets', async () => {
-      const dto: GlobalSearchDto = { query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 };
+      const dto: GlobalSearchDto = {
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      };
       const result = await service.search(dto);
 
       expect(result.markets).toEqual([mockMarket]);
@@ -125,14 +138,24 @@ describe('SearchService', () => {
     });
 
     it('caps limit at 50', async () => {
-      const dto: GlobalSearchDto = { query: 'test', type: SearchType.Markets, page: 1, limit: 999 };
+      const dto: GlobalSearchDto = {
+        query: 'test',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 999,
+      };
       await service.search(dto);
 
       expect(marketQb.take).toHaveBeenCalledWith(50);
     });
 
     it('computes correct skip for page 3 limit 10', async () => {
-      const dto: GlobalSearchDto = { query: 'test', type: SearchType.Markets, page: 3, limit: 10 };
+      const dto: GlobalSearchDto = {
+        query: 'test',
+        type: SearchType.Markets,
+        page: 3,
+        limit: 10,
+      };
       await service.search(dto);
 
       expect(marketQb.skip).toHaveBeenCalledWith(20);
@@ -142,7 +165,12 @@ describe('SearchService', () => {
 
   describe('searchMarkets FTS', () => {
     it('filters by is_public = true', async () => {
-      await service.search({ query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 });
+      await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
 
       expect(marketQb.where).toHaveBeenCalledWith(
         'market.is_public = :isPublic',
@@ -151,7 +179,12 @@ describe('SearchService', () => {
     });
 
     it('matches via search_vector @@ plainto_tsquery', async () => {
-      await service.search({ query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 });
+      await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
 
       expect(marketQb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining('search_vector @@'),
@@ -160,7 +193,12 @@ describe('SearchService', () => {
     });
 
     it('orders by ts_rank DESC', async () => {
-      await service.search({ query: 'bitcoin', type: SearchType.Markets, page: 1, limit: 20 });
+      await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
 
       expect(marketQb.orderBy).toHaveBeenCalledWith(
         expect.stringContaining('ts_rank'),
@@ -171,16 +209,25 @@ describe('SearchService', () => {
 
   describe('searchUsers FTS', () => {
     it('filters out banned users', async () => {
-      await service.search({ query: 'alice', type: SearchType.Users, page: 1, limit: 20 });
+      await service.search({
+        query: 'alice',
+        type: SearchType.Users,
+        page: 1,
+        limit: 20,
+      });
 
-      expect(userQb.where).toHaveBeenCalledWith(
-        'user.is_banned = :banned',
-        { banned: false },
-      );
+      expect(userQb.where).toHaveBeenCalledWith('user.is_banned = :banned', {
+        banned: false,
+      });
     });
 
     it('matches via search_vector @@ plainto_tsquery', async () => {
-      await service.search({ query: 'alice', type: SearchType.Users, page: 1, limit: 20 });
+      await service.search({
+        query: 'alice',
+        type: SearchType.Users,
+        page: 1,
+        limit: 20,
+      });
 
       expect(userQb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining('search_vector @@'),
@@ -189,7 +236,12 @@ describe('SearchService', () => {
     });
 
     it('orders by ts_rank DESC', async () => {
-      await service.search({ query: 'alice', type: SearchType.Users, page: 1, limit: 20 });
+      await service.search({
+        query: 'alice',
+        type: SearchType.Users,
+        page: 1,
+        limit: 20,
+      });
 
       expect(userQb.orderBy).toHaveBeenCalledWith(
         expect.stringContaining('ts_rank'),
@@ -200,7 +252,12 @@ describe('SearchService', () => {
 
   describe('searchCompetitions FTS', () => {
     it('filters by visibility = public', async () => {
-      await service.search({ query: 'league', type: SearchType.Competitions, page: 1, limit: 20 });
+      await service.search({
+        query: 'league',
+        type: SearchType.Competitions,
+        page: 1,
+        limit: 20,
+      });
 
       expect(competitionQb.where).toHaveBeenCalledWith(
         'competition.visibility = :visibility',
@@ -209,7 +266,12 @@ describe('SearchService', () => {
     });
 
     it('matches via search_vector @@ plainto_tsquery', async () => {
-      await service.search({ query: 'league', type: SearchType.Competitions, page: 1, limit: 20 });
+      await service.search({
+        query: 'league',
+        type: SearchType.Competitions,
+        page: 1,
+        limit: 20,
+      });
 
       expect(competitionQb.andWhere).toHaveBeenCalledWith(
         expect.stringContaining('search_vector @@'),
@@ -218,7 +280,12 @@ describe('SearchService', () => {
     });
 
     it('orders by ts_rank DESC', async () => {
-      await service.search({ query: 'league', type: SearchType.Competitions, page: 1, limit: 20 });
+      await service.search({
+        query: 'league',
+        type: SearchType.Competitions,
+        page: 1,
+        limit: 20,
+      });
 
       expect(competitionQb.orderBy).toHaveBeenCalledWith(
         expect.stringContaining('ts_rank'),

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -66,10 +66,9 @@ export class SearchService {
         'market.created_at',
       ])
       .where('market.is_public = :isPublic', { isPublic: true })
-      .andWhere(
-        `market.search_vector @@ plainto_tsquery('english', :query)`,
-        { query },
-      )
+      .andWhere(`market.search_vector @@ plainto_tsquery('english', :query)`, {
+        query,
+      })
       .orderBy(
         `ts_rank(market.search_vector, plainto_tsquery('english', :query))`,
         'DESC',
@@ -95,10 +94,9 @@ export class SearchService {
         'user.total_predictions',
       ])
       .where('user.is_banned = :banned', { banned: false })
-      .andWhere(
-        `user.search_vector @@ plainto_tsquery('simple', :query)`,
-        { query },
-      )
+      .andWhere(`user.search_vector @@ plainto_tsquery('simple', :query)`, {
+        query,
+      })
       .orderBy(
         `ts_rank(user.search_vector, plainto_tsquery('simple', :query))`,
         'DESC',

--- a/backend/src/webhooks/webhooks.controller.ts
+++ b/backend/src/webhooks/webhooks.controller.ts
@@ -10,7 +10,11 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { ApiKeyGuard } from '../common/guards/api-key.guard';
+import { Scopes } from '../common/decorators/scopes.decorator';
+
 import { WebhooksService } from './services/webhooks.service';
+
 import { WebhookEndpoint } from './entities/webhook-endpoint.entity';
 import { WebhookDeliveryLog } from './entities/webhook-delivery-log.entity';
 import { CreateWebhookEndpointDto } from './dto/create-webhook-endpoint.dto';
@@ -19,11 +23,12 @@ import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { User } from '../users/entities/user.entity';
 
 @Controller('webhooks')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, ApiKeyGuard)
 export class WebhooksController {
   constructor(private readonly webhooksService: WebhooksService) {}
 
   @Post('endpoints')
+  @Scopes('webhooks:write')
   async createEndpoint(
     @CurrentUser() user: User,
     @Body() dto: CreateWebhookEndpointDto,
@@ -32,11 +37,13 @@ export class WebhooksController {
   }
 
   @Get('endpoints')
+  @Scopes('webhooks:read')
   async listEndpoints(@CurrentUser() user: User): Promise<WebhookEndpoint[]> {
     return this.webhooksService.listEndpoints(user.id);
   }
 
   @Get('endpoints/:id')
+  @Scopes('webhooks:read')
   async getEndpoint(
     @CurrentUser() user: User,
     @Param('id') id: string,
@@ -45,6 +52,7 @@ export class WebhooksController {
   }
 
   @Patch('endpoints/:id')
+  @Scopes('webhooks:write')
   async updateEndpoint(
     @CurrentUser() user: User,
     @Param('id') id: string,
@@ -54,6 +62,7 @@ export class WebhooksController {
   }
 
   @Delete('endpoints/:id')
+  @Scopes('webhooks:write')
   async deleteEndpoint(
     @CurrentUser() user: User,
     @Param('id') id: string,
@@ -62,6 +71,7 @@ export class WebhooksController {
   }
 
   @Get('endpoints/:id/deliveries')
+  @Scopes('webhooks:read')
   async getDeliveryLogs(
     @CurrentUser() user: User,
     @Param('id') id: string,


### PR DESCRIPTION

- Add ApiKey entity to support securely stored hashed API keys with scopes,
  expiration dates, revocation status, and usage tracking
- Implement ApiKeyService for generating, hashing, validating, and managing
  API keys throughout their lifecycle
- Add ApiKeyGuard to authenticate requests using the X-API-Key header while
  attaching authenticated key information to request.user
- Create JWT-protected API key controller endpoints for issuing and managing
  third-party credentials
- Add scope-based authorization using the @Scopes() decorator and enforce
  permission checks for API key requests
- Add migration to create and manage the api_keys database table
- Register API key components in the auth module
- Add throttled last_used_at updates to prevent unnecessary database writes
  on frequent API requests
- Ensure revoked or expired API keys are rejected with proper authentication
  errors

This introduces secure long-lived credentials for server-to-server integrations
while keeping the existing JWT authentication flow unchanged.

closes #1002 