### PR TITLE
Backend: analytics boundary tests, leaderboard top/:n, SQL filtering or public predictions

### DIFF
--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -14,15 +14,32 @@ import { ActivityLog } from './entities/activity-log.entity';
 import { MarketHistory } from './entities/market-history.entity';
 
 describe('predictorTierFromReputation', () => {
-  it('maps thresholds to tier labels', () => {
+  it('maps 0 to Bronze Predictor', () => {
     expect(predictorTierFromReputation(0)).toBe('Bronze Predictor');
+  });
+
+  it('maps 199 to Bronze Predictor', () => {
     expect(predictorTierFromReputation(199)).toBe('Bronze Predictor');
+  });
+
+  it('maps 200 to Silver Predictor', () => {
     expect(predictorTierFromReputation(200)).toBe('Silver Predictor');
+  });
+
+  it('maps 499 to Silver Predictor', () => {
     expect(predictorTierFromReputation(499)).toBe('Silver Predictor');
+  });
+
+  it('maps 500 to Gold Predictor', () => {
     expect(predictorTierFromReputation(500)).toBe('Gold Predictor');
+  });
+
+  it('maps 999 to Gold Predictor', () => {
     expect(predictorTierFromReputation(999)).toBe('Gold Predictor');
+  });
+
+  it('maps 1000 to Platinum Predictor', () => {
     expect(predictorTierFromReputation(1000)).toBe('Platinum Predictor');
-    expect(predictorTierFromReputation(840)).toBe('Gold Predictor');
   });
 });
 

--- a/backend/src/cache/cache-warming.keys.ts
+++ b/backend/src/cache/cache-warming.keys.ts
@@ -8,4 +8,6 @@ export const CACHE_WARMING_KEYS = {
     `leaderboard:cursor:${seasonId ?? 'all'}:page:${page}`,
   leaderboardCursorPattern: (seasonId: string | null) =>
     `leaderboard:cursor:${seasonId ?? 'all'}:page:*`,
+  leaderboardTopN: (n: number, seasonId: string | null) =>
+    `leaderboard:top:${n}:${seasonId ?? 'all'}`,
 } as const;

--- a/backend/src/leaderboard/leaderboard.controller.ts
+++ b/backend/src/leaderboard/leaderboard.controller.ts
@@ -1,8 +1,15 @@
 import { Controller, Get, Query, Param } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
-import { LeaderboardService } from './leaderboard.service';
 import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
+import { LeaderboardService } from './leaderboard.service';
+import type {
   LeaderboardQueryDto,
+  LeaderboardEntryResponse,
   PaginatedLeaderboardResponse,
 } from './dto/leaderboard-query.dto';
 import {
@@ -89,6 +96,29 @@ export class LeaderboardController {
       );
     }
     return this.leaderboardService.getHistory(query);
+  }
+
+  @Get('top/:n')
+  @Public()
+  @ApiOperation({
+    summary:
+      'Get top N leaderboard entries for the current active season (lightweight shortcut)',
+  })
+  @ApiParam({
+    name: 'n',
+    description: 'Number of entries to return (max 20)',
+    type: Number,
+  })
+  @ApiQuery({ name: 'season_id', required: false, type: String })
+  @ApiResponse({
+    status: 200,
+    description: 'Top N leaderboard entries, served from cache when available',
+  })
+  async getTopN(
+    @Param('n') n: number,
+    @Query('season_id') seasonId?: string,
+  ): Promise<LeaderboardEntryResponse[]> {
+    return this.leaderboardService.getTopN(n, seasonId);
   }
 
   @Get(':address')

--- a/backend/src/leaderboard/leaderboard.service.spec.ts
+++ b/backend/src/leaderboard/leaderboard.service.spec.ts
@@ -61,6 +61,7 @@ describe('LeaderboardService', () => {
 
   const mockUsersService = {
     findAll: jest.fn(),
+    findByAddress: jest.fn(),
   };
 
   const mockDataSource = {
@@ -199,6 +200,52 @@ describe('LeaderboardService', () => {
 
       expect(mockUsersService.findAll).toHaveBeenCalled();
       expect(mockDataSource.transaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('getTopN', () => {
+    it('should return top N entries and cap at 20', async () => {
+      const entries = Array.from({ length: 20 }, (_, i) => ({
+        ...mockEntry,
+        rank: i + 1,
+      }));
+      mockQb.getMany.mockResolvedValue(entries);
+      mockCacheManager.get.mockResolvedValue(null);
+
+      const result = await service.getTopN(25);
+
+      expect(result).toHaveLength(20);
+      expect(result[0].rank).toBe(1);
+      expect(result[19].rank).toBe(20);
+      expect(mockQb.take).toHaveBeenCalledWith(20);
+      expect(mockCacheManager.set).toHaveBeenCalledWith(
+        'leaderboard:top:20:all',
+        expect.any(Array),
+        expect.any(Number),
+      );
+    });
+
+    it('should return cache hit without DB query', async () => {
+      const cached = [{ rank: 1 }] as any[];
+      mockCacheManager.get.mockResolvedValue(cached);
+
+      const result = await service.getTopN(5);
+
+      expect(result).toBe(cached);
+      expect(mockEntryRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should filter by season_id when provided', async () => {
+      const entries = [{ ...mockEntry, rank: 1 }];
+      mockQb.getMany.mockResolvedValue(entries);
+      mockCacheManager.get.mockResolvedValue(null);
+
+      const result = await service.getTopN(5, 'season-1');
+
+      expect(result).toHaveLength(1);
+      expect(mockQb.where).toHaveBeenCalledWith('entry.season_id = :seasonId', {
+        seasonId: 'season-1',
+      });
     });
   });
 

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -201,6 +201,70 @@ export class LeaderboardService {
   }
 
   /**
+   * Get top N entries for current season or all-time, lightweight shortcut
+   * Capped at 20, served from cache when available for the first page
+   */
+  async getTopN(
+    n: number,
+    seasonId?: string,
+  ): Promise<LeaderboardEntryResponse[]> {
+    const limit = Math.min(n, 20);
+    const cacheKey = CACHE_WARMING_KEYS.leaderboardTopN(
+      limit,
+      seasonId ?? null,
+    );
+
+    const cached =
+      await this.cacheManager.get<LeaderboardEntryResponse[]>(cacheKey);
+    if (cached) {
+      this.logger.debug(`Cache hit for top ${limit}: ${cacheKey}`);
+      return cached;
+    }
+
+    const qb = this.leaderboardRepository
+      .createQueryBuilder('entry')
+      .leftJoinAndSelect('entry.user', 'user');
+
+    if (seasonId) {
+      qb.where('entry.season_id = :seasonId', { seasonId });
+      qb.orderBy('entry.season_points', 'DESC');
+    } else {
+      qb.where('entry.season_id IS NULL');
+      qb.orderBy('entry.reputation_score', 'DESC');
+    }
+
+    qb.addOrderBy('entry.rank', 'ASC').take(limit);
+
+    const entries = await qb.getMany();
+
+    const data = entries.map((entry) => {
+      const accuracyRate =
+        entry.total_predictions > 0
+          ? (
+              (entry.correct_predictions / entry.total_predictions) *
+              100
+            ).toFixed(1)
+          : '0.0';
+
+      return {
+        rank: entry.rank,
+        user_id: entry.user_id,
+        username: entry.user?.username ?? null,
+        stellar_address: entry.user?.stellar_address ?? '',
+        reputation_score: entry.reputation_score,
+        accuracy_rate: accuracyRate,
+        total_winnings_stroops: entry.total_winnings_stroops,
+        season_points: entry.season_points,
+      };
+    });
+
+    await this.cacheManager.set(cacheKey, data, this.CACHE_TTL_MS);
+    this.logger.debug(`Cached top ${limit} leaderboard: ${cacheKey}`);
+
+    return data;
+  }
+
+  /**
    * Invalidate all cached leaderboard cursor pages for a season
    */
   private async invalidateLeaderboardCache(seasonId?: string): Promise<void> {

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -209,6 +209,38 @@ describe('UsersService', () => {
   });
 
   describe('findPublicPredictionsByAddress', () => {
+    it('should push outcome filter to SQL when outcome is set', async () => {
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue(mockUser);
+
+      const queryBuilder = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 2]),
+      };
+
+      jest
+        .spyOn(predictionsRepository, 'createQueryBuilder')
+        .mockReturnValue(
+          queryBuilder as any as ReturnType<
+            typeof predictionsRepository.createQueryBuilder
+          >,
+        );
+
+      await service.findPublicPredictionsByAddress(mockUser.stellar_address, {
+        outcome: 'correct',
+        page: 1,
+        limit: 20,
+      } as any);
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        'prediction.chosen_outcome = market.resolved_outcome',
+      );
+    });
+
     it('should return only resolved-market predictions with outcome mapping', async () => {
       jest.spyOn(repository, 'findOneBy').mockResolvedValue(mockUser);
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -109,14 +109,21 @@ export class UsersService {
       .skip(skip)
       .take(limit);
 
+    if (dto.outcome === PublicPredictionOutcomeFilter.Correct) {
+      qb.andWhere('prediction.chosen_outcome = market.resolved_outcome');
+    } else if (dto.outcome === PublicPredictionOutcomeFilter.Incorrect) {
+      qb.andWhere('market.resolved_outcome IS NOT NULL').andWhere(
+        'prediction.chosen_outcome != market.resolved_outcome',
+      );
+    } else if (dto.outcome === PublicPredictionOutcomeFilter.Pending) {
+      qb.andWhere('market.resolved_outcome IS NULL');
+    }
+
     const [predictions, total] = await qb.getManyAndCount();
 
-    const data = predictions
-      .map((prediction) => this.mapPublicPrediction(prediction))
-      .filter((prediction) => {
-        if (!dto.outcome) return true;
-        return prediction.outcome === dto.outcome;
-      });
+    const data = predictions.map((prediction) =>
+      this.mapPublicPrediction(prediction),
+    );
 
     return { data, total, page, limit };
   }


### PR DESCRIPTION

Implement Backend: analytics boundary tests, leaderboard top/:n, SQL filtering or public predictionspublic predict
- #1093 : predictorTierFromReputation boundary tests
- #1091 : GET /leaderboard/top/:n lightweight top-N shortcut
- #1084 : UsersService.findPublicPredictionsByAddress SQL filtering

Closes #1093 , closes #1091 , closes #1084