### PR TITLE
feat(wallet): persist and restore wallet session across page reloads

### DIFF
--- a/frontend/src/component/ConnectWalletModal.tsx
+++ b/frontend/src/component/ConnectWalletModal.tsx
@@ -8,7 +8,7 @@ type ModalStep = "idle" | "connecting" | "success" | "error";
 interface ConnectWalletModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: (address: string, token: string) => void;
+  onSuccess: (address: string, walletId: string) => void;
 }
 
 interface WalletOption {
@@ -103,7 +103,7 @@ export default function ConnectWalletModal({
 
       // Let WalletContext handle the redirect via onSuccess
       setTimeout(() => {
-        onSuccess(address, `wallet_${address}`);
+        onSuccess(address, walletId);
       }, 1200);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/frontend/src/component/Header.tsx
+++ b/frontend/src/component/Header.tsx
@@ -8,7 +8,8 @@ import { useWallet } from "@/context/WalletContext";
 
 export default function Header() {
   const pathname = usePathname();
-  const { address, isAuthenticated, logout, openConnectModal } = useWallet();
+  const { address, isAuthenticated, isRestoring, logout, openConnectModal } =
+    useWallet();
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -230,7 +231,12 @@ export default function Header() {
                 </span>
               </Link>
 
-              {!isAuthenticated ? (
+              {isRestoring && !isAuthenticated ? (
+                <div className="hidden md:inline-flex items-center gap-2 rounded-lg border border-white/10 bg-[#111726] px-6 py-2 text-sm font-semibold text-gray-400">
+                  <span className="h-2 w-2 animate-pulse rounded-full bg-gray-500" />
+                  Loading...
+                </div>
+              ) : !isAuthenticated ? (
                 <button
                   type="button"
                   className="hidden md:inline-flex rounded-lg bg-orange-500 px-6 py-2 font-semibold text-white hover:bg-orange-600"
@@ -380,7 +386,12 @@ export default function Header() {
             >
               Profile
             </Link>
-            {!isAuthenticated ? (
+            {isRestoring && !isAuthenticated ? (
+              <div className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-[#111726] px-4 py-3 text-sm font-semibold text-gray-400">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-gray-500" />
+                Loading...
+              </div>
+            ) : !isAuthenticated ? (
               <button
                 type="button"
                 className="w-full rounded-lg bg-orange-500 px-4 py-3 font-semibold text-white hover:bg-orange-600"

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -24,6 +24,7 @@ export interface WalletContextValue {
   // Auth state
   isAuthenticated: boolean;
   isAuthenticating: boolean;
+  isRestoring: boolean;
   user: AuthUser | null;
   token: string | null;
   authError: string | null;
@@ -44,6 +45,7 @@ const DEFAULT_CONTEXT_VALUE: WalletContextValue = {
   address: null,
   isAuthenticated: false,
   isAuthenticating: false,
+  isRestoring: false,
   user: null,
   token: null,
   authError: null,
@@ -53,6 +55,56 @@ const DEFAULT_CONTEXT_VALUE: WalletContextValue = {
   authenticate: async () => false,
   logout: () => {},
 };
+
+// Persisted wallet session — id/type + public key only, never secret material.
+const WALLET_STORAGE_KEY = "insightarena.wallet.v1";
+
+interface StoredWalletSession {
+  walletId: string;
+  address: string;
+}
+
+function readStoredSession(): StoredWalletSession | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(WALLET_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<StoredWalletSession> | null;
+    if (
+      !parsed ||
+      typeof parsed.walletId !== "string" ||
+      typeof parsed.address !== "string"
+    ) {
+      window.localStorage.removeItem(WALLET_STORAGE_KEY);
+      return null;
+    }
+
+    return { walletId: parsed.walletId, address: parsed.address };
+  } catch {
+    // Corrupted/old-format value — clear rather than throw.
+    window.localStorage.removeItem(WALLET_STORAGE_KEY);
+    return null;
+  }
+}
+
+function writeStoredSession(session: StoredWalletSession) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WALLET_STORAGE_KEY, JSON.stringify(session));
+  } catch {
+    // Storage unavailable/full — persistence is best-effort.
+  }
+}
+
+function clearStoredSession() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(WALLET_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
 
 const WalletContext = createContext<WalletContextValue>(DEFAULT_CONTEXT_VALUE);
 
@@ -65,10 +117,18 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [authError, setAuthError] = useState<string | null>(null);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(true);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    // Detect any Stellar wallet via the kit
+    if (typeof window === "undefined") {
+      setIsRestoring(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    // Detect any Stellar wallet via the kit, then attempt a silent
+    // reconnect if a session was persisted from a previous visit.
     Promise.all([
       import("@creit-tech/stellar-wallets-kit/sdk"),
       import("@creit-tech/stellar-wallets-kit/types"),
@@ -77,7 +137,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       import("@creit-tech/stellar-wallets-kit/modules/albedo"),
     ])
       .then(
-        ([
+        async ([
           { StellarWalletsKit },
           { Networks },
           { FreighterModule, FREIGHTER_ID },
@@ -93,13 +153,49 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
               new AlbedoModule(),
             ],
           });
-          return StellarWalletsKit.refreshSupportedWallets();
+
+          const wallets = await StellarWalletsKit.refreshSupportedWallets();
+          if (cancelled) return;
+          setIsFreighterInstalled(wallets.some((w) => w.isAvailable));
+
+          const stored = readStoredSession();
+          if (!stored) return;
+
+          try {
+            StellarWalletsKit.setWallet(stored.walletId);
+            const { address: restoredAddress } =
+              await StellarWalletsKit.fetchAddress();
+            if (cancelled) return;
+
+            if (!restoredAddress) {
+              clearStoredSession();
+              return;
+            }
+
+            setAddress(restoredAddress);
+            setToken(`wallet_${restoredAddress}`);
+            setUser({ username: "Alex" });
+            writeStoredSession({
+              walletId: stored.walletId,
+              address: restoredAddress,
+            });
+          } catch {
+            // Wallet extension rejected/unavailable — fall back to
+            // disconnected state silently, no error toast.
+            if (!cancelled) clearStoredSession();
+          }
         },
       )
-      .then((wallets) => {
-        setIsFreighterInstalled(wallets.some((w) => w.isAvailable));
+      .catch(() => {
+        if (!cancelled) setIsFreighterInstalled(false);
       })
-      .catch(() => setIsFreighterInstalled(false));
+      .finally(() => {
+        if (!cancelled) setIsRestoring(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // wallet connected = authenticated (no backend needed)
@@ -148,16 +244,18 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     setToken(null);
     setAuthError(null);
     setIsConnectModalOpen(false);
+    clearStoredSession();
     router.push("/");
   }, []);
 
   const handleModalSuccess = useCallback(
-    (walletAddress: string, _jwt: string) => {
+    (walletAddress: string, walletId: string) => {
       setAddress(walletAddress);
       setToken(`wallet_${walletAddress}`);
       setUser({ username: "Alex" });
       setAuthError(null);
       setIsConnectModalOpen(false);
+      writeStoredSession({ walletId, address: walletAddress });
       router.push("/dashboard");
     },
     [router],
@@ -169,6 +267,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       address,
       isAuthenticated,
       isAuthenticating,
+      isRestoring,
       user,
       token,
       authError,
@@ -183,6 +282,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       address,
       isAuthenticated,
       isAuthenticating,
+      isRestoring,
       user,
       token,
       authError,


### PR DESCRIPTION
## Summary
- Persist the connected wallet id and public key (never secret material) to `localStorage` under `insightarena.wallet.v1` on connect
- On app load, attempt a silent reconnect through the wallet kit using the stored wallet id; on rejection/unavailability, clear the stored session and fall back to disconnected state with no error toast
- Clear the stored session on explicit disconnect
- Guard all `localStorage` access with `typeof window !== "undefined"` for SSR safety
- Clear corrupted/old-format stored values instead of throwing
- Expose `isRestoring` from `WalletContext` and use it in `Header` to show a neutral loading state instead of flashing "Connect Wallet" during silent reconnect

`ConnectWalletModal`'s `onSuccess` callback now passes the selected `walletId` (previously an unused mock token param) so the wallet id can be persisted alongside the address.

Closes #1290

## Test plan
- [x] `npx tsc --noEmit` — no errors introduced in changed files (pre-existing unrelated SVG-import errors only)
- [ ] Manually verify: connect wallet, reload page, session restores without a popup
- [ ] Manually verify: disconnect, reload page, stays disconnected
- [ ] Manually verify: corrupt `localStorage["insightarena.wallet.v1"]` value, reload, app doesn't crash and falls back to disconnected