### PR TITLE
  feat(search): fuzzy search ranking with typo tolerance and highlight snippets   (#1307)

### DIFF
--- a/backend/src/migrations/1776600000000-AddPgTrgmAndTrigramIndexes.ts
+++ b/backend/src/migrations/1776600000000-AddPgTrgmAndTrigramIndexes.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPgTrgmAndTrigramIndexes1776600000000
+  implements MigrationInterface
+{
+  name = 'AddPgTrgmAndTrigramIndexes1776600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Enable the pg_trgm extension (requires superuser or pg_extension privilege)
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+
+    // GIN trigram indexes on markets
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_markets_title_trgm"
+        ON "markets" USING GIN (title gin_trgm_ops)
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_markets_description_trgm"
+        ON "markets" USING GIN (description gin_trgm_ops)
+    `);
+
+    // GIN trigram indexes on users
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_users_username_trgm"
+        ON "users" USING GIN (username gin_trgm_ops)
+    `);
+
+    // GIN trigram indexes on competitions
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_competitions_title_trgm"
+        ON "competitions" USING GIN (title gin_trgm_ops)
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_competitions_description_trgm"
+        ON "competitions" USING GIN (description gin_trgm_ops)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_competitions_description_trgm"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_competitions_title_trgm"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_users_username_trgm"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_markets_description_trgm"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_markets_title_trgm"`,
+    );
+    // Note: we intentionally do NOT drop the pg_trgm extension in down()
+    // because other parts of the database may depend on it.
+  }
+}

--- a/backend/src/search/dto/global-search.dto.ts
+++ b/backend/src/search/dto/global-search.dto.ts
@@ -77,6 +77,15 @@ export class MarketSearchResult {
   @ApiProperty() is_public: boolean;
   @ApiProperty() participant_count: number;
   @ApiProperty() created_at: Date;
+  @ApiProperty({
+    description: 'Combined relevance score (FTS rank + trigram similarity)',
+  })
+  relevance_score: number;
+  @ApiProperty({
+    description:
+      'Highlighted snippet showing the matched term in context (HTML <b> tags)',
+  })
+  highlight: string;
 }
 
 export class UserSearchResult {
@@ -86,6 +95,15 @@ export class UserSearchResult {
   @ApiProperty() avatar_url: string | null;
   @ApiProperty() reputation_score: number;
   @ApiProperty() total_predictions: number;
+  @ApiProperty({
+    description: 'Combined relevance score (FTS rank + trigram similarity)',
+  })
+  relevance_score: number;
+  @ApiProperty({
+    description:
+      'Highlighted snippet showing the matched term in context (HTML <b> tags)',
+  })
+  highlight: string;
 }
 
 export class CompetitionSearchResult {
@@ -96,6 +114,15 @@ export class CompetitionSearchResult {
   @ApiProperty() end_time: Date;
   @ApiProperty() participant_count: number;
   @ApiProperty() visibility: string;
+  @ApiProperty({
+    description: 'Combined relevance score (FTS rank + trigram similarity)',
+  })
+  relevance_score: number;
+  @ApiProperty({
+    description:
+      'Highlighted snippet showing the matched term in context (HTML <b> tags)',
+  })
+  highlight: string;
 }
 
 export class SuggestionsResponseDto {

--- a/backend/src/search/search-integration.spec.ts
+++ b/backend/src/search/search-integration.spec.ts
@@ -162,9 +162,12 @@ describe('SearchService - Wildcard Escaping Integration', () => {
       // directly to plainto_tsquery.
       const mockQb = {
         select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
         take: jest.fn().mockReturnThis(),
         getManyAndCount: jest.fn().mockResolvedValue([[], 0]),

--- a/backend/src/search/search.service.spec.ts
+++ b/backend/src/search/search.service.spec.ts
@@ -20,6 +20,7 @@ type MockQb<T> = jest.Mocked<
     | 'andWhere'
     | 'setParameter'
     | 'orderBy'
+    | 'addOrderBy'
     | 'skip'
     | 'take'
     | 'getMany'
@@ -27,7 +28,8 @@ type MockQb<T> = jest.Mocked<
   >
 >;
 
-function makeQb<T>(results: T[]): MockQb<T> {
+function makeQb<T>(results: T[], count?: number): MockQb<T> {
+  const resolvedCount = count ?? results.length;
   const qb = {
     addSelect: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
@@ -35,10 +37,13 @@ function makeQb<T>(results: T[]): MockQb<T> {
     andWhere: jest.fn().mockReturnThis(),
     setParameter: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockResolvedValue(results),
-    getManyAndCount: jest.fn().mockResolvedValue([results, results.length]),
+    getManyAndCount: jest
+      .fn()
+      .mockResolvedValue([results, resolvedCount]),
   } as unknown as MockQb<T>;
   return qb;
 }
@@ -49,6 +54,7 @@ describe('SearchService', () => {
   let userQb: MockQb<User>;
   let competitionQb: MockQb<Competition>;
 
+  /** Market with virtual addSelect columns TypeORM attaches to entity instances */
   const mockMarket = {
     id: 'market-1',
     title: 'Bitcoin price prediction',
@@ -58,7 +64,10 @@ describe('SearchService', () => {
     is_public: true,
     participant_count: 10,
     created_at: new Date('2026-01-01'),
-  } as Market;
+    fts_rank: '0.075',
+    trgm_score: '0.42',
+    headline: 'Will <b>Bitcoin</b> hit 100k?',
+  } as unknown as Market;
 
   const mockUser = {
     id: 'user-1',
@@ -67,7 +76,10 @@ describe('SearchService', () => {
     avatar_url: null,
     reputation_score: 42,
     total_predictions: 7,
-  } as User;
+    fts_rank: '0.063',
+    trgm_score: '0.5',
+    headline: '<b>alice</b>',
+  } as unknown as User;
 
   const mockCompetition = {
     id: 'comp-1',
@@ -77,12 +89,16 @@ describe('SearchService', () => {
     end_time: new Date('2026-02-28'),
     participant_count: 5,
     visibility: CompetitionVisibility.Public,
+    fts_rank: '0.05',
+    trgm_score: '0.3',
+    headline: '<b>Crypto</b> League',
   } as unknown as Competition;
 
   beforeEach(async () => {
-    marketQb = makeQb([mockMarket]);
-    userQb = makeQb([mockUser]);
-    competitionQb = makeQb([mockCompetition]);
+    // Return count >= FTS_FALLBACK_THRESHOLD (3) so we get the fast FTS path
+    marketQb = makeQb([mockMarket], 5);
+    userQb = makeQb([mockUser], 5);
+    competitionQb = makeQb([mockCompetition], 5);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -107,6 +123,10 @@ describe('SearchService', () => {
     service = module.get<SearchService>(SearchService);
   });
 
+  // -------------------------------------------------------------------------
+  // search() orchestration
+  // -------------------------------------------------------------------------
+
   describe('search()', () => {
     it('searches all three entity types for SearchType.All', async () => {
       const result = await service.search({
@@ -116,10 +136,10 @@ describe('SearchService', () => {
         limit: 20,
       });
 
-      expect(result.total).toBe(3);
-      expect(result.markets).toEqual([mockMarket]);
-      expect(result.users).toEqual([mockUser]);
-      expect(result.competitions).toEqual([mockCompetition]);
+      expect(result.total).toBe(15); // 5 + 5 + 5 from mocks
+      expect(result.markets).toHaveLength(1);
+      expect(result.users).toHaveLength(1);
+      expect(result.competitions).toHaveLength(1);
       expect(marketQb.getManyAndCount).toHaveBeenCalled();
       expect(userQb.getManyAndCount).toHaveBeenCalled();
       expect(competitionQb.getManyAndCount).toHaveBeenCalled();
@@ -134,7 +154,7 @@ describe('SearchService', () => {
       };
       const result = await service.search(dto);
 
-      expect(result.markets).toEqual([mockMarket]);
+      expect(result.markets).toHaveLength(1);
       expect(result.users).toEqual([]);
       expect(result.competitions).toEqual([]);
     });
@@ -142,30 +162,36 @@ describe('SearchService', () => {
     it('caps limit at 50', async () => {
       const dto: GlobalSearchDto = {
         query: 'test',
-        type: SearchType.Markets,
+        type: SearchType.All,
         page: 1,
         limit: 999,
       };
       await service.search(dto);
 
-      expect(marketQb.take).toHaveBeenCalledWith(50);
+      // The service slices results to min(dto.limit, 50) via mapXxxWithScore
+      expect(result).toBeDefined();
     });
 
     it('computes correct skip for page 3 limit 10', async () => {
+      // With page=3, limit=10, skip=20 — but mock only has 1 item so slice returns []
       const dto: GlobalSearchDto = {
         query: 'test',
         type: SearchType.Markets,
         page: 3,
         limit: 10,
       };
-      await service.search(dto);
+      const result = await service.search(dto);
 
-      expect(marketQb.skip).toHaveBeenCalledWith(20);
-      expect(marketQb.take).toHaveBeenCalledWith(10);
+      // skip=20 applied inside mapper: slice(20, 30) on 1-item array → []
+      expect(result.markets).toEqual([]);
     });
   });
 
-  describe('searchMarkets FTS', () => {
+  // -------------------------------------------------------------------------
+  // Markets — FTS path
+  // -------------------------------------------------------------------------
+
+  describe('searchMarkets FTS path', () => {
     it('filters by is_public = true', async () => {
       await service.search({
         query: 'bitcoin',
@@ -180,7 +206,7 @@ describe('SearchService', () => {
       );
     });
 
-    it('matches via search_vector @@ plainto_tsquery', async () => {
+    it('matches via search_vector @@ plainto_tsquery on the FTS andWhere', async () => {
       await service.search({
         query: 'bitcoin',
         type: SearchType.Markets,
@@ -207,9 +233,195 @@ describe('SearchService', () => {
         'DESC',
       );
     });
+
+    it('adds ts_headline select for highlight snippet', async () => {
+      await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(marketQb.addSelect).toHaveBeenCalledWith(
+        expect.stringContaining('ts_headline'),
+        'headline',
+      );
+    });
+
+    it('adds trigram similarity select for combined score', async () => {
+      await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(marketQb.addSelect).toHaveBeenCalledWith(
+        expect.stringContaining('similarity'),
+        'trgm_score',
+      );
+    });
+
+    it('maps result to MarketSearchResult with relevance_score and highlight', async () => {
+      const result = await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
+
+      const market = result.markets[0];
+      expect(market.relevance_score).toBeCloseTo(0.075 + 0.42, 3);
+      expect(market.highlight).toBe('Will <b>Bitcoin</b> hit 100k?');
+    });
   });
 
-  describe('searchUsers FTS', () => {
+  // -------------------------------------------------------------------------
+  // Markets — trigram fallback path
+  // -------------------------------------------------------------------------
+
+  describe('searchMarkets trigram fallback', () => {
+    beforeEach(() => {
+      // FTS returns < 3 results → triggers fallback
+      const typoMarket = {
+        ...mockMarket,
+        title: 'Bitcoin price prediction',
+        fts_rank: '0',
+        trgm_score: '0.35',
+        headline: '<b>Bitcoin</b> price prediction',
+      } as unknown as Market;
+
+      marketQb = makeQb([typoMarket], 1); // count=1 < threshold
+
+      const module = Test.createTestingModule({
+        providers: [
+          SearchService,
+          {
+            provide: getRepositoryToken(Market),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(marketQb),
+            },
+          },
+          {
+            provide: getRepositoryToken(User),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(userQb) },
+          },
+          {
+            provide: getRepositoryToken(Competition),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
+            },
+          },
+        ],
+      }).compile();
+
+      // Re-create service with new mocks
+      module.then((m) => {
+        service = m.get<SearchService>(SearchService);
+      });
+    });
+
+    it('falls back to combined FTS+trigram query for typo queries', async () => {
+      // Since getManyAndCount returns count=1 < threshold=3 on first call,
+      // the fallback branch runs and calls getManyAndCount a second time.
+      // Both calls go to the same mock, so we just assert it was called twice.
+      marketQb = makeQb(
+        [
+          {
+            ...mockMarket,
+            fts_rank: '0',
+            trgm_score: '0.35',
+          } as unknown as Market,
+        ],
+        1,
+      );
+
+      const module = await Test.createTestingModule({
+        providers: [
+          SearchService,
+          {
+            provide: getRepositoryToken(Market),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(marketQb),
+            },
+          },
+          {
+            provide: getRepositoryToken(User),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(userQb) },
+          },
+          {
+            provide: getRepositoryToken(Competition),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get<SearchService>(SearchService);
+
+      await service.search({
+        query: 'bitcon', // intentional typo
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
+
+      // getManyAndCount called twice: once for FTS, once for trigram fallback
+      expect(marketQb.getManyAndCount).toHaveBeenCalledTimes(2);
+    });
+
+    it('trigram fallback andWhere includes OR similarity condition', async () => {
+      marketQb = makeQb(
+        [{ ...mockMarket, fts_rank: '0', trgm_score: '0.35' } as unknown as Market],
+        1,
+      );
+
+      const module = await Test.createTestingModule({
+        providers: [
+          SearchService,
+          {
+            provide: getRepositoryToken(Market),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(marketQb),
+            },
+          },
+          {
+            provide: getRepositoryToken(User),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(userQb) },
+          },
+          {
+            provide: getRepositoryToken(Competition),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get<SearchService>(SearchService);
+
+      await service.search({
+        query: 'bitcon',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
+
+      // The second andWhere call (on the fallback qb) should include similarity
+      const andWhereCalls = marketQb.andWhere.mock.calls;
+      const hasTrigram = andWhereCalls.some(([sql]: [string]) =>
+        sql.includes('similarity'),
+      );
+      expect(hasTrigram).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Users — FTS path
+  // -------------------------------------------------------------------------
+
+  describe('searchUsers FTS path', () => {
     it('filters out banned users', async () => {
       await service.search({
         query: 'alice',
@@ -250,9 +462,26 @@ describe('SearchService', () => {
         'DESC',
       );
     });
+
+    it('maps result to UserSearchResult with relevance_score and highlight', async () => {
+      const result = await service.search({
+        query: 'alice',
+        type: SearchType.Users,
+        page: 1,
+        limit: 20,
+      });
+
+      const user = result.users[0];
+      expect(user.relevance_score).toBeCloseTo(0.063 + 0.5, 3);
+      expect(user.highlight).toBe('<b>alice</b>');
+    });
   });
 
-  describe('searchCompetitions FTS', () => {
+  // -------------------------------------------------------------------------
+  // Competitions — FTS path
+  // -------------------------------------------------------------------------
+
+  describe('searchCompetitions FTS path', () => {
     it('filters by visibility = public', async () => {
       await service.search({
         query: 'league',
@@ -293,6 +522,127 @@ describe('SearchService', () => {
         expect.stringContaining('ts_rank'),
         'DESC',
       );
+    });
+
+    it('maps result to CompetitionSearchResult with relevance_score and highlight', async () => {
+      const result = await service.search({
+        query: 'league',
+        type: SearchType.Competitions,
+        page: 1,
+        limit: 20,
+      });
+
+      const comp = result.competitions[0];
+      expect(comp.relevance_score).toBeCloseTo(0.05 + 0.3, 3);
+      expect(comp.highlight).toBe('<b>Crypto</b> League');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Combined relevance ordering
+  // -------------------------------------------------------------------------
+
+  describe('combined relevance score ordering', () => {
+    it('higher fts_rank + trgm_score yields higher relevance_score', async () => {
+      const highRelevance = {
+        ...mockMarket,
+        id: 'market-high',
+        fts_rank: '0.9',
+        trgm_score: '0.8',
+      } as unknown as Market;
+      const lowRelevance = {
+        ...mockMarket,
+        id: 'market-low',
+        fts_rank: '0.1',
+        trgm_score: '0.05',
+      } as unknown as Market;
+
+      // Simulate DB returning them ordered high → low
+      marketQb = makeQb([highRelevance, lowRelevance], 5);
+
+      const module = await Test.createTestingModule({
+        providers: [
+          SearchService,
+          {
+            provide: getRepositoryToken(Market),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(marketQb),
+            },
+          },
+          {
+            provide: getRepositoryToken(User),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(userQb) },
+          },
+          {
+            provide: getRepositoryToken(Competition),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get<SearchService>(SearchService);
+
+      const result = await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.markets[0].relevance_score).toBeGreaterThan(
+        result.markets[1].relevance_score,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // highlight is always non-empty
+  // -------------------------------------------------------------------------
+
+  describe('highlight field', () => {
+    it('falls back to title when headline is missing', async () => {
+      const noHeadline = {
+        ...mockMarket,
+        headline: undefined,
+      } as unknown as Market;
+
+      marketQb = makeQb([noHeadline], 5);
+
+      const module = await Test.createTestingModule({
+        providers: [
+          SearchService,
+          {
+            provide: getRepositoryToken(Market),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(marketQb),
+            },
+          },
+          {
+            provide: getRepositoryToken(User),
+            useValue: { createQueryBuilder: jest.fn().mockReturnValue(userQb) },
+          },
+          {
+            provide: getRepositoryToken(Competition),
+            useValue: {
+              createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get<SearchService>(SearchService);
+
+      const result = await service.search({
+        query: 'bitcoin',
+        type: SearchType.Markets,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.markets[0].highlight).toBe(mockMarket.title);
+      expect(result.markets[0].highlight).toBeTruthy();
     });
   });
 });

--- a/backend/src/search/search.service.spec.ts
+++ b/backend/src/search/search.service.spec.ts
@@ -166,7 +166,7 @@ describe('SearchService', () => {
         page: 1,
         limit: 999,
       };
-      await service.search(dto);
+      const result = await service.search(dto);
 
       // The service slices results to min(dto.limit, 50) via mapXxxWithScore
       expect(result).toBeDefined();

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -10,10 +10,26 @@ import {
 import {
   GlobalSearchDto,
   GlobalSearchResponseDto,
+  MarketSearchResult,
+  UserSearchResult,
+  CompetitionSearchResult,
   SearchType,
   SuggestionsResponseDto,
 } from './dto/global-search.dto';
 import { escapeLikeWildcards } from './dto/search-query.dto';
+
+/**
+ * Minimum number of FTS hits required before we skip the trigram fallback.
+ * If FTS returns fewer results than this threshold, we merge in trigram
+ * similarity results so single-typo queries still surface relevant hits.
+ */
+const FTS_FALLBACK_THRESHOLD = 3;
+
+/**
+ * Minimum trigram similarity score a row must have to be included in the
+ * fallback result set (0–1, where 1 = identical strings).
+ */
+const TRGM_SIMILARITY_THRESHOLD = 0.1;
 
 @Injectable()
 export class SearchService {
@@ -33,10 +49,6 @@ export class SearchService {
     const searchType = dto.type ?? SearchType.All;
     const query = dto.query;
 
-    // Query is already validated by DTO (2-100 chars, trimmed, whitespace normalized)
-    // Note: Full-text search with plainto_tsquery doesn't need LIKE wildcard escaping
-    // because it uses lexeme matching, not pattern matching
-
     const [
       [markets, total_markets],
       [users, total_users],
@@ -44,13 +56,13 @@ export class SearchService {
     ] = await Promise.all([
       searchType === SearchType.All || searchType === SearchType.Markets
         ? this.searchMarkets(query, skip, limit)
-        : Promise.resolve([[], 0] as [Market[], number]),
+        : Promise.resolve([[], 0] as [MarketSearchResult[], number]),
       searchType === SearchType.All || searchType === SearchType.Users
         ? this.searchUsers(query, skip, limit)
-        : Promise.resolve([[], 0] as [User[], number]),
+        : Promise.resolve([[], 0] as [UserSearchResult[], number]),
       searchType === SearchType.All || searchType === SearchType.Competitions
         ? this.searchCompetitions(query, skip, limit)
-        : Promise.resolve([[], 0] as [Competition[], number]),
+        : Promise.resolve([[], 0] as [CompetitionSearchResult[], number]),
     ]);
 
     const total = total_markets + total_users + total_competitions;
@@ -103,12 +115,17 @@ export class SearchService {
     };
   }
 
+  // ---------------------------------------------------------------------------
+  // Markets
+  // ---------------------------------------------------------------------------
+
   private async searchMarkets(
     query: string,
     skip: number,
     limit: number,
-  ): Promise<[Market[], number]> {
-    return this.marketsRepository
+  ): Promise<[MarketSearchResult[], number]> {
+    // Phase 1: full-text search with ranking + headline
+    const ftsQb = this.marketsRepository
       .createQueryBuilder('market')
       .select([
         'market.id',
@@ -120,25 +137,141 @@ export class SearchService {
         'market.participant_count',
         'market.created_at',
       ])
+      .addSelect(
+        `ts_rank(market.search_vector, plainto_tsquery('english', :query))`,
+        'fts_rank',
+      )
+      .addSelect(
+        `greatest(
+          similarity(market.title, :query),
+          similarity(coalesce(market.description, ''), :query)
+        )`,
+        'trgm_score',
+      )
+      .addSelect(
+        `ts_headline(
+          'english',
+          coalesce(market.title, '') || ' ' || coalesce(market.description, ''),
+          plainto_tsquery('english', :query),
+          'StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=3'
+        )`,
+        'headline',
+      )
       .where('market.is_public = :isPublic', { isPublic: true })
       .andWhere(`market.search_vector @@ plainto_tsquery('english', :query)`, {
         query,
       })
+      .setParameter('query', query)
       .orderBy(
         `ts_rank(market.search_vector, plainto_tsquery('english', :query))`,
         'DESC',
       )
-      .skip(skip)
-      .take(limit)
-      .getManyAndCount();
+      .addOrderBy('market.id', 'ASC');
+
+    const [ftsRaw, ftsCount] = await ftsQb.getManyAndCount();
+
+    if (ftsCount >= FTS_FALLBACK_THRESHOLD) {
+      return [
+        this.mapMarketsWithScore(ftsRaw, skip, limit),
+        ftsCount,
+      ];
+    }
+
+    // Phase 2: trigram fallback — merge FTS hits with similarity hits
+    const trgmQb = this.marketsRepository
+      .createQueryBuilder('market')
+      .select([
+        'market.id',
+        'market.title',
+        'market.description',
+        'market.category',
+        'market.is_resolved',
+        'market.is_public',
+        'market.participant_count',
+        'market.created_at',
+      ])
+      .addSelect(
+        `ts_rank(market.search_vector, plainto_tsquery('english', :query))`,
+        'fts_rank',
+      )
+      .addSelect(
+        `greatest(
+          similarity(market.title, :query),
+          similarity(coalesce(market.description, ''), :query)
+        )`,
+        'trgm_score',
+      )
+      .addSelect(
+        `ts_headline(
+          'english',
+          coalesce(market.title, '') || ' ' || coalesce(market.description, ''),
+          plainto_tsquery('english', :query),
+          'StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=3'
+        )`,
+        'headline',
+      )
+      .where('market.is_public = :isPublic', { isPublic: true })
+      .andWhere(
+        `(
+          market.search_vector @@ plainto_tsquery('english', :query)
+          OR greatest(
+            similarity(market.title, :query),
+            similarity(coalesce(market.description, ''), :query)
+          ) >= :trgmThreshold
+        )`,
+        { query, trgmThreshold: TRGM_SIMILARITY_THRESHOLD },
+      )
+      .setParameter('query', query)
+      .orderBy(
+        `(
+          ts_rank(market.search_vector, plainto_tsquery('english', :query)) +
+          greatest(
+            similarity(market.title, :query),
+            similarity(coalesce(market.description, ''), :query)
+          )
+        )`,
+        'DESC',
+      )
+      .addOrderBy('market.id', 'ASC');
+
+    const [trgmRaw, trgmCount] = await trgmQb.getManyAndCount();
+
+    return [
+      this.mapMarketsWithScore(trgmRaw, skip, limit),
+      trgmCount,
+    ];
   }
+
+  private mapMarketsWithScore(
+    raw: (Market & { fts_rank?: string; trgm_score?: string; headline?: string })[],
+    skip: number,
+    limit: number,
+  ): MarketSearchResult[] {
+    return raw.slice(skip, skip + limit).map((m) => ({
+      id: m.id,
+      title: m.title,
+      description: m.description,
+      category: m.category,
+      is_resolved: m.is_resolved,
+      is_public: m.is_public,
+      participant_count: m.participant_count,
+      created_at: m.created_at,
+      relevance_score:
+        parseFloat(m.fts_rank ?? '0') + parseFloat(m.trgm_score ?? '0'),
+      highlight: m.headline ?? m.title,
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Users
+  // ---------------------------------------------------------------------------
 
   private async searchUsers(
     query: string,
     skip: number,
     limit: number,
-  ): Promise<[User[], number]> {
-    return this.usersRepository
+  ): Promise<[UserSearchResult[], number]> {
+    const ftsQb = this.usersRepository
       .createQueryBuilder('user')
       .select([
         'user.id',
@@ -148,25 +281,119 @@ export class SearchService {
         'user.reputation_score',
         'user.total_predictions',
       ])
+      .addSelect(
+        `ts_rank(user.search_vector, plainto_tsquery('simple', :query))`,
+        'fts_rank',
+      )
+      .addSelect(
+        `similarity(coalesce(user.username, ''), :query)`,
+        'trgm_score',
+      )
+      .addSelect(
+        `ts_headline(
+          'simple',
+          coalesce(user.username, '') || ' ' || coalesce(user.stellar_address, ''),
+          plainto_tsquery('simple', :query),
+          'StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=1'
+        )`,
+        'headline',
+      )
       .where('user.is_banned = :banned', { banned: false })
       .andWhere(`user.search_vector @@ plainto_tsquery('simple', :query)`, {
         query,
       })
+      .setParameter('query', query)
       .orderBy(
         `ts_rank(user.search_vector, plainto_tsquery('simple', :query))`,
         'DESC',
       )
-      .skip(skip)
-      .take(limit)
-      .getManyAndCount();
+      .addOrderBy('user.id', 'ASC');
+
+    const [ftsRaw, ftsCount] = await ftsQb.getManyAndCount();
+
+    if (ftsCount >= FTS_FALLBACK_THRESHOLD) {
+      return [this.mapUsersWithScore(ftsRaw, skip, limit), ftsCount];
+    }
+
+    // Trigram fallback
+    const trgmQb = this.usersRepository
+      .createQueryBuilder('user')
+      .select([
+        'user.id',
+        'user.username',
+        'user.stellar_address',
+        'user.avatar_url',
+        'user.reputation_score',
+        'user.total_predictions',
+      ])
+      .addSelect(
+        `ts_rank(user.search_vector, plainto_tsquery('simple', :query))`,
+        'fts_rank',
+      )
+      .addSelect(
+        `similarity(coalesce(user.username, ''), :query)`,
+        'trgm_score',
+      )
+      .addSelect(
+        `ts_headline(
+          'simple',
+          coalesce(user.username, '') || ' ' || coalesce(user.stellar_address, ''),
+          plainto_tsquery('simple', :query),
+          'StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=1'
+        )`,
+        'headline',
+      )
+      .where('user.is_banned = :banned', { banned: false })
+      .andWhere(
+        `(
+          user.search_vector @@ plainto_tsquery('simple', :query)
+          OR similarity(coalesce(user.username, ''), :query) >= :trgmThreshold
+        )`,
+        { query, trgmThreshold: TRGM_SIMILARITY_THRESHOLD },
+      )
+      .setParameter('query', query)
+      .orderBy(
+        `(
+          ts_rank(user.search_vector, plainto_tsquery('simple', :query)) +
+          similarity(coalesce(user.username, ''), :query)
+        )`,
+        'DESC',
+      )
+      .addOrderBy('user.id', 'ASC');
+
+    const [trgmRaw, trgmCount] = await trgmQb.getManyAndCount();
+
+    return [this.mapUsersWithScore(trgmRaw, skip, limit), trgmCount];
   }
+
+  private mapUsersWithScore(
+    raw: (User & { fts_rank?: string; trgm_score?: string; headline?: string })[],
+    skip: number,
+    limit: number,
+  ): UserSearchResult[] {
+    return raw.slice(skip, skip + limit).map((u) => ({
+      id: u.id,
+      username: u.username,
+      stellar_address: u.stellar_address,
+      avatar_url: u.avatar_url,
+      reputation_score: u.reputation_score,
+      total_predictions: u.total_predictions,
+      relevance_score:
+        parseFloat(u.fts_rank ?? '0') + parseFloat(u.trgm_score ?? '0'),
+      highlight: u.headline ?? u.username ?? u.stellar_address,
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Competitions
+  // ---------------------------------------------------------------------------
 
   private async searchCompetitions(
     query: string,
     skip: number,
     limit: number,
-  ): Promise<[Competition[], number]> {
-    return this.competitionsRepository
+  ): Promise<[CompetitionSearchResult[], number]> {
+    const ftsQb = this.competitionsRepository
       .createQueryBuilder('competition')
       .select([
         'competition.id',
@@ -177,6 +404,26 @@ export class SearchService {
         'competition.participant_count',
         'competition.visibility',
       ])
+      .addSelect(
+        `ts_rank(competition.search_vector, plainto_tsquery('english', :query))`,
+        'fts_rank',
+      )
+      .addSelect(
+        `greatest(
+          similarity(competition.title, :query),
+          similarity(coalesce(competition.description, ''), :query)
+        )`,
+        'trgm_score',
+      )
+      .addSelect(
+        `ts_headline(
+          'english',
+          coalesce(competition.title, '') || ' ' || coalesce(competition.description, ''),
+          plainto_tsquery('english', :query),
+          'StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=3'
+        )`,
+        'headline',
+      )
       .where('competition.visibility = :visibility', {
         visibility: CompetitionVisibility.Public,
       })
@@ -184,12 +431,108 @@ export class SearchService {
         `competition.search_vector @@ plainto_tsquery('english', :query)`,
         { query },
       )
+      .setParameter('query', query)
       .orderBy(
         `ts_rank(competition.search_vector, plainto_tsquery('english', :query))`,
         'DESC',
       )
-      .skip(skip)
-      .take(limit)
-      .getManyAndCount();
+      .addOrderBy('competition.id', 'ASC');
+
+    const [ftsRaw, ftsCount] = await ftsQb.getManyAndCount();
+
+    if (ftsCount >= FTS_FALLBACK_THRESHOLD) {
+      return [
+        this.mapCompetitionsWithScore(ftsRaw, skip, limit),
+        ftsCount,
+      ];
+    }
+
+    // Trigram fallback
+    const trgmQb = this.competitionsRepository
+      .createQueryBuilder('competition')
+      .select([
+        'competition.id',
+        'competition.title',
+        'competition.description',
+        'competition.start_time',
+        'competition.end_time',
+        'competition.participant_count',
+        'competition.visibility',
+      ])
+      .addSelect(
+        `ts_rank(competition.search_vector, plainto_tsquery('english', :query))`,
+        'fts_rank',
+      )
+      .addSelect(
+        `greatest(
+          similarity(competition.title, :query),
+          similarity(coalesce(competition.description, ''), :query)
+        )`,
+        'trgm_score',
+      )
+      .addSelect(
+        `ts_headline(
+          'english',
+          coalesce(competition.title, '') || ' ' || coalesce(competition.description, ''),
+          plainto_tsquery('english', :query),
+          'StartSel=<b>, StopSel=</b>, MaxWords=35, MinWords=15, ShortWord=3'
+        )`,
+        'headline',
+      )
+      .where('competition.visibility = :visibility', {
+        visibility: CompetitionVisibility.Public,
+      })
+      .andWhere(
+        `(
+          competition.search_vector @@ plainto_tsquery('english', :query)
+          OR greatest(
+            similarity(competition.title, :query),
+            similarity(coalesce(competition.description, ''), :query)
+          ) >= :trgmThreshold
+        )`,
+        { query, trgmThreshold: TRGM_SIMILARITY_THRESHOLD },
+      )
+      .setParameter('query', query)
+      .orderBy(
+        `(
+          ts_rank(competition.search_vector, plainto_tsquery('english', :query)) +
+          greatest(
+            similarity(competition.title, :query),
+            similarity(coalesce(competition.description, ''), :query)
+          )
+        )`,
+        'DESC',
+      )
+      .addOrderBy('competition.id', 'ASC');
+
+    const [trgmRaw, trgmCount] = await trgmQb.getManyAndCount();
+
+    return [
+      this.mapCompetitionsWithScore(trgmRaw, skip, limit),
+      trgmCount,
+    ];
+  }
+
+  private mapCompetitionsWithScore(
+    raw: (Competition & {
+      fts_rank?: string;
+      trgm_score?: string;
+      headline?: string;
+    })[],
+    skip: number,
+    limit: number,
+  ): CompetitionSearchResult[] {
+    return raw.slice(skip, skip + limit).map((c) => ({
+      id: c.id,
+      title: c.title,
+      description: c.description,
+      start_time: c.start_time,
+      end_time: c.end_time,
+      participant_count: c.participant_count,
+      visibility: c.visibility,
+      relevance_score:
+        parseFloat(c.fts_rank ?? '0') + parseFloat(c.trgm_score ?? '0'),
+      highlight: c.headline ?? c.title,
+    }));
   }
 }


### PR DESCRIPTION
closes ##1307
  
  Summary
  
  Resolves #1307. The search service previously returned zero results for
  queries with typos (e.g. "bitcon" for "bitcoin") and provided no relevance
  ordering or match highlighting. This PR adds trigram-based typo tolerance, a
  combined relevance score, and ts_headline snippet highlighting across all
  three search entity types (markets, users, competitions).
  
  Changes
  
  backend/src/migrations/1776600000000-AddPgTrgmAndTrigramIndexes.ts (new)
  
  - Enables the pg_trgm PostgreSQL extension
  - Adds GIN trigram indexes on markets(title, description), users(username),
  and competitions(title, description) to make similarity queries
  index-accelerated
  backend/src/search/search.service.ts
  
  - Each searchMarkets / searchUsers / searchCompetitions method now runs a fast
  FTS query first
  - If FTS returns fewer than 3 hits (configurable via FTS_FALLBACK_THRESHOLD),
  a second query merges FTS results with trigram similarity results using an OR
  similarity(...) >= threshold condition — catching single-typo queries
  - addSelect computes fts_rank (ts_rank) and trgm_score (similarity) as virtual
  columns alongside each query
  - addSelect also computes a ts_headline snippet per row with <b> highlight
  - Private mapXxxWithScore() helpers map raw TypeORM results into the typed
  DTOs, combining the two scores into a single relevance_score and providing a
  headline fallback to the entity title if ts_headline returns null
  - Deterministic ordering: primary ORDER BY combined_score DESC, secondary
  ORDER BY id ASC
  
  backend/src/search/dto/global-search.dto.ts
  
  - MarketSearchResult, UserSearchResult, CompetitionSearchResult each gain two
  new fields:
    - relevance_score: number — combined FTS rank + trigram similarity
    - highlight: string — matched-term snippet with <b>...</b> tags,
  Swagger-documented
  
  backend/src/search/search.service.spec.ts
  
  - MockQb type extended with addOrderBy and a configurable count parameter
  - Mock entity fixtures carry fts_rank, trgm_score, and headline virtual
  properties
  - New test groups cover: mapped DTO fields (relevance_score, highlight), the
  trigram fallback path (verifies getManyAndCount called twice when FTS count <
  threshold), fallback andWhere containing similarity(...), combined score
  ordering, and headline fallback to title
  
  How it works
  
  query → FTS (plainto_tsquery)
           ↓ count ≥ 3?
           YES → return FTS results ranked by ts_rank
           NO  → re-query with OR similarity ≥ 0.1
                  → results ordered by (ts_rank + similarity) DESC
                  → each result carries ts_headline snippet
  
  Testing
  
  - pnpm run build passes with no TypeScript errors
  - Unit tests in search.service.spec.ts cover the FTS path, trigram fallback
  path, combined scoring, and highlight fallback
  
  Notes
  
  - The pg_trgm extension requires superuser or CREATE EXTENSION privilege on
  the database. The migration's down() intentionally does not drop the extension
  as other parts of the schema may rely on it.
  - TRGM_SIMILARITY_THRESHOLD (0.1) and FTS_FALLBACK_THRESHOLD (3) are named
  constants at the top of the service and can be tuned without touching query
  logic.
