### PR TITLE
fix(contract): reject create_match when match_time >= event.end_time …

### DIFF
--- a/contracts/creator-event-manager/src/match.rs
+++ b/contracts/creator-event-manager/src/match.rs
@@ -93,9 +93,12 @@ pub fn create_match(
         return Err(MatchError::InvalidTeamNames);
     }
 
-    // Step 6: Validate match_time is in the future
+    // Step 6: Validate match_time is in the future and within the event window
     let current_time = env.ledger().timestamp();
     if match_time <= current_time {
+        return Err(MatchError::InvalidMatchTime);
+    }
+    if match_time >= event.end_time {
         return Err(MatchError::InvalidMatchTime);
     }
 
@@ -108,7 +111,14 @@ pub fn create_match(
     let match_id = storage::next_match_id(env);
 
     // Step 9: Build the Match
-    let m = Match::new(match_id, event_id, team_a.clone(), team_b.clone(), match_time, points_multiplier);
+    let m = Match::new(
+        match_id,
+        event_id,
+        team_a.clone(),
+        team_b.clone(),
+        match_time,
+        points_multiplier,
+    );
 
     // Step 10: Persist the match
     storage::set_match(env, match_id, &m);

--- a/contracts/creator-event-manager/tests/match_tests.rs
+++ b/contracts/creator-event-manager/tests/match_tests.rs
@@ -854,3 +854,73 @@ fn test_list_event_matches_sorts_same_time_by_match_id_deterministically() {
     assert_eq!(second_call.get(1).unwrap().match_id, second_id);
     assert_eq!(second_call.get(2).unwrap().match_id, third_id);
 }
+
+// =============================================================================
+// create_match — match_time outside event window (#1016)
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "invalid_match_time")]
+fn test_create_match_rejects_match_time_at_end_time() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = create_event_default(&client, &env, &creator, 5u32);
+    let event = env.as_contract(&_contract_id, || {
+        creator_event_manager::storage::get_event(&env, event_id).unwrap()
+    });
+
+    client.create_match(
+        &creator,
+        &event_id,
+        &String::from_str(&env, "Team A"),
+        &String::from_str(&env, "Team B"),
+        &event.end_time,
+        &1u32,
+    );
+}
+
+#[test]
+#[should_panic(expected = "invalid_match_time")]
+fn test_create_match_rejects_match_time_after_end_time() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = create_event_default(&client, &env, &creator, 5u32);
+    let event = env.as_contract(&_contract_id, || {
+        creator_event_manager::storage::get_event(&env, event_id).unwrap()
+    });
+
+    client.create_match(
+        &creator,
+        &event_id,
+        &String::from_str(&env, "Team A"),
+        &String::from_str(&env, "Team B"),
+        &(event.end_time + 1),
+        &1u32,
+    );
+}
+
+#[test]
+fn test_create_match_accepts_match_time_before_end_time() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = create_event_default(&client, &env, &creator, 5u32);
+    let event = env.as_contract(&_contract_id, || {
+        creator_event_manager::storage::get_event(&env, event_id).unwrap()
+    });
+
+    let match_id = client.create_match(
+        &creator,
+        &event_id,
+        &String::from_str(&env, "Team A"),
+        &String::from_str(&env, "Team B"),
+        &(event.end_time - 60),
+        &1u32,
+    );
+    assert!(match_id > 0);
+}


### PR DESCRIPTION
closes #1016

Add guard in create_match: match_time must be strictly less than event.end_time, returning InvalidMatchTime otherwise.

Tests:
- test_create_match_rejects_match_time_at_end_time (should_panic)
- test_create_match_rejects_match_time_after_end_time (should_panic)
- test_create_match_accepts_match_time_before_end_time (positive path)