### PR TITLE
test: add missing interval/dispute/payout/liquidity coverage for issu…

### DIFF
--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -640,7 +640,8 @@ pub fn batch_distribute_payouts(
     }
 
     if winning_pool <= 0 {
-        return Err(InsightArenaError::EscrowEmpty);
+        emit_batch_payout_complete(env, market_id, &caller, 0);
+        return Ok(0);
     }
 
     let loser_pool = market

--- a/contracts/open-market/tests/dispute_tests.rs
+++ b/contracts/open-market/tests/dispute_tests.rs
@@ -396,3 +396,123 @@ fn test_list_active_disputes_maintains_insertion_order() {
     assert_eq!(list.get(1), Some(id2));
     assert_eq!(list.get(2), Some(id3));
 }
+
+#[test]
+fn test_dispute_concurrent_markets_tracked_independently() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let id1 = client.create_market(&creator, &market_params(&env));
+    let id2 = client.create_market(&creator, &market_params(&env));
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(&oracle, &id1, &symbol_short!("yes"));
+    client.resolve_market(&oracle, &id2, &symbol_short!("no"));
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(&env, &xlm_token).mint(&disputer, &(bond * 2));
+    TokenClient::new(&env, &xlm_token).approve(&disputer, &client.address, &(bond * 2), &9999);
+
+    assert_eq!(client.list_active_disputes().len(), 0);
+
+    client.raise_dispute(&disputer, &id1, &bond);
+    assert_eq!(client.list_active_disputes().len(), 1);
+
+    client.raise_dispute(&disputer, &id2, &bond);
+    let active = client.list_active_disputes();
+    assert_eq!(active.len(), 2);
+    assert!(active.contains(&id1));
+    assert!(active.contains(&id2));
+
+    client.resolve_dispute(&admin, &id1, &false);
+    let active = client.list_active_disputes();
+    assert_eq!(active.len(), 1);
+    assert!(!active.contains(&id1));
+    assert!(active.contains(&id2));
+}
+
+#[test]
+fn test_dispute_raise_at_window_boundary_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let id = client.create_market(&creator, &market_params_with_window(&env, 100));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    let resolved_at = env.ledger().timestamp();
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(&env, &xlm_token).mint(&disputer, &bond);
+    TokenClient::new(&env, &xlm_token).approve(&disputer, &client.address, &bond, &9999);
+
+    // Exactly at boundary: resolved_at + dispute_window — should succeed (≤ not <)
+    env.ledger().set_timestamp(resolved_at + 100);
+    let result = client.try_raise_dispute(&disputer, &id, &bond);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_dispute_raise_one_second_past_boundary_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let id = client.create_market(&creator, &market_params_with_window(&env, 100));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    let resolved_at = env.ledger().timestamp();
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(&env, &xlm_token).mint(&disputer, &bond);
+    TokenClient::new(&env, &xlm_token).approve(&disputer, &client.address, &bond, &9999);
+
+    // One second past the boundary — should fail
+    env.ledger().set_timestamp(resolved_at + 100 + 1);
+    let result = client.try_raise_dispute(&disputer, &id, &bond);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::DisputeWindowClosed))
+    ));
+}
+
+#[test]
+fn test_dispute_reraise_after_uphold_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    let disputer = Address::generate(&env);
+
+    let id = client.create_market(&creator, &market_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(&env, &xlm_token).mint(&disputer, &(bond * 2));
+    TokenClient::new(&env, &xlm_token).approve(&disputer, &client.address, &(bond * 2), &9999);
+
+    // First dispute
+    client.raise_dispute(&disputer, &id, &bond);
+    assert_eq!(client.list_active_disputes().len(), 1);
+
+    // Uphold reopens market and returns bond to disputer
+    client.resolve_dispute(&admin, &id, &true);
+    assert_eq!(client.list_active_disputes().len(), 0);
+    assert!(!client.get_market(&id).is_resolved);
+
+    // Re-resolve the market
+    client.resolve_market(&oracle, &id, &symbol_short!("no"));
+
+    // Re-raise dispute on the same market within new window — should succeed
+    let result = client.try_raise_dispute(&disputer, &id, &bond);
+    assert!(result.is_ok());
+    assert_eq!(client.list_active_disputes().len(), 1);
+}

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -1590,3 +1590,87 @@ fn test_get_outcome_price_reflects_post_swap_reserves() {
         "Total reserves should reflect net change from swap"
     );
 }
+
+#[test]
+fn test_liquidity_no_trade_returns_exact_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    let initial_deposit = 1_000_i128;
+    sa.mint(&provider, &initial_deposit);
+    token.approve(&provider, &client.address, &initial_deposit, &9999);
+    let lp_tokens = client.add_liquidity(&provider, &market_id, &initial_deposit);
+
+    // No swaps — removing all LP tokens returns exactly the deposit
+    let withdrawn = client.remove_liquidity(&provider, &market_id, &lp_tokens);
+    assert_eq!(withdrawn, initial_deposit);
+
+    let providers = client.get_all_lp_providers(&market_id);
+    assert_eq!(providers.len(), 0);
+}
+
+#[test]
+fn test_liquidity_fee_accumulation_end_to_end() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    // Add liquidity
+    let initial_deposit = 100_000_i128;
+    sa.mint(&provider, &initial_deposit);
+    token.approve(&provider, &client.address, &initial_deposit, &9999);
+    let lp_tokens = client.add_liquidity(&provider, &market_id, &initial_deposit);
+
+    // Execute 5 swaps to accumulate fees
+    let swap_amount = 5_000_i128;
+    sa.mint(&trader, &(swap_amount * 5));
+    token.approve(&trader, &client.address, &(swap_amount * 5), &9999);
+    for _ in 0..5 {
+        client.swap_outcome(
+            &trader,
+            &market_id,
+            &symbol_short!("yes"),
+            &symbol_short!("no"),
+            &swap_amount,
+            &0_i128,
+        );
+    }
+
+    // Verify fees were accumulated in the LP position
+    let position = client.get_lp_position(&provider, &market_id);
+    let fees_earned = position.fees_earned;
+    assert!(fees_earned > 0);
+
+    // Collect fees before removing LP tokens (position is deleted on full removal)
+    let collected = client.collect_lp_fees(&provider, &market_id);
+    assert_eq!(collected, fees_earned);
+
+    // Remove all LP tokens — returns principal only
+    let withdrawn = client.remove_liquidity(&provider, &market_id, &lp_tokens);
+    assert_eq!(withdrawn, initial_deposit);
+
+    // Total returned (principal + fees) exceeds the initial deposit
+    assert!(withdrawn + collected > initial_deposit);
+
+    // Pool is empty after full withdrawal
+    let providers = client.get_all_lp_providers(&market_id);
+    assert_eq!(providers.len(), 0);
+}

--- a/contracts/open-market/tests/prediction_tests.rs
+++ b/contracts/open-market/tests/prediction_tests.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::testutils::{storage::Persistent as _, Address as _, Ledger};
-use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
 
 use insightarena_contract::config::LEDGER_BUMP_MARKET;
@@ -341,10 +341,9 @@ fn test_batch_distribute_payouts_pays_all_unclaimed_winners_correctly_idempotent
         Err(Ok(InsightArenaError::InvalidOutcome))
     ));
 
-    // Second batch: Since the escrow pool is now completely empty (0 balance),
-    // the contract throws an EscrowEmpty error (#32) as expected.
-    let processed_second = client.try_batch_distribute_payouts(&oracle, &market_id);
-    assert!(processed_second.is_err());
+    // Second batch: all winning predictions already claimed — returns 0
+    let processed_second = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed_second, 0);
 }
 
 #[test]
@@ -641,4 +640,56 @@ fn test_submit_prediction_on_cancelled_market_fails() {
     // 7. Verify post-cancellation status checks remain accurate
     assert!(client.has_predicted(&market_id, &user_alpha));
     assert!(!client.has_predicted(&market_id, &user_gamma));
+}
+
+#[test]
+fn test_batch_distribute_payouts_idempotent_with_winners_and_losers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, oracle) = deploy(&env);
+
+    let winner1 = Address::generate(&env);
+    let winner2 = Address::generate(&env);
+    let loser1 = Address::generate(&env);
+    let loser2 = Address::generate(&env);
+    let stake = 50_000_000_i128;
+
+    let params = default_params(&env);
+    let market_id = client.create_market(&Address::generate(&env), &params);
+
+    fund(&env, &xlm_token, &winner1, stake);
+    fund(&env, &xlm_token, &winner2, stake);
+    fund(&env, &xlm_token, &loser1, stake);
+    fund(&env, &xlm_token, &loser2, stake);
+
+    client.submit_prediction(&winner1, &market_id, &symbol_short!("yes"), &stake);
+    client.submit_prediction(&winner2, &market_id, &symbol_short!("yes"), &stake);
+    client.submit_prediction(&loser1, &market_id, &symbol_short!("no"), &stake);
+    client.submit_prediction(&loser2, &market_id, &symbol_short!("no"), &stake);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    // First batch: processes both winners
+    let first_count = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(first_count, 2);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    let winner1_bal = token.balance(&winner1);
+    let winner2_bal = token.balance(&winner2);
+    assert!(winner1_bal > 0);
+    assert!(winner2_bal > 0);
+
+    // Second batch: all winners already paid, losers skipped — payout_claimed flag prevents double payment
+    let second_count = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(second_count, 0);
+
+    // Winner balances unchanged — no double payment
+    assert_eq!(token.balance(&winner1), winner1_bal);
+    assert_eq!(token.balance(&winner2), winner2_bal);
+
+    // Losers received nothing (their stakes funded the winner payouts)
+    assert_eq!(token.balance(&loser1), 0);
+    assert_eq!(token.balance(&loser2), 0);
 }

--- a/contracts/open-market/tests/season_tests.rs
+++ b/contracts/open-market/tests/season_tests.rs
@@ -811,3 +811,49 @@ fn test_create_season_overlapping_finalized_season_succeeds() {
     assert_eq!(season2_id, 2);
 }
 
+#[test]
+fn test_season_overlap_ends_inside_fails() {
+    // S1=[100,200], S2=[50,150]: S2 starts before S1 but ends inside it → reject
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 300_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 200_000_000);
+
+    client.create_season(&admin, &100, &200, &100_000_000);
+
+    let result = client.try_create_season(&admin, &50, &150, &100_000_000);
+    assert_eq!(result, Err(Ok(InsightArenaError::SeasonOverlap)));
+}
+
+#[test]
+fn test_season_overlap_fully_contained_fails() {
+    // S1=[100,200], S2=[120,180]: S2 is fully inside S1 → reject
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 300_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 200_000_000);
+
+    client.create_season(&admin, &100, &200, &100_000_000);
+
+    let result = client.try_create_season(&admin, &120, &180, &100_000_000);
+    assert_eq!(result, Err(Ok(InsightArenaError::SeasonOverlap)));
+}
+
+#[test]
+fn test_season_overlap_touching_at_start_succeeds() {
+    // S1=[100,200], S2=[50,100]: S2 ends exactly at S1's start → allow (no overlap)
+    let env = Env::default();
+    let (client, xlm_token, admin, _oracle) = deploy(&env);
+
+    fund(&env, &xlm_token, &admin, 300_000_000);
+    approve_reward_pool(&env, &xlm_token, &admin, &client.address, 200_000_000);
+
+    let season1_id = client.create_season(&admin, &100, &200, &100_000_000);
+    assert_eq!(season1_id, 1);
+
+    let season2_id = client.create_season(&admin, &50, &100, &100_000_000);
+    assert_eq!(season2_id, 2);
+}
+


### PR DESCRIPTION
…es #1251-#1254

- fix(prediction): batch_distribute_payouts returns Ok(0) when no unclaimed winning predictions remain (winning_pool==0), making it idempotent after losers-only predictions remain in persistent storage
- test(season): add overlap edge cases — ends-inside, fully-contained, and touching-at-start interval scenarios (Closes #1254)
- test(dispute): add window-boundary exact, one-second-past-boundary, concurrent multi-market, and re-raise-after-uphold scenarios (Closes #1252)
- test(prediction): add idempotency test with 2 winners + 2 losers verifying second batch call returns 0 and no double-payment (Closes #1253)
- test(liquidity): add no-trade exact-deposit and 5-swap fee-accumulation end-to-end tests (Closes #1251)