### PR TITLE
fix(backend): admin 403 tests, search short-circuit, upcoming matches endpoint, tier boundary tests

### DIFF
--- a/backend/src/admin/admin.controller.spec.ts
+++ b/backend/src/admin/admin.controller.spec.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
+import { RolesGuard } from '../common/guards/roles.guard';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
@@ -191,5 +194,75 @@ describe('AdminController', () => {
         'admin-1',
       );
     });
+  });
+});
+
+describe('AdminController — RolesGuard enforcement', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        Reflector,
+        RolesGuard,
+        {
+          provide: AdminService,
+          useValue: {
+            getStats: jest.fn(),
+            listUsers: jest.fn(),
+            banUser: jest.fn(),
+          },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    reflector = module.get(Reflector);
+    guard = new RolesGuard(reflector);
+  });
+
+  function makeCtx(role: string, handlerName: string): ExecutionContext {
+    const controller = module.get(AdminController);
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role } }),
+      }),
+      getHandler: () =>
+        Object.getOwnPropertyDescriptor(
+          Object.getPrototypeOf(controller),
+          handlerName,
+        )?.value,
+      getClass: () => AdminController,
+    } as unknown as ExecutionContext;
+  }
+
+  it('GET /admin/dashboard/stats — denies role=user', () => {
+    expect(guard.canActivate(makeCtx('user', 'getDashboardStats'))).toBe(false);
+  });
+
+  it('GET /admin/dashboard/stats — allows role=admin', () => {
+    expect(guard.canActivate(makeCtx('admin', 'getDashboardStats'))).toBe(true);
+  });
+
+  it('GET /admin/users — denies role=user', () => {
+    expect(guard.canActivate(makeCtx('user', 'listUsers'))).toBe(false);
+  });
+
+  it('GET /admin/users — allows role=admin', () => {
+    expect(guard.canActivate(makeCtx('admin', 'listUsers'))).toBe(true);
+  });
+
+  it('PATCH /admin/users/:id/ban — denies role=user', () => {
+    expect(guard.canActivate(makeCtx('user', 'banUser'))).toBe(false);
+  });
+
+  it('PATCH /admin/users/:id/ban — allows role=admin', () => {
+    expect(guard.canActivate(makeCtx('admin', 'banUser'))).toBe(true);
   });
 });

--- a/backend/src/creator-events/creator-events.controller.ts
+++ b/backend/src/creator-events/creator-events.controller.ts
@@ -146,6 +146,20 @@ export class CreatorEventsController {
   }
 
   /**
+   * GET /api/creator-events/:id/matches/upcoming
+   * #1131 — Fetch only future, unresolved matches ordered by match_time ASC.
+   */
+  @Get(':id/matches/upcoming')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60)
+  @ApiOperation({ summary: 'Get upcoming (unresolved, future) matches for an event' })
+  @ApiResponse({ status: 200, description: 'Upcoming matches ordered by match time' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  getUpcomingMatches(@Param('id') id: string) {
+    return this.creatorEventsService.getUpcomingMatches(id);
+  }
+
+  /**
    * GET /api/creator-events/:id/stats
    * #727 — Fetch detailed statistics for a specific event.
    */

--- a/backend/src/creator-events/creator-events.service.spec.ts
+++ b/backend/src/creator-events/creator-events.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, SelectQueryBuilder } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
 import { ContractService } from '../contract/contract.service';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { CreatorEventLeaderboardEntry } from '../matches/entities/creator-event-leaderboard-entry.entity';
@@ -228,5 +229,75 @@ describe('CreatorEventsService searchEvents', () => {
       query: '',
     });
     expect(creatorEventRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+});
+
+describe('CreatorEventsService getUpcomingMatches', () => {
+  let service: CreatorEventsService;
+  let matchRepository: { createQueryBuilder: jest.Mock };
+  let creatorEventRepository: { findOne: jest.Mock };
+
+  const futureDate = new Date(Date.now() + 86_400_000); // +1 day
+  const pastDate = new Date(Date.now() - 86_400_000);  // -1 day
+
+  const mockEvent = { id: 'event-uuid', on_chain_event_id: 42 } as any;
+
+  beforeEach(async () => {
+    const matchQb = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+
+    matchRepository = { createQueryBuilder: jest.fn().mockReturnValue(matchQb) };
+    creatorEventRepository = { findOne: jest.fn().mockResolvedValue(mockEvent) };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CreatorEventsService,
+        { provide: ContractService, useValue: {} },
+        { provide: getRepositoryToken(CreatorEvent), useValue: creatorEventRepository },
+        { provide: getRepositoryToken(Match), useValue: matchRepository },
+        { provide: getRepositoryToken(MatchPrediction), useValue: {} },
+        { provide: getRepositoryToken(User), useValue: {} },
+        { provide: getRepositoryToken(CreatorEventLeaderboardEntry), useValue: {} },
+        { provide: getRepositoryToken(CreatorEventPayout), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get(CreatorEventsService);
+  });
+
+  it('returns only future unresolved matches ordered by match_time ASC', async () => {
+    const upcoming = [
+      { id: 'm1', match_time: futureDate, result_submitted: false },
+      { id: 'm2', match_time: new Date(futureDate.getTime() + 3600_000), result_submitted: false },
+    ] as any[];
+
+    const qb = matchRepository.createQueryBuilder();
+    qb.getMany.mockResolvedValue(upcoming);
+
+    const result = await service.getUpcomingMatches('42');
+
+    expect(result).toEqual(upcoming);
+    expect(qb.where).toHaveBeenCalledWith('match.event_id = :eventId', { eventId: mockEvent.id });
+    expect(qb.andWhere).toHaveBeenCalledWith('match.match_time > :now', { now: expect.any(Date) });
+    expect(qb.andWhere).toHaveBeenCalledWith('match.result_submitted = false');
+    expect(qb.orderBy).toHaveBeenCalledWith('match.match_time', 'ASC');
+  });
+
+  it('returns empty array when no upcoming matches', async () => {
+    const qb = matchRepository.createQueryBuilder();
+    qb.getMany.mockResolvedValue([]);
+
+    const result = await service.getUpcomingMatches('42');
+    expect(result).toEqual([]);
+  });
+
+  it('throws NotFoundException when event does not exist', async () => {
+    creatorEventRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.getUpcomingMatches('999')).rejects.toThrow(NotFoundException);
   });
 });

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -265,12 +265,26 @@ export class CreatorEventsService {
     return config;
   }
 
+  async getUpcomingMatches(eventId: string): Promise<Match[]> {
+    const event = await this.creatorEventRepository.findOne({
+      where: { on_chain_event_id: Number(eventId) as unknown as number },
+    });
+    if (!event) {
+      throw new NotFoundException(`Event ${eventId} not found`);
+    }
+    return this.matchRepository
+      .createQueryBuilder('match')
+      .where('match.event_id = :eventId', { eventId: event.id })
+      .andWhere('match.match_time > :now', { now: new Date() })
+      .andWhere('match.result_submitted = false')
+      .orderBy('match.match_time', 'ASC')
+      .getMany();
+  }
+
   async getEventMatches(
     eventId: string,
     query: ListMatchesQueryDto,
-  ): Promise<
-    Array<ContractMatch & { predictionCount: number; userPrediction?: string }>
-  > {
+  ): Promise<Array<ContractMatch & { predictionCount: number; userPrediction?: string }>> {
     const event = await this.contractService.getEvent(eventId);
     if (!event) {
       throw new NotFoundException(`Event ${eventId} not found`);

--- a/backend/src/search/search.service.spec.ts
+++ b/backend/src/search/search.service.spec.ts
@@ -108,6 +108,37 @@ describe('SearchService', () => {
   });
 
   describe('search()', () => {
+    it('short-circuits on empty string without querying any repository', async () => {
+      const result = await service.search({
+        query: '',
+        type: SearchType.All,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.total).toBe(0);
+      expect(result.markets).toEqual([]);
+      expect(result.users).toEqual([]);
+      expect(result.competitions).toEqual([]);
+      expect(marketQb.getManyAndCount).not.toHaveBeenCalled();
+      expect(userQb.getManyAndCount).not.toHaveBeenCalled();
+      expect(competitionQb.getManyAndCount).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits on single-character query without querying any repository', async () => {
+      const result = await service.search({
+        query: 'a',
+        type: SearchType.All,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.total).toBe(0);
+      expect(marketQb.getManyAndCount).not.toHaveBeenCalled();
+      expect(userQb.getManyAndCount).not.toHaveBeenCalled();
+      expect(competitionQb.getManyAndCount).not.toHaveBeenCalled();
+    });
+
     it('returns all three entity types for SearchType.All', async () => {
       const dto: GlobalSearchDto = {
         query: 'bitcoin',

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -31,6 +31,20 @@ export class SearchService {
     const searchType = dto.type ?? SearchType.All;
     const query = dto.query;
 
+    if (!query || query.trim().length < 2) {
+      return {
+        markets: [],
+        users: [],
+        competitions: [],
+        total: 0,
+        total_markets: 0,
+        total_users: 0,
+        total_competitions: 0,
+        page,
+        limit,
+      };
+    }
+
     const [
       [markets, total_markets],
       [users, total_users],


### PR DESCRIPTION
## Summary

Resolves four backend issues in a single clean pass.

## Changes

### #1121 — SearchService short-circuit on short queries
- Added guard at top of `SearchService.search`: queries shorter than 2 characters return an empty response without hitting any repository
- Added unit tests: empty string `""` and single char `"a"` both short-circuit (no DB call, `total = 0`)

### #1123 — AdminController rejects non-admin users with 403
- Added `describe('AdminController — RolesGuard enforcement')` block in `admin.controller.spec.ts`
- Uses a real `RolesGuard` + `Reflector` to assert `canActivate` returns `false` for `role='user'` and `true` for `role='admin'` on:
  - `GET /admin/dashboard/stats`
  - `GET /admin/users`
  - `PATCH /admin/users/:id/ban`

### #1131 — GET /creator-events/:id/matches/upcoming
- Added `getUpcomingMatches(eventId)` to `CreatorEventsService`: queries DB for `match_time > now AND result_submitted = false ORDER BY match_time ASC`, throws 404 for unknown events
- Added `GET :id/matches/upcoming` route to `CreatorEventsController`
- Added unit tests: future matches returned, empty result, 404 on unknown event

### #1120 — predictorTierFromReputation boundary values
- All boundary tests (0, 199, 200, 499, 500, 999, 1000) were already present in `analytics.service.spec.ts` — no code changes needed, confirmed passing

## Test results

```
Test Suites: 4 passed, 4 total
Tests:       53 passed, 53 total
```

Closes #1120
Closes #1121
Closes #1123
Closes #1131