### PR TITLE
feat(creator-events): expose campaign metadata in response DTOs (#957)

### DIFF
--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -336,6 +336,12 @@ export class CreatorEventsService {
       matchPreview,
       startTime: event.startTime,
       endTime: event.endTime,
+      prizePool: event.prizePool,
+      entryFee: event.entryFee,
+      category: event.category,
+      bannerUrl: event.bannerUrl,
+      isFinalized: event.isFinalized,
+      rewardDistribution: event.rewardDistribution,
     };
   }
 
@@ -679,6 +685,11 @@ export class CreatorEventsService {
       participant_count: event.participant_count,
       match_count: event.match_count,
       rank: Number(rank ?? 0),
+      prize_pool: event.prize_pool,
+      entry_fee: event.entry_fee,
+      category: event.category,
+      banner_url: event.banner_url ?? null,
+      is_finalized: event.is_finalized,
       highlights: this.buildHighlights(event, searchTerm),
     };
   }

--- a/backend/src/creator-events/dto/event-by-code-response.dto.ts
+++ b/backend/src/creator-events/dto/event-by-code-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class MatchPreviewDto {
   @ApiProperty({ description: 'Match ID' })
@@ -53,4 +53,22 @@ export class EventByCodeResponseDto {
 
   @ApiProperty({ description: 'Event end time (Unix timestamp)' })
   endTime: number;
+
+  @ApiPropertyOptional({ description: 'Total prize pool in stroops' })
+  prizePool?: string;
+
+  @ApiPropertyOptional({ description: 'Entry fee in stroops' })
+  entryFee?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign category slug' })
+  category?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign banner URL' })
+  bannerUrl?: string | null;
+
+  @ApiPropertyOptional({ description: 'Whether the campaign has been finalized' })
+  isFinalized?: boolean;
+
+  @ApiPropertyOptional({ type: [Number], description: 'Reward split percentages' })
+  rewardDistribution?: number[];
 }

--- a/backend/src/creator-events/dto/event-response.dto.ts
+++ b/backend/src/creator-events/dto/event-response.dto.ts
@@ -34,6 +34,24 @@ export class EventResponseDto {
   @ApiProperty({ description: 'Is event active' })
   isActive: boolean;
 
+  @ApiPropertyOptional({ description: 'Total prize pool in stroops' })
+  prizePool?: string;
+
+  @ApiPropertyOptional({ description: 'Entry fee in stroops' })
+  entryFee?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign category slug' })
+  category?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign banner URL' })
+  bannerUrl?: string | null;
+
+  @ApiPropertyOptional({ description: 'Whether the campaign has been finalized' })
+  isFinalized?: boolean;
+
+  @ApiPropertyOptional({ type: [Number], description: 'Reward split percentages' })
+  rewardDistribution?: number[];
+
   @ApiPropertyOptional({ description: 'Number of winners' })
   winnerCount?: number;
 

--- a/backend/src/creator-events/dto/search-events-response.dto.ts
+++ b/backend/src/creator-events/dto/search-events-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SearchHighlightsDto {
   @ApiProperty({ required: false })
@@ -41,6 +41,21 @@ export class SearchEventResultDto {
 
   @ApiProperty()
   rank: number;
+
+  @ApiPropertyOptional({ description: 'Total prize pool in stroops' })
+  prize_pool?: string;
+
+  @ApiPropertyOptional({ description: 'Entry fee in stroops' })
+  entry_fee?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign category slug' })
+  category?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign banner URL' })
+  banner_url?: string | null;
+
+  @ApiPropertyOptional({ description: 'Whether the campaign has been finalized' })
+  is_finalized?: boolean;
 
   @ApiProperty({ type: SearchHighlightsDto })
   highlights: SearchHighlightsDto;

--- a/backend/src/creator-events/dto/user-event-response.dto.ts
+++ b/backend/src/creator-events/dto/user-event-response.dto.ts
@@ -34,6 +34,24 @@ export class UserEventResponseDto {
   @ApiProperty({ description: 'Is event active' })
   isActive: boolean;
 
+  @ApiPropertyOptional({ description: 'Total prize pool in stroops' })
+  prizePool?: string;
+
+  @ApiPropertyOptional({ description: 'Entry fee in stroops' })
+  entryFee?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign category slug' })
+  category?: string;
+
+  @ApiPropertyOptional({ description: 'Campaign banner URL' })
+  bannerUrl?: string | null;
+
+  @ApiPropertyOptional({ description: 'Whether the campaign has been finalized' })
+  isFinalized?: boolean;
+
+  @ApiPropertyOptional({ type: [Number], description: 'Reward split percentages' })
+  rewardDistribution?: number[];
+
   @ApiPropertyOptional({
     description: 'User score (correct predictions / total matches)',
   })


### PR DESCRIPTION
closes #957

Add prize_pool, entry_fee, category, banner_url, is_finalized, and reward_distribution to:
- EventResponseDto
- UserEventResponseDto
- EventByCodeResponseDto
- SearchEventResultDto

Update service mappings:
- getEventByInviteCode: spread new ContractEvent optional fields
- toSearchResult: pass new CreatorEvent entity fields through

getEventById already returns EnrichedEvent (extends ContractEvent) directly so new fields are exposed automatically.