### PR TITLE
test(season): cover active season overlap rejection

### DIFF
--- a/contracts/open-market/tests/season_tests.rs
+++ b/contracts/open-market/tests/season_tests.rs
@@ -781,3 +781,27 @@ fn test_create_season_before_previous_starts_succeeds() {
     let season2_id = client.create_season(&admin, &100, &200, &100_000_000);
     assert_eq!(season2_id, 2);
 }
+
+#[test]
+fn test_create_season_overlapping_finalized_season_succeeds() {
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 300_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 300_000_000);
+
+    let season1_id = client.create_season(&admin, &100, &200, &100_000_000);
+    assert_eq!(season1_id, 1);
+
+    let result = client.try_create_season(&admin, &150, &250, &100_000_000);
+    assert_eq!(result, Err(Ok(InsightArenaError::SeasonOverlap)));
+
+    client.update_leaderboard(&admin, &season1_id, &sample_entries(&env));
+
+    env.ledger().set_timestamp(200);
+    client.finalize_season(&admin, &season1_id);
+
+    let season2_id = client.create_season(&admin, &150, &250, &100_000_000);
+    assert_eq!(season2_id, 2);
+}
+


### PR DESCRIPTION
Closes #1052

# PR Description

This PR adds an integration test to verify the overlap validation logic when creating seasons. The test ensures that creating a season that overlaps with an active season is rejected, but creating one that overlaps with a finalized season is permitted.

In the test, we first set up a season (S1) spanning time 100 to 200. We confirm that attempting to create S2 spanning 150 to 250 fails with a `SeasonOverlap` error. Next, we update the leaderboard, advance the ledger timestamp to 200, and finalize S1. Once finalized, we confirm S2 can be successfully created with the same time range.

# Changes Made
- Added `test_create_season_overlapping_finalized_season_succeeds` to `contracts/open-market/tests/season_tests.rs` to cover the overlap rejection and post-finalization creation path.

# Testing
Ran the integration tests from the `contracts/open-market` directory:
```bash
cargo test --test season_tests
```
All 21 tests compiled and passed successfully.