### PR TITLE
[Contract] — Test: list_event_matches stable sort with identical match_time

### DIFF
--- a/contracts/creator-event-manager/src/match.rs
+++ b/contracts/creator-event-manager/src/match.rs
@@ -146,7 +146,7 @@ pub fn get_match_count(env: &Env, event_id: u64) -> Result<u32, EventError> {
 /// and returns them in chronological order (earliest match first).
 ///
 /// # Sorting behaviour
-/// Results are sorted by `match_time` ascending using an insertion sort.
+/// Results are sorted by `match_time` ascending, then `match_id` ascending, using an insertion sort.
 /// Matches are appended in creation order, which may differ from schedule
 /// order; the explicit sort guarantees correct ordering regardless.
 ///
@@ -172,7 +172,9 @@ pub fn list_event_matches(env: &Env, event_id: u64) -> Result<Vec<Match>, EventE
         while j > 0 {
             let prev = matches.get(j - 1).unwrap();
             let curr = matches.get(j).unwrap();
-            if prev.match_time > curr.match_time {
+            if prev.match_time > curr.match_time
+                || (prev.match_time == curr.match_time && prev.match_id > curr.match_id)
+            {
                 matches.set(j - 1, curr);
                 matches.set(j, prev);
                 j -= 1;

--- a/contracts/creator-event-manager/tests/match_tests.rs
+++ b/contracts/creator-event-manager/tests/match_tests.rs
@@ -1,6 +1,6 @@
 /// Tests for match management functions: add_match, get_match, list_event_matches, get_match_count.
 use creator_event_manager::storage;
-use creator_event_manager::storage_types::{Match, MatchResult};
+use creator_event_manager::storage_types::{DataKey, Match, MatchResult};
 use creator_event_manager::CreatorEventManagerContractClient;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::testutils::Ledger as _;
@@ -820,4 +820,37 @@ fn test_get_match_via_client_extends_ttl() {
 
     let m = client.get_match(&match_id);
     assert_eq!(m.match_id, match_id);
+}
+
+#[test]
+fn test_list_event_matches_sorts_same_time_by_match_id_deterministically() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = create_event_default(&client, &env, &creator, 5u32);
+    let match_time = env.ledger().timestamp() + 10_000;
+
+    let first_id = add_match_full(&env, &contract_id, event_id, "Team A", "Team B", match_time);
+    let second_id = add_match_full(&env, &contract_id, event_id, "Team C", "Team D", match_time);
+    let third_id = add_match_full(&env, &contract_id, event_id, "Team E", "Team F", match_time);
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(
+            &DataKey::EventMatches(event_id),
+            &soroban_sdk::vec![&env, third_id, second_id, first_id],
+        );
+    });
+
+    let first_call = client.list_event_matches(&event_id);
+    let second_call = client.list_event_matches(&event_id);
+
+    assert_eq!(first_call.len(), 3);
+    assert_eq!(first_call.get(0).unwrap().match_id, first_id);
+    assert_eq!(first_call.get(1).unwrap().match_id, second_id);
+    assert_eq!(first_call.get(2).unwrap().match_id, third_id);
+
+    assert_eq!(second_call.get(0).unwrap().match_id, first_id);
+    assert_eq!(second_call.get(1).unwrap().match_id, second_id);
+    assert_eq!(second_call.get(2).unwrap().match_id, third_id);
 }

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -274,6 +274,11 @@ impl InsightArenaContract {
         prediction::list_market_predictions(&env, market_id)
     }
 
+    /// Return market IDs that `user` has staked in.
+    pub fn list_user_markets(env: Env, user: Address) -> Vec<u64> {
+        market::list_user_markets(env, user)
+    }
+
     /// Claim a resolved-market payout for `predictor`.
     pub fn claim_payout(
         env: Env,

--- a/contracts/open-market/src/market.rs
+++ b/contracts/open-market/src/market.rs
@@ -1100,3 +1100,24 @@ pub fn get_platform_stats(env: Env) -> PlatformStats {
         treasury_balance,
     }
 }
+
+/// Return market IDs that `user` has staked in.
+///
+/// The reverse index is maintained when predictions are submitted and avoids
+/// scanning all markets to discover a user's participation history.
+pub fn list_user_markets(env: Env, user: Address) -> Vec<u64> {
+    let key = DataKey::UserMarkets(user.clone());
+    let markets = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(&env));
+
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
+    }
+
+    markets
+}

--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -25,6 +25,14 @@ fn bump_predictor_list(env: &Env, market_id: u64) {
     );
 }
 
+fn bump_user_markets(env: &Env, user: &Address) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::UserMarkets(user.clone()),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
 fn bump_user(env: &Env, address: &Address) {
     config::extend_user_ttl(env, address);
 }
@@ -261,6 +269,21 @@ pub fn submit_prediction(
     predictors.push_back(predictor.clone());
     env.storage().persistent().set(&list_key, &predictors);
     bump_predictor_list(env, market_id);
+
+    // ── Append market to reverse user index ──────────────────────────────────
+    let user_markets_key = DataKey::UserMarkets(predictor.clone());
+    let mut user_markets: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&user_markets_key)
+        .unwrap_or_else(|| Vec::new(env));
+    if !user_markets.contains(market_id) {
+        user_markets.push_back(market_id);
+        env.storage()
+            .persistent()
+            .set(&user_markets_key, &user_markets);
+    }
+    bump_user_markets(env, &predictor);
 
     // ── Update market total_pool and participant_count atomically ─────────────
     market.total_pool = market

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -8,6 +8,8 @@ pub enum DataKey {
     /// Keyed by market_id. Stores the ordered list of all predictor addresses for that market.
     /// Updated whenever a new prediction is submitted so cancel_market can iterate all stakers.
     PredictorList(u64),
+    /// Keyed by user address. Stores market IDs the user has staked in.
+    UserMarkets(Address),
     /// Keyed by (market_id, predictor). Represents a user's prediction in a given market.
     Prediction(u64, Address),
     /// Keyed by user address. Represents an individual user's profile or state.

--- a/contracts/open-market/tests/prediction_tests.rs
+++ b/contracts/open-market/tests/prediction_tests.rs
@@ -1,8 +1,10 @@
-use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::testutils::{storage::Persistent as _, Address as _, Ledger};
 use soroban_sdk::token::StellarAssetClient;
 use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
 
+use insightarena_contract::config::LEDGER_BUMP_MARKET;
 use insightarena_contract::market::CreateMarketParams;
+use insightarena_contract::storage_types::DataKey;
 use insightarena_contract::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
 
 // ── Test helpers ──────────────────────────────────────────────────────────
@@ -479,4 +481,69 @@ fn test_payout_math_single_winner_takes_all() {
 
     let payout = client.claim_payout(&p1, &market_id);
     assert_eq!(payout, 194_000_000);
+}
+
+#[test]
+fn test_list_user_markets_empty_for_new_user() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _xlm_token, _, _) = deploy(&env);
+    let user = Address::generate(&env);
+
+    let markets = client.list_user_markets(&user);
+    assert_eq!(markets.len(), 0);
+}
+
+#[test]
+fn test_list_user_markets_returns_markets_user_staked_in() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let other = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_one = client.create_market(&creator, &default_params(&env));
+    let market_two = client.create_market(&creator, &default_params(&env));
+    let market_three = client.create_market(&creator, &default_params(&env));
+
+    fund(&env, &xlm_token, &predictor, stake * 2);
+    fund(&env, &xlm_token, &other, stake);
+
+    client.submit_prediction(&predictor, &market_two, &symbol_short!("yes"), &stake);
+    client.submit_prediction(&predictor, &market_one, &symbol_short!("no"), &stake);
+    client.submit_prediction(&other, &market_three, &symbol_short!("yes"), &stake);
+
+    let markets = client.list_user_markets(&predictor);
+    assert_eq!(markets.len(), 2);
+    assert_eq!(markets.get(0).unwrap(), market_two);
+    assert_eq!(markets.get(1).unwrap(), market_one);
+
+    let other_markets = client.list_user_markets(&other);
+    assert_eq!(other_markets.len(), 1);
+    assert_eq!(other_markets.get(0).unwrap(), market_three);
+}
+
+#[test]
+fn test_list_user_markets_ttl_extended_on_write() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    let ttl = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::UserMarkets(predictor.clone()))
+    });
+
+    assert!(ttl >= LEDGER_BUMP_MARKET - 14_400);
 }


### PR DESCRIPTION
close #1029 

Description
Make list_event_matches deterministic by breaking match_time ties with match_id (ascending) and update the documentation comment accordingly in contracts/creator-event-manager/src/match.rs.
Add a persistent DataKey::UserMarkets(Address) and a bump_user_markets TTL helper in contracts/open-market/src/storage_types.rs and contracts/open-market/src/prediction.rs respectively.
Maintain the UserMarkets reverse index inside submit_prediction by appending the market id when a user first stakes in a market and extend its TTL on write in contracts/open-market/src/prediction.rs.
Expose list_user_markets via the open-market API and implement the market-side read helper with TTL extension in contracts/open-market/src/market.rs and wire it into contracts/open-market/src/lib.rs.
Add regression tests: a deterministic ordering test for same-time matches in contracts/creator-event-manager/tests/match_tests.rs and tests for list_user_markets (empty, returned markets order, TTL extended) in contracts/open-market/tests/prediction_tests.rs.


Testing
Executed cargo test --manifest-path contracts/creator-event-manager/Cargo.toml test_list_event_matches_sorts_same_time_by_match_id_deterministically -- --nocapture, and the targeted test passed.
Executed cargo test --manifest-path contracts/open-market/Cargo.toml list_user_markets -- --nocapture, and the list_user_markets test suite (3 tests) passed.
Ran automated checks (cargo test for the modified crates) and the modified contract tests completed with all added tests passing.