### PR TITLE
Add boundary tests for kickoff time, address tiebreaker, batch verify counts, and get_event_count view

### DIFF
--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -765,4 +765,12 @@ impl CreatorEventManagerContract {
     pub fn get_platform_statistics(env: Env) -> PlatformStatistics {
         views::get_platform_statistics(&env)
     }
+
+    /// Return the total number of events created on the platform.
+    ///
+    /// Lightweight alternative to `get_platform_statistics` for callers that
+    /// only need the event count. Returns `0` before any events are created.
+    pub fn get_event_count(env: Env) -> u64 {
+        views::get_event_count(&env)
+    }
 }

--- a/contracts/creator-event-manager/src/views.rs
+++ b/contracts/creator-event-manager/src/views.rs
@@ -233,6 +233,17 @@ pub fn get_platform_statistics(env: &Env) -> PlatformStatistics {
     }
 }
 
+/// Return the total number of events created on the platform.
+///
+/// Reads `DataKey::EventCounter` from instance storage. Returns `0` before
+/// any events are created or before initialization.
+pub fn get_event_count(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get::<DataKey, u64>(&DataKey::EventCounter(0))
+        .unwrap_or(0)
+}
+
 /// Check whether a single event has been finalized.
 ///
 /// Returns `Ok(bool)` representing the event's `is_finalized` flag.

--- a/contracts/creator-event-manager/tests/leaderboard_tests.rs
+++ b/contracts/creator-event-manager/tests/leaderboard_tests.rs
@@ -324,3 +324,84 @@ fn test_leaderboard_single_participant() {
     assert_eq!(leaderboard.get(0).unwrap().exact_scores, 1);
     assert_eq!(leaderboard.get(0).unwrap().matches_played, 1);
 }
+
+// ===========================================================================
+// Address tiebreaker tests (#1018)
+// ===========================================================================
+
+/// Two participants with identical scores in every dimension are ranked by
+/// address: the address that compares as `<` under Soroban's `Address` `Ord`
+/// implementation always gets rank 1.
+#[test]
+fn test_leaderboard_address_tiebreaker_smaller_address_ranks_first() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token) = setup();
+
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    let (event_id, invite_code, match_ids) =
+        create_event_with_matches(&env, &contract_id, &client, &creator, &xlm_token, 1);
+
+    // Determine lexicographic ordering at runtime.
+    let (smaller, larger) = if user_a < user_b {
+        (user_a.clone(), user_b.clone())
+    } else {
+        (user_b.clone(), user_a.clone())
+    };
+
+    // Both join and predict the same outcome at the same ledger timestamp so
+    // that total_points, exact_scores, and last_prediction_time are identical.
+    client.join_event(&smaller, &invite_code);
+    client.join_event(&larger, &invite_code);
+    client.submit_prediction(&smaller, &match_ids.get(0).unwrap(), &1u32, &0u32);
+    client.submit_prediction(&larger, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    // Advance past match time and submit result so both earn the same points.
+    env.ledger().set_timestamp(env.ledger().timestamp() + 300);
+    submit_match_result(&env, &client, &ai_agent, *match_ids.get(0).unwrap(), MatchResult::TeamA);
+
+    let leaderboard = client.get_event_leaderboard(&event_id);
+
+    assert_eq!(leaderboard.len(), 2);
+    assert_eq!(leaderboard.get(0).unwrap().rank, 1);
+    assert_eq!(leaderboard.get(0).unwrap().user, smaller);
+    assert_eq!(leaderboard.get(1).unwrap().rank, 2);
+    assert_eq!(leaderboard.get(1).unwrap().user, larger);
+}
+
+/// Swapping the join/predict insertion order must not change the outcome:
+/// the lexicographically smaller address always gets rank 1.
+#[test]
+fn test_leaderboard_address_tiebreaker_insertion_order_irrelevant() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token) = setup();
+
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    let (event_id, invite_code, match_ids) =
+        create_event_with_matches(&env, &contract_id, &client, &creator, &xlm_token, 1);
+
+    let (smaller, larger) = if user_a < user_b {
+        (user_a.clone(), user_b.clone())
+    } else {
+        (user_b.clone(), user_a.clone())
+    };
+
+    // Insert in REVERSE order: larger joins and predicts first.
+    client.join_event(&larger, &invite_code);
+    client.join_event(&smaller, &invite_code);
+    client.submit_prediction(&larger, &match_ids.get(0).unwrap(), &1u32, &0u32);
+    client.submit_prediction(&smaller, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 300);
+    submit_match_result(&env, &client, &ai_agent, *match_ids.get(0).unwrap(), MatchResult::TeamA);
+
+    let leaderboard = client.get_event_leaderboard(&event_id);
+
+    assert_eq!(leaderboard.len(), 2);
+    // Smaller address must still be rank 1 regardless of insertion order.
+    assert_eq!(leaderboard.get(0).unwrap().user, smaller);
+    assert_eq!(leaderboard.get(0).unwrap().rank, 1);
+    assert_eq!(leaderboard.get(1).unwrap().user, larger);
+    assert_eq!(leaderboard.get(1).unwrap().rank, 2);
+}

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -816,6 +816,76 @@ fn test_get_prediction_distribution_multiple_matches_independent() {
 
 
 // ---------------------------------------------------------------------------
+// Kickoff time boundary tests (#1017)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "match_started")]
+fn test_submit_prediction_at_exact_match_time_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    let match_time_offset: u64 = 1000;
+    let initial_ts = env.ledger().timestamp();
+    let match_time = initial_ts + match_time_offset;
+
+    let (_event_id, invite_code, match_id) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, match_time_offset);
+
+    client.join_event(&predictor, &invite_code);
+
+    // Advance to exactly match_time — prediction must be rejected.
+    env.ledger().with_mut(|l| l.timestamp = match_time);
+
+    client.submit_prediction(&predictor, &match_id, &1u32, &0u32);
+}
+
+#[test]
+#[should_panic(expected = "match_started")]
+fn test_submit_prediction_after_kickoff_plus_3600_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    let match_time_offset: u64 = 1000;
+    let initial_ts = env.ledger().timestamp();
+    let match_time = initial_ts + match_time_offset;
+
+    let (_event_id, invite_code, match_id) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, match_time_offset);
+
+    client.join_event(&predictor, &invite_code);
+
+    // Advance to match_time + 3600 — well past kickoff.
+    env.ledger().with_mut(|l| l.timestamp = match_time + 3600);
+
+    client.submit_prediction(&predictor, &match_id, &1u32, &0u32);
+}
+
+#[test]
+fn test_submit_prediction_just_before_kickoff_succeeds() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    let match_time_offset: u64 = 1000;
+    let initial_ts = env.ledger().timestamp();
+    let match_time = initial_ts + match_time_offset;
+
+    let (_event_id, invite_code, match_id) =
+        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, match_time_offset);
+
+    client.join_event(&predictor, &invite_code);
+
+    // Advance to one second before match_time — prediction must succeed.
+    env.ledger().with_mut(|l| l.timestamp = match_time - 1);
+
+    let prediction_id = client.submit_prediction(&predictor, &match_id, &1u32, &0u32);
+    assert!(prediction_id >= 1);
+}
+
+// ---------------------------------------------------------------------------
 // Scoreline prediction tests (#xxx) — acceptance tests
 // These tests are intentionally omitted from compilation.
 // See SCORELINE_TESTS.md for the specification of these tests.

--- a/contracts/creator-event-manager/tests/verification_tests.rs
+++ b/contracts/creator-event-manager/tests/verification_tests.rs
@@ -261,6 +261,90 @@ fn test_unverify_address_repeated_unverify_returns_not_verified() {
 }
 
 // ===========================================================================
+// #1026 — batch_verify_addresses returns count of only newly-verified addresses
+// ===========================================================================
+
+#[test]
+fn test_batch_verify_count_all_new_returns_full_count() {
+    let (env, client, _contract_id, admin) = setup_initialized();
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+
+    let mut addresses = Vec::new(&env);
+    addresses.push_back(user1.clone());
+    addresses.push_back(user2.clone());
+    addresses.push_back(user3.clone());
+
+    // All three are unverified; count must equal the batch size.
+    let count = client.batch_verify_addresses(&admin, &addresses);
+
+    assert_eq!(count, 3);
+    assert!(client.is_verified(&user1));
+    assert!(client.is_verified(&user2));
+    assert!(client.is_verified(&user3));
+}
+
+#[test]
+fn test_batch_verify_count_mixed_batch_returns_only_new_count() {
+    let (env, client, _contract_id, admin) = setup_initialized();
+
+    let pre1 = Address::generate(&env);
+    let pre2 = Address::generate(&env);
+    let new1 = Address::generate(&env);
+    let new2 = Address::generate(&env);
+    let new3 = Address::generate(&env);
+
+    // Pre-verify two addresses.
+    client.verify_address(&admin, &pre1);
+    client.verify_address(&admin, &pre2);
+
+    let mut addresses = Vec::new(&env);
+    addresses.push_back(pre1.clone());
+    addresses.push_back(pre2.clone());
+    addresses.push_back(new1.clone());
+    addresses.push_back(new2.clone());
+    addresses.push_back(new3.clone());
+
+    // Only the 3 fresh addresses should be counted.
+    let count = client.batch_verify_addresses(&admin, &addresses);
+
+    assert_eq!(count, 3);
+    // Pre-verified addresses remain verified.
+    assert!(client.is_verified(&pre1));
+    assert!(client.is_verified(&pre2));
+    // Newly verified addresses are now verified.
+    assert!(client.is_verified(&new1));
+    assert!(client.is_verified(&new2));
+    assert!(client.is_verified(&new3));
+}
+
+#[test]
+fn test_batch_verify_count_all_already_verified_returns_zero() {
+    let (env, client, _contract_id, admin) = setup_initialized();
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    // Pre-verify all addresses in the batch.
+    client.verify_address(&admin, &user1);
+    client.verify_address(&admin, &user2);
+
+    let mut addresses = Vec::new(&env);
+    addresses.push_back(user1.clone());
+    addresses.push_back(user2.clone());
+
+    // No new verifications — count must be 0.
+    let count = client.batch_verify_addresses(&admin, &addresses);
+
+    assert_eq!(count, 0);
+    // Addresses remain verified.
+    assert!(client.is_verified(&user1));
+    assert!(client.is_verified(&user2));
+}
+
+// ===========================================================================
 // #793 — is_verified
 // ===========================================================================
 

--- a/contracts/creator-event-manager/tests/views_tests.rs
+++ b/contracts/creator-event-manager/tests/views_tests.rs
@@ -597,3 +597,96 @@ fn test_is_event_finalized_not_found() {
     client.is_event_finalized(&9999u64);
 }
 
+// =============================================================================
+// get_event_count tests (#1028)
+// =============================================================================
+
+#[test]
+fn test_get_event_count_returns_zero_before_any_events() {
+    let (_env, client, _contract_id, _xlm_token) = setup();
+    assert_eq!(client.get_event_count(), 0);
+}
+
+#[test]
+fn test_get_event_count_increments_monotonically() {
+    let (env, client, _contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+
+    assert_eq!(client.get_event_count(), 0);
+
+    fund(&env, &xlm_token, &creator, FEE);
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &5u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+    assert_eq!(client.get_event_count(), 1);
+
+    fund(&env, &xlm_token, &creator, FEE);
+    let start_time2 = get_future_time(&env, 3600);
+    let end_time2 = get_future_time(&env, 7200);
+    client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &5u32,
+        &start_time2,
+        &end_time2,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+    assert_eq!(client.get_event_count(), 2);
+
+    fund(&env, &xlm_token, &creator, FEE);
+    let start_time3 = get_future_time(&env, 3600);
+    let end_time3 = get_future_time(&env, 7200);
+    client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &5u32,
+        &start_time3,
+        &end_time3,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+    assert_eq!(client.get_event_count(), 3);
+}
+
+#[test]
+fn test_get_event_count_matches_platform_statistics_total_events() {
+    let (env, client, _contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+
+    // Verified that get_event_count and get_platform_statistics.total_events agree.
+    assert_eq!(client.get_event_count(), client.get_platform_statistics().total_events);
+
+    fund(&env, &xlm_token, &creator, FEE);
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &5u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+
+    assert_eq!(client.get_event_count(), client.get_platform_statistics().total_events);
+    assert_eq!(client.get_event_count(), 1);
+}
+


### PR DESCRIPTION
[Contract] — Test: `submit_prediction` is rejected after match kickoff time Fixes #1017

[Contract] — Test: Leaderboard address tiebreaker produces deterministic rank Fixes #1018

[Contract] — Test: `batch_verify_addresses` returns count of only newly-verified addresses Fixes #1026

[Contract] — Feature: Add `get_event_count` platform-level view Fixes #1028

closes

#1017 
#1018 
#1026
#1028 