### PR TITLE
#1077 [Backend] — Feature: Add GET /predictions/market/:marketId public predictions list

### DIFF
--- a/backend/src/notifications/notification-generator.service.ts
+++ b/backend/src/notifications/notification-generator.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification, NotificationType } from './entities/notification.entity';
@@ -19,12 +19,13 @@ export interface NotificationBatch {
 }
 
 @Injectable()
-export class NotificationGeneratorService {
+export class NotificationGeneratorService implements OnModuleDestroy {
   private readonly logger = new Logger(NotificationGeneratorService.name);
   private readonly notificationQueue: Array<NotificationBatch> = [];
   private isProcessing = false;
   private readonly BATCH_SIZE = 50;
   private readonly FLUSH_INTERVAL = 5000; // 5 seconds
+  private queueProcessorInterval?: NodeJS.Timeout;
 
   constructor(
     @InjectRepository(Notification)
@@ -41,6 +42,13 @@ export class NotificationGeneratorService {
     private readonly userRepository: Repository<User>,
   ) {
     this.startQueueProcessor();
+  }
+
+  onModuleDestroy(): void {
+    if (this.queueProcessorInterval) {
+      clearInterval(this.queueProcessorInterval);
+      this.queueProcessorInterval = undefined;
+    }
   }
 
   async handleEventCreated(data: Record<string, unknown>): Promise<void> {
@@ -324,9 +332,10 @@ export class NotificationGeneratorService {
   }
 
   private startQueueProcessor(): void {
-    setInterval(() => {
+    this.queueProcessorInterval = setInterval(() => {
       void this.processQueue();
     }, this.FLUSH_INTERVAL);
+    this.queueProcessorInterval.unref?.();
   }
 
   private async processQueue(): Promise<void> {

--- a/backend/src/predictions/dto/list-market-predictions.dto.ts
+++ b/backend/src/predictions/dto/list-market-predictions.dto.ts
@@ -1,6 +1,6 @@
 import { IsOptional, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ListMarketPredictionsDto {
   @ApiPropertyOptional({ description: 'Page number', minimum: 1, default: 1 })
@@ -23,3 +23,46 @@ export class ListMarketPredictionsDto {
   @Max(50)
   limit?: number = 20;
 }
+
+export class MarketPredictionResponseDto {
+  @ApiProperty({ description: 'Prediction ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Selected outcome option' })
+  chosen_outcome: string;
+
+  @ApiProperty({ description: 'Stake amount in stroops' })
+  stake_amount_stroops: string;
+
+  @ApiProperty({ description: 'Whether payout has been claimed' })
+  payout_claimed: boolean;
+
+  @ApiProperty({ description: 'Claimed payout amount in stroops' })
+  payout_amount_stroops: string;
+
+  @ApiProperty({
+    description: 'Latest related transaction hash',
+    nullable: true,
+  })
+  tx_hash: string | null;
+
+  @ApiProperty({ description: 'Prediction submission time' })
+  submitted_at: Date;
+}
+
+export class PaginatedMarketPredictionsResponseDto {
+  @ApiProperty({ type: [MarketPredictionResponseDto] })
+  data: MarketPredictionResponseDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+}
+
+export type PaginatedMarketPredictionsResponse =
+  PaginatedMarketPredictionsResponseDto;

--- a/backend/src/predictions/predictions.controller.ts
+++ b/backend/src/predictions/predictions.controller.ts
@@ -26,7 +26,11 @@ import {
   PaginatedMyPredictionsResponse,
   PredictionWithStatus,
 } from './dto/list-my-predictions.dto';
-import { ListMarketPredictionsDto } from './dto/list-market-predictions.dto';
+import {
+  ListMarketPredictionsDto,
+  PaginatedMarketPredictionsResponse,
+  PaginatedMarketPredictionsResponseDto,
+} from './dto/list-market-predictions.dto';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { Public } from '../common/decorators/public.decorator';
 import { User } from '../users/entities/user.entity';
@@ -139,15 +143,18 @@ export class PredictionsController {
   @Public()
   @Get('market/:marketId')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Get paginated, anonymized predictions for a market (public)' })
+  @ApiOperation({
+    summary: 'Get paginated, anonymized predictions for a market (public)',
+  })
   @ApiResponse({
     status: 200,
     description: 'Paginated, anonymized predictions list',
+    type: PaginatedMarketPredictionsResponseDto,
   })
   async getMarketPredictions(
     @Param('marketId', ParseUUIDPipe) marketId: string,
     @Query() query: ListMarketPredictionsDto,
-  ): Promise<{ data: any[]; total: number; page: number; limit: number }> {
+  ): Promise<PaginatedMarketPredictionsResponse> {
     return this.predictionsService.findByMarket(marketId, query);
   }
 }

--- a/backend/src/predictions/predictions.service.spec.ts
+++ b/backend/src/predictions/predictions.service.spec.ts
@@ -14,7 +14,7 @@ import { User } from '../users/entities/user.entity';
 import { SorobanService } from '../soroban/soroban.service';
 
 type MockRepo<T extends ObjectLiteral> = jest.Mocked<
-  Pick<Repository<T>, 'findOne' | 'create' | 'save'>
+  Pick<Repository<T>, 'findOne' | 'create' | 'save' | 'findAndCount'>
 >;
 
 const makeUser = (overrides: Partial<User> = {}): User =>
@@ -74,12 +74,14 @@ describe('PredictionsService', () => {
       findOne: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
+      findAndCount: jest.fn(),
     };
 
     mockMarketsRepo = {
       findOne: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
+      findAndCount: jest.fn(),
     };
 
     mockSoroban = {
@@ -511,11 +513,19 @@ describe('PredictionsService', () => {
           submitted_at: new Date(),
         },
       ];
-      mockPredictionsRepo.findAndCount = jest.fn().mockResolvedValue([mockPredictions, 1]);
+      mockPredictionsRepo.findAndCount.mockResolvedValue([
+        mockPredictions as Prediction[],
+        1,
+      ]);
 
-      const result = await service.findByMarket(market.id, { page: 1, limit: 10 });
+      const result = await service.findByMarket(market.id, {
+        page: 2,
+        limit: 10,
+      });
 
       expect(result.total).toBe(1);
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(10);
       expect(result.data[0]).toEqual({
         id: 'pred-1',
         chosen_outcome: 'Yes',
@@ -527,15 +537,25 @@ describe('PredictionsService', () => {
       });
       expect(result.data[0]).not.toHaveProperty('user');
       expect(result.data[0]).not.toHaveProperty('userId');
+      expect(mockPredictionsRepo.findAndCount).toHaveBeenCalledWith({
+        where: { market: { id: market.id } },
+        order: { submitted_at: 'DESC' },
+        skip: 10,
+        take: 10,
+      });
     });
 
     it('returns empty list for non-existent market', async () => {
       mockMarketsRepo.findOne.mockResolvedValue(null);
 
-      const result = await service.findByMarket('non-existent', { page: 1, limit: 10 });
+      const result = await service.findByMarket('non-existent', {
+        page: 1,
+        limit: 10,
+      });
 
       expect(result.total).toBe(0);
       expect(result.data).toEqual([]);
+      expect(mockPredictionsRepo.findAndCount).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/predictions/predictions.service.ts
+++ b/backend/src/predictions/predictions.service.ts
@@ -11,7 +11,11 @@ import { Repository, DataSource } from 'typeorm';
 import { Prediction } from './entities/prediction.entity';
 import { SubmitPredictionDto } from './dto/submit-prediction.dto';
 import { UpdatePredictionNoteDto } from './dto/update-prediction-note.dto';
-import { ListMarketPredictionsDto } from './dto/list-market-predictions.dto';
+import {
+  ListMarketPredictionsDto,
+  MarketPredictionResponseDto,
+  PaginatedMarketPredictionsResponse,
+} from './dto/list-market-predictions.dto';
 import {
   ListMyPredictionsDto,
   PredictionStatus,
@@ -286,7 +290,7 @@ export class PredictionsService {
   async findByMarket(
     marketId: string,
     dto: ListMarketPredictionsDto,
-  ): Promise<{ data: any[]; total: number; page: number; limit: number }> {
+  ): Promise<PaginatedMarketPredictionsResponse> {
     const market = await this.marketsRepository.findOne({
       where: { id: marketId },
     });
@@ -310,7 +314,7 @@ export class PredictionsService {
       take: limit,
     });
 
-    const data = predictions.map((p) => ({
+    const data: MarketPredictionResponseDto[] = predictions.map((p) => ({
       id: p.id,
       chosen_outcome: p.chosen_outcome,
       stake_amount_stroops: p.stake_amount_stroops,

--- a/backend/src/websocket/events.gateway.ts
+++ b/backend/src/websocket/events.gateway.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { Logger, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import {
@@ -20,13 +20,16 @@ interface AuthenticatedSocket extends Socket {
   cors: { origin: '*', credentials: true },
   namespace: '/ws',
 })
-export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class EventsGateway
+  implements OnGatewayConnection, OnGatewayDisconnect, OnModuleDestroy
+{
   @WebSocketServer()
   server: Server;
 
   private readonly logger = new Logger(EventsGateway.name);
   private readonly connections = new Map<string, string>(); // socketId → userAddress
   private readonly rateLimits = new Map<string, number>(); // socketId → message count
+  private readonly heartbeats = new Map<string, NodeJS.Timeout>();
   private readonly RATE_LIMIT = 60; // messages per minute
   private readonly RATE_WINDOW = 60_000;
 
@@ -63,18 +66,29 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const heartbeat = setInterval(() => {
       client.emit('ping');
     }, 25_000);
+    heartbeat.unref?.();
+    this.clearHeartbeat(client.id);
+    this.heartbeats.set(client.id, heartbeat);
 
     client.on('pong', () => {
       this.logger.debug(`Pong from ${client.id}`);
     });
 
-    client.on('disconnect', () => clearInterval(heartbeat));
+    client.on('disconnect', () => this.clearHeartbeat(client.id));
   }
 
   handleDisconnect(client: AuthenticatedSocket): void {
+    this.clearHeartbeat(client.id);
     this.connections.delete(client.id);
     this.rateLimits.delete(client.id);
     this.logger.log(`Client disconnected: ${client.id}`);
+  }
+
+  onModuleDestroy(): void {
+    for (const heartbeat of this.heartbeats.values()) {
+      clearInterval(heartbeat);
+    }
+    this.heartbeats.clear();
   }
 
   @SubscribeMessage('join')
@@ -137,9 +151,20 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     if (count >= this.RATE_LIMIT) return false;
     this.rateLimits.set(socketId, count + 1);
     if (count === 0) {
-      setTimeout(() => this.rateLimits.delete(socketId), this.RATE_WINDOW);
+      const timeout = setTimeout(
+        () => this.rateLimits.delete(socketId),
+        this.RATE_WINDOW,
+      );
+      timeout.unref?.();
     }
     return true;
+  }
+
+  private clearHeartbeat(socketId: string): void {
+    const heartbeat = this.heartbeats.get(socketId);
+    if (!heartbeat) return;
+    clearInterval(heartbeat);
+    this.heartbeats.delete(socketId);
   }
 
   getServer(): Server {

--- a/backend/test/e2e/critical-flows.e2e-spec.ts
+++ b/backend/test/e2e/critical-flows.e2e-spec.ts
@@ -33,7 +33,7 @@ import { UserAchievement } from '../../src/achievements/entities/user-achievemen
 import { Achievement } from '../../src/achievements/entities/achievement.entity';
 import { UserFollow } from '../../src/users/entities/user-follow.entity';
 import { Comment } from '../../src/markets/entities/comment.entity';
-import { Bookmark } from '../../src/markets/entities/bookmark.entity';
+import { UserBookmark } from '../../src/markets/entities/user-bookmark.entity';
 import { CompetitionParticipant } from '../../src/competitions/entities/competition-participant.entity';
 import { Flag } from '../../src/flags/entities/flag.entity';
 
@@ -120,7 +120,7 @@ const allEntities = [
   Achievement,
   UserFollow,
   Comment,
-  Bookmark,
+  UserBookmark,
   CompetitionParticipant,
   Flag,
 ];

--- a/backend/test/integration/api-integration.e2e-spec.ts
+++ b/backend/test/integration/api-integration.e2e-spec.ts
@@ -33,7 +33,7 @@ import { UserAchievement } from '../../src/achievements/entities/user-achievemen
 import { Achievement } from '../../src/achievements/entities/achievement.entity';
 import { UserFollow } from '../../src/users/entities/user-follow.entity';
 import { Comment } from '../../src/markets/entities/comment.entity';
-import { Bookmark } from '../../src/markets/entities/bookmark.entity';
+import { UserBookmark } from '../../src/markets/entities/user-bookmark.entity';
 import { CompetitionParticipant } from '../../src/competitions/entities/competition-participant.entity';
 import { Flag } from '../../src/flags/entities/flag.entity';
 
@@ -100,7 +100,7 @@ const allEntities = [
   Achievement,
   UserFollow,
   Comment,
-  Bookmark,
+  UserBookmark,
   CompetitionParticipant,
   Flag,
 ];


### PR DESCRIPTION
## Resolution Summary

Implemented and verified the public predictions list endpoint for markets:

`GET /predictions/market/:marketId`

This endpoint returns paginated, anonymized predictions for a given market and does not expose user identifiers.

## What Changed

- Added/confirmed public route in `PredictionsController`:
  - `GET /predictions/market/:marketId`
  - Marked with `@Public()`
  - Uses `ListMarketPredictionsDto` for pagination query params.

- Added/typed the market prediction response DTO:
  - `MarketPredictionResponseDto`
  - `PaginatedMarketPredictionsResponseDto`

- Updated `PredictionsService.findByMarket()` to:
  - Return paginated predictions ordered by `submitted_at DESC`.
  - Return an empty paginated response when the market does not exist.
  - Exclude user/userId data from the response.
  - Limit pagination size to a max of 50.

- Strengthened unit tests for:
  - Existing market returns anonymized predictions.
  - Pagination uses correct `skip`/`take`.
  - Non-existent market returns an empty list.
  - Response does not include `user` or `userId`.

- Fixed two unrelated test stability issues discovered while running the full backend suite:
  - Cleaned/unref’d websocket heartbeat/rate-limit timers so Jest exits normally.
  - Added lifecycle cleanup for the notification generator queue interval.

- Fixed stale e2e imports:
  - Replaced old `bookmark.entity` references with `user-bookmark.entity`.

## Verification

Passed locally:

- `npm test -- predictions.service.spec.ts --runInBand`
  - 21 tests passed.

- `npm test -- --runInBand`
  - 58 test suites passed.
  - 503 tests passed.

- `npm run build`
  - Build completed successfully.

- `npm run test:e2e -- api-versioning.e2e-spec.ts --runInBand`
  - 5 tests passed.

## Note

The full DB-backed e2e suite was attempted but could not be completed locally because the environment does not have valid Postgres credentials configured. The e2e runner itself works, and the non-DB e2e spec passes.

Closes #1077