### PR TITLE
Add admin transfer and resolution time boundary tests

### DIFF
--- a/contracts/open-market/tests/config_tests.rs
+++ b/contracts/open-market/tests/config_tests.rs
@@ -1,7 +1,7 @@
 use insightarena_contract::config;
 use insightarena_contract::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
-use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, Env};
+use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::{Address, Env, IntoVal};
 
 fn deploy(env: &Env) -> InsightArenaContractClient<'_> {
     let id = env.register(InsightArenaContract, ());
@@ -130,4 +130,62 @@ fn test_config_update_unauthorized() {
     client.initialize(&admin, &oracle, &200_u32, &register_token(&env));
 
     let _ = env.as_contract(&client.address, || config::set_paused(&env, true));
+}
+
+#[test]
+fn transfer_admin_revokes_old_admin_privileges() {
+    let env = Env::default();
+    let client = deploy(&env);
+    let admin_a = Address::generate(&env);
+    let admin_b = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin_a, &oracle, &200_u32, &register_token(&env));
+
+    env.mock_auths(&[MockAuth {
+        address: &admin_a,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "transfer_admin",
+            args: (admin_b.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.transfer_admin(&admin_b);
+    assert_eq!(client.get_config().admin, admin_b);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin_a,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "update_protocol_fee",
+            args: (300_u32,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(client.try_update_protocol_fee(&300_u32).is_err());
+
+    env.mock_auths(&[MockAuth {
+        address: &admin_b,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "update_protocol_fee",
+            args: (300_u32,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.update_protocol_fee(&300_u32);
+    assert_eq!(client.get_config().protocol_fee_bps, 300);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin_a,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "transfer_admin",
+            args: (admin_a.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(client.try_transfer_admin(&admin_a).is_err());
+    assert_eq!(client.get_config().admin, admin_b);
 }

--- a/contracts/open-market/tests/oracle_tests.rs
+++ b/contracts/open-market/tests/oracle_tests.rs
@@ -237,3 +237,24 @@ fn test_resolve_market_before_resolution_time() {
         Err(Ok(InsightArenaError::MarketStillOpen))
     ));
 }
+
+#[test]
+fn resolve_market_rejects_one_second_before_and_succeeds_at_resolution_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle) = deploy(&env);
+    let creator = Address::generate(&env);
+    let now = env.ledger().timestamp();
+    let mut params = default_params(&env);
+    params.resolution_time = now + 3600;
+
+    let id = client.create_market(&creator, &params);
+
+    env.ledger().set_timestamp(now + 3599);
+    let early = client.try_resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert!(matches!(early, Err(Ok(InsightArenaError::MarketStillOpen))));
+
+    env.ledger().set_timestamp(now + 3600);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert!(client.get_market(&id).is_resolved);
+}


### PR DESCRIPTION
Closes #1050
Closes #1051
Closes #1048

## Changes
- Adds a regression test proving transfer_admin removes the former admin's ability to change fees or reclaim admin rights, while the replacement admin can update fees.
- Adds a resolution-time boundary test: the oracle is rejected exactly one second early and succeeds exactly at resolution_time.

## Testing
Not run, per contributor request.