### PR TITLE
Add auth replay and prediction guard tests

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -161,30 +161,22 @@ describe('AuthService', () => {
     expect(service.isValidChallenge('unknown')).toBe(false);
   });
 
-  it('verifySignature() throws when nonce is already used', async () => {
-    const challenge = service.generateChallenge(address);
+  it('verifySignature() rejects a replayed challenge', async () => {
+    service.generateChallenge(address);
+    const verifySignature = jest
+      .spyOn(service, 'verifyStellarSignature')
+      .mockReturnValue(true);
+    const savedUser = { id: 'u-replay', stellar_address: address } as User;
+    usersRepository.findOneBy.mockResolvedValue(null);
+    usersRepository.create.mockReturnValue(savedUser);
+    usersRepository.save.mockResolvedValue(savedUser);
 
-    const cache = (
-      service as unknown as {
-        challengeCache: Map<string, { expiresAt: number; used: boolean }>;
-      }
-    ).challengeCache;
-    const entry = cache.get(challenge)!;
-    entry.used = true;
-    cache.set(challenge, entry);
+    await service.verifySignature(address, 'signed-hex');
 
-    jest
-      .spyOn(
-        service as unknown as {
-          findValidChallengeForAddress: (addr: string) => string | null;
-        },
-        'findValidChallengeForAddress',
-      )
-      .mockReturnValue(challenge);
-
-    await expect(service.verifySignature(address, 'any-sig')).rejects.toThrow(
-      UnauthorizedException,
-    );
+    await expect(
+      service.verifySignature(address, 'signed-hex'),
+    ).rejects.toThrow('Challenge already used');
+    expect(verifySignature).toHaveBeenCalledTimes(1);
   });
 
   it('isValidChallenge() deletes and rejects expired challenges', () => {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -133,14 +133,13 @@ export class AuthService {
     return user;
   }
 
-  /** Finds the most recent valid (non-expired, non-used) challenge for a given address. */
+  /** Finds the most recent valid (non-expired) challenge for a given address. */
   private findValidChallengeForAddress(stellar_address: string): string | null {
     const now = Date.now();
     for (const [key, entry] of this.challengeCache.entries()) {
       if (
         key.endsWith(`:${stellar_address}`) &&
-        now <= entry.expiresAt &&
-        !entry.used
+        now <= entry.expiresAt
       ) {
         return key;
       }

--- a/backend/src/predictions/predictions.service.spec.ts
+++ b/backend/src/predictions/predictions.service.spec.ts
@@ -61,6 +61,7 @@ describe('PredictionsService', () => {
   let mockPredictionsRepo: MockRepo<Prediction>;
   let mockMarketsRepo: MockRepo<Market>;
   let mockSoroban: jest.Mocked<SorobanService>;
+  let submitPrediction: jest.SpyInstance;
 
   beforeEach(async () => {
     const qbMock = {
@@ -87,6 +88,7 @@ describe('PredictionsService', () => {
       claimPayout: jest.fn(),
       getEvents: jest.fn(),
     } as unknown as jest.Mocked<SorobanService>;
+    submitPrediction = jest.spyOn(mockSoroban, 'submitPrediction');
 
     const mockDataSource = {
       transaction: jest.fn((cb: (manager: unknown) => Promise<Prediction>) => {
@@ -155,6 +157,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(NotFoundException);
+      expect(submitPrediction).not.toHaveBeenCalled();
       expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
@@ -173,6 +176,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(submitPrediction).not.toHaveBeenCalled();
       expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
@@ -191,6 +195,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(submitPrediction).not.toHaveBeenCalled();
       expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
@@ -209,6 +214,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(submitPrediction).not.toHaveBeenCalled();
       expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
@@ -225,6 +231,7 @@ describe('PredictionsService', () => {
           makeUser(),
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(submitPrediction).not.toHaveBeenCalled();
       expect(mockSoroban.submitPrediction).not.toHaveBeenCalled();
     });
 
@@ -381,6 +388,7 @@ describe('PredictionsService', () => {
       await expect(
         service.updateNote('non-existent', { note: 'Some note' }, makeUser()),
       ).rejects.toThrow(NotFoundException);
+      expect(submitPrediction).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes #1074
Closes #1078
Closes #1090

## Changes
- Adds replay coverage for reused auth challenges and keeps replayed nonces on the lookup path long enough to return the explicit challenge reuse error.
- Asserts invalid prediction submissions do not call Soroban when market validation fails.

## Testing
Not run, per contributor request.