### PR TITLE
feat(creator-event-manager): staged prize distribution with claims & no-show clawback

### DIFF
--- a/contracts/creator-event-manager/src/event.rs
+++ b/contracts/creator-event-manager/src/event.rs
@@ -57,6 +57,15 @@ pub enum EventError {
     InvalidEntryFee = 20,
     /// Caller is not the event creator.
     Unauthorized = 21,
+    /// claim_prize / clawback_unclaimed called before the event is finalized.
+    EventNotFinalized = 22,
+    /// claim_prize called for an address with no recorded prize allocation.
+    NoAllocation = 23,
+    /// Second settlement of the same allocation — either a repeat claim, or a
+    /// claim attempted after clawback_unclaimed already swept it.
+    AlreadyClaimed = 24,
+    /// clawback_unclaimed called before the event's claim deadline has passed.
+    ClaimPeriodNotExpired = 25,
 }
 
 impl From<InviteError> for EventError {

--- a/contracts/creator-event-manager/src/finalize.rs
+++ b/contracts/creator-event-manager/src/finalize.rs
@@ -1,10 +1,14 @@
-//! Prize-pool finalization (#... finalize_event).
+//! Prize-pool finalization, staged claims, and no-show clawback (#1312).
 //!
 //! Once an event has ended and every match is resolved, [`finalize_event`]
-//! ranks participants, splits the escrowed prize pool according to the event's
-//! `reward_distribution`, and pays the top-N addresses. It is **permissionless**:
-//! anyone may call it (it simply triggers the payout once all conditions are
-//! met), mirroring the old `verify_event_winners` entry point.
+//! ranks participants and splits the escrowed prize pool according to the
+//! event's `reward_distribution` — but instead of transferring winnings
+//! immediately, it records a per-winner [`PrizeAllocation`] with a claim
+//! deadline. Winners settle their own allocation via [`claim_prize`]; any
+//! allocation still unclaimed once the deadline passes may be swept to
+//! treasury via [`clawback_unclaimed`]. `finalize_event` remains
+//! **permissionless**: anyone may call it once all conditions are met,
+//! mirroring the old `verify_event_winners` entry point.
 
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
@@ -12,14 +16,14 @@ use crate::admin;
 use crate::event::{self, EventError};
 use crate::leaderboard;
 use crate::storage::{self, TTL_LEDGERS};
-use crate::storage_types::DataKey;
+use crate::storage_types::{DataKey, PrizeAllocation, CLAIM_PERIOD_SECONDS};
 use crate::token::TokenHelper;
 
 // ---------------------------------------------------------------------------
 // finalize_event
 // ---------------------------------------------------------------------------
 
-/// Rank participants, split the prize pool, and pay out the top-N addresses.
+/// Rank participants, split the prize pool, and stage per-winner allocations.
 ///
 /// `caller.require_auth()` is enforced but the call is otherwise permissionless:
 /// anyone may finalize an event once its conditions are met.
@@ -42,20 +46,25 @@ use crate::token::TokenHelper;
 ///
 /// For each paid rank `i` in `0..n.min(leaderboard.len())` (where
 /// `n = reward_distribution.len()`):
-/// `amount = prize_pool * reward_distribution[i] / 100`, transferred to
-/// `leaderboard[i].user`.
+/// `amount = prize_pool * reward_distribution[i] / 100`. Rather than
+/// transferring this amount immediately, a [`PrizeAllocation`] is recorded
+/// under [`DataKey::PrizeAllocation`] for `leaderboard[i].user` — the winner
+/// must call [`claim_prize`] to receive it. This is what enables
+/// [`clawback_unclaimed`] to reclaim allocations nobody ever claims.
 ///
 /// Any leftover — the unallocated percentage when there are fewer participants
 /// than reward ranks, plus integer-division dust — is sent to `event.creator`
-/// in a single transfer (`prize_pool - total_distributed`). With zero
-/// participants the entire prize pool is refunded to the creator. After this
-/// call no XLM is left stranded in the contract.
+/// immediately, in a single transfer (`prize_pool - total_distributed`). With
+/// zero participants the entire prize pool is refunded to the creator. This
+/// creator refund is not staged: only winner allocations go through
+/// claim/clawback.
 ///
 /// On success the event is marked `is_finalized`, the payout vector is stored
-/// under [`DataKey::EventPayouts`] for historical queries, a
-/// `(event, finalized)` event is emitted with
-/// `(event_id, winners_paid, total_distributed)`, and the payout vector is
-/// returned.
+/// under [`DataKey::EventPayouts`] for historical queries, the claim deadline
+/// (`now + CLAIM_PERIOD_SECONDS`) is stored under [`DataKey::ClaimDeadline`],
+/// a `(event, finalized)` event is emitted with
+/// `(event_id, winners_paid, total_distributed)`, and the payout vector
+/// (allocated amounts, not yet transferred) is returned.
 pub fn finalize_event(
     env: &Env,
     caller: Address,
@@ -128,11 +137,18 @@ pub fn finalize_event(
         let entry = leaderboard.get(i).unwrap();
         let amount = prize_pool * percent as i128 / 100;
 
-        // Skip zero-value transfers (the token client rejects amount <= 0), but
-        // still record the rank so the snapshot reflects every paid position.
+        // Skip zero-value allocations (nothing to claim), but still record
+        // the rank so the snapshot reflects every paid position.
         if amount > 0 {
-            TokenHelper::distribute_winnings(env, &xlm_token, &entry.user, amount)
-                .map_err(|_| EventError::TransferFailed)?;
+            storage::set_prize_allocation(
+                env,
+                &PrizeAllocation {
+                    winner: entry.user.clone(),
+                    event_id,
+                    amount,
+                    claimed: false,
+                },
+            );
             total_distributed += amount;
         }
 
@@ -158,12 +174,147 @@ pub fn finalize_event(
         .persistent()
         .extend_ttl(&payouts_key, TTL_LEDGERS, TTL_LEDGERS);
 
+    // Winners have from now until this deadline to claim_prize before their
+    // allocation becomes eligible for clawback_unclaimed.
+    storage::set_claim_deadline(env, event_id, now + CLAIM_PERIOD_SECONDS);
+
     env.events().publish(
         (Symbol::new(env, "event"), Symbol::new(env, "finalized")),
         (event_id, payouts.len(), total_distributed),
     );
 
     Ok(payouts)
+}
+
+// ---------------------------------------------------------------------------
+// claim_prize (#1312)
+// ---------------------------------------------------------------------------
+
+/// Claim a winner's staged prize allocation from a finalized event.
+///
+/// Transfers the winner's [`PrizeAllocation::amount`] to `winner` exactly
+/// once. Requires `winner.require_auth()` — only the allocated winner may
+/// claim their own allocation.
+///
+/// # Checks (in order)
+/// 1. Contract not paused ([`EventError::Paused`]).
+/// 2. Event exists ([`EventError::EventNotFound`]).
+/// 3. Event is finalized ([`EventError::EventNotFinalized`]).
+/// 4. `winner` has a recorded allocation ([`EventError::NoAllocation`]).
+/// 5. The allocation has not already been settled — by an earlier
+///    `claim_prize` call or by `clawback_unclaimed`
+///    ([`EventError::AlreadyClaimed`]).
+///
+/// On success, marks the allocation `claimed`, transfers the funds, emits a
+/// `(prize, claimed)` event with `(event_id, winner, amount)`, and returns
+/// the claimed amount.
+pub fn claim_prize(env: &Env, winner: Address, event_id: u64) -> Result<i128, EventError> {
+    winner.require_auth();
+
+    if admin::is_paused(env) {
+        return Err(EventError::Paused);
+    }
+
+    let event = event::get_event(env, event_id)?;
+    if !event.is_finalized {
+        return Err(EventError::EventNotFinalized);
+    }
+
+    let mut allocation =
+        storage::get_prize_allocation(env, event_id, &winner).ok_or(EventError::NoAllocation)?;
+
+    if allocation.claimed {
+        return Err(EventError::AlreadyClaimed);
+    }
+
+    let xlm_token = admin::get_xlm_token(env).unwrap_or_else(|| panic!("not_initialized"));
+    TokenHelper::distribute_winnings(env, &xlm_token, &winner, allocation.amount)
+        .map_err(|_| EventError::TransferFailed)?;
+
+    allocation.claimed = true;
+    storage::set_prize_allocation(env, &allocation);
+
+    env.events().publish(
+        (Symbol::new(env, "prize"), Symbol::new(env, "claimed")),
+        (event_id, winner, allocation.amount),
+    );
+
+    Ok(allocation.amount)
+}
+
+// ---------------------------------------------------------------------------
+// clawback_unclaimed (#1312)
+// ---------------------------------------------------------------------------
+
+/// Sweep every still-unclaimed prize allocation for a finalized event to
+/// treasury, once the event's claim deadline has passed.
+///
+/// Permissionless — like `finalize_event`, anyone may trigger the sweep, but
+/// they must authorize the call. Only allocations with `claimed == false` are
+/// swept; allocations already claimed by their winner are left untouched.
+/// Calling this again after a full sweep is a harmless no-op (every
+/// allocation is already `claimed`, so nothing more moves).
+///
+/// # Checks (in order)
+/// 1. Contract not paused ([`EventError::Paused`]).
+/// 2. Event exists ([`EventError::EventNotFound`]).
+/// 3. Event is finalized ([`EventError::EventNotFinalized`]).
+/// 4. The claim deadline has passed — `now >= claim_deadline`
+///    ([`EventError::ClaimPeriodNotExpired`]).
+///
+/// Returns the total amount swept to treasury (`0` if nothing was
+/// unclaimed).
+pub fn clawback_unclaimed(env: &Env, caller: Address, event_id: u64) -> Result<i128, EventError> {
+    caller.require_auth();
+
+    if admin::is_paused(env) {
+        return Err(EventError::Paused);
+    }
+
+    let event = event::get_event(env, event_id)?;
+    if !event.is_finalized {
+        return Err(EventError::EventNotFinalized);
+    }
+
+    let deadline = storage::get_claim_deadline(env, event_id).unwrap_or(u64::MAX);
+    let now = env.ledger().timestamp();
+    if now < deadline {
+        return Err(EventError::ClaimPeriodNotExpired);
+    }
+
+    let treasury = admin::get_treasury(env).unwrap_or_else(|| panic!("not_initialized"));
+    let xlm_token = admin::get_xlm_token(env).unwrap_or_else(|| panic!("not_initialized"));
+
+    let payouts = get_event_payouts(env, event_id);
+    let mut swept: i128 = 0;
+
+    for (winner, amount) in payouts.iter() {
+        if amount <= 0 {
+            continue;
+        }
+        let mut allocation = match storage::get_prize_allocation(env, event_id, &winner) {
+            Some(a) => a,
+            None => continue,
+        };
+        if allocation.claimed {
+            continue;
+        }
+        allocation.claimed = true;
+        storage::set_prize_allocation(env, &allocation);
+        swept += allocation.amount;
+    }
+
+    if swept > 0 {
+        TokenHelper::distribute_winnings(env, &xlm_token, &treasury, swept)
+            .map_err(|_| EventError::TransferFailed)?;
+    }
+
+    env.events().publish(
+        (Symbol::new(env, "prize"), Symbol::new(env, "clawed_back")),
+        (event_id, swept),
+    );
+
+    Ok(swept)
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -811,8 +811,67 @@ impl CreatorEventManagerContract {
     ///
     /// Returns the `(address, amount)` vector recorded by `finalize_event`, or
     /// an empty vector if the event has not been finalized (or does not exist).
+    /// Note this reflects staged *allocations*, not necessarily transferred
+    /// funds — see `claim_prize` / `clawback_unclaimed` (#1312).
     pub fn get_event_payouts(env: Env, event_id: u64) -> Vec<(Address, i128)> {
         finalize::get_event_payouts(&env, event_id)
+    }
+
+    /// Claim a winner's staged prize allocation from a finalized event (#1312).
+    ///
+    /// `finalize_event` stages per-winner allocations instead of transferring
+    /// them immediately; this transfers `winner`'s allocation to them exactly
+    /// once. Only `winner` may claim their own allocation.
+    ///
+    /// Returns the claimed amount (in stroops).
+    ///
+    /// # Panics
+    /// * `"contract_paused"` — the contract is paused.
+    /// * `"event_not_found"` — no event exists with the given ID.
+    /// * `"event_not_finalized"` — the event has not been finalized yet.
+    /// * `"no_allocation"` — `winner` has no recorded allocation for this event.
+    /// * `"already_claimed"` — the allocation was already claimed, or already
+    ///   swept to treasury by `clawback_unclaimed`.
+    /// * `"transfer_failed"` — the payout transfer failed.
+    pub fn claim_prize(env: Env, winner: Address, event_id: u64) -> i128 {
+        match finalize::claim_prize(&env, winner, event_id) {
+            Ok(amount) => amount,
+            Err(EventError::Paused) => panic!("contract_paused"),
+            Err(EventError::EventNotFound) => panic!("event_not_found"),
+            Err(EventError::EventNotFinalized) => panic!("event_not_finalized"),
+            Err(EventError::NoAllocation) => panic!("no_allocation"),
+            Err(EventError::AlreadyClaimed) => panic!("already_claimed"),
+            Err(EventError::TransferFailed) => panic!("transfer_failed"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
+    /// Sweep unclaimed prize allocations for a finalized event to treasury,
+    /// once the claim deadline has passed (#1312).
+    ///
+    /// Permissionless — anyone may trigger the sweep once the deadline has
+    /// passed, but they must authorize the call. Allocations already claimed
+    /// by their winner are left untouched. Safe to call repeatedly: once every
+    /// allocation is settled, further calls are a no-op that return `0`.
+    ///
+    /// Returns the total amount swept to treasury.
+    ///
+    /// # Panics
+    /// * `"contract_paused"` — the contract is paused.
+    /// * `"event_not_found"` — no event exists with the given ID.
+    /// * `"event_not_finalized"` — the event has not been finalized yet.
+    /// * `"claim_period_not_expired"` — the claim deadline has not passed yet.
+    /// * `"transfer_failed"` — the sweep transfer failed.
+    pub fn clawback_unclaimed(env: Env, caller: Address, event_id: u64) -> i128 {
+        match finalize::clawback_unclaimed(&env, caller, event_id) {
+            Ok(amount) => amount,
+            Err(EventError::Paused) => panic!("contract_paused"),
+            Err(EventError::EventNotFound) => panic!("event_not_found"),
+            Err(EventError::EventNotFinalized) => panic!("event_not_finalized"),
+            Err(EventError::ClaimPeriodNotExpired) => panic!("claim_period_not_expired"),
+            Err(EventError::TransferFailed) => panic!("transfer_failed"),
+            Err(_) => panic!("unexpected_error"),
+        }
     }
 
     /// Check whether an event is finalized.

--- a/contracts/creator-event-manager/src/storage.rs
+++ b/contracts/creator-event-manager/src/storage.rs
@@ -8,7 +8,9 @@
 /// the returned ID immediately.
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::storage_types::{DataKey, Event, Match, ParticipantScore, Prediction, StandingEntry};
+use crate::storage_types::{
+    DataKey, Event, Match, ParticipantScore, Prediction, PrizeAllocation, StandingEntry,
+};
 
 // ---------------------------------------------------------------------------
 // TTL constant
@@ -268,11 +270,7 @@ pub fn add_event_participant(env: &Env, event_id: u64, participant: &Address) {
 
 /// Read a participant's stored weighted score components, or `None` if the
 /// participant has never been scored for this event.
-pub fn get_participant_score(
-    env: &Env,
-    event_id: u64,
-    user: &Address,
-) -> Option<ParticipantScore> {
+pub fn get_participant_score(env: &Env, event_id: u64, user: &Address) -> Option<ParticipantScore> {
     let key = DataKey::ParticipantScore(user.clone(), event_id);
     match env
         .storage()
@@ -321,6 +319,62 @@ pub fn get_event_standings(env: &Env, event_id: u64) -> Vec<StandingEntry> {
 pub fn set_event_standings(env: &Env, event_id: u64, standings: &Vec<StandingEntry>) {
     let key = DataKey::EventStandings(event_id);
     env.storage().persistent().set(&key, standings);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+// ---------------------------------------------------------------------------
+// Staged prize claims & clawback helpers (#1312)
+// ---------------------------------------------------------------------------
+
+/// Read a winner's staged prize allocation for an event, or `None` if this
+/// winner was never allocated a prize for the event.
+pub fn get_prize_allocation(env: &Env, event_id: u64, winner: &Address) -> Option<PrizeAllocation> {
+    let key = DataKey::PrizeAllocation(winner.clone(), event_id);
+    match env
+        .storage()
+        .persistent()
+        .get::<DataKey, PrizeAllocation>(&key)
+    {
+        Some(allocation) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            Some(allocation)
+        }
+        None => None,
+    }
+}
+
+/// Write a winner's prize allocation and set its TTL.
+pub fn set_prize_allocation(env: &Env, allocation: &PrizeAllocation) {
+    let key = DataKey::PrizeAllocation(allocation.winner.clone(), allocation.event_id);
+    env.storage().persistent().set(&key, allocation);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+}
+
+/// Read an event's claim deadline, or `None` if the event has not been
+/// finalized yet (no deadline has been recorded).
+pub fn get_claim_deadline(env: &Env, event_id: u64) -> Option<u64> {
+    let key = DataKey::ClaimDeadline(event_id);
+    match env.storage().persistent().get::<DataKey, u64>(&key) {
+        Some(deadline) => {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+            Some(deadline)
+        }
+        None => None,
+    }
+}
+
+/// Write an event's claim deadline and set its TTL.
+pub fn set_claim_deadline(env: &Env, event_id: u64, deadline: u64) {
+    let key = DataKey::ClaimDeadline(event_id);
+    env.storage().persistent().set(&key, &deadline);
     env.storage()
         .persistent()
         .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -17,6 +17,10 @@ pub const MAX_DESCRIPTION_LEN: u32 = 1000;
 pub const MAX_TEAM_NAME_LEN: u32 = 100;
 /// Maximum event duration in seconds (90 days)
 pub const MAX_EVENT_DURATION_SECONDS: u64 = 7_776_000;
+/// Duration after `finalize_event` during which a winner may `claim_prize`
+/// their allocation before it becomes eligible for `clawback_unclaimed` to
+/// treasury (#1312).
+pub const CLAIM_PERIOD_SECONDS: u64 = 2_592_000; // 30 days
 /// Valid predicted outcome symbols
 pub const OUTCOME_TEAM_A: &str = "TEAM_A";
 pub const OUTCOME_TEAM_B: &str = "TEAM_B";
@@ -261,6 +265,17 @@ pub enum DataKey {
     /// Vec<StandingEntry> ranked weighted standings snapshot for an event
     /// (event_id). Recomputed on `submit_match_result` and `finalize_event`.
     EventStandings(u64),
+
+    // ── Staged prize claims & clawback (#1312) ───────────────────────────────
+    /// A winner's staged prize allocation for an event  (winner, event_id).
+    /// Written once by `finalize_event`; settled exactly once by either
+    /// `claim_prize` or `clawback_unclaimed`.
+    PrizeAllocation(Address, u64),
+
+    /// Unix timestamp after which unclaimed allocations may be swept to
+    /// treasury via `clawback_unclaimed`  (event_id). Written once by
+    /// `finalize_event`.
+    ClaimDeadline(u64),
 }
 
 // ---------------------------------------------------------------------------
@@ -889,6 +904,40 @@ impl LeaderboardEntry {
         // Compare the addresses directly; Soroban Address implements Ord
         self.user < other.user
     }
+}
+
+// ---------------------------------------------------------------------------
+// PrizeAllocation (#1312)
+// ---------------------------------------------------------------------------
+
+/// A winner's staged prize-pool allocation, recorded by `finalize_event` in
+/// place of an immediate transfer.
+///
+/// Settled exactly once, through either path:
+/// * the winner calls `claim_prize`, transferring `amount` to themselves, or
+/// * anyone calls `clawback_unclaimed` after the event's claim deadline,
+///   sweeping any still-unclaimed allocation to treasury.
+///
+/// `claimed` guards both paths against a second settlement, so a claim
+/// attempted after a clawback (or vice versa) is rejected identically to a
+/// plain double-claim.
+///
+/// Stored under `DataKey::PrizeAllocation(winner, event_id)`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrizeAllocation {
+    /// Address of the allocated winner
+    pub winner: Address,
+
+    /// Event identifier
+    pub event_id: u64,
+
+    /// XLM amount (in stroops) allocated to this winner
+    pub amount: i128,
+
+    /// `true` once settled — either claimed by the winner or clawed back to
+    /// treasury.
+    pub claimed: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/creator-event-manager/tests/finalize_tests.rs
+++ b/contracts/creator-event-manager/tests/finalize_tests.rs
@@ -210,10 +210,22 @@ fn test_finalize_event_distributes_top5_split() {
         let (addr, amount) = payouts.get(i as u32).unwrap();
         assert_eq!(addr, *user);
         assert_eq!(amount, expected[i]);
+        // Allocations are staged, not transferred, until claim_prize is called.
+        assert_eq!(balance(&env, &xlm_token, user), 0);
+    }
+
+    // Full pool staged in the contract; nothing refunded to the creator.
+    assert_eq!(balance(&env, &xlm_token, &contract_id), PRIZE);
+    assert_eq!(balance(&env, &xlm_token, &creator), 0);
+
+    // Each winner claims their own allocation exactly once.
+    for (i, user) in users.iter().enumerate() {
+        let claimed = client.claim_prize(user, &event_id);
+        assert_eq!(claimed, expected[i]);
         assert_eq!(balance(&env, &xlm_token, user), expected[i]);
     }
 
-    // Full pool distributed: nothing left in the contract, nothing refunded.
+    // Full pool distributed: nothing left in the contract.
     assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
     assert_eq!(balance(&env, &xlm_token, &creator), 0);
 
@@ -366,10 +378,19 @@ fn test_finalize_event_fewer_participants_than_ranks_refunds_creator() {
     let refund = PRIZE - rank1 - rank2; // 30% (ranks 3-5) back to creator
 
     assert_eq!(payouts.len(), 2);
+    // Winner allocations are staged; the creator's refund is unaffected and
+    // still transfers immediately at finalize.
+    assert_eq!(balance(&env, &xlm_token, &user1), 0);
+    assert_eq!(balance(&env, &xlm_token, &user2), 0);
+    assert_eq!(balance(&env, &xlm_token, &creator), refund);
+    // Only the two staged allocations remain in the contract.
+    assert_eq!(balance(&env, &xlm_token, &contract_id), rank1 + rank2);
+
+    assert_eq!(client.claim_prize(&user1, &event_id), rank1);
+    assert_eq!(client.claim_prize(&user2, &event_id), rank2);
     assert_eq!(balance(&env, &xlm_token, &user1), rank1);
     assert_eq!(balance(&env, &xlm_token, &user2), rank2);
-    assert_eq!(balance(&env, &xlm_token, &creator), refund);
-    // Nothing stranded.
+    // Nothing stranded once both winners have claimed.
     assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
 }
 
@@ -450,16 +471,29 @@ fn test_finalize_event_integer_division_dust_refunded_to_creator() {
     let expected_dust = prize_pool - expected_rank1 - expected_rank2; // 1
 
     assert_eq!(payouts.len(), 2);
-    assert_eq!(balance(&env, &xlm_token, &user1), expected_rank1);
-    assert_eq!(balance(&env, &xlm_token, &user2), expected_rank2);
+    // Winner allocations are staged, not yet transferred.
+    assert_eq!(balance(&env, &xlm_token, &user1), 0);
+    assert_eq!(balance(&env, &xlm_token, &user2), 0);
 
-    // Creator gets the dust (plus any refund from unallocated percentage).
+    // Creator gets the dust immediately (plus any refund from unallocated
+    // percentage) — the creator refund is not staged.
     assert_eq!(
         balance(&env, &xlm_token, &creator),
         creator_balance_before + expected_dust,
     );
 
-    // Contract is empty — nothing stranded.
+    // Contract still holds the two staged allocations.
+    assert_eq!(
+        balance(&env, &xlm_token, &contract_id),
+        expected_rank1 + expected_rank2
+    );
+
+    assert_eq!(client.claim_prize(&user1, &event_id), expected_rank1);
+    assert_eq!(client.claim_prize(&user2, &event_id), expected_rank2);
+    assert_eq!(balance(&env, &xlm_token, &user1), expected_rank1);
+    assert_eq!(balance(&env, &xlm_token, &user2), expected_rank2);
+
+    // Contract is empty — nothing stranded once both winners have claimed.
     assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
 
     // Total outflows equal the full prize pool.
@@ -611,6 +645,12 @@ fn test_finalize_event_permissionless() {
     let payouts = client.finalize_event(&random_caller, &event_id);
 
     assert_eq!(payouts.len(), 1);
+    // Allocation staged, not yet transferred.
+    assert_eq!(balance(&env, &xlm_token, &user), 0);
+    assert_eq!(balance(&env, &xlm_token, &contract_id), PRIZE);
+
+    // The winner (or anyone, on the winner's behalf via auth) claims.
+    assert_eq!(client.claim_prize(&user, &event_id), PRIZE);
     assert_eq!(balance(&env, &xlm_token, &user), PRIZE);
     assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
 }
@@ -707,18 +747,28 @@ fn test_finalize_event_seed_pool_plus_entry_fees_combined() {
 
     assert_eq!(payouts.len(), 2);
 
-    // Verify token balances for each winner numerically.
-    assert_eq!(balance(&env, &xlm_token, &user1), expected_rank1);
-    assert_eq!(balance(&env, &xlm_token, &user2), expected_rank2);
-    // user3 paid the entry fee and scored 0 pts — receives no prize.
+    // Allocations are staged until claimed.
+    assert_eq!(balance(&env, &xlm_token, &user1), 0);
+    assert_eq!(balance(&env, &xlm_token, &user2), 0);
+    // user3 paid the entry fee and scored 0 pts — receives no allocation.
     assert_eq!(balance(&env, &xlm_token, &user3), 0);
 
-    // Integer-division remainder goes to creator, not lost.
+    // Integer-division remainder goes to creator immediately, not lost.
     assert_eq!(balance(&env, &xlm_token, &creator), expected_dust);
 
     // Total distributed equals seed_pool + N × entry_fee.
     let total_out = expected_rank1 + expected_rank2 + expected_dust;
     assert_eq!(total_out, total_pool);
+    assert_eq!(
+        balance(&env, &xlm_token, &contract_id),
+        expected_rank1 + expected_rank2
+    );
+
+    // Winners claim their staged allocations.
+    assert_eq!(client.claim_prize(&user1, &event_id), expected_rank1);
+    assert_eq!(client.claim_prize(&user2, &event_id), expected_rank2);
+    assert_eq!(balance(&env, &xlm_token, &user1), expected_rank1);
+    assert_eq!(balance(&env, &xlm_token, &user2), expected_rank2);
     assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
 
     assert!(client.get_event(&event_id).is_finalized);

--- a/contracts/creator-event-manager/tests/prize_claims_tests.rs
+++ b/contracts/creator-event-manager/tests/prize_claims_tests.rs
@@ -1,0 +1,623 @@
+/// Tests for staged prize distribution via `claim_prize` / `clawback_unclaimed` (#1312).
+///
+/// Coverage:
+/// - Winners claim their staged allocation exactly once; a second claim errors
+///   with no extra funds moved.
+/// - `clawback_unclaimed` before the claim deadline errors; after the
+///   deadline it sweeps only unclaimed allocations, leaving claimed winners
+///   untouched.
+/// - A claim attempted after `clawback_unclaimed` already swept the
+///   allocation errors identically to a double-claim.
+/// - `claim_prize` / `clawback_unclaimed` before finalization error.
+/// - A repeated `clawback_unclaimed` call is a harmless no-op.
+/// - Property test: across many randomized (winner count, pool size,
+///   claim/no-show subset) scenarios, `sum(claims) + clawed_back` always
+///   equals the original prize pool.
+use creator_event_manager::storage;
+use creator_event_manager::storage_types::{MatchResult, CLAIM_PERIOD_SECONDS};
+use creator_event_manager::CreatorEventManagerContractClient;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger as _;
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, Env, String, Symbol, Vec};
+
+const FEE: i128 = 1_000_000;
+const PRIZE: i128 = 10_000_000;
+
+fn setup() -> (
+    Env,
+    CreatorEventManagerContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(creator_event_manager::CreatorEventManagerContract, ());
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> =
+        unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+    (
+        env,
+        client,
+        contract_id,
+        admin,
+        ai_agent,
+        xlm_token,
+        treasury,
+    )
+}
+
+fn fund(env: &Env, token: &Address, user: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(user, &amount);
+}
+
+fn balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    TokenClient::new(env, token).balance(who)
+}
+
+fn title(env: &Env) -> String {
+    String::from_str(env, "Test Event")
+}
+
+fn desc(env: &Env) -> String {
+    String::from_str(env, "Test Description")
+}
+
+/// Create a funded event (prize_pool + reward_distribution) and `num_matches`
+/// matches. The creator is funded with exactly `FEE + prize_pool`.
+fn create_funded_event(
+    env: &Env,
+    contract_id: &Address,
+    client: &CreatorEventManagerContractClient<'static>,
+    creator: &Address,
+    xlm_token: &Address,
+    prize_pool: i128,
+    reward_distribution: Vec<u32>,
+    num_matches: u32,
+) -> (u64, Symbol, Vec<u64>) {
+    fund(env, xlm_token, creator, FEE + prize_pool);
+    let start_time = env.ledger().timestamp() + 3600;
+    let end_time = env.ledger().timestamp() + 7200;
+    let (event_id, invite_code) = client.create_event(
+        creator,
+        &title(env),
+        &desc(env),
+        &100u32,
+        &start_time,
+        &end_time,
+        &prize_pool,
+        &reward_distribution,
+        &0i128,
+    );
+
+    let mut match_ids: Vec<u64> = Vec::new(env);
+
+    env.as_contract(contract_id, || {
+        for i in 0..num_matches {
+            let match_id = storage::next_match_id(env);
+            let match_record = creator_event_manager::storage_types::Match::new(
+                match_id,
+                event_id,
+                String::from_str(env, &std::format!("Team A{}", i)),
+                String::from_str(env, &std::format!("Team B{}", i)),
+                env.ledger().timestamp() + 100 + (i as u64) * 60,
+                1u32,
+            );
+            storage::set_match(env, match_id, &match_record);
+            storage::add_event_match(env, event_id, match_id);
+            match_ids.push_back(match_id);
+
+            let mut event = storage::get_event(env, event_id).expect("event exists");
+            event.add_match();
+            storage::set_event(env, event_id, &event);
+        }
+    });
+
+    (event_id, invite_code, match_ids)
+}
+
+fn submit_result(
+    client: &CreatorEventManagerContractClient<'static>,
+    ai_agent: &Address,
+    match_id: u64,
+    result: MatchResult,
+) {
+    let (home_score, away_score) = match result {
+        MatchResult::TeamA => (1u32, 0u32),
+        MatchResult::TeamB => (0u32, 1u32),
+        MatchResult::Draw => (1u32, 1u32),
+    };
+    client.submit_match_result(ai_agent, &match_id, &home_score, &away_score);
+}
+
+fn reward_dist(env: &Env, percents: &[u32]) -> Vec<u32> {
+    let mut v = Vec::new(env);
+    for p in percents {
+        v.push_back(*p);
+    }
+    v
+}
+
+// ---------------------------------------------------------------------------
+// claim_prize — happy path & double-claim guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_claim_prize_transfers_allocation_once() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token, _treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let user = Address::generate(&env);
+    client.join_event(&user, &invite_code);
+    client.submit_prediction(&user, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
+
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+
+    // Nothing moved yet.
+    assert_eq!(balance(&env, &xlm_token, &user), 0);
+
+    let claimed = client.claim_prize(&user, &event_id);
+    assert_eq!(claimed, PRIZE);
+    assert_eq!(balance(&env, &xlm_token, &user), PRIZE);
+    assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
+}
+
+#[test]
+#[should_panic(expected = "already_claimed")]
+fn test_claim_prize_twice_rejected() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token, _treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let user = Address::generate(&env);
+    client.join_event(&user, &invite_code);
+    client.submit_prediction(&user, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
+
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+
+    client.claim_prize(&user, &event_id);
+    let balance_after_first_claim = balance(&env, &xlm_token, &user);
+    assert_eq!(balance_after_first_claim, PRIZE);
+
+    // Second claim must panic and move no additional funds.
+    client.claim_prize(&user, &event_id);
+}
+
+#[test]
+#[should_panic(expected = "no_allocation")]
+fn test_claim_prize_non_winner_rejected() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token, _treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let winner = Address::generate(&env);
+    client.join_event(&winner, &invite_code);
+    client.submit_prediction(&winner, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
+
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+
+    // Never joined, never allocated a prize.
+    let stranger = Address::generate(&env);
+    client.claim_prize(&stranger, &event_id);
+}
+
+#[test]
+#[should_panic(expected = "event_not_finalized")]
+fn test_claim_prize_before_finalize_rejected() {
+    let (env, client, contract_id, creator, _ai_agent, xlm_token, _treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, _match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let user = Address::generate(&env);
+    client.join_event(&user, &invite_code);
+
+    client.claim_prize(&user, &event_id);
+}
+
+// ---------------------------------------------------------------------------
+// clawback_unclaimed — deadline guard & selective sweep
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "claim_period_not_expired")]
+fn test_clawback_before_deadline_rejected() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token, _treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let user = Address::generate(&env);
+    client.join_event(&user, &invite_code);
+    client.submit_prediction(&user, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
+
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+
+    // Deadline is CLAIM_PERIOD_SECONDS away — calling immediately must fail.
+    client.clawback_unclaimed(&caller, &event_id);
+}
+
+#[test]
+#[should_panic(expected = "event_not_finalized")]
+fn test_clawback_before_finalize_rejected() {
+    let (env, client, contract_id, creator, _ai_agent, xlm_token, _treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, _invite_code, _match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let caller = Address::generate(&env);
+    client.clawback_unclaimed(&caller, &event_id);
+}
+
+#[test]
+fn test_clawback_after_deadline_sweeps_only_unclaimed() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token, treasury) = setup();
+
+    // Two winners with distinct ranks (60/40 split).
+    let dist = reward_dist(&env, &[60, 40]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let claimer = Address::generate(&env);
+    let no_show = Address::generate(&env);
+
+    client.join_event(&claimer, &invite_code);
+    client.submit_prediction(&claimer, &match_ids.get(0).unwrap(), &1u32, &0u32); // exact → rank 1
+    client.join_event(&no_show, &invite_code);
+    client.submit_prediction(&no_show, &match_ids.get(0).unwrap(), &2u32, &0u32); // correct result only → rank 2
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
+
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+
+    let rank1 = PRIZE * 60 / 100;
+    let rank2 = PRIZE * 40 / 100;
+
+    // Only the claimer settles before the deadline.
+    assert_eq!(client.claim_prize(&claimer, &event_id), rank1);
+    assert_eq!(balance(&env, &xlm_token, &claimer), rank1);
+
+    let treasury_before = balance(&env, &xlm_token, &treasury);
+
+    // Past the deadline, sweep whatever the no-show never claimed.
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + CLAIM_PERIOD_SECONDS + 1);
+    let swept = client.clawback_unclaimed(&caller, &event_id);
+
+    assert_eq!(swept, rank2);
+    assert_eq!(
+        balance(&env, &xlm_token, &treasury),
+        treasury_before + rank2
+    );
+    // The claimer's settled funds are untouched by the sweep.
+    assert_eq!(balance(&env, &xlm_token, &claimer), rank1);
+    // The no-show never receives anything.
+    assert_eq!(balance(&env, &xlm_token, &no_show), 0);
+    // Nothing stranded.
+    assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
+}
+
+#[test]
+#[should_panic(expected = "already_claimed")]
+fn test_claim_after_clawback_rejected() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token, _treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let no_show = Address::generate(&env);
+    client.join_event(&no_show, &invite_code);
+    client.submit_prediction(&no_show, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
+
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + CLAIM_PERIOD_SECONDS + 1);
+    let swept = client.clawback_unclaimed(&caller, &event_id);
+    assert_eq!(swept, PRIZE);
+
+    // The allocation was already swept to treasury — this must panic, not
+    // move any (more) funds.
+    client.claim_prize(&no_show, &event_id);
+}
+
+#[test]
+fn test_clawback_called_twice_is_noop() {
+    let (env, client, contract_id, creator, ai_agent, xlm_token, treasury) = setup();
+
+    let dist = reward_dist(&env, &[100]);
+    let (event_id, invite_code, match_ids) = create_funded_event(
+        &env,
+        &contract_id,
+        &client,
+        &creator,
+        &xlm_token,
+        PRIZE,
+        dist,
+        1,
+    );
+
+    let no_show = Address::generate(&env);
+    client.join_event(&no_show, &invite_code);
+    client.submit_prediction(&no_show, &match_ids.get(0).unwrap(), &1u32, &0u32);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+    submit_result(
+        &client,
+        &ai_agent,
+        match_ids.get(0).unwrap(),
+        MatchResult::TeamA,
+    );
+
+    let caller = Address::generate(&env);
+    client.finalize_event(&caller, &event_id);
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + CLAIM_PERIOD_SECONDS + 1);
+    assert_eq!(client.clawback_unclaimed(&caller, &event_id), PRIZE);
+    let treasury_after_first_sweep = balance(&env, &xlm_token, &treasury);
+
+    // A second sweep finds nothing unclaimed and moves nothing.
+    assert_eq!(client.clawback_unclaimed(&caller, &event_id), 0);
+    assert_eq!(
+        balance(&env, &xlm_token, &treasury),
+        treasury_after_first_sweep
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Property test (#1312): claims + clawback == original prize pool
+// ---------------------------------------------------------------------------
+
+/// Across randomized winner counts, pool sizes, and claim/no-show subsets,
+/// `sum(amounts actually claimed) + amount clawed back` always equals the
+/// original prize pool.
+///
+/// Reward distributions are constructed to sum to exactly 100, and the prize
+/// pool is always a multiple of 100, so every rank's `prize_pool * percent /
+/// 100` divides evenly — no integer-division dust and no unallocated
+/// percentage leaks to the creator. That isolates the invariant to exactly
+/// the winners' staged allocations, which is what claim_prize and
+/// clawback_unclaimed are responsible for settling.
+///
+/// Randomness comes from a small deterministic LCG (no proptest dependency
+/// needed) so the test is reproducible and doesn't touch the network.
+#[test]
+fn test_property_claims_plus_clawback_equals_prize_pool() {
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut next_u32 = move || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (state >> 33) as u32
+    };
+
+    for iteration in 0..40u32 {
+        let num_winners = 1 + (next_u32() % 5); // 1..=5 distinct ranks
+
+        let base = 100 / num_winners;
+        let remainder = 100 % num_winners;
+        let mut percents: std::vec::Vec<u32> = std::vec::Vec::new();
+        for i in 0..num_winners {
+            percents.push(if i < remainder { base + 1 } else { base });
+        }
+        assert_eq!(percents.iter().sum::<u32>(), 100);
+
+        // A multiple of 100 so every percent above divides evenly.
+        let k: i128 = 1_000 + (next_u32() % 9_000) as i128;
+        let prize_pool = k * 100;
+
+        let (env, client, contract_id, creator, ai_agent, xlm_token, _treasury) = setup();
+        let dist = reward_dist(&env, &percents);
+        let (event_id, invite_code, match_ids) = create_funded_event(
+            &env,
+            &contract_id,
+            &client,
+            &creator,
+            &xlm_token,
+            prize_pool,
+            dist,
+            num_winners,
+        );
+
+        let mut users: std::vec::Vec<Address> = std::vec::Vec::new();
+        for _ in 0..num_winners {
+            users.push(Address::generate(&env));
+        }
+
+        // user i predicts correctly on the first (num_winners - i) matches →
+        // strictly decreasing points → distinct ranks in user order.
+        for (i, user) in users.iter().enumerate() {
+            client.join_event(user, &invite_code);
+            let correct = num_winners - i as u32;
+            for (m, match_id) in match_ids.iter().enumerate() {
+                if (m as u32) < correct {
+                    client.submit_prediction(user, &match_id, &1u32, &0u32);
+                } else {
+                    client.submit_prediction(user, &match_id, &0u32, &1u32);
+                }
+            }
+        }
+
+        env.ledger().set_timestamp(env.ledger().timestamp() + 7300);
+        for match_id in match_ids.iter() {
+            submit_result(&client, &ai_agent, match_id, MatchResult::TeamA);
+        }
+
+        let caller = Address::generate(&env);
+        let payouts = client.finalize_event(&caller, &event_id);
+        assert_eq!(payouts.len(), num_winners);
+
+        // Every rank filled by a 100%-summing distribution over a pool
+        // divisible by 100 → no leftover for the creator.
+        assert_eq!(balance(&env, &xlm_token, &creator), 0);
+
+        // Randomly pick which winners claim before the deadline; the rest
+        // are no-shows swept by clawback_unclaimed.
+        let mut claimed_total: i128 = 0;
+        for (i, user) in users.iter().enumerate() {
+            let (_, amount) = payouts.get(i as u32).unwrap();
+            if next_u32() % 2 == 0 {
+                let claimed = client.claim_prize(user, &event_id);
+                assert_eq!(claimed, amount);
+                claimed_total += claimed;
+            }
+        }
+
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CLAIM_PERIOD_SECONDS + 1);
+        let swept = client.clawback_unclaimed(&caller, &event_id);
+
+        assert_eq!(
+            claimed_total + swept,
+            prize_pool,
+            "iteration {iteration}: num_winners={num_winners} prize_pool={prize_pool} claimed_total={claimed_total} swept={swept}",
+        );
+
+        // Nothing stranded once every allocation is settled one way or the other.
+        assert_eq!(balance(&env, &xlm_token, &contract_id), 0);
+
+        // Repeat clawback is a harmless no-op — invariant still holds.
+        assert_eq!(client.clawback_unclaimed(&caller, &event_id), 0);
+        assert_eq!(claimed_total + swept, prize_pool);
+    }
+}


### PR DESCRIPTION


<img width="836" height="907" alt="Screenshot from 2026-07-22 23-37-30" src="https://github.com/user-attachments/assets/da6927df-8c76-443f-8530-d91f27fd09d0" />
## Summary
- `finalize_event` now stages per-winner allocations (`PrizeAllocation`) with a claim deadline instead of transferring winnings immediately. The creator's unallocated/dust refund is unaffected.
- `claim_prize(winner, event_id)` — winner-authorized, transfers the allocation exactly once.
- `clawback_unclaimed(caller, event_id)` — permissionless, sweeps unclaimed allocations to treasury once the deadline passes.
- Both settle through the same `claimed` flag, so double-claim, claim-after-clawback, and early-clawback are all rejected with typed errors (`AlreadyClaimed`, `ClaimPeriodNotExpired`, `EventNotFinalized`, `NoAllocation`).
- Added a property test asserting `sum(claims) + clawed_back == prize_pool` across 40 randomized (winner count, pool size, claim/no-show subset) scenarios.

## Test plan
- [x] `cargo test` — 645 tests passed, 0 failed (19 test binaries, including new `prize_claims_tests.rs`)
- [x] `cargo build --target wasm32-unknown-unknown --release` — clean build
- [x] Updated existing `finalize_tests.rs` for the new staged-allocation flow

Closes #1312
