### PR TITLE
feat: list_active_disputes, close_market creator auth, invite public guard, price tests

### DIFF
--- a/contracts/open-market/src/dispute.rs
+++ b/contracts/open-market/src/dispute.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{symbol_short, Address, Env};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
 
 use crate::config;
 use crate::errors::InsightArenaError;
@@ -11,6 +11,14 @@ fn bump_dispute(env: &Env, market_id: u64) {
     config::extend_market_ttl(env, market_id);
     env.storage().persistent().extend_ttl(
         &DataKey::Dispute(market_id),
+        config::PERSISTENT_THRESHOLD,
+        config::PERSISTENT_BUMP,
+    );
+}
+
+fn bump_active_dispute_list(env: &Env) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::ActiveDisputeList,
         config::PERSISTENT_THRESHOLD,
         config::PERSISTENT_BUMP,
     );
@@ -87,6 +95,21 @@ pub fn raise_dispute(
     env.storage()
         .persistent()
         .set(&DataKey::Dispute(market_id), &dispute);
+
+    // Add market_id to active dispute list
+    let mut active_list: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ActiveDisputeList)
+        .unwrap_or_else(|| Vec::new(&env));
+    if !active_list.contains(&market_id) {
+        active_list.push_back(market_id);
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::ActiveDisputeList, &active_list);
+    bump_active_dispute_list(&env);
+
     bump_dispute(&env, market_id);
 
     // Update creator's dispute count and reputation
@@ -129,6 +152,23 @@ pub fn resolve_dispute(
         escrow::add_to_treasury_balance(&env, dispute.bond);
     }
 
+    // Remove market_id from active dispute list
+    let mut active_list: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ActiveDisputeList)
+        .unwrap_or_else(|| Vec::new(&env));
+    let mut new_list: Vec<u64> = Vec::new(&env);
+    for id in active_list.iter() {
+        if id != market_id {
+            new_list.push_back(id);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::ActiveDisputeList, &new_list);
+    bump_active_dispute_list(&env);
+
     env.storage()
         .persistent()
         .remove(&DataKey::Dispute(market_id));
@@ -136,4 +176,16 @@ pub fn resolve_dispute(
     emit_dispute_resolved(&env, market_id, &admin, uphold);
 
     Ok(())
+}
+
+pub fn list_active_disputes(env: &Env) -> Vec<u64> {
+    let list: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ActiveDisputeList)
+        .unwrap_or_else(|| Vec::new(env));
+    if env.storage().persistent().has(&DataKey::ActiveDisputeList) {
+        bump_active_dispute_list(env);
+    }
+    list
 }

--- a/contracts/open-market/src/invite.rs
+++ b/contracts/open-market/src/invite.rs
@@ -29,6 +29,9 @@ pub fn generate_invite_code(
     if market.creator != creator {
         return Err(InsightArenaError::Unauthorized);
     }
+    if market.is_public {
+        return Err(InsightArenaError::InvalidInput);
+    }
 
     // 2. Validate usage constraints
     if max_uses < 1 {

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -252,6 +252,11 @@ impl InsightArenaContract {
         dispute::resolve_dispute(env, admin, market_id, uphold)
     }
 
+    /// Enumerate all markets that currently have an active dispute.
+    pub fn list_active_disputes(env: Env) -> Vec<u64> {
+        dispute::list_active_disputes(&env)
+    }
+
     // ── Prediction ────────────────────────────────────────────────────────────
 
     /// Submit a prediction for an open market by staking XLM on a chosen outcome.

--- a/contracts/open-market/src/market.rs
+++ b/contracts/open-market/src/market.rs
@@ -451,10 +451,10 @@ pub fn close_market(env: &Env, caller: Address, market_id: u64) -> Result<(), In
         return Err(InsightArenaError::MarketAlreadyResolved);
     }
 
-    // ── Guard 4: caller must be admin or oracle ────────────────────────────────
+    // ── Guard 4: caller must be creator, admin, or oracle ──────────────────────
     caller.require_auth();
     let cfg = config::get_config(env)?;
-    if caller != cfg.admin && caller != cfg.oracle_address {
+    if caller != market.creator && caller != cfg.admin && caller != cfg.oracle_address {
         return Err(InsightArenaError::Unauthorized);
     }
 

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -52,6 +52,8 @@ pub enum DataKey {
     EscrowLock,
     /// Keyed by market_id. Stores an active dispute (if any) for that market.
     Dispute(u64),
+    /// Singleton list of market IDs that currently have an active dispute.
+    ActiveDisputeList,
     /// Singleton. Cumulative platform stake volume (stroops) for analytics.
     PlatformVolume,
     /// Keyed by creator address. Aggregated creator reputation statistics.

--- a/contracts/open-market/tests/dispute_tests.rs
+++ b/contracts/open-market/tests/dispute_tests.rs
@@ -296,3 +296,103 @@ fn test_raise_dispute_on_resolved_market_success_within_window() {
     // 3. Assert success
     assert!(result.is_ok());
 }
+
+#[test]
+fn test_list_active_disputes_empty_initially() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _xlm_token) = deploy(&env);
+    let list = client.list_active_disputes();
+    assert_eq!(list.len(), 0);
+}
+
+#[test]
+fn test_list_active_disputes_includes_raised_disputes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    // Create two markets
+    let id1 = client.create_market(&creator, &market_params(&env));
+    let id2 = client.create_market(&creator, &market_params(&env));
+
+    // Advance and resolve both
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(&oracle, &id1, &symbol_short!("yes"));
+    client.resolve_market(&oracle, &id2, &symbol_short!("yes"));
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(&env, &xlm_token).mint(&disputer, &(bond * 2));
+    TokenClient::new(&env, &xlm_token).approve(&disputer, &client.address, &(bond * 2), &9999);
+
+    // Raise dispute on first market
+    client.raise_dispute(&disputer, &id1, &bond);
+    let list = client.list_active_disputes();
+    assert_eq!(list.len(), 1);
+    assert!(list.contains(&id1));
+
+    // Raise dispute on second market
+    client.raise_dispute(&disputer, &id2, &bond);
+    let list = client.list_active_disputes();
+    assert_eq!(list.len(), 2);
+    assert!(list.contains(&id1));
+    assert!(list.contains(&id2));
+}
+
+#[test]
+fn test_list_active_disputes_removes_after_resolve() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let id = client.create_market(&creator, &market_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(&env, &xlm_token).mint(&disputer, &bond);
+    TokenClient::new(&env, &xlm_token).approve(&disputer, &client.address, &bond, &9999);
+
+    client.raise_dispute(&disputer, &id, &bond);
+    assert_eq!(client.list_active_disputes().len(), 1);
+
+    // Resolve the dispute (uphold)
+    client.resolve_dispute(&admin, &id, &true);
+    assert_eq!(client.list_active_disputes().len(), 0);
+}
+
+#[test]
+fn test_list_active_disputes_maintains_insertion_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let id1 = client.create_market(&creator, &market_params(&env));
+    let id2 = client.create_market(&creator, &market_params(&env));
+    let id3 = client.create_market(&creator, &market_params(&env));
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(&oracle, &id1, &symbol_short!("yes"));
+    client.resolve_market(&oracle, &id2, &symbol_short!("yes"));
+    client.resolve_market(&oracle, &id3, &symbol_short!("yes"));
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(&env, &xlm_token).mint(&disputer, &(bond * 3));
+    TokenClient::new(&env, &xlm_token).approve(&disputer, &client.address, &(bond * 3), &9999);
+
+    client.raise_dispute(&disputer, &id1, &bond);
+    client.raise_dispute(&disputer, &id2, &bond);
+    client.raise_dispute(&disputer, &id3, &bond);
+
+    let list = client.list_active_disputes();
+    assert_eq!(list.len(), 3);
+    assert_eq!(list.get(0), Some(id1));
+    assert_eq!(list.get(1), Some(id2));
+    assert_eq!(list.get(2), Some(id3));
+}

--- a/contracts/open-market/tests/invite_tests.rs
+++ b/contracts/open-market/tests/invite_tests.rs
@@ -295,3 +295,73 @@ fn test_multiple_invite_codes_per_market() {
     assert!(allowlist.iter().any(|a| a == invitee1));
     assert!(allowlist.iter().any(|a| a == invitee2));
 }
+
+#[test]
+fn test_generate_invite_code_rejects_public_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    let contract_id = env.register(InsightArenaContract, ());
+    let client = InsightArenaContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &oracle, &200, &xlm_token);
+
+    // Create a PUBLIC market
+    let params = CreateMarketParams {
+        title: String::from_str(&env, "Public Market"),
+        description: String::from_str(&env, "Open to all"),
+        category: Symbol::new(&env, "Sports"),
+        outcomes: vec![&env, Symbol::new(&env, "TeamA"), Symbol::new(&env, "TeamB")],
+        end_time: 200,
+        resolution_time: 300,
+        dispute_window: 86_400,
+        creator_fee_bps: 100,
+        min_stake: 10_000_000,
+        max_stake: 100_000_000,
+        is_public: true,
+    };
+    let market_id = client.create_market(&creator, &params);
+
+    let result = client.try_generate_invite_code(&creator, &market_id, &10, &3600);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn test_generate_invite_code_succeeds_for_private_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    let contract_id = env.register(InsightArenaContract, ());
+    let client = InsightArenaContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &oracle, &200, &xlm_token);
+
+    // Create a PRIVATE market
+    let params = CreateMarketParams {
+        title: String::from_str(&env, "Private Market"),
+        description: String::from_str(&env, "Invite only"),
+        category: Symbol::new(&env, "Sports"),
+        outcomes: vec![&env, Symbol::new(&env, "TeamA"), Symbol::new(&env, "TeamB")],
+        end_time: 200,
+        resolution_time: 300,
+        dispute_window: 86_400,
+        creator_fee_bps: 100,
+        min_stake: 10_000_000,
+        max_stake: 100_000_000,
+        is_public: false,
+    };
+    let market_id = client.create_market(&creator, &params);
+
+    let result = client.try_generate_invite_code(&creator, &market_id, &10, &3600);
+    assert!(result.is_ok());
+}

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -1522,3 +1522,62 @@ fn test_pool_volume_accumulates_across_swaps() {
     // Volume should accumulate both swaps
     assert_eq!(volume_after_swap2, swap1 + swap2);
 }
+
+#[test]
+fn test_get_outcome_price_reflects_post_swap_reserves() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    // Add liquidity so that initial reserves are 500_000 each (out of 1_000_000 total)
+    // For a 2-outcome market with equal first deposit, reserves are split evenly
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    // Verify initial prices are equal (50/50)
+    let price_yes_before = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+    let price_no_before = client.get_outcome_price(&market_id, &symbol_short!("no"));
+    assert_eq!(price_yes_before, price_no_before);
+    assert!(price_yes_before > 0);
+
+    let total_before = price_yes_before + price_no_before;
+
+    // Perform a large swap: buy outcome A (yes), selling from B (no)
+    // This sends XLM from the trader into the contract, increasing the YES reserve
+    let swap_amount = 200_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+    let amount_out = client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    // Get updated prices
+    let price_yes_after = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+    let price_no_after = client.get_outcome_price(&market_id, &symbol_short!("no"));
+
+    // Prices should move in correct direction:
+    // - YES reserve increased (more YES in pool), so YES price goes UP
+    // - NO reserve decreased (NO taken from pool), so NO price goes DOWN
+    assert!(price_yes_after > price_yes_before, "YES reserve should increase after selling YES");
+    assert!(price_no_after < price_no_before, "NO reserve should decrease after buying NO");
+
+    // Total reserves change by swap_amount (added) minus amount_out (removed)
+    let total_after = price_yes_after + price_no_after;
+    assert_eq!(total_after, total_before + swap_amount - amount_out,
+        "Total reserves should reflect net change from swap");
+}

--- a/contracts/open-market/tests/market_tests.rs
+++ b/contracts/open-market/tests/market_tests.rs
@@ -835,3 +835,47 @@ fn cancel_market_refunds_all_predictors() {
     assert_eq!(token_client.balance(&predictor_b), stake_b);
     assert!(client.get_market(&id).is_cancelled);
 }
+
+#[test]
+fn test_close_market_by_creator_after_end_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 1001);
+
+    client.close_market(&creator, &id);
+    assert!(client.get_market(&id).is_closed);
+}
+
+#[test]
+fn test_close_market_by_admin_on_third_party_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, _) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 1001);
+
+    // Admin closes a market they didn't create
+    client.close_market(&admin, &id);
+    assert!(client.get_market(&id).is_closed);
+}
+
+#[test]
+fn test_close_market_rejects_third_party() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _) = deploy_with_token(&env);
+    let creator = Address::generate(&env);
+    let random = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 1001);
+
+    let result = client.try_close_market(&random, &id);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}


### PR DESCRIPTION
Implements 4 issues:

**Closes #1059 — Feature: list_active_disputes**
- Added DataKey::ActiveDisputeList singleton
- raise_dispute appends market_id to list, resolve_dispute removes it
- New public query list_active_disputes() -> Vec<u64>
- 4 tests: empty initially, includes raised, removed after resolve, insertion order preserved

**Closes #1055 — Test: close_market by non-creator/non-admin rejected**
- Updated close_market to also allow the market creator
- Tests: creator can close, admin can close third-party market, random third-party rejected

**Closes #1054 — Test: generate_invite_code on public market returns error**
- Added guard in generate_invite_code to reject public markets (InvalidInput)
- Tests: public market rejected, private market succeeds

**Closes #1061 — Test: get_outcome_price after swap**
- Integration test: initial equal prices, swap from YES to NO, verify price direction and reserve invariant