### PR TITLE
[Contract] Add integration tests for multiplied scoring, entry-fee joins, prize-pool finalization, and get_event_prize_pool view

### DIFF
--- a/contracts/creator-event-manager/src/event.rs
+++ b/contracts/creator-event-manager/src/event.rs
@@ -4,8 +4,8 @@ use crate::admin;
 use crate::invite::{self, InviteError};
 use crate::storage::{self, TTL_LEDGERS};
 use crate::storage_types::{
-    DataKey, Event, MAX_DESCRIPTION_LEN, MAX_EVENT_DURATION_SECONDS, MAX_REWARD_RANKS, MAX_TITLE_LEN,
-    REWARD_PERCENT_TOTAL,
+    DataKey, Event, MAX_DESCRIPTION_LEN, MAX_EVENT_DURATION_SECONDS, MAX_REWARD_RANKS,
+    MAX_TITLE_LEN, REWARD_PERCENT_TOTAL,
 };
 
 // ---------------------------------------------------------------------------

--- a/contracts/creator-event-manager/src/finalize.rs
+++ b/contracts/creator-event-manager/src/finalize.rs
@@ -105,8 +105,8 @@ pub fn finalize_event(
     // Ranked, deterministic leaderboard. The event was already loaded above, so
     // the only residual error path here is an (effectively unreachable) points
     // overflow; collapse it onto EventNotFound to stay within EventError.
-    let leaderboard = leaderboard::get_event_leaderboard(env, event_id)
-        .map_err(|_| EventError::EventNotFound)?;
+    let leaderboard =
+        leaderboard::get_event_leaderboard(env, event_id).map_err(|_| EventError::EventNotFound)?;
 
     let xlm_token = admin::get_xlm_token(env).unwrap_or_else(|| panic!("not_initialized"));
 

--- a/contracts/creator-event-manager/src/leaderboard.rs
+++ b/contracts/creator-event-manager/src/leaderboard.rs
@@ -93,8 +93,9 @@ pub fn get_event_leaderboard(
             if let Ok(prediction) = storage::get_prediction(env, prediction_id) {
                 // Add earned points (None counts as 0)
                 if let Some(points) = prediction.points_earned {
-                    total_points =
-                        total_points.checked_add(points).ok_or(LeaderboardError::Overflow)?;
+                    total_points = total_points
+                        .checked_add(points)
+                        .ok_or(LeaderboardError::Overflow)?;
                 }
 
                 // Count correct results
@@ -105,12 +106,15 @@ pub fn get_event_leaderboard(
                 }
 
                 // Count exact scores (4 points means exact score)
-                if prediction.points_earned == Some(
-                    crate::storage_types::POINTS_CORRECT_RESULT
-                        + crate::storage_types::POINTS_EXACT_SCORE,
-                ) {
-                    exact_scores =
-                        exact_scores.checked_add(1).ok_or(LeaderboardError::Overflow)?;
+                if prediction.points_earned
+                    == Some(
+                        crate::storage_types::POINTS_CORRECT_RESULT
+                            + crate::storage_types::POINTS_EXACT_SCORE,
+                    )
+                {
+                    exact_scores = exact_scores
+                        .checked_add(1)
+                        .ok_or(LeaderboardError::Overflow)?;
                 }
 
                 // Track latest prediction time

--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -20,7 +20,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 use admin::AdminError;
 use event::EventError;
 use r#match::MatchError;
-use storage_types::{Event, Match, Prediction, LeaderboardEntry};
+use storage_types::{Event, LeaderboardEntry, Match, Prediction};
 use verification::VerificationError;
 use views::{EventStatistics, PlatformStatistics};
 
@@ -469,7 +469,15 @@ impl CreatorEventManagerContract {
         match_time: u64,
         points_multiplier: u32,
     ) -> u64 {
-        match r#match::create_match(&env, caller, event_id, team_a, team_b, match_time, points_multiplier) {
+        match r#match::create_match(
+            &env,
+            caller,
+            event_id,
+            team_a,
+            team_b,
+            match_time,
+            points_multiplier,
+        ) {
             Ok(match_id) => match_id,
             Err(MatchError::Paused) => panic!("paused"),
             Err(MatchError::EventNotFound) => panic!("event_not_found"),
@@ -643,7 +651,13 @@ impl CreatorEventManagerContract {
     /// * `"match_not_found"` — no match exists with the given ID.
     /// * `"result_already_submitted"` — a result was already submitted.
     /// * `"match_not_started"` — current time is before the match start time.
-    pub fn submit_match_result(env: Env, caller: Address, match_id: u64, home_score: u32, away_score: u32) {
+    pub fn submit_match_result(
+        env: Env,
+        caller: Address,
+        match_id: u64,
+        home_score: u32,
+        away_score: u32,
+    ) {
         match oracle::submit_match_result(&env, caller, match_id, home_score, away_score) {
             Ok(()) => {}
             Err(oracle::OracleError::Paused) => panic!("contract_paused"),

--- a/contracts/creator-event-manager/src/oracle.rs
+++ b/contracts/creator-event-manager/src/oracle.rs
@@ -195,11 +195,15 @@ pub fn get_user_score(
         if let Ok(prediction) = storage::get_prediction(env, prediction_id) {
             // Add earned points
             if let Some(points) = prediction.points_earned {
-                total_points = total_points.checked_add(points).ok_or(OracleError::Overflow)?;
+                total_points = total_points
+                    .checked_add(points)
+                    .ok_or(OracleError::Overflow)?;
             }
             // Count correct results
             if prediction.is_correct == Some(true) {
-                correct_results = correct_results.checked_add(1).ok_or(OracleError::Overflow)?;
+                correct_results = correct_results
+                    .checked_add(1)
+                    .ok_or(OracleError::Overflow)?;
             }
             // Count exact scores: load the match to compare actual vs predicted scores.
             // This is multiplier-agnostic — an exact score is one where both predicted
@@ -211,8 +215,7 @@ pub fn get_user_score(
                     if prediction.predicted_home_score == actual_home
                         && prediction.predicted_away_score == actual_away
                     {
-                        exact_scores =
-                            exact_scores.checked_add(1).ok_or(OracleError::Overflow)?;
+                        exact_scores = exact_scores.checked_add(1).ok_or(OracleError::Overflow)?;
                     }
                 }
             }

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -644,8 +644,8 @@ impl Prediction {
         predicted_at: u64,
         env: &soroban_sdk::Env,
     ) -> Self {
-        let predicted_outcome = MatchResult::from_scores(predicted_home_score, predicted_away_score)
-            .to_u8();
+        let predicted_outcome =
+            MatchResult::from_scores(predicted_home_score, predicted_away_score).to_u8();
         let outcome_symbol = match predicted_outcome {
             0 => Symbol::new(env, OUTCOME_TEAM_A),
             1 => Symbol::new(env, OUTCOME_TEAM_B),

--- a/contracts/creator-event-manager/tests/admin_tests.rs
+++ b/contracts/creator-event-manager/tests/admin_tests.rs
@@ -519,4 +519,3 @@ fn test_update_creation_fee_must_be_strictly_positive() {
 
     client.update_creation_fee(&admin, &0i128);
 }
-

--- a/contracts/creator-event-manager/tests/data_structures_test.rs
+++ b/contracts/creator-event-manager/tests/data_structures_test.rs
@@ -445,7 +445,7 @@ fn test_prediction_grade_team_a_correct() {
         1_640_995_200,
         &env,
     );
-    pred.grade(2u32, 1u32, 1u32);  // Exact match
+    pred.grade(2u32, 1u32, 1u32); // Exact match
     assert_eq!(pred.is_correct, Some(true));
     assert_eq!(pred.points_earned, Some(4)); // 1 + 3 for exact
     assert!(pred.is_winner());
@@ -464,7 +464,7 @@ fn test_prediction_grade_team_a_wrong() {
         1_640_995_200,
         &env,
     );
-    pred.grade(1u32, 2u32, 1u32);  // Wrong result
+    pred.grade(1u32, 2u32, 1u32); // Wrong result
     assert_eq!(pred.is_correct, Some(false));
     assert_eq!(pred.points_earned, Some(0));
     assert!(!pred.is_winner());
@@ -483,7 +483,7 @@ fn test_prediction_grade_draw_correct() {
         1_640_995_200,
         &env,
     );
-    pred.grade(1u32, 1u32, 1u32);  // Exact draw
+    pred.grade(1u32, 1u32, 1u32); // Exact draw
     assert_eq!(pred.is_correct, Some(true));
     assert_eq!(pred.points_earned, Some(4)); // Exact draw
     assert!(pred.is_winner());
@@ -492,16 +492,7 @@ fn test_prediction_grade_draw_correct() {
 #[test]
 fn test_prediction_is_before_match_time_boundary() {
     let env = Env::default();
-    let pred = Prediction::new(
-        1,
-        5,
-        10,
-        Address::generate(&env),
-        2u32,
-        1u32,
-        100,
-        &env,
-    );
+    let pred = Prediction::new(1, 5, 10, Address::generate(&env), 2u32, 1u32, 100, &env);
     // predicted_at (100) < match_time (100) => false (not strictly before)
     assert!(!pred.is_before_match_time(100));
     // predicted_at (100) < match_time (101) => true

--- a/contracts/creator-event-manager/tests/event_tests.rs
+++ b/contracts/creator-event-manager/tests/event_tests.rs
@@ -711,7 +711,10 @@ fn test_get_event_prize_pool_and_distribution_views() {
     );
 
     assert_eq!(client.get_event_prize_pool(&event_id), PRIZE_POOL);
-    assert_eq!(client.get_event_reward_distribution(&event_id), distribution(&env));
+    assert_eq!(
+        client.get_event_reward_distribution(&event_id),
+        distribution(&env)
+    );
 
     // Fields are persisted on the event itself, not finalized at creation.
     let event = client.get_event(&event_id);

--- a/contracts/creator-event-manager/tests/finalize_tests.rs
+++ b/contracts/creator-event-manager/tests/finalize_tests.rs
@@ -274,7 +274,12 @@ fn test_finalize_event_with_unresolved_match_rejected() {
 
     // Past end_time, but only resolve the first of two matches.
     env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
-    submit_result(&client, &ai_agent, match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let caller = Address::generate(&env);
     client.finalize_event(&caller, &event_id);
@@ -302,7 +307,12 @@ fn test_finalize_event_twice_rejected() {
     client.submit_prediction(&user, &match_ids.get(0).unwrap(), &1u32, &0u32);
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
-    submit_result(&client, &ai_agent, match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let caller = Address::generate(&env);
     client.finalize_event(&caller, &event_id);
@@ -341,7 +351,12 @@ fn test_finalize_event_fewer_participants_than_ranks_refunds_creator() {
     client.submit_prediction(&user2, &match_ids.get(0).unwrap(), &0u32, &1u32);
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
-    submit_result(&client, &ai_agent, match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let caller = Address::generate(&env);
     let payouts = client.finalize_event(&caller, &event_id);
@@ -418,7 +433,12 @@ fn test_finalize_event_integer_division_dust_refunded_to_creator() {
     client.submit_prediction(&user2, &match_ids.get(0).unwrap(), &0u32, &1u32);
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
-    submit_result(&client, &ai_agent, match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let creator_balance_before = balance(&env, &xlm_token, &creator);
 
@@ -468,7 +488,12 @@ fn test_finalize_event_zero_prize_pool_noop() {
     client.submit_prediction(&user, &match_ids.get(0).unwrap(), &1u32, &0u32);
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
-    submit_result(&client, &ai_agent, match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
 
@@ -505,7 +530,12 @@ fn test_finalize_event_permissionless() {
     client.submit_prediction(&user, &match_ids.get(0).unwrap(), &1u32, &0u32);
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
-    submit_result(&client, &ai_agent, match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     // A random address — neither admin nor creator — can finalize.
     let random_caller = Address::generate(&env);
@@ -514,4 +544,113 @@ fn test_finalize_event_permissionless() {
     assert_eq!(payouts.len(), 1);
     assert_eq!(balance(&env, &xlm_token, &user), PRIZE);
     assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Entry-fee accumulation before finalize (#1027)
+// ---------------------------------------------------------------------------
+
+/// Seed pool + entry fees accumulate correctly and the full combined pool is
+/// distributed on finalization.  An odd seed is used so that integer-division
+/// dust is generated and verified to reach the creator rather than being lost.
+#[test]
+fn test_finalize_event_seed_pool_plus_entry_fees_combined() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token) = setup();
+
+    // Odd seed so 60/40 split leaves a 1-stroop dust remainder.
+    let seed_pool: i128 = 5_000_001;
+    let entry_fee: i128 = 1_000_000;
+
+    fund(&env, &xlm_token, &creator, FEE + seed_pool);
+
+    let start_time = env.ledger().timestamp() + 3600;
+    let end_time = env.ledger().timestamp() + 7200;
+    let dist = reward_dist(&env, &[60, 40]);
+
+    let (event_id, invite_code) = client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &100u32,
+        &start_time,
+        &end_time,
+        &seed_pool,
+        &dist,
+        &entry_fee,
+    );
+
+    // Before any joins, prize pool equals the seed.
+    assert_eq!(client.get_event_prize_pool(&event_id), seed_pool);
+
+    // Three participants each pay entry_fee.
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+
+    for user in [&user1, &user2, &user3] {
+        fund(&env, &xlm_token, user, entry_fee);
+        client.join_event(user, &invite_code);
+    }
+
+    // Prize pool is now seed + 3 × entry_fee.
+    let total_pool = seed_pool + 3 * entry_fee; // 5_000_001 + 3_000_000 = 8_000_001
+    assert_eq!(client.get_event_prize_pool(&event_id), total_pool);
+
+    // Add one match via storage.
+    let match_id = env.as_contract(&contract_id, || {
+        let mid = storage::next_match_id(&env);
+        let m = creator_event_manager::storage_types::Match::new(
+            mid,
+            event_id,
+            String::from_str(&env, "Team A"),
+            String::from_str(&env, "Team B"),
+            env.ledger().timestamp() + 100,
+            1u32,
+        );
+        storage::set_match(&env, mid, &m);
+        storage::add_event_match(&env, event_id, mid);
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.add_match();
+        storage::set_event(&env, event_id, &event);
+        mid
+    });
+
+    // user1: exact 1-0 → 4 pts (rank 1)
+    // user2: correct result 2-0 → 1 pt  (rank 2)
+    // user3: wrong result  0-1 → 0 pts  (no prize)
+    client.submit_prediction(&user1, &match_id, &1u32, &0u32);
+    client.submit_prediction(&user2, &match_id, &2u32, &0u32);
+    client.submit_prediction(&user3, &match_id, &0u32, &1u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    // Actual result: Team A wins 1-0.
+    submit_result(&client, &ai_agent, match_id, MatchResult::TeamA);
+
+    let caller = Address::generate(&env);
+    let payouts = client.finalize_event(&caller, &event_id);
+
+    // 8_000_001 * 60 / 100 = 4_800_000  (truncated)
+    // 8_000_001 * 40 / 100 = 3_200_000  (truncated)
+    // dust = 8_000_001 − 4_800_000 − 3_200_000 = 1 → creator
+    let expected_rank1 = total_pool * 60 / 100; // 4_800_000
+    let expected_rank2 = total_pool * 40 / 100; // 3_200_000
+    let expected_dust = total_pool - expected_rank1 - expected_rank2; // 1
+
+    assert_eq!(payouts.len(), 2);
+
+    // Verify token balances for each winner numerically.
+    assert_eq!(balance(&env, &xlm_token, &user1), expected_rank1);
+    assert_eq!(balance(&env, &xlm_token, &user2), expected_rank2);
+    // user3 paid the entry fee and scored 0 pts — receives no prize.
+    assert_eq!(balance(&env, &xlm_token, &user3), 0);
+
+    // Integer-division remainder goes to creator, not lost.
+    assert_eq!(balance(&env, &xlm_token, &creator), expected_dust);
+
+    // Total distributed equals seed_pool + N × entry_fee.
+    let total_out = expected_rank1 + expected_rank2 + expected_dust;
+    assert_eq!(total_out, total_pool);
+    assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
+
+    assert!(client.get_event(&event_id).is_finalized);
 }

--- a/contracts/creator-event-manager/tests/leaderboard_tests.rs
+++ b/contracts/creator-event-manager/tests/leaderboard_tests.rs
@@ -209,8 +209,20 @@ fn test_leaderboard_tiebreak_by_exact_scores() {
 
     // Advance time and submit results
     env.ledger().set_timestamp(env.ledger().timestamp() + 200);
-    submit_match_result(&env, &client, &ai_agent, *match_ids.get(0).unwrap(), MatchResult::Draw);
-    submit_match_result(&env, &client, &ai_agent, *match_ids.get(1).unwrap(), MatchResult::TeamA);
+    submit_match_result(
+        &env,
+        &client,
+        &ai_agent,
+        *match_ids.get(0).unwrap(),
+        MatchResult::Draw,
+    );
+    submit_match_result(
+        &env,
+        &client,
+        &ai_agent,
+        *match_ids.get(1).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let leaderboard = client.get_event_leaderboard(&event_id);
 
@@ -249,7 +261,13 @@ fn test_leaderboard_tiebreak_by_earliest_prediction() {
 
     // Advance time and submit result
     env.ledger().set_timestamp(env.ledger().timestamp() + 200);
-    submit_match_result(&env, &client, &ai_agent, *match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_match_result(
+        &env,
+        &client,
+        &ai_agent,
+        *match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let leaderboard = client.get_event_leaderboard(&event_id);
 
@@ -312,7 +330,13 @@ fn test_leaderboard_single_participant() {
     client.submit_prediction(&user1, match_ids.get(0).unwrap(), &1u32, &0u32);
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 200);
-    submit_match_result(&env, &client, &ai_agent, *match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_match_result(
+        &env,
+        &client,
+        &ai_agent,
+        *match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let leaderboard = client.get_event_leaderboard(&event_id);
 
@@ -358,7 +382,13 @@ fn test_leaderboard_address_tiebreaker_smaller_address_ranks_first() {
 
     // Advance past match time and submit result so both earn the same points.
     env.ledger().set_timestamp(env.ledger().timestamp() + 300);
-    submit_match_result(&env, &client, &ai_agent, *match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_match_result(
+        &env,
+        &client,
+        &ai_agent,
+        *match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let leaderboard = client.get_event_leaderboard(&event_id);
 
@@ -394,7 +424,13 @@ fn test_leaderboard_address_tiebreaker_insertion_order_irrelevant() {
     client.submit_prediction(&smaller, &match_ids.get(0).unwrap(), &1u32, &0u32);
 
     env.ledger().set_timestamp(env.ledger().timestamp() + 300);
-    submit_match_result(&env, &client, &ai_agent, *match_ids.get(0).unwrap(), MatchResult::TeamA);
+    submit_match_result(
+        &env,
+        &client,
+        &ai_agent,
+        *match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
 
     let leaderboard = client.get_event_leaderboard(&event_id);
 

--- a/contracts/creator-event-manager/tests/oracle_tests.rs
+++ b/contracts/creator-event-manager/tests/oracle_tests.rs
@@ -102,9 +102,9 @@ fn submit_match_result(
     result: MatchResult,
 ) {
     let (home_score, away_score) = match result {
-        MatchResult::TeamA => (2, 1),   // Default: Team A wins 2-1
-        MatchResult::TeamB => (1, 2),   // Default: Team B wins 1-2
-        MatchResult::Draw => (1, 1),    // Default: 1-1 draw
+        MatchResult::TeamA => (2, 1), // Default: Team A wins 2-1
+        MatchResult::TeamB => (1, 2), // Default: Team B wins 1-2
+        MatchResult::Draw => (1, 1),  // Default: 1-1 draw
     };
     client.submit_match_result(ai_agent, &match_id, &home_score, &away_score);
 }
@@ -112,9 +112,9 @@ fn submit_match_result(
 /// Convert an expected result to a default scoreline for testing.
 fn result_to_scores(result: MatchResult) -> (u32, u32) {
     match result {
-        MatchResult::TeamA => (2, 1),   // Team A wins 2-1
-        MatchResult::TeamB => (1, 2),   // Team B wins 1-2
-        MatchResult::Draw => (1, 1),    // 1-1 draw
+        MatchResult::TeamA => (2, 1), // Team A wins 2-1
+        MatchResult::TeamB => (1, 2), // Team B wins 1-2
+        MatchResult::Draw => (1, 1),  // 1-1 draw
     }
 }
 
@@ -245,22 +245,11 @@ fn test_get_user_score_calculation_accurate() {
     client.submit_prediction(&user, &match_id_2, &1u32, &2u32);
 
     env.ledger().with_mut(|l| l.timestamp += 25_000);
-    submit_match_result(
-        &env,
-        &client,
-        &ai_agent,
-        match_id_1,
-        MatchResult::TeamA,
-    );
-    submit_match_result(
-        &env,
-        &client,
-        &ai_agent,
-        match_id_2,
-        MatchResult::TeamA,
-    );
+    submit_match_result(&env, &client, &ai_agent, match_id_1, MatchResult::TeamA);
+    submit_match_result(&env, &client, &ai_agent, match_id_2, MatchResult::TeamA);
 
-    let (total_points, correct_results, _exact_scores, total_matches) = client.get_user_score(&user, &event_id);
+    let (total_points, correct_results, _exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
     assert_eq!(correct_results, 1);
     assert_eq!(total_matches, 2);
 }
@@ -277,7 +266,8 @@ fn test_get_user_score_unresolved_predictions_not_counted() {
     client.join_event(&user, &invite_code);
     client.submit_prediction(&user, &match_id, &2u32, &1u32);
 
-    let (total_points, correct_results, exact_scores, total_matches) = client.get_user_score(&user, &event_id);
+    let (total_points, correct_results, exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
     assert_eq!(correct_results, 0);
     assert_eq!(total_matches, 1);
 }
@@ -297,17 +287,15 @@ fn test_get_user_score_zero_score_handled() {
     env.ledger().with_mut(|l| l.timestamp += 15_000);
     submit_match_result(&env, &client, &ai_agent, match_id, MatchResult::TeamB);
 
-    let (total_points, correct_results, exact_scores, total_matches) = client.get_user_score(&user, &event_id);
+    let (total_points, correct_results, exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
     assert_eq!(correct_results, 0);
     assert_eq!(total_matches, 1);
 }
 
-
 // ============================================================================
 // Scoreline grading additional tests (#xxx)
 // ============================================================================
-
-
 
 // ============================================================================
 // Scoreline grading additional tests (#xxx)
@@ -320,3 +308,268 @@ fn test_get_user_score_zero_score_handled() {
 //   - User 2 (result): predicts 3-0, actual 2-1 → (1, 1, 0, 1)
 //   - User 3 (wrong): predicts 0-1, actual 2-1 → (0, 0, 0, 1)
 // ============================================================================
+
+// ============================================================================
+// Points multiplier tests (#1024)
+// ============================================================================
+
+fn create_event_with_match_and_multiplier(
+    env: &Env,
+    contract_id: &Address,
+    client: &CreatorEventManagerContractClient<'static>,
+    creator: &Address,
+    xlm_token: &Address,
+    match_time_offset: u64,
+    points_multiplier: u32,
+) -> (u64, Symbol, u64) {
+    fund(env, xlm_token, creator, FEE);
+    let start_time = env.ledger().timestamp() + 3600;
+    let end_time = env.ledger().timestamp() + 7200;
+    let (event_id, invite_code) = client.create_event(
+        creator,
+        &title(env),
+        &desc(env),
+        &10u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(env),
+        &0i128,
+    );
+
+    let match_id = env.as_contract(contract_id, || {
+        let match_id = storage::next_match_id(env);
+        let match_record = creator_event_manager::storage_types::Match::new(
+            match_id,
+            event_id,
+            String::from_str(env, "Team A"),
+            String::from_str(env, "Team B"),
+            env.ledger().timestamp() + match_time_offset,
+            points_multiplier,
+        );
+        storage::set_match(env, match_id, &match_record);
+        storage::add_event_match(env, event_id, match_id);
+
+        let mut event = storage::get_event(env, event_id).expect("event exists");
+        event.add_match();
+        storage::set_event(env, event_id, &event);
+        match_id
+    });
+
+    (event_id, invite_code, match_id)
+}
+
+/// Double result test: points_multiplier=2, correct result (not exact) → 1 × 2 = 2 points
+#[test]
+fn test_get_user_score_double_multiplier_correct_result() {
+    let (env, client, contract_id, _admin, ai_agent, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (event_id, invite_code, match_id) = create_event_with_match_and_multiplier(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        10_000,
+        2,
+    );
+
+    client.join_event(&user, &invite_code);
+    // Predict 3-0: Team A wins (correct result) but wrong scoreline
+    client.submit_prediction(&user, &match_id, &3u32, &0u32);
+
+    env.ledger().with_mut(|l| l.timestamp += 15_000);
+    // Actual: Team A wins 2-1
+    client.submit_match_result(&ai_agent, &match_id, &2u32, &1u32);
+
+    let (total_points, correct_results, exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
+    assert_eq!(total_points, 2); // 1 base point × 2 multiplier
+    assert_eq!(correct_results, 1);
+    assert_eq!(exact_scores, 0);
+    assert_eq!(total_matches, 1);
+}
+
+/// Double exact-score test: points_multiplier=2, exact score → 4 × 2 = 8 points
+#[test]
+fn test_get_user_score_double_multiplier_exact_score() {
+    let (env, client, contract_id, _admin, ai_agent, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (event_id, invite_code, match_id) = create_event_with_match_and_multiplier(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        10_000,
+        2,
+    );
+
+    client.join_event(&user, &invite_code);
+    // Predict exact score 2-1
+    client.submit_prediction(&user, &match_id, &2u32, &1u32);
+
+    env.ledger().with_mut(|l| l.timestamp += 15_000);
+    // Actual: Team A wins 2-1 (exact match)
+    client.submit_match_result(&ai_agent, &match_id, &2u32, &1u32);
+
+    let (total_points, correct_results, exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
+    assert_eq!(total_points, 8); // 4 base points × 2 multiplier
+    assert_eq!(correct_results, 1);
+    assert_eq!(exact_scores, 1);
+    assert_eq!(total_matches, 1);
+}
+
+/// Triple exact-score test: points_multiplier=3, exact score → 4 × 3 = 12 points
+#[test]
+fn test_get_user_score_triple_multiplier_exact_score() {
+    let (env, client, contract_id, _admin, ai_agent, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (event_id, invite_code, match_id) = create_event_with_match_and_multiplier(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        10_000,
+        3,
+    );
+
+    client.join_event(&user, &invite_code);
+    // Predict exact score 1-0
+    client.submit_prediction(&user, &match_id, &1u32, &0u32);
+
+    env.ledger().with_mut(|l| l.timestamp += 15_000);
+    // Actual: Team A wins 1-0 (exact match)
+    client.submit_match_result(&ai_agent, &match_id, &1u32, &0u32);
+
+    let (total_points, correct_results, exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
+    assert_eq!(total_points, 12); // 4 base points × 3 multiplier
+    assert_eq!(correct_results, 1);
+    assert_eq!(exact_scores, 1);
+    assert_eq!(total_matches, 1);
+}
+
+/// Wrong prediction with multiplier: wrong result → 0 points regardless of multiplier
+#[test]
+fn test_get_user_score_wrong_result_with_multiplier_yields_zero() {
+    let (env, client, contract_id, _admin, ai_agent, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (event_id, invite_code, match_id) = create_event_with_match_and_multiplier(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        10_000,
+        2,
+    );
+
+    client.join_event(&user, &invite_code);
+    // Predict Team B wins (wrong: actual is Team A)
+    client.submit_prediction(&user, &match_id, &0u32, &1u32);
+
+    env.ledger().with_mut(|l| l.timestamp += 15_000);
+    // Actual: Team A wins 2-1
+    client.submit_match_result(&ai_agent, &match_id, &2u32, &1u32);
+
+    let (total_points, correct_results, exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
+    assert_eq!(total_points, 0); // 0 base points × 2 multiplier = 0
+    assert_eq!(correct_results, 0);
+    assert_eq!(exact_scores, 0);
+    assert_eq!(total_matches, 1);
+}
+
+/// Mixed multiplier event: match1 (multiplier=1) correct result + match2 (multiplier=2) correct
+/// result → total = 1×1 + 1×2 = 3 points
+#[test]
+fn test_get_user_score_mixed_multiplier_event() {
+    let (env, client, contract_id, _admin, ai_agent, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    fund(&env, &xlm_token, &creator, FEE);
+    let start_time = env.ledger().timestamp() + 3600;
+    let end_time = env.ledger().timestamp() + 7200;
+    let (event_id, invite_code) = client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &10u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+
+    let (match_id_1, match_id_2) = env.as_contract(&contract_id, || {
+        let m1 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m1,
+            &creator_event_manager::storage_types::Match::new(
+                m1,
+                event_id,
+                String::from_str(&env, "Team A"),
+                String::from_str(&env, "Team B"),
+                env.ledger().timestamp() + 10_000,
+                1u32,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m1);
+
+        let m2 = storage::next_match_id(&env);
+        storage::set_match(
+            &env,
+            m2,
+            &creator_event_manager::storage_types::Match::new(
+                m2,
+                event_id,
+                String::from_str(&env, "Team C"),
+                String::from_str(&env, "Team D"),
+                env.ledger().timestamp() + 20_000,
+                2u32,
+            ),
+        );
+        storage::add_event_match(&env, event_id, m2);
+
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.add_match();
+        event.add_match();
+        storage::set_event(&env, event_id, &event);
+
+        (m1, m2)
+    });
+
+    client.join_event(&user, &invite_code);
+    // Both matches: predict correct result (Team A wins) but wrong score
+    client.submit_prediction(&user, &match_id_1, &3u32, &0u32);
+    client.submit_prediction(&user, &match_id_2, &3u32, &0u32);
+
+    env.ledger().with_mut(|l| l.timestamp += 25_000);
+    // Actual for both: Team A wins 2-1
+    client.submit_match_result(&ai_agent, &match_id_1, &2u32, &1u32);
+    client.submit_match_result(&ai_agent, &match_id_2, &2u32, &1u32);
+
+    let (total_points, correct_results, exact_scores, total_matches) =
+        client.get_user_score(&user, &event_id);
+    // Match 1: 1 pt × multiplier 1 = 1
+    // Match 2: 1 pt × multiplier 2 = 2
+    // Total: 3 pts
+    assert_eq!(total_points, 3);
+    assert_eq!(correct_results, 2);
+    assert_eq!(exact_scores, 0);
+    assert_eq!(total_matches, 2);
+}

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -2,8 +2,8 @@
 use creator_event_manager::storage;
 use creator_event_manager::CreatorEventManagerContractClient;
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::testutils::Ledger as _;
 use soroban_sdk::testutils::Events as _;
+use soroban_sdk::testutils::Ledger as _;
 use soroban_sdk::token::{StellarAssetClient, TokenClient};
 use soroban_sdk::{Address, Env, String, Symbol, Vec};
 
@@ -130,7 +130,10 @@ fn test_join_event_emits_correct_event() {
 
     let events = env.events().all();
     let mut found = false;
-    let expected_topics = (Symbol::new(&env, "participant"), Symbol::new(&env, "joined"));
+    let expected_topics = (
+        Symbol::new(&env, "participant"),
+        Symbol::new(&env, "joined"),
+    );
     let expected_data = (event_id, user.clone());
 
     use soroban_sdk::TryIntoVal;
@@ -169,18 +172,21 @@ fn test_join_event_failed_does_not_emit_event() {
     use soroban_sdk::TryIntoVal;
 
     let events_before = env.events().all();
-    let num_participant_joined_before = events_before.iter().filter(|event| {
-        if event.0 != contract_id || event.1.len() != 2 {
-            return false;
-        }
-        let topic0: Result<Symbol, _> = event.1.get(0).unwrap().try_into_val(&env);
-        let topic1: Result<Symbol, _> = event.1.get(1).unwrap().try_into_val(&env);
-        if let (Ok(t0), Ok(t1)) = (topic0, topic1) {
-            t0 == Symbol::new(&env, "participant") && t1 == Symbol::new(&env, "joined")
-        } else {
-            false
-        }
-    }).count();
+    let num_participant_joined_before = events_before
+        .iter()
+        .filter(|event| {
+            if event.0 != contract_id || event.1.len() != 2 {
+                return false;
+            }
+            let topic0: Result<Symbol, _> = event.1.get(0).unwrap().try_into_val(&env);
+            let topic1: Result<Symbol, _> = event.1.get(1).unwrap().try_into_val(&env);
+            if let (Ok(t0), Ok(t1)) = (topic0, topic1) {
+                t0 == Symbol::new(&env, "participant") && t1 == Symbol::new(&env, "joined")
+            } else {
+                false
+            }
+        })
+        .count();
 
     // Call join_event expecting panic
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -189,22 +195,27 @@ fn test_join_event_failed_does_not_emit_event() {
     assert!(result.is_err());
 
     let events_after = env.events().all();
-    let num_participant_joined_after = events_after.iter().filter(|event| {
-        if event.0 != contract_id || event.1.len() != 2 {
-            return false;
-        }
-        let topic0: Result<Symbol, _> = event.1.get(0).unwrap().try_into_val(&env);
-        let topic1: Result<Symbol, _> = event.1.get(1).unwrap().try_into_val(&env);
-        if let (Ok(t0), Ok(t1)) = (topic0, topic1) {
-            t0 == Symbol::new(&env, "participant") && t1 == Symbol::new(&env, "joined")
-        } else {
-            false
-        }
-    }).count();
+    let num_participant_joined_after = events_after
+        .iter()
+        .filter(|event| {
+            if event.0 != contract_id || event.1.len() != 2 {
+                return false;
+            }
+            let topic0: Result<Symbol, _> = event.1.get(0).unwrap().try_into_val(&env);
+            let topic1: Result<Symbol, _> = event.1.get(1).unwrap().try_into_val(&env);
+            if let (Ok(t0), Ok(t1)) = (topic0, topic1) {
+                t0 == Symbol::new(&env, "participant") && t1 == Symbol::new(&env, "joined")
+            } else {
+                false
+            }
+        })
+        .count();
 
-    assert_eq!(num_participant_joined_before, num_participant_joined_after, "Failed join should not emit event");
+    assert_eq!(
+        num_participant_joined_before, num_participant_joined_after,
+        "Failed join should not emit event"
+    );
 }
-
 
 #[test]
 #[should_panic(expected = "invalid_invite_code")]
@@ -814,7 +825,6 @@ fn test_get_prediction_distribution_multiple_matches_independent() {
     assert_eq!((a2, b2, d2), (0, 0, 1));
 }
 
-
 // ---------------------------------------------------------------------------
 // Kickoff time boundary tests (#1017)
 // ---------------------------------------------------------------------------
@@ -830,8 +840,15 @@ fn test_submit_prediction_at_exact_match_time_rejected() {
     let initial_ts = env.ledger().timestamp();
     let match_time = initial_ts + match_time_offset;
 
-    let (_event_id, invite_code, match_id) =
-        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, match_time_offset);
+    let (_event_id, invite_code, match_id) = create_event_and_match(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        2,
+        match_time_offset,
+    );
 
     client.join_event(&predictor, &invite_code);
 
@@ -852,8 +869,15 @@ fn test_submit_prediction_after_kickoff_plus_3600_rejected() {
     let initial_ts = env.ledger().timestamp();
     let match_time = initial_ts + match_time_offset;
 
-    let (_event_id, invite_code, match_id) =
-        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, match_time_offset);
+    let (_event_id, invite_code, match_id) = create_event_and_match(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        2,
+        match_time_offset,
+    );
 
     client.join_event(&predictor, &invite_code);
 
@@ -873,8 +897,15 @@ fn test_submit_prediction_just_before_kickoff_succeeds() {
     let initial_ts = env.ledger().timestamp();
     let match_time = initial_ts + match_time_offset;
 
-    let (_event_id, invite_code, match_id) =
-        create_event_and_match(&env, &contract_id, &client, &creator, &xlm_token, 2, match_time_offset);
+    let (_event_id, invite_code, match_id) = create_event_and_match(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        2,
+        match_time_offset,
+    );
 
     client.join_event(&predictor, &invite_code);
 
@@ -1018,14 +1049,7 @@ fn test_prize_pool_reflects_creator_seed_plus_entry_fees() {
     reward.push_back(100u32);
 
     let (event_id, invite_code) = create_paid_event(
-        &env,
-        &client,
-        &creator,
-        &xlm_token,
-        n as u32,
-        entry_fee,
-        seed,
-        reward,
+        &env, &client, &creator, &xlm_token, n as u32, entry_fee, seed, reward,
     );
 
     // The seed is in the pool before anyone joins.
@@ -1040,4 +1064,100 @@ fn test_prize_pool_reflects_creator_seed_plus_entry_fees() {
     let expected = seed + (n as i128) * entry_fee;
     assert_eq!(client.get_event_prize_pool(&event_id), expected);
     assert_eq!(client.get_event(&event_id).participant_count, n as u32);
+}
+
+// ---------------------------------------------------------------------------
+// Entry-fee tests (#1023) — explicit balance-before/after verification
+// ---------------------------------------------------------------------------
+
+/// Happy-path: verify the entry fee is debited exactly once and the prize pool
+/// increases by exactly the same amount in a single join call.
+#[test]
+fn test_entry_fee_happy_path_single_transfer_verified() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let entry_fee: i128 = 7_500_000;
+    let (event_id, invite_code) = create_paid_event(
+        &env,
+        &client,
+        &creator,
+        &xlm_token,
+        10,
+        entry_fee,
+        0,
+        Vec::new(&env),
+    );
+
+    // Fund the user with exactly entry_fee — no more, no less.
+    fund(&env, &xlm_token, &user, entry_fee);
+    let balance_before = TokenClient::new(&env, &xlm_token).balance(&user);
+    assert_eq!(balance_before, entry_fee);
+
+    client.join_event(&user, &invite_code);
+
+    let balance_after = TokenClient::new(&env, &xlm_token).balance(&user);
+    // Exactly one transfer of entry_fee occurred.
+    assert_eq!(balance_after, 0);
+    assert_eq!(balance_before - balance_after, entry_fee);
+    // Prize pool grew by exactly entry_fee.
+    assert_eq!(client.get_event_prize_pool(&event_id), entry_fee);
+    assert_eq!(client.get_event(&event_id).participant_count, 1);
+}
+
+/// Insufficient funds test: funding with exactly entry_fee − 1 stroops must be rejected.
+#[test]
+#[should_panic(expected = "insufficient_entry_fee_balance")]
+fn test_entry_fee_insufficient_by_one_stroop_rejected() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let entry_fee: i128 = 5_000_000;
+    let (_event_id, invite_code) = create_paid_event(
+        &env,
+        &client,
+        &creator,
+        &xlm_token,
+        10,
+        entry_fee,
+        0,
+        Vec::new(&env),
+    );
+
+    // Fund with exactly one stroop less than the required entry fee.
+    fund(&env, &xlm_token, &user, entry_fee - 1);
+
+    client.join_event(&user, &invite_code);
+}
+
+/// Zero fee test: a user with no XLM can join an event whose entry_fee = 0;
+/// no token transfer must occur and the prize pool stays unchanged.
+#[test]
+fn test_entry_fee_zero_join_requires_no_xlm() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    // Explicitly create a paid-event helper with entry_fee = 0 (and no seed pool).
+    let (event_id, invite_code) = create_paid_event(
+        &env,
+        &client,
+        &creator,
+        &xlm_token,
+        10,
+        0i128,
+        0i128,
+        Vec::new(&env),
+    );
+
+    // User starts with zero XLM; join must succeed without any transfer.
+    assert_eq!(TokenClient::new(&env, &xlm_token).balance(&user), 0);
+    client.join_event(&user, &invite_code);
+
+    // Balance unchanged; pool still 0; participant count incremented.
+    assert_eq!(TokenClient::new(&env, &xlm_token).balance(&user), 0);
+    assert_eq!(client.get_event_prize_pool(&event_id), 0);
+    assert_eq!(client.get_event(&event_id).participant_count, 1);
 }

--- a/contracts/creator-event-manager/tests/storage_types_tests.rs
+++ b/contracts/creator-event-manager/tests/storage_types_tests.rs
@@ -483,29 +483,11 @@ fn test_prediction_is_before_match_time() {
     assert!(pred_before.is_before_match_time(match_time));
 
     // Predicted exactly at match time — not before
-    let pred_at = Prediction::new(
-        2,
-        5,
-        10,
-        predictor.clone(),
-        2u32,
-        1u32,
-        match_time,
-        &env,
-    );
+    let pred_at = Prediction::new(2, 5, 10, predictor.clone(), 2u32, 1u32, match_time, &env);
     assert!(!pred_at.is_before_match_time(match_time));
 
     // Predicted after match time
-    let pred_after = Prediction::new(
-        3,
-        5,
-        10,
-        predictor,
-        2u32,
-        1u32,
-        match_time + 1,
-        &env,
-    );
+    let pred_after = Prediction::new(3, 5, 10, predictor, 2u32, 1u32, match_time + 1, &env);
     assert!(!pred_after.is_before_match_time(match_time));
 }
 

--- a/contracts/creator-event-manager/tests/submit_match_result_contract_tests.rs
+++ b/contracts/creator-event-manager/tests/submit_match_result_contract_tests.rs
@@ -245,8 +245,7 @@ fn test_full_prediction_flow_with_scoring() {
     assert_eq!(alice_exact, 1);
     assert_eq!(alice_total, 1);
 
-    let (bob_points, bob_correct, bob_exact, bob_total) =
-        client.get_user_score(&bob, &event_id);
+    let (bob_points, bob_correct, bob_exact, bob_total) = client.get_user_score(&bob, &event_id);
     assert_eq!(bob_points, 0); // Wrong result (predicted 2-0, got 1-1)
     assert_eq!(bob_correct, 0);
     assert_eq!(bob_exact, 0);
@@ -259,7 +258,6 @@ fn test_full_prediction_flow_with_scoring() {
     assert_eq!(m.home_score, Some(1));
     assert_eq!(m.away_score, Some(1));
 }
-
 
 // ============================================================================
 // New tests for exact scoreline predictions (#966)
@@ -449,7 +447,6 @@ fn test_submit_prediction_stores_scoreline() {
     assert_eq!(prediction.points_earned, None); // Not yet graded
     assert_eq!(prediction.is_correct, None); // Not yet graded
 }
-
 
 // ============================================================================
 // Scoreline grading tests (#xxx — exact score predictions)

--- a/contracts/creator-event-manager/tests/views_tests.rs
+++ b/contracts/creator-event-manager/tests/views_tests.rs
@@ -556,12 +556,18 @@ fn test_is_event_finalized_states() {
 
     // State 1: Active (not finalized)
     assert!(!client.is_event_finalized(&event_id));
-    assert_eq!(client.is_event_finalized(&event_id), client.get_event(&event_id).is_finalized);
+    assert_eq!(
+        client.is_event_finalized(&event_id),
+        client.get_event(&event_id).is_finalized
+    );
 
     // State 2: Cancelled (not finalized)
     client.cancel_event(&creator, &event_id);
     assert!(!client.is_event_finalized(&event_id));
-    assert_eq!(client.is_event_finalized(&event_id), client.get_event(&event_id).is_finalized);
+    assert_eq!(
+        client.is_event_finalized(&event_id),
+        client.get_event(&event_id).is_finalized
+    );
 
     // State 3: Finalized
     let creator2 = Address::generate(&env);
@@ -587,7 +593,10 @@ fn test_is_event_finalized_states() {
     client.finalize_event(&creator2, &event_id2);
 
     assert!(client.is_event_finalized(&event_id2));
-    assert_eq!(client.is_event_finalized(&event_id2), client.get_event(&event_id2).is_finalized);
+    assert_eq!(
+        client.is_event_finalized(&event_id2),
+        client.get_event(&event_id2).is_finalized
+    );
 }
 
 #[test]
@@ -669,7 +678,10 @@ fn test_get_event_count_matches_platform_statistics_total_events() {
     let creator = Address::generate(&env);
 
     // Verified that get_event_count and get_platform_statistics.total_events agree.
-    assert_eq!(client.get_event_count(), client.get_platform_statistics().total_events);
+    assert_eq!(
+        client.get_event_count(),
+        client.get_platform_statistics().total_events
+    );
 
     fund(&env, &xlm_token, &creator, FEE);
     let start_time = get_future_time(&env, 3600);
@@ -686,7 +698,167 @@ fn test_get_event_count_matches_platform_statistics_total_events() {
         &0i128,
     );
 
-    assert_eq!(client.get_event_count(), client.get_platform_statistics().total_events);
+    assert_eq!(
+        client.get_event_count(),
+        client.get_platform_statistics().total_events
+    );
     assert_eq!(client.get_event_count(), 1);
 }
 
+// =============================================================================
+// get_event_prize_pool tests (#1021)
+// =============================================================================
+
+/// Pre-join test: get_event_prize_pool returns the creator-seeded amount before
+/// any participants join.
+#[test]
+fn test_get_event_prize_pool_pre_join_equals_initial_seed() {
+    let (env, client, _contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+
+    let prize_pool: i128 = 1_000_000_000;
+    fund(&env, &xlm_token, &creator, FEE + prize_pool);
+
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    let mut dist = Vec::new(&env);
+    dist.push_back(100u32);
+
+    let (event_id, _invite_code) = client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &10u32,
+        &start_time,
+        &end_time,
+        &prize_pool,
+        &dist,
+        &0i128,
+    );
+
+    // Before any joins the pool must equal the seeded amount.
+    assert_eq!(client.get_event_prize_pool(&event_id), prize_pool);
+}
+
+/// Post-join growth test: prize pool grows by entry_fee with every join.
+#[test]
+fn test_get_event_prize_pool_grows_with_entry_fees() {
+    let (env, client, _contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+
+    let seed: i128 = 500_000_000;
+    let entry_fee: i128 = 50_000_000;
+    let n: usize = 3;
+
+    fund(&env, &xlm_token, &creator, FEE + seed);
+
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    let mut dist = Vec::new(&env);
+    dist.push_back(100u32);
+
+    let (event_id, invite_code) = client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &10u32,
+        &start_time,
+        &end_time,
+        &seed,
+        &dist,
+        &entry_fee,
+    );
+
+    // Pool starts at seed.
+    assert_eq!(client.get_event_prize_pool(&event_id), seed);
+
+    // Each join adds exactly entry_fee to the pool.
+    for i in 0..n {
+        let user = Address::generate(&env);
+        fund(&env, &xlm_token, &user, entry_fee);
+        client.join_event(&user, &invite_code);
+        let expected = seed + ((i + 1) as i128) * entry_fee;
+        assert_eq!(client.get_event_prize_pool(&event_id), expected);
+    }
+
+    // Final pool = seed + n × entry_fee.
+    assert_eq!(
+        client.get_event_prize_pool(&event_id),
+        seed + (n as i128) * entry_fee
+    );
+}
+
+/// Post-finalize test: get_event_prize_pool does not panic after finalization
+/// and still reflects the total pool that was distributed.
+#[test]
+fn test_get_event_prize_pool_post_finalize_is_readable() {
+    let (env, client, contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+
+    let prize_pool: i128 = 10_000_000;
+    fund(&env, &xlm_token, &creator, FEE + prize_pool);
+
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    let mut dist = Vec::new(&env);
+    dist.push_back(100u32);
+
+    let (event_id, invite_code) = client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &10u32,
+        &start_time,
+        &end_time,
+        &prize_pool,
+        &dist,
+        &0i128,
+    );
+
+    // Retrieve the ai_agent so we can submit a match result.
+    let ai_agent = client.get_ai_agent();
+
+    // Add one match directly via storage.
+    let match_id = env.as_contract(&contract_id, || {
+        let mid = storage::next_match_id(&env);
+        let m = Match::new(
+            mid,
+            event_id,
+            String::from_str(&env, "Team A"),
+            String::from_str(&env, "Team B"),
+            env.ledger().timestamp() + 100,
+            1u32,
+        );
+        storage::set_match(&env, mid, &m);
+        storage::add_event_match(&env, event_id, mid);
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.add_match();
+        storage::set_event(&env, event_id, &event);
+        mid
+    });
+
+    let user = Address::generate(&env);
+    client.join_event(&user, &invite_code);
+    client.submit_prediction(&user, &match_id, &1u32, &0u32);
+
+    // Advance past end_time, submit result, then finalize.
+    env.ledger().with_mut(|l| l.timestamp = end_time + 10);
+    client.submit_match_result(&ai_agent, &match_id, &1u32, &0u32);
+    client.finalize_event(&creator, &event_id);
+
+    assert!(client.get_event(&event_id).is_finalized);
+
+    // get_event_prize_pool must not panic for a finalized event and must return
+    // the recorded pool amount (prize_pool field is not zeroed by finalization).
+    let pool = client.get_event_prize_pool(&event_id);
+    assert_eq!(pool, prize_pool);
+}
+
+/// Not-found test: calling get_event_prize_pool with a non-existent event_id
+/// panics with "event_not_found".
+#[test]
+#[should_panic(expected = "event_not_found")]
+fn test_get_event_prize_pool_not_found_panics() {
+    let (_env, client, _contract_id, _xlm_token) = setup();
+    client.get_event_prize_pool(&9999u64);
+}


### PR DESCRIPTION
Summary
closes #1024 — Added 5 tests in oracle_tests.rs covering the points_multiplier field in get_user_score: 2× correct-result (2 pts), 2× exact-score (8 pts), 3× exact-score (12 pts), wrong-result with any multiplier (0 pts), and a mixed-multiplier event (two matches with multipliers 1 and 2, total 3 pts). Introduced create_event_with_match_and_multiplier helper to keep test setup concise.

closes #1023 — Added 3 tests in prediction_tests.rs verifying the paid-join flow: happy-path with explicit before/after balance capture (proves exactly one entry_fee transfer per join), insufficient-by-one-stroop rejection (insufficient_entry_fee_balance), and zero-fee join succeeding with no XLM balance required.

closes #1027 — Added test_finalize_event_seed_pool_plus_entry_fees_combined in finalize_tests.rs: creates an event with a seeded prize pool (5 000 001 stroops) and entry fee (1 000 000), has 3 participants join (total pool 8 000 001), finalizes with a 60/40 split, and asserts winner balances numerically plus that the 1-stroop integer-division remainder goes to the creator.

closes #1021 — Added 4 tests in views_tests.rs for get_event_prize_pool: pre-join pool equals the creator seed, pool grows by entry_fee on each join (verified after every individual join), pool is still readable and non-zero after finalization (the field is not zeroed out), and a non-existent event panics with event_not_found.

Test plan
 cargo test — all 280+ tests pass with 0 failures
 Verify multiplied scoring: cargo test test_get_user_score_double_multiplier
 Verify entry-fee flow: cargo test test_entry_fee
 Verify combined finalize: cargo test test_finalize_event_seed_pool_plus_entry_fees_combined
 Verify prize pool views: cargo test test_get_event_prize_pool