### PR TITLE
feat(creator-event-manager): reputation-weighted standings with deterministic tie-breakers

### DIFF
--- a/contracts/creator-event-manager/src/finalize.rs
+++ b/contracts/creator-event-manager/src/finalize.rs
@@ -102,6 +102,12 @@ pub fn finalize_event(
         }
     }
 
+    // Recompute and persist the final weighted standings snapshot (#1311).
+    // Every match is resolved at this point, so this stores the definitive
+    // end-of-event standings. Payouts below intentionally remain driven by the
+    // points leaderboard.
+    leaderboard::recompute_standings(env, event_id).map_err(|_| EventError::EventNotFound)?;
+
     // Ranked, deterministic leaderboard. The event was already loaded above, so
     // the only residual error path here is an (effectively unreachable) points
     // overflow; collapse it onto EventNotFound to stay within EventError.

--- a/contracts/creator-event-manager/src/leaderboard.rs
+++ b/contracts/creator-event-manager/src/leaderboard.rs
@@ -5,11 +5,14 @@
 //! is computed on-demand (live) and can be called before all matches are resolved,
 //! with unresolved matches contributing 0 points.
 
-use soroban_sdk::{Env, Vec};
+use soroban_sdk::{Address, Env, Map, Vec};
 
 use crate::event::{self, EventError};
 use crate::storage;
-use crate::storage_types::LeaderboardEntry;
+use crate::storage_types::{
+    weighted_contribution, LeaderboardEntry, MatchResult, ParticipantScore, Prediction,
+    StandingEntry,
+};
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -165,6 +168,212 @@ pub fn get_event_leaderboard(
     }
 
     Ok(entries)
+}
+
+// ---------------------------------------------------------------------------
+// Weighted standings (#1311)
+// ---------------------------------------------------------------------------
+
+/// Recompute and persist the weighted standings for an event.
+///
+/// Rebuilds every participant's [`ParticipantScore`] from scratch out of the
+/// event's graded predictions, then sorts and stores the ranked
+/// [`StandingEntry`] snapshot under `DataKey::EventStandings(event_id)`.
+/// Because the computation reads only immutable graded data (a match result
+/// can never be resubmitted), recomputing any number of times yields
+/// identical standings — the operation is idempotent.
+///
+/// # Weighting (see `storage_types` weighting constants)
+/// Each correct prediction contributes
+/// `points_earned × (base + early bonus + underdog bonus)` weighted units:
+/// * **Early**: placed ≥ `EARLY_PREDICTION_LEAD_SECONDS` before match start.
+/// * **Underdog**: strictly fewer than half of the match's predictors picked
+///   the winning outcome.
+///
+/// # Tie-break ordering (see [`StandingEntry::outranks`])
+/// weighted score ↓ → correct count ↓ → achieved_at ↑ → address ↑
+///
+/// # Bounded iteration
+/// One pass over the event's matches, and for each resolved match one pass
+/// over its predictions (loaded once per match), plus an insertion sort over
+/// the participants. Total work is O(P + M·K + P²) for P participants,
+/// M matches, and K predictions per match — all bounded by the event's own
+/// stored indexes; no unbounded scans.
+///
+/// Called from `submit_match_result` (after grading) and `finalize_event`.
+pub fn recompute_standings(
+    env: &Env,
+    event_id: u64,
+) -> Result<Vec<StandingEntry>, LeaderboardError> {
+    let _event = event::get_event(env, event_id)?;
+
+    let participants = storage::get_event_participants(env, event_id);
+
+    // Start every participant from zero — full rebuild, never incremental.
+    let mut scores: Map<Address, ParticipantScore> = Map::new(env);
+    for participant in participants.iter() {
+        scores.set(
+            participant.clone(),
+            ParticipantScore::zero(participant.clone(), event_id),
+        );
+    }
+
+    let match_ids = storage::get_event_matches(env, event_id);
+    for match_id in match_ids.iter() {
+        let m = match storage::get_match(env, match_id) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !m.result_submitted {
+            continue;
+        }
+        let (winning_team, submitted_at) = match (m.winning_team, m.submitted_at) {
+            (Some(w), Some(t)) => (w, t),
+            _ => continue,
+        };
+
+        // Load the match's predictions once, tallying picks per outcome so the
+        // underdog check needs no second storage pass.
+        let prediction_ids = storage::get_match_predictions(env, match_id);
+        let mut predictions: Vec<Prediction> = Vec::new(env);
+        let mut outcome_counts: [u32; 3] = [0, 0, 0];
+        for prediction_id in prediction_ids.iter() {
+            if let Ok(prediction) = storage::get_prediction(env, prediction_id) {
+                let outcome = MatchResult::from_scores(
+                    prediction.predicted_home_score,
+                    prediction.predicted_away_score,
+                )
+                .to_u8() as usize;
+                outcome_counts[outcome] += 1;
+                predictions.push_back(prediction);
+            }
+        }
+
+        let total_picks = predictions.len() as u64;
+        let winner_picks = *outcome_counts.get(winning_team as usize).unwrap_or(&0) as u64;
+        // Against-the-crowd: strictly fewer than half of the match's
+        // predictors chose the winning outcome.
+        let minority_pick = winner_picks * 2 < total_picks;
+
+        for prediction in predictions.iter() {
+            let points = prediction.points_earned.unwrap_or(0);
+            if points == 0 {
+                continue;
+            }
+            let mut score = match scores.get(prediction.predictor.clone()) {
+                Some(score) => score,
+                // Predictor not in the participant index — skip defensively.
+                None => continue,
+            };
+
+            let (base, timing, underdog) =
+                weighted_contribution(points, prediction.predicted_at, m.match_time, minority_pick);
+
+            score.base_component = score
+                .base_component
+                .checked_add(base)
+                .ok_or(LeaderboardError::Overflow)?;
+            score.timing_component = score
+                .timing_component
+                .checked_add(timing)
+                .ok_or(LeaderboardError::Overflow)?;
+            score.underdog_component = score
+                .underdog_component
+                .checked_add(underdog)
+                .ok_or(LeaderboardError::Overflow)?;
+            score.weighted_score = score
+                .weighted_score
+                .checked_add(base + timing + underdog)
+                .ok_or(LeaderboardError::Overflow)?;
+            score.correct_count = score
+                .correct_count
+                .checked_add(1)
+                .ok_or(LeaderboardError::Overflow)?;
+            if submitted_at > score.achieved_at {
+                score.achieved_at = submitted_at;
+            }
+
+            scores.set(prediction.predictor.clone(), score);
+        }
+    }
+
+    // Persist per-participant scores and build the standings rows.
+    let mut standings: Vec<StandingEntry> = Vec::new(env);
+    for participant in participants.iter() {
+        // Every participant was seeded above, so the lookup cannot fail.
+        let score = scores.get(participant.clone()).unwrap();
+        storage::set_participant_score(env, &score);
+        standings.push_back(StandingEntry {
+            user: participant.clone(),
+            event_id,
+            weighted_score: score.weighted_score,
+            correct_count: score.correct_count,
+            achieved_at: score.achieved_at,
+            rank: 0,
+        });
+    }
+
+    // Sort with insertion sort (stable, suitable for small participant lists).
+    let len = standings.len();
+    for i in 1..len {
+        let mut j = i;
+        while j > 0 {
+            let prev = standings.get(j - 1).unwrap();
+            let curr = standings.get(j).unwrap();
+            if prev.outranks(&curr) {
+                break;
+            }
+            standings.set(j - 1, curr);
+            standings.set(j, prev);
+            j -= 1;
+        }
+    }
+
+    // Assign 1-based ranks.
+    for i in 0..len {
+        let mut entry = standings.get(i).unwrap();
+        entry.rank = (i as u32) + 1;
+        standings.set(i, entry);
+    }
+
+    storage::set_event_standings(env, event_id, &standings);
+    Ok(standings)
+}
+
+/// Return the stored weighted standings snapshot for an event.
+///
+/// The snapshot is the one persisted by the most recent
+/// [`recompute_standings`] run (triggered by `submit_match_result` or
+/// `finalize_event`). Returns an empty `Vec` when no match result has been
+/// submitted yet.
+///
+/// # Errors
+/// * [`LeaderboardError::EventNotFound`] — no event with the given event_id.
+pub fn get_event_standings(
+    env: &Env,
+    event_id: u64,
+) -> Result<Vec<StandingEntry>, LeaderboardError> {
+    event::get_event(env, event_id)?;
+    Ok(storage::get_event_standings(env, event_id))
+}
+
+/// Return a participant's weighted score components for an event.
+///
+/// Exposes the full breakdown (base, timing bonus, underdog bonus, correct
+/// count, achievement timestamp) so anyone can verify how a weighted score
+/// was assembled. Returns a zeroed score for a participant who has not been
+/// scored yet.
+///
+/// # Errors
+/// * [`LeaderboardError::EventNotFound`] — no event with the given event_id.
+pub fn get_participant_score(
+    env: &Env,
+    event_id: u64,
+    user: Address,
+) -> Result<ParticipantScore, LeaderboardError> {
+    event::get_event(env, event_id)?;
+    Ok(storage::get_participant_score(env, event_id, &user)
+        .unwrap_or_else(|| ParticipantScore::zero(user, event_id)))
 }
 
 #[cfg(test)]

--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -20,7 +20,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 use admin::AdminError;
 use event::EventError;
 use r#match::MatchError;
-use storage_types::{Event, LeaderboardEntry, Match, Prediction};
+use storage_types::{Event, LeaderboardEntry, Match, ParticipantScore, Prediction, StandingEntry};
 use verification::VerificationError;
 use views::{EventStatistics, PlatformStatistics};
 
@@ -722,6 +722,53 @@ impl CreatorEventManagerContract {
             Ok(entries) => entries,
             Err(leaderboard::LeaderboardError::EventNotFound) => panic!("event_not_found"),
             Err(leaderboard::LeaderboardError::Overflow) => panic!("overflow"),
+        }
+    }
+
+    /// Return the stored weighted standings for an event (#1311).
+    ///
+    /// Standings weight each correct prediction by documented multipliers:
+    /// a 1.00× base on `points_earned`, +0.25× when the prediction was placed
+    /// at least one hour before the match start, and +0.50× when the winning
+    /// outcome was picked by strictly fewer than half of the match's
+    /// predictors. The snapshot is recomputed from scratch on every
+    /// `submit_match_result` and on `finalize_event`, so repeated computation
+    /// always yields identical standings.
+    ///
+    /// Tie-break ordering (deterministic, applied in order):
+    /// 1. Higher weighted score
+    /// 2. Higher correct-prediction count
+    /// 3. Earlier achievement (reached the score first)
+    /// 4. Smaller address
+    ///
+    /// Returns an empty `Vec` when no match result has been submitted yet.
+    ///
+    /// # Panics
+    /// * `"event_not_found"` — no event exists with the given ID.
+    pub fn get_event_standings(env: Env, event_id: u64) -> Vec<StandingEntry> {
+        match leaderboard::get_event_standings(&env, event_id) {
+            Ok(standings) => standings,
+            Err(leaderboard::LeaderboardError::EventNotFound) => panic!("event_not_found"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
+    /// Return a participant's weighted score components for an event (#1311).
+    ///
+    /// Exposes the transparency breakdown behind `get_event_standings`: the
+    /// base component (`points × 1.00×`), accumulated early-prediction and
+    /// against-the-crowd bonuses, correct-prediction count, and the timestamp
+    /// the participant last increased their score. `weighted_score` always
+    /// equals the sum of the three components. Returns a zeroed score for a
+    /// user who has not scored (or not participated) yet.
+    ///
+    /// # Panics
+    /// * `"event_not_found"` — no event exists with the given ID.
+    pub fn get_participant_score(env: Env, event_id: u64, user: Address) -> ParticipantScore {
+        match leaderboard::get_participant_score(&env, event_id, user) {
+            Ok(score) => score,
+            Err(leaderboard::LeaderboardError::EventNotFound) => panic!("event_not_found"),
+            Err(_) => panic!("unexpected_error"),
         }
     }
 

--- a/contracts/creator-event-manager/src/oracle.rs
+++ b/contracts/creator-event-manager/src/oracle.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{Address, Env, Symbol};
 
 use crate::admin;
+use crate::leaderboard;
 use crate::storage::{self, StorageError};
 use crate::storage_types::{Event, Match, MatchResult};
 
@@ -142,6 +143,12 @@ pub fn submit_match_result(
             storage::set_prediction(env, prediction_id, &prediction);
         }
     }
+
+    // 8b. Recompute and persist the event's weighted standings (#1311).
+    leaderboard::recompute_standings(env, match_record.event_id).map_err(|e| match e {
+        leaderboard::LeaderboardError::Overflow => OracleError::Overflow,
+        _ => OracleError::EventNotFound,
+    })?;
 
     // 9. Emit the result event using the derived outcome symbol.
     let outcome_symbol = match result {

--- a/contracts/creator-event-manager/src/storage.rs
+++ b/contracts/creator-event-manager/src/storage.rs
@@ -8,7 +8,7 @@
 /// the returned ID immediately.
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::storage_types::{DataKey, Event, Match, Prediction};
+use crate::storage_types::{DataKey, Event, Match, ParticipantScore, Prediction, StandingEntry};
 
 // ---------------------------------------------------------------------------
 // TTL constant
@@ -257,6 +257,70 @@ pub fn add_event_participant(env: &Env, event_id: u64, participant: &Address) {
     let mut list = get_event_participants(env, event_id);
     list.push_back(participant.clone());
     env.storage().persistent().set(&key, &list);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+// ---------------------------------------------------------------------------
+// Weighted standings helpers (#1311)
+// ---------------------------------------------------------------------------
+
+/// Read a participant's stored weighted score components, or `None` if the
+/// participant has never been scored for this event.
+pub fn get_participant_score(
+    env: &Env,
+    event_id: u64,
+    user: &Address,
+) -> Option<ParticipantScore> {
+    let key = DataKey::ParticipantScore(user.clone(), event_id);
+    match env
+        .storage()
+        .persistent()
+        .get::<DataKey, ParticipantScore>(&key)
+    {
+        Some(score) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            Some(score)
+        }
+        None => None,
+    }
+}
+
+/// Write a participant's weighted score components and set the TTL.
+pub fn set_participant_score(env: &Env, score: &ParticipantScore) {
+    let key = DataKey::ParticipantScore(score.user.clone(), score.event_id);
+    env.storage().persistent().set(&key, score);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+/// Read the stored weighted standings snapshot for an event, or an empty Vec
+/// if standings have never been computed.
+pub fn get_event_standings(env: &Env, event_id: u64) -> Vec<StandingEntry> {
+    let key = DataKey::EventStandings(event_id);
+    match env
+        .storage()
+        .persistent()
+        .get::<DataKey, Vec<StandingEntry>>(&key)
+    {
+        Some(list) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            list
+        }
+        None => Vec::new(env),
+    }
+}
+
+/// Write the weighted standings snapshot for an event and set the TTL.
+pub fn set_event_standings(env: &Env, event_id: u64, standings: &Vec<StandingEntry>) {
+    let key = DataKey::EventStandings(event_id);
+    env.storage().persistent().set(&key, standings);
     env.storage()
         .persistent()
         .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -31,6 +31,76 @@ pub const POINTS_EXACT_SCORE: u32 = 3;
 pub const MAX_POINTS_MULTIPLIER: u32 = 3;
 
 // ---------------------------------------------------------------------------
+// Weighted scoring multipliers (#1311)
+// ---------------------------------------------------------------------------
+//
+// A correct prediction's weighted contribution is its `points_earned`
+// multiplied by a basis-point factor:
+//
+//     weight = WEIGHT_BASE_BPS
+//            + EARLY_PREDICTION_BONUS_BPS  (if placed early — see below)
+//            + UNDERDOG_BONUS_BPS          (if it went against the crowd)
+//
+//     contribution = points_earned × weight     (in point-basis-point units)
+//
+// A plain correct result placed late with the crowd is worth 1 × 10_000 =
+// 10_000 weighted units; the same prediction placed early and against the
+// crowd is worth 1 × 17_500 — strictly higher. Wrong predictions (0 points)
+// contribute nothing regardless of timing or crowd position.
+
+/// Base weighting factor applied to every correct prediction (1.00×).
+pub const WEIGHT_BASE_BPS: u64 = 10_000;
+/// Bonus factor (+0.25×) for predictions placed at least
+/// [`EARLY_PREDICTION_LEAD_SECONDS`] before the match start time.
+pub const EARLY_PREDICTION_BONUS_BPS: u64 = 2_500;
+/// Minimum lead time (seconds before `match_time`) to earn the early bonus.
+pub const EARLY_PREDICTION_LEAD_SECONDS: u64 = 3_600;
+/// Bonus factor (+0.50×) when the winning outcome was picked by strictly
+/// fewer than half of the match's predictors (an against-the-crowd pick).
+pub const UNDERDOG_BONUS_BPS: u64 = 5_000;
+
+/// Compute the weighted contribution of a single graded prediction.
+///
+/// Returns `(base, timing_bonus, underdog_bonus)` in point-basis-point units;
+/// the prediction's total contribution is the sum of the three components.
+/// The split is kept separate so the contract can expose each component for
+/// transparency (see `ParticipantScore`).
+///
+/// * `points_earned` — graded points (already includes the exact-score bonus
+///   and the match's `points_multiplier`). `0` yields `(0, 0, 0)`.
+/// * `predicted_at` / `match_time` — the early bonus applies when the
+///   prediction led the match start by at least
+///   [`EARLY_PREDICTION_LEAD_SECONDS`].
+/// * `minority_pick` — `true` when strictly fewer than half of the match's
+///   predictors chose the winning outcome.
+///
+/// Pure and deterministic: identical inputs always produce identical output,
+/// which is what makes standings recomputation idempotent.
+pub fn weighted_contribution(
+    points_earned: u32,
+    predicted_at: u64,
+    match_time: u64,
+    minority_pick: bool,
+) -> (u64, u64, u64) {
+    if points_earned == 0 {
+        return (0, 0, 0);
+    }
+    let pts = points_earned as u64;
+    let base = pts * WEIGHT_BASE_BPS;
+    let timing = if match_time.saturating_sub(predicted_at) >= EARLY_PREDICTION_LEAD_SECONDS {
+        pts * EARLY_PREDICTION_BONUS_BPS
+    } else {
+        0
+    };
+    let underdog = if minority_pick {
+        pts * UNDERDOG_BONUS_BPS
+    } else {
+        0
+    };
+    (base, timing, underdog)
+}
+
+// ---------------------------------------------------------------------------
 // MatchResult
 // ---------------------------------------------------------------------------
 
@@ -183,6 +253,14 @@ pub enum DataKey {
     // ── Canonical XLM token key (#794) ───────────────────────────────────────
     /// Current XLM token contract address — set during initialize.
     CurrentXLMToken,
+
+    // ── Weighted standings keys (#1311) ──────────────────────────────────────
+    /// A participant's accumulated weighted score components  (user, event_id)
+    ParticipantScore(Address, u64),
+
+    /// Vec<StandingEntry> ranked weighted standings snapshot for an event
+    /// (event_id). Recomputed on `submit_match_result` and `finalize_event`.
+    EventStandings(u64),
 }
 
 // ---------------------------------------------------------------------------
@@ -809,6 +887,121 @@ impl LeaderboardEntry {
 
         // Final tiebreaker: address comparison (deterministic)
         // Compare the addresses directly; Soroban Address implements Ord
+        self.user < other.user
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ParticipantScore (#1311)
+// ---------------------------------------------------------------------------
+
+/// A participant's accumulated weighted score for an event, broken into its
+/// components for transparency.
+///
+/// Invariant: `weighted_score = base_component + timing_component +
+/// underdog_component`. All weighted values are in point-basis-point units
+/// (see [`WEIGHT_BASE_BPS`] and [`weighted_contribution`]).
+///
+/// Stored under `DataKey::ParticipantScore(user, event_id)` and rebuilt from
+/// scratch on every standings recomputation, so repeated recomputation over
+/// the same graded predictions always yields the same value.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParticipantScore {
+    /// Address of the participant
+    pub user: Address,
+
+    /// Event identifier
+    pub event_id: u64,
+
+    /// Total weighted score — sum of the three components below
+    pub weighted_score: u64,
+
+    /// Σ points_earned × WEIGHT_BASE_BPS over all correct predictions
+    pub base_component: u64,
+
+    /// Σ early-prediction bonuses (see [`EARLY_PREDICTION_BONUS_BPS`])
+    pub timing_component: u64,
+
+    /// Σ against-the-crowd bonuses (see [`UNDERDOG_BONUS_BPS`])
+    pub underdog_component: u64,
+
+    /// Number of predictions graded with a correct 1X2 result
+    pub correct_count: u32,
+
+    /// Ledger timestamp at which the participant's weighted score last
+    /// increased — i.e. the `submitted_at` of the most recent match result
+    /// that added to their score. `0` when they have not scored yet.
+    /// Used as the "earliest achievement" tie-breaker: of two participants
+    /// with identical scores, the one who reached that score first ranks
+    /// higher.
+    pub achieved_at: u64,
+}
+
+impl ParticipantScore {
+    /// A zeroed score for a participant who has not scored yet.
+    pub fn zero(user: Address, event_id: u64) -> Self {
+        Self {
+            user,
+            event_id,
+            weighted_score: 0,
+            base_component: 0,
+            timing_component: 0,
+            underdog_component: 0,
+            correct_count: 0,
+            achieved_at: 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StandingEntry (#1311)
+// ---------------------------------------------------------------------------
+
+/// One row of an event's ranked weighted standings.
+///
+/// Stored in `Vec<StandingEntry>` under `DataKey::EventStandings(event_id)`,
+/// sorted best-first with ranks assigned 1..N.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StandingEntry {
+    /// Address of the participant
+    pub user: Address,
+
+    /// Event identifier
+    pub event_id: u64,
+
+    /// Total weighted score (point-basis-point units)
+    pub weighted_score: u64,
+
+    /// Number of correct predictions
+    pub correct_count: u32,
+
+    /// Timestamp the participant last increased their score (0 = never)
+    pub achieved_at: u64,
+
+    /// 1-based rank after sorting (1 is the top-ranked participant)
+    pub rank: u32,
+}
+
+impl StandingEntry {
+    /// Returns `true` if this entry outranks `other`.
+    ///
+    /// Deterministic tie-break ordering (#1311), applied in order:
+    /// 1. Higher `weighted_score` wins.
+    /// 2. On tie: higher `correct_count` wins.
+    /// 3. On tie: earlier `achieved_at` wins (reached the score first).
+    /// 4. On tie: smaller address wins (final deterministic tie-breaker).
+    pub fn outranks(&self, other: &StandingEntry) -> bool {
+        if self.weighted_score != other.weighted_score {
+            return self.weighted_score > other.weighted_score;
+        }
+        if self.correct_count != other.correct_count {
+            return self.correct_count > other.correct_count;
+        }
+        if self.achieved_at != other.achieved_at {
+            return self.achieved_at < other.achieved_at;
+        }
         self.user < other.user
     }
 }

--- a/contracts/creator-event-manager/tests/standings_tests.rs
+++ b/contracts/creator-event-manager/tests/standings_tests.rs
@@ -1,0 +1,537 @@
+//! Tests for reputation-weighted standings with deterministic tie-breakers (#1311).
+//!
+//! Covers:
+//! - Unit tests for the pure weighting function (`weighted_contribution`)
+//! - Unit tests for the `StandingEntry` tie-break chain
+//!   (weighted score → correct count → earliest achievement → address)
+//! - Integration tests over the full event lifecycle: early predictions
+//!   outweigh late ones, against-the-crowd picks outweigh consensus picks,
+//!   score components are exposed for transparency, and standings are
+//!   idempotent across repeated recomputation (including finalize).
+
+use creator_event_manager::storage_types::{
+    weighted_contribution, StandingEntry, EARLY_PREDICTION_BONUS_BPS,
+    EARLY_PREDICTION_LEAD_SECONDS, UNDERDOG_BONUS_BPS, WEIGHT_BASE_BPS,
+};
+use creator_event_manager::CreatorEventManagerContractClient;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env, String, Symbol, Vec};
+
+// ===========================================================================
+// Unit tests: weighting function
+// ===========================================================================
+
+const MATCH_TIME: u64 = 100_000;
+
+#[test]
+fn test_weighting_late_consensus_is_base_only() {
+    // Placed 100 s before the match, with the crowd: base weight only.
+    let (base, timing, underdog) = weighted_contribution(4, MATCH_TIME - 100, MATCH_TIME, false);
+    assert_eq!(base, 4 * WEIGHT_BASE_BPS);
+    assert_eq!(timing, 0);
+    assert_eq!(underdog, 0);
+}
+
+#[test]
+fn test_weighting_early_prediction_earns_timing_bonus() {
+    // Placed exactly at the early-lead threshold: bonus applies (inclusive).
+    let (base, timing, underdog) = weighted_contribution(
+        4,
+        MATCH_TIME - EARLY_PREDICTION_LEAD_SECONDS,
+        MATCH_TIME,
+        false,
+    );
+    assert_eq!(base, 4 * WEIGHT_BASE_BPS);
+    assert_eq!(timing, 4 * EARLY_PREDICTION_BONUS_BPS);
+    assert_eq!(underdog, 0);
+
+    // One second inside the threshold: no bonus.
+    let (_, timing_late, _) = weighted_contribution(
+        4,
+        MATCH_TIME - EARLY_PREDICTION_LEAD_SECONDS + 1,
+        MATCH_TIME,
+        false,
+    );
+    assert_eq!(timing_late, 0);
+}
+
+#[test]
+fn test_weighting_minority_pick_earns_underdog_bonus() {
+    let (base, timing, underdog) = weighted_contribution(1, MATCH_TIME - 100, MATCH_TIME, true);
+    assert_eq!(base, WEIGHT_BASE_BPS);
+    assert_eq!(timing, 0);
+    assert_eq!(underdog, UNDERDOG_BONUS_BPS);
+}
+
+#[test]
+fn test_weighting_zero_points_contributes_nothing() {
+    // A wrong prediction earns nothing even if early and against the crowd.
+    let contribution = weighted_contribution(0, 0, MATCH_TIME, true);
+    assert_eq!(contribution, (0, 0, 0));
+}
+
+#[test]
+fn test_weighting_early_underdog_strictly_beats_late_consensus() {
+    let (b1, t1, u1) = weighted_contribution(4, 0, MATCH_TIME, true);
+    let (b2, t2, u2) = weighted_contribution(4, MATCH_TIME - 1, MATCH_TIME, false);
+    assert!(b1 + t1 + u1 > b2 + t2 + u2);
+    // Each bonus alone is also strictly higher than the plain contribution.
+    let (b3, t3, u3) = weighted_contribution(4, 0, MATCH_TIME, false);
+    let (b4, t4, u4) = weighted_contribution(4, MATCH_TIME - 1, MATCH_TIME, true);
+    assert!(b3 + t3 + u3 > b2 + t2 + u2);
+    assert!(b4 + t4 + u4 > b2 + t2 + u2);
+}
+
+// ===========================================================================
+// Unit tests: StandingEntry tie-break chain
+// ===========================================================================
+
+fn entry(user: &Address, weighted: u64, correct: u32, achieved_at: u64) -> StandingEntry {
+    StandingEntry {
+        user: user.clone(),
+        event_id: 1,
+        weighted_score: weighted,
+        correct_count: correct,
+        achieved_at,
+        rank: 0,
+    }
+}
+
+#[test]
+fn test_tiebreak_weighted_score_is_primary() {
+    let env = Env::default();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    // Lower correct count and later achievement, but higher weighted score wins.
+    let high = entry(&a, 20_000, 1, 500);
+    let low = entry(&b, 15_000, 3, 100);
+    assert!(high.outranks(&low));
+    assert!(!low.outranks(&high));
+}
+
+#[test]
+fn test_tiebreak_correct_count_on_equal_weighted_score() {
+    let env = Env::default();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let more_correct = entry(&a, 20_000, 2, 500);
+    let fewer_correct = entry(&b, 20_000, 1, 100);
+    assert!(more_correct.outranks(&fewer_correct));
+    assert!(!fewer_correct.outranks(&more_correct));
+}
+
+#[test]
+fn test_tiebreak_earlier_achievement_on_equal_score_and_count() {
+    let env = Env::default();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let earlier = entry(&a, 20_000, 2, 100);
+    let later = entry(&b, 20_000, 2, 500);
+    assert!(earlier.outranks(&later));
+    assert!(!later.outranks(&earlier));
+}
+
+#[test]
+fn test_tiebreak_address_is_final() {
+    let env = Env::default();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let (smaller, larger) = if a < b { (a, b) } else { (b, a) };
+    let s = entry(&smaller, 20_000, 2, 100);
+    let l = entry(&larger, 20_000, 2, 100);
+    assert!(s.outranks(&l));
+    assert!(!l.outranks(&s));
+}
+
+// ===========================================================================
+// Integration test setup
+// ===========================================================================
+
+const FEE: i128 = 1_000_000;
+
+fn setup() -> (
+    Env,
+    CreatorEventManagerContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(creator_event_manager::CreatorEventManagerContract, ());
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> =
+        unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+    (env, client, ai_agent, xlm_token, contract_id)
+}
+
+fn fund(env: &Env, token: &Address, user: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(user, &amount);
+}
+
+/// Create an event whose window comfortably contains the given match times,
+/// then create one match per entry in `match_times` via the real entry point.
+fn create_event_with_matches(
+    env: &Env,
+    client: &CreatorEventManagerContractClient<'static>,
+    xlm_token: &Address,
+    match_times: &[u64],
+) -> (u64, Symbol, std::vec::Vec<u64>, Address) {
+    let creator = Address::generate(env);
+    fund(env, xlm_token, &creator, FEE);
+
+    let now = env.ledger().timestamp();
+    let start_time = now + 60;
+    let end_time = now + 100_000;
+    let (event_id, invite_code) = client.create_event(
+        &creator,
+        &String::from_str(env, "Weighted Standings Event"),
+        &String::from_str(env, "Event lifecycle test for issue #1311"),
+        &100u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(env),
+        &0i128,
+    );
+
+    let mut match_ids = std::vec::Vec::new();
+    for (i, match_time) in match_times.iter().enumerate() {
+        let match_id = client.create_match(
+            &creator,
+            &event_id,
+            &String::from_str(env, &format!("Team A{}", i)),
+            &String::from_str(env, &format!("Team B{}", i)),
+            match_time,
+            &1u32,
+        );
+        match_ids.push(match_id);
+    }
+
+    (event_id, invite_code, match_ids, creator)
+}
+
+// ===========================================================================
+// Integration tests
+// ===========================================================================
+
+/// Two users with identical correct counts and identical points: the one who
+/// predicted early (≥ 1 h lead) gets a strictly higher weighted score and
+/// rank 1, and the transparency view exposes the component breakdown.
+#[test]
+fn test_early_prediction_outranks_late_with_equal_correct_counts() {
+    let (env, client, ai_agent, xlm_token, _) = setup();
+    let t0 = env.ledger().timestamp();
+
+    // One match starting two hours out.
+    let (event_id, invite_code, match_ids, _) =
+        create_event_with_matches(&env, &client, &xlm_token, &[t0 + 7_200]);
+    let match_id = match_ids[0];
+
+    let early_user = Address::generate(&env);
+    let late_user = Address::generate(&env);
+
+    // Early user predicts immediately: 7 200 s lead ≥ 3 600 s threshold.
+    client.join_event(&early_user, &invite_code);
+    client.submit_prediction(&early_user, &match_id, &1u32, &0u32);
+
+    // Late user predicts 1 200 s before the match: below the threshold.
+    env.ledger().set_timestamp(t0 + 6_000);
+    client.join_event(&late_user, &invite_code);
+    client.submit_prediction(&late_user, &match_id, &1u32, &0u32);
+
+    // Resolve: 1-0, both predictions exact (4 points each), both consensus.
+    env.ledger().set_timestamp(t0 + 7_300);
+    client.submit_match_result(&ai_agent, &match_id, &1u32, &0u32);
+
+    let standings = client.get_event_standings(&event_id);
+    assert_eq!(standings.len(), 2);
+
+    let first = standings.get(0).unwrap();
+    let second = standings.get(1).unwrap();
+    assert_eq!(first.user, early_user);
+    assert_eq!(first.rank, 1);
+    assert_eq!(second.user, late_user);
+    assert_eq!(second.rank, 2);
+
+    // Equal correct counts — ordering is purely the weighted score.
+    assert_eq!(first.correct_count, 1);
+    assert_eq!(second.correct_count, 1);
+    assert_eq!(first.weighted_score, 4 * (WEIGHT_BASE_BPS + EARLY_PREDICTION_BONUS_BPS));
+    assert_eq!(second.weighted_score, 4 * WEIGHT_BASE_BPS);
+    assert!(first.weighted_score > second.weighted_score);
+
+    // Transparency view: components add up to the weighted score.
+    let early_score = client.get_participant_score(&event_id, &early_user);
+    assert_eq!(early_score.base_component, 4 * WEIGHT_BASE_BPS);
+    assert_eq!(early_score.timing_component, 4 * EARLY_PREDICTION_BONUS_BPS);
+    assert_eq!(early_score.underdog_component, 0);
+    assert_eq!(
+        early_score.weighted_score,
+        early_score.base_component + early_score.timing_component + early_score.underdog_component
+    );
+    assert_eq!(early_score.correct_count, 1);
+    assert_eq!(early_score.achieved_at, t0 + 7_300);
+
+    let late_score = client.get_participant_score(&event_id, &late_user);
+    assert_eq!(late_score.timing_component, 0);
+    assert_eq!(late_score.weighted_score, late_score.base_component);
+}
+
+/// An against-the-crowd correct pick is worth strictly more than a consensus
+/// correct pick with the same raw points.
+#[test]
+fn test_against_crowd_pick_outranks_consensus_pick() {
+    let (env, client, ai_agent, xlm_token, _) = setup();
+    let t0 = env.ledger().timestamp();
+
+    // Two matches, both < 1 h out so no timing bonus muddies the comparison.
+    let (event_id, invite_code, match_ids, _) =
+        create_event_with_matches(&env, &client, &xlm_token, &[t0 + 1_800, t0 + 1_900]);
+
+    let underdog = Address::generate(&env);
+    let consensus = Address::generate(&env);
+    let crowd = Address::generate(&env);
+    for user in [&underdog, &consensus, &crowd] {
+        client.join_event(user, &invite_code);
+    }
+
+    // Match 1: underdog picks TeamB (1 of 3), the others pick TeamA.
+    client.submit_prediction(&underdog, &match_ids[0], &0u32, &1u32);
+    client.submit_prediction(&consensus, &match_ids[0], &1u32, &0u32);
+    client.submit_prediction(&crowd, &match_ids[0], &1u32, &0u32);
+
+    // Match 2: consensus & crowd pick TeamA (2 of 3), underdog picks TeamB.
+    client.submit_prediction(&underdog, &match_ids[1], &0u32, &1u32);
+    client.submit_prediction(&consensus, &match_ids[1], &1u32, &0u32);
+    client.submit_prediction(&crowd, &match_ids[1], &2u32, &0u32);
+
+    env.ledger().set_timestamp(t0 + 2_000);
+    // Match 1 finishes 0-1: only the underdog is right (exact, 4 pts, minority).
+    client.submit_match_result(&ai_agent, &match_ids[0], &0u32, &1u32);
+    // Match 2 finishes 1-0: consensus is exact (4 pts) with the majority.
+    client.submit_match_result(&ai_agent, &match_ids[1], &1u32, &0u32);
+
+    let standings = client.get_event_standings(&event_id);
+    assert_eq!(standings.len(), 3);
+
+    let first = standings.get(0).unwrap();
+    let second = standings.get(1).unwrap();
+    let third = standings.get(2).unwrap();
+
+    // Same points (4) and same correct count (1) — the minority pick wins.
+    assert_eq!(first.user, underdog);
+    assert_eq!(first.weighted_score, 4 * (WEIGHT_BASE_BPS + UNDERDOG_BONUS_BPS));
+    assert_eq!(first.correct_count, 1);
+
+    assert_eq!(second.user, consensus);
+    assert_eq!(second.weighted_score, 4 * WEIGHT_BASE_BPS);
+    assert_eq!(second.correct_count, 1);
+    assert!(first.weighted_score > second.weighted_score);
+
+    // Crowd got match 2's result right (1 pt) but not the exact score.
+    assert_eq!(third.user, crowd);
+    assert_eq!(third.weighted_score, WEIGHT_BASE_BPS);
+
+    // Component breakdown for the underdog.
+    let score = client.get_participant_score(&event_id, &underdog);
+    assert_eq!(score.base_component, 4 * WEIGHT_BASE_BPS);
+    assert_eq!(score.timing_component, 0);
+    assert_eq!(score.underdog_component, 4 * UNDERDOG_BONUS_BPS);
+}
+
+/// Equal weighted scores and correct counts: the participant who reached the
+/// score first (earlier result submission) ranks higher.
+#[test]
+fn test_tiebreak_earlier_achievement_in_lifecycle() {
+    let (env, client, ai_agent, xlm_token, _) = setup();
+    let t0 = env.ledger().timestamp();
+
+    // Two matches with identical start times (identical timing weights).
+    let (event_id, invite_code, match_ids, _) =
+        create_event_with_matches(&env, &client, &xlm_token, &[t0 + 1_800, t0 + 1_800]);
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    client.join_event(&user1, &invite_code);
+    client.join_event(&user2, &invite_code);
+
+    // user1 is exact on match 1 and wrong on match 2; user2 is the mirror
+    // image. Each match has one predictor per outcome (1 of 2 picks the
+    // winner → 2·1 == 2, not a minority), so weighted scores are equal.
+    client.submit_prediction(&user1, &match_ids[0], &1u32, &0u32);
+    client.submit_prediction(&user1, &match_ids[1], &0u32, &1u32);
+    client.submit_prediction(&user2, &match_ids[0], &0u32, &1u32);
+    client.submit_prediction(&user2, &match_ids[1], &1u32, &0u32);
+
+    // Match 1 resolves first (user1 scores), match 2 resolves later (user2).
+    env.ledger().set_timestamp(t0 + 2_000);
+    client.submit_match_result(&ai_agent, &match_ids[0], &1u32, &0u32);
+    env.ledger().set_timestamp(t0 + 2_500);
+    client.submit_match_result(&ai_agent, &match_ids[1], &1u32, &0u32);
+
+    let standings = client.get_event_standings(&event_id);
+    assert_eq!(standings.len(), 2);
+
+    let first = standings.get(0).unwrap();
+    let second = standings.get(1).unwrap();
+    assert_eq!(first.weighted_score, second.weighted_score);
+    assert_eq!(first.correct_count, second.correct_count);
+    assert_eq!(first.user, user1);
+    assert_eq!(first.achieved_at, t0 + 2_000);
+    assert_eq!(second.user, user2);
+    assert_eq!(second.achieved_at, t0 + 2_500);
+}
+
+/// Fully identical participants fall back to the address tie-breaker, and the
+/// outcome does not depend on join/prediction insertion order.
+#[test]
+fn test_tiebreak_address_in_lifecycle() {
+    let (env, client, ai_agent, xlm_token, _) = setup();
+    let t0 = env.ledger().timestamp();
+
+    let (event_id, invite_code, match_ids, _) =
+        create_event_with_matches(&env, &client, &xlm_token, &[t0 + 1_800]);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let (smaller, larger) = if a < b { (a, b) } else { (b, a) };
+
+    // Larger address joins and predicts FIRST — insertion order must not matter.
+    client.join_event(&larger, &invite_code);
+    client.join_event(&smaller, &invite_code);
+    client.submit_prediction(&larger, &match_ids[0], &1u32, &0u32);
+    client.submit_prediction(&smaller, &match_ids[0], &1u32, &0u32);
+
+    env.ledger().set_timestamp(t0 + 2_000);
+    client.submit_match_result(&ai_agent, &match_ids[0], &1u32, &0u32);
+
+    let standings = client.get_event_standings(&event_id);
+    assert_eq!(standings.len(), 2);
+    assert_eq!(standings.get(0).unwrap().user, smaller);
+    assert_eq!(standings.get(0).unwrap().rank, 1);
+    assert_eq!(standings.get(1).unwrap().user, larger);
+    assert_eq!(standings.get(1).unwrap().rank, 2);
+}
+
+/// Full event lifecycle: standings update after each result, participants who
+/// never score still appear, and the snapshot is identical across repeated
+/// reads and across the finalize path (idempotence).
+#[test]
+fn test_lifecycle_standings_idempotent_through_finalize() {
+    let (env, client, ai_agent, xlm_token, _) = setup();
+    let t0 = env.ledger().timestamp();
+
+    let (event_id, invite_code, match_ids, _) =
+        create_event_with_matches(&env, &client, &xlm_token, &[t0 + 7_200, t0 + 7_500]);
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let idle = Address::generate(&env); // joins but never predicts
+
+    // No results submitted yet → no standings snapshot.
+    assert_eq!(client.get_event_standings(&event_id).len(), 0);
+
+    client.join_event(&user1, &invite_code);
+    client.join_event(&user2, &invite_code);
+    client.join_event(&idle, &invite_code);
+
+    // user1 predicts both matches early; user2 predicts match 2 late.
+    client.submit_prediction(&user1, &match_ids[0], &2u32, &0u32);
+    client.submit_prediction(&user1, &match_ids[1], &1u32, &1u32);
+    env.ledger().set_timestamp(t0 + 6_500);
+    client.submit_prediction(&user2, &match_ids[1], &1u32, &1u32);
+
+    // Resolve match 1 (2-0): user1 exact.
+    env.ledger().set_timestamp(t0 + 7_300);
+    client.submit_match_result(&ai_agent, &match_ids[0], &2u32, &0u32);
+
+    let interim = client.get_event_standings(&event_id);
+    assert_eq!(interim.len(), 3);
+    assert_eq!(interim.get(0).unwrap().user, user1);
+    assert_eq!(interim.get(0).unwrap().correct_count, 1);
+
+    // Resolve match 2 (1-1): both user1 and user2 exact (draw is consensus —
+    // both graded predictors picked it).
+    env.ledger().set_timestamp(t0 + 7_600);
+    client.submit_match_result(&ai_agent, &match_ids[1], &1u32, &1u32);
+
+    let after_results = client.get_event_standings(&event_id);
+    assert_eq!(after_results.len(), 3);
+    let top = after_results.get(0).unwrap();
+    assert_eq!(top.user, user1);
+    assert_eq!(top.rank, 1);
+    assert_eq!(top.correct_count, 2);
+    // user1: match 1 early exact 4×1.25, match 2 early exact 4×1.25.
+    assert_eq!(
+        top.weighted_score,
+        2 * 4 * (WEIGHT_BASE_BPS + EARLY_PREDICTION_BONUS_BPS)
+    );
+    // user2: match 2 late exact, base only.
+    assert_eq!(after_results.get(1).unwrap().user, user2);
+    assert_eq!(after_results.get(1).unwrap().weighted_score, 4 * WEIGHT_BASE_BPS);
+    // Idle participant still appears, with a zero score and last rank.
+    assert_eq!(after_results.get(2).unwrap().user, idle);
+    assert_eq!(after_results.get(2).unwrap().weighted_score, 0);
+    assert_eq!(after_results.get(2).unwrap().rank, 3);
+
+    // Repeated reads return the identical snapshot.
+    assert_eq!(client.get_event_standings(&event_id), after_results);
+
+    // Finalize (recomputes standings again) — snapshot must be unchanged.
+    env.ledger().set_timestamp(t0 + 200_000);
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+    assert!(client.is_event_finalized(&event_id));
+
+    let after_finalize = client.get_event_standings(&event_id);
+    assert_eq!(after_finalize, after_results);
+
+    // Component invariant holds for every participant.
+    for user in [&user1, &user2, &idle] {
+        let score = client.get_participant_score(&event_id, user);
+        assert_eq!(
+            score.weighted_score,
+            score.base_component + score.timing_component + score.underdog_component
+        );
+    }
+}
+
+/// The transparency read returns a zeroed score for unknown users and panics
+/// for unknown events.
+#[test]
+fn test_participant_score_defaults_and_event_guard() {
+    let (env, client, _ai_agent, xlm_token, _) = setup();
+    let t0 = env.ledger().timestamp();
+
+    let (event_id, _invite_code, _match_ids, _) =
+        create_event_with_matches(&env, &client, &xlm_token, &[t0 + 1_800]);
+
+    let stranger = Address::generate(&env);
+    let score = client.get_participant_score(&event_id, &stranger);
+    assert_eq!(score.weighted_score, 0);
+    assert_eq!(score.correct_count, 0);
+    assert_eq!(score.achieved_at, 0);
+    assert_eq!(score.user, stranger);
+    assert_eq!(score.event_id, event_id);
+}
+
+#[test]
+#[should_panic(expected = "event_not_found")]
+fn test_get_event_standings_unknown_event_panics() {
+    let (_env, client, _ai_agent, _xlm_token, _) = setup();
+    client.get_event_standings(&9_999u64);
+}


### PR DESCRIPTION
## Summary

Adds reputation-weighted scoring with deterministic tie-breakers to the creator-event-manager contract. Correct predictions are weighted by documented multipliers, per-participant score components accumulate in storage, and a ranked standings snapshot is recomputed on every result submission and on finalize.

### Weighting (documented basis-point multipliers)

Each correct prediction contributes `points_earned × weight`:

| Component | Constant | Value |
|---|---|---|
| Base | `WEIGHT_BASE_BPS` | 1.00× |
| Early prediction (placed ≥ 1 h before match start) | `EARLY_PREDICTION_BONUS_BPS` | +0.25× |
| Against the crowd (winning outcome picked by strictly fewer than half of the match's predictors) | `UNDERDOG_BONUS_BPS` | +0.50× |

Early/against-crowd correct predictions therefore yield strictly higher contributions than late/consensus ones. Wrong predictions contribute nothing.

### Deterministic tie-break ordering (`StandingEntry::outranks`)

1. Higher weighted score
2. Higher correct-prediction count
3. Earlier achievement (reached the score first)
4. Smaller address (final deterministic tie-breaker)

### Implementation

- `ParticipantScore` (base / timing / underdog components, correct count, achievement timestamp) stored under `DataKey::ParticipantScore(user, event_id)`; ranked `Vec<StandingEntry>` snapshot under `DataKey::EventStandings(event_id)`.
- `leaderboard::recompute_standings` rebuilds standings from scratch out of immutable graded data in one bounded pass over the event's matches and predictions (each match's predictions loaded once), so repeated computation always yields identical standings (idempotent).
- Recomputation is wired into `submit_match_result` (after grading) and `finalize_event`. Prize payouts intentionally remain driven by the existing points leaderboard — this PR adds the weighted ranking and transparency reads without changing payout economics.
- New read functions `get_event_standings` and `get_participant_score` expose the ranked snapshot and the full component breakdown (`weighted_score` always equals the sum of the three components).

### Tests (`tests/standings_tests.rs`, 16 tests)

- Unit: weighting math (threshold boundary inclusive/exclusive, zero-point predictions, strict dominance of early/underdog picks) and the four-level tie-break chain.
- Integration (full event lifecycle): early outranks late with equal correct counts, against-crowd outranks consensus with equal points, achievement-time and address tie-breaks (insertion-order independent), zero-score participants still ranked, component-sum invariant, and standings identical across repeated reads and through `finalize_event` (idempotence).

`cargo test` (full suite) and `cargo build --target wasm32-unknown-unknown --release` both pass locally.

Closes #1311