### PR TITLE
feat(backend): implement user preferences on signup and public predictions list with unit tests

### DIFF
--- a/backend/src/auth/auth.e2e.spec.ts
+++ b/backend/src/auth/auth.e2e.spec.ts
@@ -6,6 +6,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Keypair } from '@stellar/stellar-sdk';
 import request, { SuperTest, Test as SuperTestRequest } from 'supertest';
 import { User } from '../users/entities/user.entity';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
@@ -43,8 +44,20 @@ describe('Auth E2E — challenge → verify flow', () => {
     save: jest.Mock;
   };
 
+  let mockUserPreferencesRepository: {
+    findOneBy: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+
   beforeAll(async () => {
     mockUsersRepository = {
+      findOneBy: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    mockUserPreferencesRepository = {
       findOneBy: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
@@ -87,6 +100,10 @@ describe('Auth E2E — challenge → verify flow', () => {
           provide: getRepositoryToken(User),
           useValue: mockUsersRepository,
         },
+        {
+          provide: getRepositoryToken(UserPreferences),
+          useValue: mockUserPreferencesRepository,
+        },
       ],
     })
       .overrideGuard(JwtAuthGuard)
@@ -125,6 +142,10 @@ describe('Auth E2E — challenge → verify flow', () => {
     mockUsersRepository.save.mockImplementation((user: User) =>
       Promise.resolve({ ...user, id: user.id || 'e2e-uuid' }),
     );
+
+    mockUserPreferencesRepository.findOneBy.mockResolvedValue(null);
+    mockUserPreferencesRepository.create.mockImplementation((dto: any) => dto);
+    mockUserPreferencesRepository.save.mockImplementation((dto: any) => Promise.resolve(dto));
 
     mockJwtService.signAsync.mockResolvedValue('mock-jwt-token');
   });

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../users/entities/user.entity';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { RateLimitService } from './rate-limit.service';
@@ -16,7 +17,7 @@ import { ApiKeyController } from './api-key.controller';
   imports: [
     PassportModule,
     ConfigModule,
-    TypeOrmModule.forFeature([User, ApiKey]),
+    TypeOrmModule.forFeature([User, ApiKey, UserPreferences]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -5,16 +5,22 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Keypair } from '@stellar/stellar-sdk';
 import { Repository } from 'typeorm';
 import { User } from '../users/entities/user.entity';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
 import { AuthService } from './auth.service';
 
 type UsersRepoMock = jest.Mocked<
   Pick<Repository<User>, 'findOneBy' | 'create' | 'save'>
 >;
 
+type PreferencesRepoMock = jest.Mocked<
+  Pick<Repository<UserPreferences>, 'findOneBy' | 'create' | 'save'>
+>;
+
 describe('AuthService', () => {
   let service: AuthService;
   let jwtService: jest.Mocked<JwtService>;
   let usersRepository: UsersRepoMock;
+  let preferencesRepository: PreferencesRepoMock;
 
   const address = 'GABC1234567890';
 
@@ -36,12 +42,21 @@ describe('AuthService', () => {
             save: jest.fn(),
           },
         },
+        {
+          provide: getRepositoryToken(UserPreferences),
+          useValue: {
+            findOneBy: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
     jwtService = module.get(JwtService);
     usersRepository = module.get(getRepositoryToken(User));
+    preferencesRepository = module.get(getRepositoryToken(UserPreferences));
   });
 
   afterEach(() => {
@@ -58,7 +73,7 @@ describe('AuthService', () => {
     expect(two).toContain(address);
   });
 
-  it('verifySignature() returns user on valid sig', async () => {
+  it('verifySignature() returns user on valid sig and creates preferences if new user', async () => {
     service.generateChallenge(address);
     jest.spyOn(service, 'verifyStellarSignature').mockReturnValue(true);
 
@@ -67,10 +82,31 @@ describe('AuthService', () => {
     usersRepository.create.mockReturnValue(savedUser);
     usersRepository.save.mockResolvedValue(savedUser);
 
+    preferencesRepository.findOneBy.mockResolvedValue(null);
+    preferencesRepository.create.mockReturnValue({ id: 'p-1', userId: 'u-1' } as UserPreferences);
+    preferencesRepository.save.mockResolvedValue({ id: 'p-1', userId: 'u-1' } as UserPreferences);
+
     const user = await service.verifySignature(address, 'signed-hex');
 
     expect(user).toEqual(savedUser);
     expect(usersRepository.save).toHaveBeenCalledWith(savedUser);
+    expect(preferencesRepository.findOneBy).toHaveBeenCalledWith({ userId: 'u-1' });
+    expect(preferencesRepository.create).toHaveBeenCalledWith({ userId: 'u-1' });
+    expect(preferencesRepository.save).toHaveBeenCalled();
+  });
+
+  it('verifySignature() does not create duplicate preferences for existing users', async () => {
+    service.generateChallenge(address);
+    jest.spyOn(service, 'verifyStellarSignature').mockReturnValue(true);
+
+    const existingUser = { id: 'u-1', stellar_address: address } as User;
+    usersRepository.findOneBy.mockResolvedValue(existingUser);
+    usersRepository.save.mockResolvedValue(existingUser);
+
+    const user = await service.verifySignature(address, 'signed-hex');
+
+    expect(user).toEqual(existingUser);
+    expect(preferencesRepository.save).not.toHaveBeenCalled();
   });
 
   it('verifySignature() throws UnauthorizedException on invalid sig', async () => {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import { randomBytes } from 'crypto';
 import { Keypair } from '@stellar/stellar-sdk';
 import { Repository } from 'typeorm';
 import { User } from '../users/entities/user.entity';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
 
 @Injectable()
 export class AuthService {
@@ -19,6 +20,8 @@ export class AuthService {
     private readonly jwtService: JwtService,
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
+    @InjectRepository(UserPreferences)
+    private readonly preferencesRepository: Repository<UserPreferences>,
   ) {}
 
   generateChallenge(stellar_address: string): string {
@@ -112,11 +115,21 @@ export class AuthService {
 
     // Upsert the user record
     let user = await this.usersRepository.findOneBy({ stellar_address });
+    const isNewUser = !user;
     if (!user) {
       this.logger.debug(`Creating new user for ${stellar_address}`);
       user = this.usersRepository.create({ stellar_address });
     }
     user = await this.usersRepository.save(user);
+
+    if (isNewUser) {
+      const existingPrefs = await this.preferencesRepository.findOneBy({ userId: user.id });
+      if (!existingPrefs) {
+        const prefs = this.preferencesRepository.create({ userId: user.id });
+        await this.preferencesRepository.save(prefs);
+      }
+    }
+
     return user;
   }
 

--- a/backend/src/predictions/dto/list-market-predictions.dto.ts
+++ b/backend/src/predictions/dto/list-market-predictions.dto.ts
@@ -1,0 +1,25 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListMarketPredictionsDto {
+  @ApiPropertyOptional({ description: 'Page number', minimum: 1, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    minimum: 1,
+    maximum: 50,
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 20;
+}

--- a/backend/src/predictions/predictions.controller.ts
+++ b/backend/src/predictions/predictions.controller.ts
@@ -26,7 +26,9 @@ import {
   PaginatedMyPredictionsResponse,
   PredictionWithStatus,
 } from './dto/list-my-predictions.dto';
+import { ListMarketPredictionsDto } from './dto/list-market-predictions.dto';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Public } from '../common/decorators/public.decorator';
 import { User } from '../users/entities/user.entity';
 import { Prediction } from './entities/prediction.entity';
 
@@ -132,5 +134,20 @@ export class PredictionsController {
     @CurrentUser() user: User,
   ): Promise<Prediction> {
     return this.predictionsService.claim(id, user);
+  }
+
+  @Public()
+  @Get('market/:marketId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get paginated, anonymized predictions for a market (public)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated, anonymized predictions list',
+  })
+  async getMarketPredictions(
+    @Param('marketId', ParseUUIDPipe) marketId: string,
+    @Query() query: ListMarketPredictionsDto,
+  ): Promise<{ data: any[]; total: number; page: number; limit: number }> {
+    return this.predictionsService.findByMarket(marketId, query);
   }
 }

--- a/backend/src/predictions/predictions.service.spec.ts
+++ b/backend/src/predictions/predictions.service.spec.ts
@@ -155,6 +155,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(NotFoundException);
+      expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
     it('throws BadRequestException when market is resolved', async () => {
@@ -172,6 +173,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
     it('throws BadRequestException when market is cancelled', async () => {
@@ -189,6 +191,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
     it('throws BadRequestException when end_time has passed', async () => {
@@ -206,6 +209,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
     it('throws BadRequestException for invalid outcome', async () => {
@@ -221,6 +225,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
     it('throws ConflictException for duplicate prediction', async () => {
@@ -239,6 +244,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(ConflictException);
+      expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
   });
 
@@ -486,6 +492,50 @@ describe('PredictionsService', () => {
       const result = await service.findById('pred-1', user.id);
 
       expect(result.status).toBe('lost');
+    });
+  });
+
+  describe('findByMarket', () => {
+    it('returns anonymized and paginated predictions for an existing market', async () => {
+      const market = makeMarket();
+      mockMarketsRepo.findOne.mockResolvedValue(market);
+
+      const mockPredictions = [
+        {
+          id: 'pred-1',
+          chosen_outcome: 'Yes',
+          stake_amount_stroops: '1000',
+          payout_claimed: false,
+          payout_amount_stroops: '0',
+          tx_hash: 'tx-1',
+          submitted_at: new Date(),
+        },
+      ];
+      mockPredictionsRepo.findAndCount = jest.fn().mockResolvedValue([mockPredictions, 1]);
+
+      const result = await service.findByMarket(market.id, { page: 1, limit: 10 });
+
+      expect(result.total).toBe(1);
+      expect(result.data[0]).toEqual({
+        id: 'pred-1',
+        chosen_outcome: 'Yes',
+        stake_amount_stroops: '1000',
+        payout_claimed: false,
+        payout_amount_stroops: '0',
+        tx_hash: 'tx-1',
+        submitted_at: mockPredictions[0].submitted_at,
+      });
+      expect(result.data[0]).not.toHaveProperty('user');
+      expect(result.data[0]).not.toHaveProperty('userId');
+    });
+
+    it('returns empty list for non-existent market', async () => {
+      mockMarketsRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.findByMarket('non-existent', { page: 1, limit: 10 });
+
+      expect(result.total).toBe(0);
+      expect(result.data).toEqual([]);
     });
   });
 });

--- a/backend/src/predictions/predictions.service.ts
+++ b/backend/src/predictions/predictions.service.ts
@@ -11,6 +11,7 @@ import { Repository, DataSource } from 'typeorm';
 import { Prediction } from './entities/prediction.entity';
 import { SubmitPredictionDto } from './dto/submit-prediction.dto';
 import { UpdatePredictionNoteDto } from './dto/update-prediction-note.dto';
+import { ListMarketPredictionsDto } from './dto/list-market-predictions.dto';
 import {
   ListMyPredictionsDto,
   PredictionStatus,
@@ -276,5 +277,49 @@ export class PredictionsService {
     prediction.tx_hash = tx_hash;
 
     return this.predictionsRepository.save(prediction);
+  }
+
+  /**
+   * Retrieve paginated, anonymized predictions for a specific market.
+   * Returns empty list if market does not exist.
+   */
+  async findByMarket(
+    marketId: string,
+    dto: ListMarketPredictionsDto,
+  ): Promise<{ data: any[]; total: number; page: number; limit: number }> {
+    const market = await this.marketsRepository.findOne({
+      where: { id: marketId },
+    });
+    if (!market) {
+      return {
+        data: [],
+        total: 0,
+        page: dto.page ?? 1,
+        limit: dto.limit ?? 20,
+      };
+    }
+
+    const page = dto.page ?? 1;
+    const limit = Math.min(dto.limit ?? 20, 50);
+    const skip = (page - 1) * limit;
+
+    const [predictions, total] = await this.predictionsRepository.findAndCount({
+      where: { market: { id: marketId } },
+      order: { submitted_at: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    const data = predictions.map((p) => ({
+      id: p.id,
+      chosen_outcome: p.chosen_outcome,
+      stake_amount_stroops: p.stake_amount_stroops,
+      payout_claimed: p.payout_claimed,
+      payout_amount_stroops: p.payout_amount_stroops,
+      tx_hash: p.tx_hash ?? null,
+      submitted_at: p.submitted_at,
+    }));
+
+    return { data, total, page, limit };
   }
 }


### PR DESCRIPTION
## Summary of Changes

This PR addresses four assigned issues regarding automatic preference creation, short-circuit validation checks, public prediction lists, and leaderboard ordering switch tests.

### 1. Automatic UserPreferences Creation (#1087)
- **Goal:** Automatically initialize a `UserPreferences` row when a new user signs up.
- **Implemented:**
  - Added `UserPreferences` to `TypeOrmModule.forFeature` in `AuthModule`.
  - In `AuthService.verifySignature()`, we check if the user is a newly created record and create/save a corresponding default `UserPreferences` record.
  - Implemented logic to ensure existing users do not receive duplicate preference records.
  - Added unit tests in `auth.service.spec.ts` asserting both preference creation for new users and non-creation/idempotency for existing users.

### 2. Predictions Short-Circuit Verification (#1088)
- **Goal:** Prevent Soroban on-chain prediction locks when a local market validation fails.
- **Implemented:**
  - Added assertions to `predictions.service.spec.ts` verifying that `SorobanService.submitPrediction` is never called when market validation fails (e.g., market is resolved, cancelled, expired, not found, or outcome is invalid).

### 3. Public Route for Predictions by Market ID (#1094)
- **Goal:** Add `GET /predictions/market/:marketId` public route for anonymized, paginated prediction data.
- **Implemented:**
  - Created `ListMarketPredictionsDto` for page/limit query validation.
  - Implemented `findByMarket` on `PredictionsService`, mapping and returning paginated predictions with user details completely removed (anonymized). Returns an empty list if the market does not exist (not a 404).
  - Added public `GET /predictions/market/:marketId` route to `PredictionsController`.
  - Added comprehensive unit tests in `predictions.service.spec.ts`.

### 4. Leaderboard Order Switch Verification (#1089)
- **Goal:** Confirm sorting paths in `LeaderboardService` tests.
- **Verified:**
  - Verified that tests in `leaderboard.service.spec.ts` already correctly test global sorting by `reputation_score` and seasonal sorting by `season_points`, as well as validating that accuracy rate defaults to `"0.0"` when `total_predictions` is `0`.

---

## Verification & Testing
Ran the following tests to verify correctness:
```bash
npm test src/auth/auth.service.spec.ts src/predictions/predictions.service.spec.ts src/leaderboard/leaderboard.service.spec.ts
```

Closes #1089 
Closes #1094 
Closes #1088 
Closes #1087
