### PR TITLE
Validate analytics date-range query parameters

### DIFF
--- a/backend/src/analytics/analytics.controller.spec.ts
+++ b/backend/src/analytics/analytics.controller.spec.ts
@@ -7,6 +7,7 @@ import { DashboardKpisDto } from './dto/dashboard-kpis.dto';
 import { MarketAnalyticsDto } from './dto/market-analytics.dto';
 import { MarketHistoryResponseDto } from './dto/market-history.dto';
 import { User } from '../users/entities/user.entity';
+import { DateRangeQueryDto } from '../common/dto/date-range-query.dto';
 
 describe('AnalyticsController', () => {
   let controller: AnalyticsController;
@@ -176,57 +177,67 @@ describe('AnalyticsController', () => {
   describe('getMarketHistory', () => {
     it('should return market history with default parameters', async () => {
       service.getMarketHistory.mockResolvedValue(mockMarketHistory);
+      const query = new DateRangeQueryDto();
+      const before = Date.now();
 
-      const result = await controller.getMarketHistory('market-123');
+      const result = await controller.getMarketHistory('market-123', query);
+
+      const [marketId, from, to, interval] =
+        service.getMarketHistory.mock.calls[0];
 
       expect(result).toEqual(mockMarketHistory);
-      expect(service.getMarketHistory).toHaveBeenCalledWith(
-        'market-123',
-        undefined,
-        undefined,
-        undefined,
+      expect(marketId).toBe('market-123');
+      expect(interval).toBeUndefined();
+      expect((to as Date).getTime()).toBeGreaterThanOrEqual(before);
+      expect((to as Date).getTime() - (from as Date).getTime()).toBeCloseTo(
+        30 * 24 * 60 * 60 * 1000,
+        -3,
       );
     });
 
     it('should return market history with query parameters', async () => {
       service.getMarketHistory.mockResolvedValue(mockMarketHistory);
+      const query = new DateRangeQueryDto();
+      query.from = '2024-01-01T00:00:00.000Z';
+      query.to = '2024-01-31T23:59:59.999Z';
 
       const result = await controller.getMarketHistory(
         'market-123',
-        '2024-01-01',
-        '2024-01-31',
+        query,
         'day',
       );
 
       expect(result).toEqual(mockMarketHistory);
       expect(service.getMarketHistory).toHaveBeenCalledWith(
         'market-123',
-        '2024-01-01',
-        '2024-01-31',
+        new Date('2024-01-01T00:00:00.000Z'),
+        new Date('2024-01-31T23:59:59.999Z'),
         'day',
       );
     });
 
-    it('should default to last 7 days if no range provided', async () => {
+    it('should default to the last 30 days when no range is provided', async () => {
       const historyWithDefaults = { ...mockMarketHistory };
       service.getMarketHistory.mockResolvedValue(historyWithDefaults);
+      const query = new DateRangeQueryDto();
 
-      const result = await controller.getMarketHistory('market-123');
+      const result = await controller.getMarketHistory('market-123', query);
+
+      const [, from, to] = service.getMarketHistory.mock.calls.at(-1)!;
 
       expect(result).toEqual(historyWithDefaults);
-      expect(service.getMarketHistory).toHaveBeenCalledWith(
-        'market-123',
-        undefined,
-        undefined,
-        undefined,
+      expect((to as Date).getTime() - (from as Date).getTime()).toBeCloseTo(
+        30 * 24 * 60 * 60 * 1000,
+        -3,
       );
     });
 
     it('should throw 404 for unknown market ID', async () => {
       service.getMarketHistory.mockRejectedValue(new Error('Market not found'));
+      const query = new DateRangeQueryDto();
 
       await expect(
-        controller.getMarketHistory('unknown-market'),
+        controller.getMarketHistory('unknown-market', query),
       ).rejects.toThrow();
     });
   });

--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, Query, UseInterceptors } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseInterceptors,
+  ValidationPipe,
+} from '@nestjs/common';
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
 import {
   ApiBearerAuth,
@@ -8,6 +15,7 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { DateRangeQueryDto } from '../common/dto/date-range-query.dto';
 import { Public } from '../common/decorators/public.decorator';
 import { User } from '../users/entities/user.entity';
 import { AnalyticsService } from './analytics.service';
@@ -57,18 +65,6 @@ export class AnalyticsController {
   @Public()
   @ApiOperation({ summary: 'Get historical data for a market over time' })
   @ApiQuery({
-    name: 'from',
-    required: false,
-    type: String,
-    description: 'Start date (ISO string)',
-  })
-  @ApiQuery({
-    name: 'to',
-    required: false,
-    type: String,
-    description: 'End date (ISO string)',
-  })
-  @ApiQuery({
     name: 'interval',
     required: false,
     type: String,
@@ -80,13 +76,15 @@ export class AnalyticsController {
       'Market history with prediction volume, pool size, and participant growth',
     type: MarketHistoryResponseDto,
   })
+  @ApiResponse({ status: 400, description: 'Invalid date range query' })
   @ApiResponse({ status: 404, description: 'Market not found' })
   async getMarketHistory(
     @Param('id') id: string,
-    @Query('from') from?: string,
-    @Query('to') to?: string,
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: DateRangeQueryDto,
     @Query('interval') interval?: string, // TODO: Implement interval-based aggregation
   ): Promise<MarketHistoryResponseDto> {
+    const { from, to } = query.resolveRange();
     return this.analyticsService.getMarketHistory(id, from, to, interval);
   }
 

--- a/backend/src/analytics/analytics.service.history.spec.ts
+++ b/backend/src/analytics/analytics.service.history.spec.ts
@@ -100,7 +100,9 @@ describe('AnalyticsService - Market History', () => {
     const qb = marketHistoryRepository.createQueryBuilder();
     (qb.getMany as jest.Mock).mockResolvedValue(mockHistory);
 
-    const result = await service.getMarketHistory('market-1');
+    const from = new Date('2026-05-01T00:00:00.000Z');
+    const to = new Date('2026-06-01T00:00:00.000Z');
+    const result = await service.getMarketHistory('market-1', from, to);
 
     expect(result.market_id).toBe('market-1');
     expect(result.title).toBe('Test Market');
@@ -129,6 +131,12 @@ describe('AnalyticsService - Market History', () => {
   it('should throw NotFoundException for non-existent market', async () => {
     marketsRepository.findOne.mockResolvedValue(null);
 
-    await expect(service.getMarketHistory('invalid-id')).rejects.toThrow();
+    await expect(
+      service.getMarketHistory(
+        'invalid-id',
+        new Date('2026-05-01T00:00:00.000Z'),
+        new Date('2026-06-01T00:00:00.000Z'),
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -294,7 +294,9 @@ describe('AnalyticsService', () => {
         .spyOn(marketHistoryRepository, 'createQueryBuilder')
         .mockReturnValue(qb as any);
 
-      const result = await service.getMarketHistory('market-1');
+      const from = new Date('2026-05-01T00:00:00.000Z');
+      const to = new Date('2026-06-01T00:00:00.000Z');
+      const result = await service.getMarketHistory('market-1', from, to);
 
       expect(result.market_id).toBe('market-1');
       expect(result.history).toHaveLength(1);
@@ -307,7 +309,11 @@ describe('AnalyticsService', () => {
       });
       expect(qb.andWhere).toHaveBeenCalledWith(
         'history.recorded_at >= :from',
-        expect.any(Object),
+        { from },
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'history.recorded_at <= :to',
+        { to },
       );
     });
 
@@ -315,7 +321,13 @@ describe('AnalyticsService', () => {
       const marketsRepository = module.get(getRepositoryToken(Market));
       jest.spyOn(marketsRepository, 'findOne').mockResolvedValue(null);
 
-      await expect(service.getMarketHistory('invalid')).rejects.toThrow(
+      await expect(
+        service.getMarketHistory(
+          'invalid',
+          new Date('2026-05-01T00:00:00.000Z'),
+          new Date('2026-06-01T00:00:00.000Z'),
+        ),
+      ).rejects.toThrow(
         'Market "invalid" not found',
       );
     });

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -197,8 +197,8 @@ export class AnalyticsService {
    */
   async getMarketHistory(
     marketId: string,
-    from?: string,
-    to?: string,
+    from: Date,
+    to: Date,
     interval?: string, // TODO: Implement interval-based aggregation
   ): Promise<MarketHistoryResponseDto> {
     if (interval) {
@@ -219,17 +219,8 @@ export class AnalyticsService {
       .createQueryBuilder('history')
       .where('history.marketId = :marketId', { marketId: market.id });
 
-    if (from) {
-      qb.andWhere('history.recorded_at >= :from', { from });
-    } else {
-      const lastWeek = new Date();
-      lastWeek.setDate(lastWeek.getDate() - 7);
-      qb.andWhere('history.recorded_at >= :from', { from: lastWeek });
-    }
-
-    if (to) {
-      qb.andWhere('history.recorded_at <= :to', { to });
-    }
+    qb.andWhere('history.recorded_at >= :from', { from });
+    qb.andWhere('history.recorded_at <= :to', { to });
 
     qb.orderBy('history.recorded_at', 'ASC');
 

--- a/backend/src/common/dto/date-range-query.dto.spec.ts
+++ b/backend/src/common/dto/date-range-query.dto.spec.ts
@@ -1,0 +1,122 @@
+import { validate } from 'class-validator';
+import {
+  DateRangeQueryDto,
+  DEFAULT_DATE_RANGE_DAYS,
+  MAX_DATE_RANGE_DAYS,
+} from './date-range-query.dto';
+
+describe('DateRangeQueryDto', () => {
+  const reference = new Date('2026-06-15T12:00:00.000Z');
+
+  async function expectValid(dto: DateRangeQueryDto) {
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  }
+
+  async function expectInvalid(dto: DateRangeQueryDto, message: string) {
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const messages = errors.flatMap((error) =>
+      Object.values(error.constraints ?? {}),
+    );
+    const nestedMessages = errors.flatMap((error) =>
+      (error.children ?? []).flatMap((child) =>
+        Object.values(child.constraints ?? {}),
+      ),
+    );
+    expect(
+      [...messages, ...nestedMessages].some((entry) => entry.includes(message)),
+    ).toBe(true);
+  }
+
+  it('defaults to the last 30 days when from and to are omitted', () => {
+    const dto = new DateRangeQueryDto();
+    const { from, to } = dto.resolveRange(reference);
+
+    expect(to.toISOString()).toBe(reference.toISOString());
+    expect(from.toISOString()).toBe(
+      new Date('2026-05-16T12:00:00.000Z').toISOString(),
+    );
+    expect(
+      (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000),
+    ).toBeCloseTo(DEFAULT_DATE_RANGE_DAYS, 5);
+  });
+
+  it('accepts a valid explicit range', async () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2026-01-01T00:00:00.000Z';
+    dto.to = '2026-01-31T23:59:59.999Z';
+
+    await expectValid(dto);
+  });
+
+  it('rejects inverted ranges with from must be before to', async () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2026-02-01T00:00:00.000Z';
+    dto.to = '2026-01-01T00:00:00.000Z';
+
+    await expectInvalid(dto, 'from must be before to');
+  });
+
+  it('rejects oversized ranges beyond 365 days', async () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2024-01-01T00:00:00.000Z';
+    dto.to = '2026-01-02T00:00:00.000Z';
+
+    await expectInvalid(
+      dto,
+      `Date range must not exceed ${MAX_DATE_RANGE_DAYS} days`,
+    );
+  });
+
+  it('rejects future from dates', async () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2099-01-01T00:00:00.000Z';
+    dto.to = '2099-01-02T00:00:00.000Z';
+
+    await expectInvalid(dto, 'from must not be in the future');
+  });
+
+  it('rejects future to dates', async () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2026-01-01T00:00:00.000Z';
+    dto.to = '2099-01-01T00:00:00.000Z';
+
+    await expectInvalid(dto, 'to must not be in the future');
+  });
+
+  it('rejects inverted ranges when only from is provided and it is after now', async () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2099-01-01T00:00:00.000Z';
+
+    await expectInvalid(dto, 'from must not be in the future');
+  });
+
+  it('rejects malformed ISO date strings', async () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2026-13-45T00:00:00.000Z';
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('defaults from when only to is provided', () => {
+    const dto = new DateRangeQueryDto();
+    dto.to = '2026-06-10T00:00:00.000Z';
+
+    const { from, to } = dto.resolveRange(reference);
+
+    expect(to.toISOString()).toBe('2026-06-10T00:00:00.000Z');
+    expect(from.toISOString()).toBe('2026-05-11T00:00:00.000Z');
+  });
+
+  it('defaults to now when only from is provided', () => {
+    const dto = new DateRangeQueryDto();
+    dto.from = '2026-06-01T00:00:00.000Z';
+
+    const { from, to } = dto.resolveRange(reference);
+
+    expect(from.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+    expect(to.toISOString()).toBe(reference.toISOString());
+  });
+});

--- a/backend/src/common/dto/date-range-query.dto.ts
+++ b/backend/src/common/dto/date-range-query.dto.ts
@@ -1,0 +1,121 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsISO8601,
+  IsOptional,
+  Validate,
+  ValidateIf,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+export const DEFAULT_DATE_RANGE_DAYS = 30;
+export const MAX_DATE_RANGE_DAYS = 365;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function subtractDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() - days);
+  return result;
+}
+
+function parseIsoDate(value: string): Date | undefined {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date;
+}
+
+@ValidatorConstraint({ name: 'ValidAnalyticsDateRange', async: false })
+export class ValidAnalyticsDateRangeConstraint
+  implements ValidatorConstraintInterface
+{
+  private message = 'Invalid date range';
+
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    const dto = args.object as DateRangeQueryDto;
+    const now = new Date();
+
+    const fromDate = dto.from ? parseIsoDate(dto.from) : undefined;
+    const toDate = dto.to ? parseIsoDate(dto.to) : undefined;
+
+    if (dto.from && !fromDate) {
+      this.message = 'from must be a valid ISO-8601 datetime';
+      return false;
+    }
+
+    if (dto.to && !toDate) {
+      this.message = 'to must be a valid ISO-8601 datetime';
+      return false;
+    }
+
+    if (fromDate && fromDate > now) {
+      this.message = 'from must not be in the future';
+      return false;
+    }
+
+    if (toDate && toDate > now) {
+      this.message = 'to must not be in the future';
+      return false;
+    }
+
+    const resolvedTo = toDate ?? now;
+    const resolvedFrom =
+      fromDate ?? subtractDays(toDate ?? now, DEFAULT_DATE_RANGE_DAYS);
+
+    if (resolvedFrom > resolvedTo) {
+      this.message = 'from must be before to';
+      return false;
+    }
+
+    const windowDays =
+      (resolvedTo.getTime() - resolvedFrom.getTime()) / MS_PER_DAY;
+    if (windowDays > MAX_DATE_RANGE_DAYS) {
+      this.message = `Date range must not exceed ${MAX_DATE_RANGE_DAYS} days`;
+      return false;
+    }
+
+    return true;
+  }
+
+  defaultMessage(): string {
+    return this.message;
+  }
+}
+
+export class DateRangeQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Start of the time window (ISO-8601 datetime). Defaults to 30 days before `to`, or 30 days before now when both bounds are omitted.',
+    example: '2026-01-01T00:00:00.000Z',
+  })
+  @IsOptional()
+  @IsISO8601({ strict: true, strictSeparator: true })
+  from?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'End of the time window (ISO-8601 datetime). Defaults to now when omitted.',
+    example: '2026-01-31T23:59:59.999Z',
+  })
+  @IsOptional()
+  @IsISO8601({ strict: true, strictSeparator: true })
+  to?: string;
+
+  @ValidateIf(
+    (dto: DateRangeQueryDto) => dto.from !== undefined || dto.to !== undefined,
+  )
+  @Validate(ValidAnalyticsDateRangeConstraint)
+  private readonly rangeValidation?: unknown;
+
+  resolveRange(reference: Date = new Date()): { from: Date; to: Date } {
+    const to = this.to ? new Date(this.to) : new Date(reference);
+    const from = this.from
+      ? new Date(this.from)
+      : subtractDays(this.to ? to : reference, DEFAULT_DATE_RANGE_DAYS);
+
+    return { from, to };
+  }
+}

--- a/backend/src/markets/markets.controller.ts
+++ b/backend/src/markets/markets.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   Query,
   UseGuards,
+  ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -19,6 +20,7 @@ import {
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { DateRangeQueryDto } from '../common/dto/date-range-query.dto';
 import { Public } from '../common/decorators/public.decorator';
 import { BanGuard } from '../common/guards/ban.guard';
 import { User } from '../users/entities/user.entity';
@@ -338,12 +340,14 @@ export class MarketsController {
     status: 200,
     description: 'Historical data points',
   })
+  @ApiResponse({ status: 400, description: 'Invalid date range query' })
   @ApiResponse({ status: 404, description: 'Market not found' })
   async getMarketHistory(
     @Param('id') id: string,
-    @Query('from') from?: string,
-    @Query('to') to?: string,
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: DateRangeQueryDto,
   ) {
+    const { from, to } = query.resolveRange();
     return this.analyticsService.getMarketHistory(id, from, to);
   }
 


### PR DESCRIPTION
Add shared DateRangeQueryDto with ISO-8601 checks, 30-day defaults, 365-day max window, and future-date rejection for market history endpoints. Closes #1279