### PR TITLE
test: add contract-level tests for issues

### DIFF
--- a/contracts/creator-event-manager/tests/fee_views_tests.rs
+++ b/contracts/creator-event-manager/tests/fee_views_tests.rs
@@ -179,6 +179,110 @@ fn test_withdraw_insufficient_balance_rejected() {
 }
 
 #[test]
+#[should_panic(expected = "contract_paused")]
+fn test_withdraw_fees_while_paused_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(creator_event_manager::CreatorEventManagerContract, ());
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> =
+        unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+
+    // Create an event to deposit the creation fee into the treasury.
+    let creator = Address::generate(&env);
+    StellarAssetClient::new(&env, &xlm_token).mint(&creator, &FEE);
+
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &2u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+
+    // Pause the contract.
+    client.pause(&admin);
+
+    let recipient = Address::generate(&env);
+    // withdraw_fees must be rejected while the contract is paused.
+    client.withdraw_fees(&admin, &recipient, &FEE);
+}
+
+#[test]
+fn test_withdraw_fees_after_unpause_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(creator_event_manager::CreatorEventManagerContract, ());
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> =
+        unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+
+    // Create an event to deposit the creation fee into the treasury.
+    let creator = Address::generate(&env);
+    StellarAssetClient::new(&env, &xlm_token).mint(&creator, &FEE);
+
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &2u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+
+    assert_eq!(client.get_treasury_balance(), FEE);
+
+    // Grant the contract an allowance to pull funds from the treasury.
+    let token = TokenClient::new(&env, &xlm_token);
+    token.approve(&treasury, &contract_id, &FEE, &0u32);
+
+    // Pause then unpause the contract.
+    client.pause(&admin);
+    client.unpause(&admin);
+
+    // withdraw_fees must succeed after the contract is unpaused.
+    let recipient = Address::generate(&env);
+    client.withdraw_fees(&admin, &recipient, &FEE);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&recipient), FEE);
+    assert_eq!(client.get_treasury_balance(), 0);
+}
+
+#[test]
 #[should_panic(expected = "invalid_amount")]
 fn test_withdraw_zero_amount_rejected() {
     let env = Env::default();

--- a/contracts/creator-event-manager/tests/finalize_tests.rs
+++ b/contracts/creator-event-manager/tests/finalize_tests.rs
@@ -509,6 +509,75 @@ fn test_finalize_event_zero_prize_pool_noop() {
     assert!(client.get_event(&event_id).is_finalized);
 }
 
+// ---------------------------------------------------------------------------
+// get_event_payouts — pre-finalization, non-existent, post-finalization (#1033)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_event_payouts_before_finalization_returns_empty() {
+    let (env, client, contract_id, creator, _ai_agent, xlm_token) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, _invite, _match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    // The event is funded but finalize_event has not been called yet.
+    let payouts = client.get_event_payouts(&event_id);
+    assert_eq!(payouts.len(), 0);
+}
+
+#[test]
+fn test_get_event_payouts_nonexistent_event_returns_empty() {
+    let (_env, client, _contract_id, _creator, _ai_agent, _xlm_token) = setup();
+
+    // No event with this ID has ever been created; must return empty, not panic.
+    let payouts = client.get_event_payouts(&99999u64);
+    assert_eq!(payouts.len(), 0);
+}
+
+#[test]
+fn test_get_event_payouts_after_finalization_returns_correct_entries() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let user = Address::generate(&env);
+    client.join_event(&user, &invite_code);
+    client.submit_prediction(&user, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(&client, &ai_agent, match_ids.get(0).unwrap(), MatchResult::TeamA);
+
+    let caller = Address::generate(&env);
+    let payouts = client.finalize_event(&caller, &event_id);
+
+    // Snapshot must match the returned payout vector.
+    let snapshot = client.get_event_payouts(&event_id);
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot, payouts);
+    let (winner, amount) = snapshot.get(0).unwrap();
+    assert_eq!(winner, user);
+    assert_eq!(amount, PRIZE);
+}
+
 #[test]
 fn test_finalize_event_permissionless() {
     let (env, client, contract_id, creator, ai_agent, xlm_token) = setup();

--- a/contracts/creator-event-manager/tests/match_tests.rs
+++ b/contracts/creator-event-manager/tests/match_tests.rs
@@ -757,6 +757,53 @@ fn test_add_match_team_time_can_be_in_future() {
     assert_eq!(stored.match_time, future_time);
 }
 
+// =============================================================================
+// create_match on a cancelled event (#1032)
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "event_cancelled")]
+fn test_create_match_on_cancelled_event_panics_event_cancelled() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = create_event_default(&client, &env, &creator, 5u32);
+
+    // Transition the event to cancelled state via the contract entry point.
+    client.cancel_event(&creator, &event_id);
+
+    // create_match on a cancelled event must panic with "event_cancelled".
+    client.create_match(
+        &creator,
+        &event_id,
+        &String::from_str(&env, "Team A"),
+        &String::from_str(&env, "Team B"),
+        &get_future_time(&env, 4000),
+        &1u32,
+    );
+}
+
+#[test]
+fn test_create_match_on_non_cancelled_event_same_creator_succeeds() {
+    let (env, client, _contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let (event_id, _) = create_event_default(&client, &env, &creator, 5u32);
+
+    // Event is active; create_match by the same creator must succeed.
+    let match_id = client.create_match(
+        &creator,
+        &event_id,
+        &String::from_str(&env, "Team A"),
+        &String::from_str(&env, "Team B"),
+        &get_future_time(&env, 4000),
+        &1u32,
+    );
+    assert!(match_id >= 1);
+}
+
 #[test]
 fn test_add_match_team_time_can_be_in_past() {
     let (env, client, contract_id, _admin, xlm_token) = setup();

--- a/contracts/creator-event-manager/tests/prediction_tests.rs
+++ b/contracts/creator-event-manager/tests/prediction_tests.rs
@@ -1132,6 +1132,74 @@ fn test_entry_fee_insufficient_by_one_stroop_rejected() {
     client.join_event(&user, &invite_code);
 }
 
+// ---------------------------------------------------------------------------
+// Ledger-time-advancing tests (#1034)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "match_started")]
+fn test_submit_prediction_well_after_kickoff_7200_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    let match_time_offset: u64 = 1000;
+    let initial_ts = env.ledger().timestamp();
+    let match_time = initial_ts + match_time_offset;
+
+    let (_event_id, invite_code, match_id) = create_event_and_match(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        2,
+        match_time_offset,
+    );
+
+    client.join_event(&predictor, &invite_code);
+
+    // Advance to match_time + 7200 — well past kickoff.
+    env.ledger().with_mut(|l| l.timestamp = match_time + 7200);
+
+    client.submit_prediction(&predictor, &match_id, &1u32, &0u32);
+}
+
+#[test]
+#[should_panic(expected = "match_started")]
+fn test_submit_prediction_after_result_submitted_rejected() {
+    let (env, client, contract_id, _admin, xlm_token) = setup();
+    // Retrieve the registered AI agent address so submit_match_result passes the role check.
+    let ai_agent = client.get_ai_agent();
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    let match_time_offset: u64 = 1000;
+    let initial_ts = env.ledger().timestamp();
+    let match_time = initial_ts + match_time_offset;
+
+    let (_event_id, invite_code, match_id) = create_event_and_match(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        2,
+        match_time_offset,
+    );
+
+    client.join_event(&predictor, &invite_code);
+
+    // Advance past match_time so the oracle can submit a result.
+    env.ledger().with_mut(|l| l.timestamp = match_time + 1);
+
+    // AI agent submits the match result.
+    client.submit_match_result(&ai_agent, &match_id, &1u32, &0u32);
+
+    // Prediction after result submission must be rejected with "match_started".
+    client.submit_prediction(&predictor, &match_id, &1u32, &0u32);
+}
+
 /// Zero fee test: a user with no XLM can join an event whose entry_fee = 0;
 /// no token transfer must occur and the prize pool stays unchanged.
 #[test]


### PR DESCRIPTION
[Contract] — Test: `create_match` on a cancelled event panics `event_cancelled` Fixes #1032

[Contract] — Test: `get_event_payouts` before finalization returns empty vector Fixes #1033

[Contract] — Test: `submit_prediction` after match has started is rejected Fixes #1034

[Contract] — Test: `withdraw_fees` while contract is paused is rejected Fixes #1039