### PR TITLE
Add creator fee updates, participant boundary tests, and user stats endpoint

### DIFF
--- a/backend/src/users/dto/user-stats.dto.ts
+++ b/backend/src/users/dto/user-stats.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserStatsResponseDto {
+  @ApiProperty()
+  total_predictions: number;
+
+  @ApiProperty()
+  correct_predictions: number;
+
+  @ApiProperty()
+  incorrect_predictions: number;
+
+  @ApiProperty({ example: '70.0' })
+  accuracy_rate: string;
+
+  @ApiProperty({ example: 'Bronze Predictor' })
+  tier: string;
+
+  @ApiProperty()
+  reputation_score: number;
+
+  @ApiProperty()
+  season_points: number;
+
+  @ApiProperty()
+  total_staked_stroops: string;
+
+  @ApiProperty()
+  total_winnings_stroops: string;
+}

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -34,6 +34,7 @@ describe('UsersController', () => {
           useValue: {
             findByAddress: jest.fn(),
             findPublicPredictionsByAddress: jest.fn(),
+            getMyStats: jest.fn(),
           },
         },
       ],
@@ -45,6 +46,28 @@ describe('UsersController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getMyStats', () => {
+    it('should return stats for the authenticated user', async () => {
+      const mockStats = {
+        total_predictions: 10,
+        correct_predictions: 7,
+        incorrect_predictions: 3,
+        accuracy_rate: '70.0',
+        tier: 'Bronze Predictor',
+        reputation_score: 85,
+        season_points: 100,
+        total_staked_stroops: '1000000',
+        total_winnings_stroops: '500000',
+      };
+      jest.spyOn(service, 'getMyStats').mockResolvedValue(mockStats);
+
+      const result = await controller.getMyStats(mockUser);
+
+      expect(service.getMyStats).toHaveBeenCalledWith(mockUser.id);
+      expect(result).toEqual(mockStats);
+    });
   });
 
   describe('getPublicProfile', () => {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -44,6 +44,7 @@ import {
   ListUserMarketsDto,
   PaginatedUserMarketsResponse,
 } from './dto/list-user-markets.dto';
+import { UserStatsResponseDto } from './dto/user-stats.dto';
 
 @Controller('users')
 export class UsersController {
@@ -61,6 +62,18 @@ export class UsersController {
     return plainToInstance(UserResponseDto, user, {
       excludeExtraneousValues: true,
     });
+  }
+
+  @Get('me/stats')
+  @ApiOperation({ summary: 'Get lightweight prediction stats for current user' })
+  @ApiResponse({
+    status: 200,
+    description: 'User stats retrieved successfully',
+    type: UserStatsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  getMyStats(@CurrentUser() user: User): Promise<UserStatsResponseDto> {
+    return this.usersService.getMyStats(user.id);
   }
 
   @Get('me/bookmarks')

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -512,4 +512,46 @@ describe('UsersService', () => {
       );
     });
   });
+
+  describe('getMyStats', () => {
+    it('should return lightweight stats with computed accuracy and tier', async () => {
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue(mockUser);
+
+      const result = await service.getMyStats(mockUser.id);
+
+      expect(result).toEqual({
+        total_predictions: 10,
+        correct_predictions: 7,
+        incorrect_predictions: 3,
+        accuracy_rate: '70.0',
+        tier: 'Bronze Predictor',
+        reputation_score: 85,
+        season_points: 100,
+        total_staked_stroops: '1000000',
+        total_winnings_stroops: '500000',
+      });
+    });
+
+    it('should return 0.0 accuracy when user has no predictions', async () => {
+      const userWithNoPredictions = {
+        ...mockUser,
+        total_predictions: 0,
+        correct_predictions: 0,
+      };
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue(userWithNoPredictions);
+
+      const result = await service.getMyStats(mockUser.id);
+
+      expect(result.accuracy_rate).toBe('0.0');
+      expect(result.incorrect_predictions).toBe(0);
+    });
+
+    it('should throw NotFoundException when user not found', async () => {
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue(null);
+
+      await expect(service.getMyStats('missing-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -47,6 +47,11 @@ import {
   ListUserBookmarksDto,
   PaginatedUserBookmarksResponse,
 } from './dto/list-user-bookmarks.dto';
+import { UserStatsResponseDto } from './dto/user-stats.dto';
+import {
+  accuracyRateFromUser,
+  predictorTierFromReputation,
+} from '../analytics/analytics.service';
 
 @Injectable()
 export class UsersService {
@@ -71,6 +76,22 @@ export class UsersService {
 
   async findAll(): Promise<User[]> {
     return this.usersRepository.find();
+  }
+
+  async getMyStats(userId: string): Promise<UserStatsResponseDto> {
+    const user = await this.findById(userId);
+
+    return {
+      total_predictions: user.total_predictions,
+      correct_predictions: user.correct_predictions,
+      incorrect_predictions: user.total_predictions - user.correct_predictions,
+      accuracy_rate: accuracyRateFromUser(user),
+      tier: predictorTierFromReputation(user.reputation_score),
+      reputation_score: user.reputation_score,
+      season_points: user.season_points,
+      total_staked_stroops: user.total_staked_stroops,
+      total_winnings_stroops: user.total_winnings_stroops,
+    };
   }
 
   async findById(id: string): Promise<User> {

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -243,6 +243,99 @@ fn test_join_event_full_event_blocks_joining() {
 }
 
 #[test]
+fn test_join_event_max_participants_one_first_user_succeeds() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let (event_id, invite_code, _) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 1, 10_000);
+
+    client.join_event(&user_a, &invite_code);
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.participant_count, 1);
+    assert_eq!(client.get_event_participants(&event_id).len(), 1);
+}
+
+#[test]
+fn test_join_event_participant_count_equals_max_at_boundary() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let (event_id, invite_code, _) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 1, 10_000);
+
+    client.join_event(&user_a, &invite_code);
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.participant_count, event.max_participants);
+    assert_eq!(event.participant_count, 1);
+
+    let can_accept = env.as_contract(&contract_id, || {
+        storage::get_event(&env, event_id)
+            .unwrap()
+            .can_accept_participants()
+    });
+    assert!(!can_accept);
+}
+
+#[test]
+fn test_join_event_max_participants_zero_allows_unlimited_joins() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let (event_id, invite_code, _) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 1, 10_000);
+
+    env.as_contract(&contract_id, || {
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.max_participants = 0;
+        storage::set_event(&env, event_id, &event);
+    });
+
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let user_c = Address::generate(&env);
+    client.join_event(&user_a, &invite_code);
+    client.join_event(&user_b, &invite_code);
+    client.join_event(&user_c, &invite_code);
+
+    assert_eq!(client.get_event(&event_id).participant_count, 3);
+}
+
+#[test]
+fn test_join_event_max_participants_two_allows_exactly_two() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let (event_id, invite_code, _) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&user_a, &invite_code);
+    client.join_event(&user_b, &invite_code);
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.participant_count, 2);
+    assert_eq!(event.max_participants, 2);
+}
+
+#[test]
+#[should_panic(expected = "event_full")]
+fn test_join_event_max_participants_two_third_user_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let user_c = Address::generate(&env);
+    let (_event_id, invite_code, _) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, 10_000);
+
+    client.join_event(&user_a, &invite_code);
+    client.join_event(&user_b, &invite_code);
+    client.join_event(&user_c, &invite_code);
+}
+
+#[test]
 #[should_panic(expected = "event_cancelled")]
 fn test_join_event_cancelled_event_blocks_joining() {
     let (env, client, contract_id, _admin, xlm_token) = setup();

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -165,6 +165,16 @@ impl InsightArenaContract {
         market::close_market(&env, caller, market_id)
     }
 
+    /// Update the creator fee for a market before it closes.
+    pub fn update_creator_fee(
+        env: Env,
+        creator: Address,
+        market_id: u64,
+        new_creator_fee_bps: u32,
+    ) -> Result<(), InsightArenaError> {
+        market::update_creator_fee(&env, creator, market_id, new_creator_fee_bps)
+    }
+
     /// Cancel a market and refund all stakers.
     pub fn cancel_market(
         env: Env,

--- a/contracts/open-market/src/market.rs
+++ b/contracts/open-market/src/market.rs
@@ -471,6 +471,53 @@ pub fn close_market(env: &Env, caller: Address, market_id: u64) -> Result<(), In
     Ok(())
 }
 
+/// Update the creator fee for a market while it is still open for trading.
+///
+/// Only the market creator may call this, and only before `end_time` has passed.
+/// The new fee is capped at the platform maximum (500 bps).
+pub fn update_creator_fee(
+    env: &Env,
+    creator: Address,
+    market_id: u64,
+    new_creator_fee_bps: u32,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
+
+    creator.require_auth();
+
+    let mut market = get_market(env, market_id)?;
+
+    if market.creator != creator {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    if market.is_resolved {
+        return Err(InsightArenaError::MarketAlreadyResolved);
+    }
+
+    if market.is_cancelled {
+        return Err(InsightArenaError::MarketAlreadyCancelled);
+    }
+
+    let now = env.ledger().timestamp();
+    if now >= market.end_time {
+        return Err(InsightArenaError::MarketExpired);
+    }
+
+    let cfg = config::get_config(env)?;
+    if new_creator_fee_bps > cfg.max_creator_fee_bps {
+        return Err(InsightArenaError::InvalidFee);
+    }
+
+    market.creator_fee_bps = new_creator_fee_bps;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Market(market_id), &market);
+    bump_market(env, market_id);
+
+    Ok(())
+}
+
 /// Cancel a market that could not be resolved (oracle failure, creator error, etc.).
 ///
 /// Upon cancellation every predictor's full stake is refunded via the escrow

--- a/contracts/open-market/tests/market_tests.rs
+++ b/contracts/open-market/tests/market_tests.rs
@@ -174,6 +174,92 @@ fn create_market_fails_fee_too_high() {
     assert!(matches!(result, Err(Ok(InsightArenaError::InvalidFee))));
 }
 
+fn fund(env: &Env, xlm_token: &Address, recipient: &Address, amount: i128) {
+    StellarAssetClient::new(env, xlm_token).mint(recipient, &amount);
+}
+
+#[test]
+fn update_creator_fee_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    client.update_creator_fee(&creator, &id, &250_u32);
+
+    let market = client.get_market(&id);
+    assert_eq!(market.creator_fee_bps, 250);
+}
+
+#[test]
+fn update_creator_fee_fails_fee_too_high() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    let result = client.try_update_creator_fee(&creator, &id, &501_u32);
+
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidFee))));
+}
+
+#[test]
+fn update_creator_fee_fails_non_creator() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    let result = client.try_update_creator_fee(&other, &id, &200_u32);
+
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+#[test]
+fn update_creator_fee_fails_after_end_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+
+    let params = default_params(&env);
+    let id = client.create_market(&creator, &params);
+
+    env.ledger().set_timestamp(params.end_time);
+
+    let result = client.try_update_creator_fee(&creator, &id, &200_u32);
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketExpired))));
+}
+
+#[test]
+fn update_creator_fee_applies_to_subsequent_payout() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle, xlm_token) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 50_000_000_i128;
+
+    let params = default_params(&env);
+    let market_id = client.create_market(&creator, &params);
+    fund(&env, &xlm_token, &predictor, stake);
+
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+    client.update_creator_fee(&creator, &market_id, &200_u32);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    let payout = client.claim_payout(&predictor, &market_id);
+    // Sole winner: gross = 50M, fees = 2% protocol + 2% creator = 4%. net = 48M
+    assert_eq!(payout, 48_000_000);
+}
+
 #[test]
 fn test_create_market_min_stake_exceeds_max_stake() {
     let env = Env::default();


### PR DESCRIPTION
## Summary

- **#1049** — Add `update_creator_fee` to the open-market contract so creators can adjust their fee before `end_time`, capped at 500 bps. Includes auth, lifecycle guards, and payout integration tests.
- **#1040** — Add boundary tests for `max_participants` in creator-event-manager: exactly-one slot, fence-post count verification, unlimited (`max=0`), and boundary at 2.
- **#1086** — Add lightweight `GET /users/me/stats` endpoint returning accuracy rate, predictor tier, and win/loss counts without full user entity serialization.

Closes #1049
Closes #1040
Closes #1086

## Test plan

- [ ] `cd contracts/open-market && cargo test update_creator_fee`
- [ ] `cd contracts/creator-event-manager && cargo test max_participants`
- [ ] `cd backend && npm test -- --testPathPattern="users\.(service|controller)\.spec"`
- [ ] Verify `GET /users/me/stats` returns compact stats for an authenticated user


Made with [Cursor](https://cursor.com)