### PR TITLE
feat: add per-page metadata and OG tags to public pages

### DIFF
--- a/frontend/src/app/Faq/layout.tsx
+++ b/frontend/src/app/Faq/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "FAQ",
+  description:
+    "Find answers to common questions about InsightArena, cryptocurrency basics, tournaments, and how to get started on the platform.",
+  openGraph: {
+    title: "FAQ | InsightArena",
+    description:
+      "Find answers to common questions about InsightArena, cryptocurrency basics, tournaments, and how to get started on the platform.",
+    type: "website",
+  },
+};
+
+export default function FaqLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,8 +1,21 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import Footer from "@/component/Footer";
 import Header from "@/component/Header";
 import PageBackground from "@/component/PageBackground";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Learn about InsightArena, the decentralized prediction market built on Stellar, and how we make forecasting accessible and community-owned.",
+  openGraph: {
+    title: "About | InsightArena",
+    description:
+      "Learn about InsightArena, the decentralized prediction market built on Stellar, and how we make forecasting accessible and community-owned.",
+    type: "website",
+  },
+};
 
 type StatCard = {
   label: string;

--- a/frontend/src/app/contact/layout.tsx
+++ b/frontend/src/app/contact/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact",
+  description:
+    "Get in touch with the InsightArena team for technical support, account issues, trading questions, or general feedback.",
+  openGraph: {
+    title: "Contact | InsightArena",
+    description:
+      "Get in touch with the InsightArena team for technical support, account issues, trading questions, or general feedback.",
+    type: "website",
+  },
+};
+
+export default function ContactLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/docs/layout.tsx
+++ b/frontend/src/app/docs/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Documentation",
+  description:
+    "Explore the InsightArena documentation for guides on wallet setup, trading, smart contracts, and platform API integration.",
+  openGraph: {
+    title: "Documentation | InsightArena",
+    description:
+      "Explore the InsightArena documentation for guides on wallet setup, trading, smart contracts, and platform API integration.",
+    type: "website",
+  },
+};
+
+export default function DocsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/privacy/layout.tsx
+++ b/frontend/src/app/privacy/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "Learn how InsightArena collects, uses, and protects your data. Read our privacy policy covering blockchain data, cookies, and GDPR compliance.",
+  openGraph: {
+    title: "Privacy Policy | InsightArena",
+    description:
+      "Learn how InsightArena collects, uses, and protects your data. Read our privacy policy covering blockchain data, cookies, and GDPR compliance.",
+    type: "website",
+  },
+};
+
+export default function PrivacyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import Head from "next/head";
 import Link from "next/link";
 import Header from "@/component/Header";
 import Footer from "@/component/Footer";
@@ -11,10 +10,6 @@ export default function PrivacyPolicy() {
 
   return (
     <>
-      <Head>
-        <title>Privacy Policy | InsightArena</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
       <div className="relative min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 overflow-x-hidden text-gray-300 font-sans">
         {/* Global Network Lines Background */}
         <div className="absolute inset-0 w-full h-full z-0 pointer-events-none">

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,7 +1,20 @@
+import type { Metadata } from "next";
 import Header from '@/component/Header';
 import Footer from "@/component/Footer";
 import PageBackground from "@/component/PageBackground";
 import React from 'react';
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "Read the InsightArena terms of service covering user responsibilities, trading rules, disclaimers, and platform usage guidelines.",
+  openGraph: {
+    title: "Terms of Service | InsightArena",
+    description:
+      "Read the InsightArena terms of service covering user responsibilities, trading rules, disclaimers, and platform usage guidelines.",
+    type: "website",
+  },
+};
 
 const TermsPage = () => {
   const lastUpdated = "March 29, 2026";


### PR DESCRIPTION
## What
Adds unique `<title>`, `<meta description>`, and Open Graph tags to all six public-facing pages (about, contact, FAQ, terms, privacy, docs).

## Why
These pages shared a generic title/description from the root layout, hurting SEO rankings and social share previews. Each page now renders its own metadata for better discoverability and link previews.

## Changes
- **`about/page.tsx`** — added `Metadata` export with title and description
- **`terms/page.tsx`** — added `Metadata` export with title and description
- **`contact/layout.tsx`** — new server layout for metadata (page uses `"use client"`)
- **`Faq/layout.tsx`** — new server layout for metadata (page uses `"use client"`)
- **`privacy/layout.tsx`** — new server layout for metadata (page uses `"use client"`)
- **`privacy/page.tsx`** — removed unused `next/head` import and `<Head>` block (does nothing in App Router)
- **`docs/layout.tsx`** — new server layout for metadata (page uses `"use client"`)

No changes to `layout.tsx` — `metadataBase` and title template (`%s | InsightArena`) were already in place. No client components were converted to server components.

closes #1289