### PR TITLE
feat : Volatility-Adjusted Dynamic AMM Fee Tiers

### DIFF
--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -26,9 +26,9 @@ pub use crate::liquidity::{calculate_liquidity_value, calculate_lp_tokens, calcu
 pub use crate::market::CreateMarketParams;
 pub use crate::storage_types::{
     ConditionalChain, ConditionalMarket, CreatorLeaderboardEntry, CreatorStats, DataKey, Dispute,
-    Event, EventMatch, EventPrediction, InviteCode, LPPosition, LeaderboardEntry,
-    LeaderboardSnapshot, LiquidityPool, Market, MarketStats, PlatformStats, Prediction, Season,
-    SwapRecord, UserProfile, Winner,
+    Event, EventMatch, EventPrediction, FeeTier, FeeTierConfig, InviteCode, LPPosition,
+    LeaderboardEntry, LeaderboardSnapshot, LiquidityPool, Market, MarketFeeInfo, MarketStats,
+    PlatformStats, Prediction, Season, SwapRecord, UserProfile, VolatilityState, Winner,
 };
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
@@ -653,5 +653,29 @@ impl InsightArenaContract {
         market_id: u64,
     ) -> Result<i128, InsightArenaError> {
         liquidity::collect_lp_fees(&env, provider, market_id)
+    }
+
+    // ── Dynamic Swap Fee ──────────────────────────────────────────────────────
+
+    /// Return the current dynamic fee tier and effective swap fee for a market.
+    pub fn get_market_fee_info(
+        env: Env,
+        market_id: u64,
+    ) -> Result<crate::storage_types::MarketFeeInfo, InsightArenaError> {
+        liquidity::get_market_fee_info(&env, market_id)
+    }
+
+    /// Return the current admin-configured volatility fee tier schedule.
+    pub fn get_fee_tier_config(env: Env) -> crate::storage_types::FeeTierConfig {
+        liquidity::get_fee_tier_config(&env)
+    }
+
+    /// Update the volatility fee tier schedule. Caller must be the platform admin.
+    pub fn update_fee_tier_config(
+        env: Env,
+        admin: Address,
+        new_config: crate::storage_types::FeeTierConfig,
+    ) -> Result<(), InsightArenaError> {
+        liquidity::set_fee_tier_config(&env, admin, new_config)
     }
 }

--- a/contracts/open-market/src/liquidity.rs
+++ b/contracts/open-market/src/liquidity.rs
@@ -4,7 +4,10 @@ use crate::config::{self, PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
 use crate::errors::InsightArenaError;
 use crate::escrow;
 use crate::market;
-use crate::storage_types::{DataKey, LPPosition, LiquidityPool, SwapRecord};
+use crate::storage_types::{
+    DataKey, FeeTier, FeeTierConfig, LPPosition, LiquidityPool, MarketFeeInfo, SwapRecord,
+    VolatilityState,
+};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -13,6 +16,11 @@ pub const MIN_LIQUIDITY: i128 = 1000;
 
 /// Default trading fee in basis points (0.3% = 30 bps).
 pub const DEFAULT_FEE_BPS: u32 = 30;
+
+/// Smoothing factor (bps) applied to each new price-move sample when updating
+/// the rolling volatility EMA. Higher values make the measure more reactive
+/// to recent swaps; lower values smooth it out over a longer window.
+pub const VOLATILITY_ALPHA_BPS: u32 = 2000;
 
 // ── AMM Math Functions ────────────────────────────────────────────────────────
 
@@ -53,6 +61,203 @@ pub fn calculate_swap_output(
         .ok_or(InsightArenaError::Overflow)?;
 
     Ok(amount_out_with_fee)
+}
+
+// ── Dynamic Fee / Volatility Math ─────────────────────────────────────────────
+
+/// Compute the traded-pair reserve ratio in bps: `reserve_a * 10_000 / (reserve_a + reserve_b)`.
+/// Used as the "price" sample for volatility tracking. Range is `[0, 10_000]`.
+pub fn compute_price_bps(reserve_a: i128, reserve_b: i128) -> Result<u32, InsightArenaError> {
+    let total = reserve_a
+        .checked_add(reserve_b)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    if total <= 0 || reserve_a < 0 || reserve_b < 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    let bps = reserve_a
+        .checked_mul(10_000)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(total)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    Ok(bps as u32)
+}
+
+/// Blend a new price-move sample (bps) into the previous EMA (bps) using `alpha_bps`
+/// as the smoothing weight: `ema' = (ema * (10_000 - alpha) + sample * alpha) / 10_000`.
+pub fn compute_ema(prev_ema_bps: u32, sample_bps: u32, alpha_bps: u32) -> u32 {
+    let prev = prev_ema_bps as u64;
+    let sample = sample_bps as u64;
+    let alpha = (alpha_bps as u64).min(10_000);
+
+    let blended = prev
+        .saturating_mul(10_000u64.saturating_sub(alpha))
+        .saturating_add(sample.saturating_mul(alpha))
+        / 10_000;
+
+    blended.min(u32::MAX as u64) as u32
+}
+
+/// Classify a rolling volatility measure (bps) into a fee tier using admin-configured thresholds.
+pub fn determine_fee_tier(ema_bps: u32, cfg: &FeeTierConfig) -> FeeTier {
+    if ema_bps <= cfg.calm_threshold_bps {
+        FeeTier::Calm
+    } else if ema_bps <= cfg.volatile_threshold_bps {
+        FeeTier::Normal
+    } else {
+        FeeTier::Volatile
+    }
+}
+
+/// Look up the swap fee (bps) configured for a given tier.
+pub fn fee_bps_for_tier(tier: &FeeTier, cfg: &FeeTierConfig) -> u32 {
+    match tier {
+        FeeTier::Calm => cfg.calm_fee_bps,
+        FeeTier::Normal => cfg.normal_fee_bps,
+        FeeTier::Volatile => cfg.volatile_fee_bps,
+    }
+}
+
+fn validate_fee_tier_config(cfg: &FeeTierConfig) -> Result<(), InsightArenaError> {
+    if cfg.calm_threshold_bps >= cfg.volatile_threshold_bps {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    if cfg.calm_fee_bps > 10_000 || cfg.normal_fee_bps > 10_000 || cfg.volatile_fee_bps > 10_000 {
+        return Err(InsightArenaError::InvalidFee);
+    }
+
+    if cfg.calm_fee_bps > cfg.normal_fee_bps || cfg.normal_fee_bps > cfg.volatile_fee_bps {
+        return Err(InsightArenaError::InvalidFee);
+    }
+
+    if cfg.protocol_share_bps > 10_000 {
+        return Err(InsightArenaError::InvalidFee);
+    }
+
+    Ok(())
+}
+
+fn bump_fee_tier_config(env: &Env) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::FeeTierConfig,
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
+fn bump_volatility_state(env: &Env, market_id: u64) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::VolatilityState(market_id),
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+}
+
+/// Return the current admin-configured fee tier schedule, or built-in defaults
+/// if the admin has never customised it.
+pub fn get_fee_tier_config(env: &Env) -> FeeTierConfig {
+    if env.storage().persistent().has(&DataKey::FeeTierConfig) {
+        bump_fee_tier_config(env);
+    }
+    env.storage()
+        .persistent()
+        .get(&DataKey::FeeTierConfig)
+        .unwrap_or_else(FeeTierConfig::default_config)
+}
+
+/// Update the fee tier schedule. Caller must be the platform admin.
+pub fn set_fee_tier_config(
+    env: &Env,
+    admin: Address,
+    new_config: FeeTierConfig,
+) -> Result<(), InsightArenaError> {
+    admin.require_auth();
+
+    let cfg = config::get_config(env)?;
+    if admin != cfg.admin {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    validate_fee_tier_config(&new_config)?;
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::FeeTierConfig, &new_config);
+    bump_fee_tier_config(env);
+
+    Ok(())
+}
+
+fn get_volatility_state(env: &Env, market_id: u64) -> VolatilityState {
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::VolatilityState(market_id))
+    {
+        bump_volatility_state(env, market_id);
+    }
+    env.storage()
+        .persistent()
+        .get(&DataKey::VolatilityState(market_id))
+        .unwrap_or_else(|| VolatilityState::empty(market_id))
+}
+
+fn save_volatility_state(env: &Env, state: &VolatilityState) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::VolatilityState(state.market_id), state);
+    bump_volatility_state(env, state.market_id);
+}
+
+/// Record a swap's effect on the traded pair's reserve ratio and roll it into
+/// the market's volatility EMA. `new_from_reserve`/`new_to_reserve` must be the
+/// pool reserves *after* the swap has been applied.
+fn update_volatility_state(
+    env: &Env,
+    market_id: u64,
+    prev: &VolatilityState,
+    new_from_reserve: i128,
+    new_to_reserve: i128,
+) -> Result<VolatilityState, InsightArenaError> {
+    let new_price_bps = compute_price_bps(new_from_reserve, new_to_reserve)?;
+
+    let new_ema_bps = if prev.sample_count == 0 {
+        0
+    } else {
+        let delta_bps = new_price_bps.abs_diff(prev.last_price_bps);
+        compute_ema(prev.ema_bps, delta_bps, VOLATILITY_ALPHA_BPS)
+    };
+
+    let state = VolatilityState {
+        market_id,
+        ema_bps: new_ema_bps,
+        last_price_bps: new_price_bps,
+        last_updated: env.ledger().timestamp(),
+        sample_count: prev.sample_count.saturating_add(1),
+    };
+
+    save_volatility_state(env, &state);
+    Ok(state)
+}
+
+/// Return the current dynamic fee tier and effective swap fee for a market.
+pub fn get_market_fee_info(env: &Env, market_id: u64) -> Result<MarketFeeInfo, InsightArenaError> {
+    market::get_market(env, market_id)?;
+
+    let tier_config = get_fee_tier_config(env);
+    let volatility = get_volatility_state(env, market_id);
+    let tier = determine_fee_tier(volatility.ema_bps, &tier_config);
+    let effective_fee_bps = fee_bps_for_tier(&tier, &tier_config);
+
+    Ok(MarketFeeInfo {
+        market_id,
+        tier,
+        effective_fee_bps,
+        volatility_ema_bps: volatility.ema_bps,
+    })
 }
 
 // ── Helper Functions ──────────────────────────────────────────────────────────
@@ -330,36 +535,65 @@ pub fn swap_outcome(
         .get(to_outcome.clone())
         .ok_or(InsightArenaError::InvalidOutcome)?;
 
-    let amount_out = calculate_swap_output(amount_in, from_reserve, to_reserve, pool.fee_bps)?;
+    // Fee tier is derived from volatility observed *before* this swap, so a
+    // trade cannot influence the fee rate it itself pays.
+    let tier_config = get_fee_tier_config(env);
+    let volatility_before = get_volatility_state(env, market_id);
+    let tier = determine_fee_tier(volatility_before.ema_bps, &tier_config);
+    let effective_fee_bps = fee_bps_for_tier(&tier, &tier_config);
+
+    let amount_out = calculate_swap_output(amount_in, from_reserve, to_reserve, effective_fee_bps)?;
 
     if amount_out < min_amount_out {
         return Err(InsightArenaError::InvalidInput);
     }
 
     let fee_amount = amount_in
-        .checked_mul(pool.fee_bps as i128)
+        .checked_mul(effective_fee_bps as i128)
         .ok_or(InsightArenaError::Overflow)?
         .checked_div(10_000)
         .ok_or(InsightArenaError::Overflow)?;
 
+    // Split the fee between the protocol treasury and liquidity providers.
+    // `lp_fee_share` is derived by subtraction so the two shares always sum
+    // to `fee_amount` exactly, with no stroop lost or double-counted.
+    let protocol_fee_share = fee_amount
+        .checked_mul(tier_config.protocol_share_bps as i128)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(10_000)
+        .ok_or(InsightArenaError::Overflow)?;
+    let lp_fee_share = fee_amount
+        .checked_sub(protocol_fee_share)
+        .ok_or(InsightArenaError::Overflow)?;
+
     escrow::lock_stake(env, &trader, amount_in)?;
 
-    pool.outcome_reserves.set(
-        from_outcome.clone(),
-        from_reserve
-            .checked_add(amount_in)
-            .ok_or(InsightArenaError::Overflow)?,
-    );
-    pool.outcome_reserves.set(
-        to_outcome.clone(),
-        to_reserve
-            .checked_sub(amount_out)
-            .ok_or(InsightArenaError::Overflow)?,
-    );
+    let new_from_reserve = from_reserve
+        .checked_add(amount_in)
+        .ok_or(InsightArenaError::Overflow)?;
+    let new_to_reserve = to_reserve
+        .checked_sub(amount_out)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    pool.outcome_reserves
+        .set(from_outcome.clone(), new_from_reserve);
+    pool.outcome_reserves.set(to_outcome.clone(), new_to_reserve);
+    pool.fee_bps = effective_fee_bps;
 
     save_pool(env, &pool);
 
-    distribute_fees_to_lps(env, market_id, fee_amount)?;
+    update_volatility_state(
+        env,
+        market_id,
+        &volatility_before,
+        new_from_reserve,
+        new_to_reserve,
+    )?;
+
+    distribute_fees_to_lps(env, market_id, lp_fee_share)?;
+    if protocol_fee_share > 0 {
+        escrow::add_to_treasury_balance(env, protocol_fee_share);
+    }
 
     let record = SwapRecord::new(
         trader,

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -70,6 +70,10 @@ pub enum DataKey {
     SwapHistory(u64),
     /// Keyed by market_id. Stores rolling 24h pool volume.
     PoolVolume(u64),
+    /// Keyed by market_id. Stores the rolling volatility measure used to derive the dynamic swap fee tier.
+    VolatilityState(u64),
+    /// Singleton. Admin-configurable thresholds and fee rates for the volatility-tiered swap fee schedule.
+    FeeTierConfig,
 
     // Conditional Market keys
     ConditionalMarket(u64),   // market_id -> ConditionalMarket
@@ -385,6 +389,94 @@ impl SwapRecord {
             timestamp,
         }
     }
+}
+
+// ── Dynamic Fee / Volatility Types ────────────────────────────────────────────
+
+/// Rolling record of recent price movement for a single market's AMM pool.
+/// Updated on every swap; used to derive the current [`FeeTier`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct VolatilityState {
+    pub market_id: u64,
+    /// Exponentially-weighted moving average of recent per-swap price moves,
+    /// expressed in bps of the traded pair's reserve ratio (0-10000).
+    pub ema_bps: u32,
+    /// The traded-pair reserve ratio (in bps) observed after the most recent swap.
+    /// Used as the reference point to measure the next swap's price delta.
+    pub last_price_bps: u32,
+    /// Ledger timestamp of the most recent update.
+    pub last_updated: u64,
+    /// Total number of swaps that have contributed to this rolling measure.
+    /// Zero means no swap has occurred yet, so `ema_bps`/`last_price_bps` are not yet meaningful.
+    pub sample_count: u32,
+}
+
+impl VolatilityState {
+    pub fn empty(market_id: u64) -> Self {
+        Self {
+            market_id,
+            ema_bps: 0,
+            last_price_bps: 0,
+            last_updated: 0,
+            sample_count: 0,
+        }
+    }
+}
+
+/// The current dynamic-fee tier for a market, derived from its rolling volatility measure.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FeeTier {
+    Calm,
+    Normal,
+    Volatile,
+}
+
+/// Admin-configurable thresholds and per-tier fee rates driving the dynamic swap fee,
+/// plus the split of every collected fee between liquidity providers and the protocol treasury.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeTierConfig {
+    /// Inclusive upper bound (bps) of rolling volatility for the "calm" tier.
+    pub calm_threshold_bps: u32,
+    /// Inclusive upper bound (bps) of rolling volatility for the "normal" tier.
+    /// Anything above this threshold is classified "volatile". Must be strictly
+    /// greater than `calm_threshold_bps`.
+    pub volatile_threshold_bps: u32,
+    /// Swap fee (bps) applied while in the "calm" tier.
+    pub calm_fee_bps: u32,
+    /// Swap fee (bps) applied while in the "normal" tier.
+    pub normal_fee_bps: u32,
+    /// Swap fee (bps) applied while in the "volatile" tier.
+    pub volatile_fee_bps: u32,
+    /// Share of every collected swap fee routed to the protocol treasury, in bps
+    /// of the fee itself (0-10000). The remainder is credited to liquidity providers.
+    pub protocol_share_bps: u32,
+}
+
+impl FeeTierConfig {
+    /// Sensible defaults used whenever no admin-configured schedule has been stored yet.
+    pub fn default_config() -> Self {
+        Self {
+            calm_threshold_bps: 50,
+            volatile_threshold_bps: 200,
+            calm_fee_bps: 15,
+            normal_fee_bps: 30,
+            volatile_fee_bps: 100,
+            protocol_share_bps: 2000,
+        }
+    }
+}
+
+/// Read-only view of a market's current dynamic fee state, returned by `get_market_fee_info`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MarketFeeInfo {
+    pub market_id: u64,
+    pub tier: FeeTier,
+    pub effective_fee_bps: u32,
+    pub volatility_ema_bps: u32,
 }
 
 #[contracttype]

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -11,7 +11,8 @@
 
 use insightarena_contract::liquidity::*;
 use insightarena_contract::{
-    CreateMarketParams, InsightArenaContract, InsightArenaContractClient, InsightArenaError,
+    CreateMarketParams, FeeTier, FeeTierConfig, InsightArenaContract, InsightArenaContractClient,
+    InsightArenaError,
 };
 use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
@@ -1736,4 +1737,429 @@ fn test_remove_liquidity_returns_principal_plus_accumulated_fees() {
     // Verify provider's LPPosition no longer exists
     let position_result = client.try_get_lp_position(&provider, &market_id);
     assert!(position_result.is_err(), "LPPosition should not exist after full removal");
+}
+
+// ── Dynamic Fee: Volatility Math (Unit Tests) ─────────────────────────────────
+
+#[test]
+fn test_compute_price_bps_equal_reserves() {
+    assert_eq!(compute_price_bps(500, 500).unwrap(), 5000);
+}
+
+#[test]
+fn test_compute_price_bps_skewed_reserves() {
+    assert_eq!(compute_price_bps(9000, 1000).unwrap(), 9000);
+    assert_eq!(compute_price_bps(1000, 9000).unwrap(), 1000);
+}
+
+#[test]
+fn test_compute_price_bps_extremes() {
+    assert_eq!(compute_price_bps(100, 0).unwrap(), 10_000);
+    assert_eq!(compute_price_bps(0, 100).unwrap(), 0);
+}
+
+#[test]
+fn test_compute_price_bps_zero_reserves_fails() {
+    let result = compute_price_bps(0, 0);
+    assert_eq!(result, Err(InsightArenaError::InvalidInput));
+}
+
+#[test]
+fn test_compute_ema_zero_alpha_keeps_previous() {
+    // alpha = 0 -> the new sample has no effect.
+    assert_eq!(compute_ema(300, 9000, 0), 300);
+}
+
+#[test]
+fn test_compute_ema_full_alpha_takes_sample() {
+    // alpha = 10_000 (100%) -> EMA becomes the new sample exactly.
+    assert_eq!(compute_ema(300, 9000, 10_000), 9000);
+}
+
+#[test]
+fn test_compute_ema_partial_blend() {
+    // prev = 0, sample = 1000, alpha = 2000 (20%) -> (0*8000 + 1000*2000) / 10000 = 200
+    assert_eq!(compute_ema(0, 1000, 2000), 200);
+    // prev = 200, sample = 0, alpha = 2000 -> (200*8000 + 0) / 10000 = 160
+    assert_eq!(compute_ema(200, 0, 2000), 160);
+}
+
+#[test]
+fn test_determine_fee_tier_boundaries_are_exact() {
+    let cfg = FeeTierConfig::default_config();
+    assert_eq!(cfg.calm_threshold_bps, 50);
+    assert_eq!(cfg.volatile_threshold_bps, 200);
+
+    // Exactly at the calm boundary is still calm.
+    assert_eq!(determine_fee_tier(0, &cfg), FeeTier::Calm);
+    assert_eq!(determine_fee_tier(50, &cfg), FeeTier::Calm);
+    // One bps past calm tips into normal.
+    assert_eq!(determine_fee_tier(51, &cfg), FeeTier::Normal);
+    // Exactly at the volatile boundary is still normal.
+    assert_eq!(determine_fee_tier(200, &cfg), FeeTier::Normal);
+    // One bps past that tips into volatile.
+    assert_eq!(determine_fee_tier(201, &cfg), FeeTier::Volatile);
+    assert_eq!(determine_fee_tier(10_000, &cfg), FeeTier::Volatile);
+}
+
+#[test]
+fn test_fee_bps_for_tier_matches_config() {
+    let cfg = FeeTierConfig::default_config();
+    assert_eq!(fee_bps_for_tier(&FeeTier::Calm, &cfg), cfg.calm_fee_bps);
+    assert_eq!(fee_bps_for_tier(&FeeTier::Normal, &cfg), cfg.normal_fee_bps);
+    assert_eq!(
+        fee_bps_for_tier(&FeeTier::Volatile, &cfg),
+        cfg.volatile_fee_bps
+    );
+}
+
+// ── Dynamic Fee: Admin Configuration ──────────────────────────────────────────
+
+fn custom_fee_tier_config() -> FeeTierConfig {
+    FeeTierConfig {
+        calm_threshold_bps: 100,
+        volatile_threshold_bps: 500,
+        calm_fee_bps: 10,
+        normal_fee_bps: 50,
+        volatile_fee_bps: 200,
+        protocol_share_bps: 3000,
+    }
+}
+
+#[test]
+fn test_get_fee_tier_config_defaults_when_unset() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _xlm_token) = deploy_with_token(&env);
+
+    let cfg = client.get_fee_tier_config();
+    let expected = FeeTierConfig::default_config();
+    assert_eq!(cfg.calm_threshold_bps, expected.calm_threshold_bps);
+    assert_eq!(cfg.volatile_threshold_bps, expected.volatile_threshold_bps);
+    assert_eq!(cfg.calm_fee_bps, expected.calm_fee_bps);
+    assert_eq!(cfg.normal_fee_bps, expected.normal_fee_bps);
+    assert_eq!(cfg.volatile_fee_bps, expected.volatile_fee_bps);
+    assert_eq!(cfg.protocol_share_bps, expected.protocol_share_bps);
+}
+
+#[test]
+fn test_update_fee_tier_config_persists_new_values() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, _xlm_token) = deploy_with_token(&env);
+
+    let new_config = custom_fee_tier_config();
+    client.update_fee_tier_config(&admin, &new_config);
+
+    let stored = client.get_fee_tier_config();
+    assert_eq!(stored.calm_threshold_bps, 100);
+    assert_eq!(stored.volatile_threshold_bps, 500);
+    assert_eq!(stored.calm_fee_bps, 10);
+    assert_eq!(stored.normal_fee_bps, 50);
+    assert_eq!(stored.volatile_fee_bps, 200);
+    assert_eq!(stored.protocol_share_bps, 3000);
+}
+
+#[test]
+fn test_update_fee_tier_config_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _xlm_token) = deploy_with_token(&env);
+
+    let not_admin = Address::generate(&env);
+    let new_config = custom_fee_tier_config();
+
+    let result = client.try_update_fee_tier_config(&not_admin, &new_config);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+#[test]
+fn test_update_fee_tier_config_rejects_inverted_thresholds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, _xlm_token) = deploy_with_token(&env);
+
+    let mut bad_config = FeeTierConfig::default_config();
+    bad_config.calm_threshold_bps = 500;
+    bad_config.volatile_threshold_bps = 500; // must be strictly greater than calm
+
+    let result = client.try_update_fee_tier_config(&admin, &bad_config);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn test_update_fee_tier_config_rejects_non_monotonic_fees() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, _xlm_token) = deploy_with_token(&env);
+
+    let mut bad_config = FeeTierConfig::default_config();
+    bad_config.calm_fee_bps = 200; // higher than normal_fee_bps
+
+    let result = client.try_update_fee_tier_config(&admin, &bad_config);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidFee))));
+}
+
+#[test]
+fn test_update_fee_tier_config_rejects_invalid_protocol_share() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, _xlm_token) = deploy_with_token(&env);
+
+    let mut bad_config = FeeTierConfig::default_config();
+    bad_config.protocol_share_bps = 10_001;
+
+    let result = client.try_update_fee_tier_config(&admin, &bad_config);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidFee))));
+}
+
+// ── Dynamic Fee: End-to-End Swap Behaviour ────────────────────────────────────
+
+#[test]
+fn test_market_fee_info_defaults_to_calm_before_any_swap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let info = client.get_market_fee_info(&market_id);
+    assert_eq!(info.tier, FeeTier::Calm);
+    assert_eq!(info.volatility_ema_bps, 0);
+    assert_eq!(info.effective_fee_bps, FeeTierConfig::default_config().calm_fee_bps);
+}
+
+#[test]
+fn test_price_moving_swap_burst_raises_fee_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    // Balanced pool: 500_000 / 500_000 reserves.
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 500_000_i128;
+    sa.mint(&trader, &(swap_amount * 5));
+    token.approve(&trader, &client.address, &(swap_amount * 5), &9999);
+
+    // Swap 1: pool has no prior sample, so the EMA stays at 0 (still calm).
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+    assert_eq!(client.get_market_fee_info(&market_id).tier, FeeTier::Calm);
+
+    // Swap 2: a large same-direction trade moves the price sharply -> tier rises to normal.
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+    assert_eq!(client.get_market_fee_info(&market_id).tier, FeeTier::Normal);
+
+    // Swap 3: another large same-direction trade -> tier rises to volatile.
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+    let info_after_3 = client.get_market_fee_info(&market_id);
+    assert_eq!(info_after_3.tier, FeeTier::Volatile);
+    assert_eq!(
+        info_after_3.effective_fee_bps,
+        FeeTierConfig::default_config().volatile_fee_bps
+    );
+
+    // Two more bursts stay in the volatile tier.
+    for _ in 0..2 {
+        client.swap_outcome(
+            &trader,
+            &market_id,
+            &symbol_short!("yes"),
+            &symbol_short!("no"),
+            &swap_amount,
+            &0_i128,
+        );
+    }
+    assert_eq!(client.get_market_fee_info(&market_id).tier, FeeTier::Volatile);
+}
+
+#[test]
+fn test_quiet_period_lowers_fee_tier_back_to_calm() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let burst_amount = 500_000_i128;
+    let quiet_amount = 10_i128;
+    let quiet_swaps = 7_u32;
+
+    sa.mint(&trader, &(burst_amount * 5 + quiet_amount * quiet_swaps as i128));
+    token.approve(
+        &trader,
+        &client.address,
+        &(burst_amount * 5 + quiet_amount * quiet_swaps as i128),
+        &9999,
+    );
+
+    // Drive the market into the volatile tier with a burst of large same-direction swaps.
+    for _ in 0..5 {
+        client.swap_outcome(
+            &trader,
+            &market_id,
+            &symbol_short!("yes"),
+            &symbol_short!("no"),
+            &burst_amount,
+            &0_i128,
+        );
+    }
+    assert_eq!(client.get_market_fee_info(&market_id).tier, FeeTier::Volatile);
+
+    // A quiet period of tiny swaps should decay the EMA back down.
+    for _ in 0..quiet_swaps {
+        client.swap_outcome(
+            &trader,
+            &market_id,
+            &symbol_short!("yes"),
+            &symbol_short!("no"),
+            &quiet_amount,
+            &0_i128,
+        );
+    }
+
+    let info = client.get_market_fee_info(&market_id);
+    assert_eq!(info.tier, FeeTier::Calm);
+    assert_eq!(
+        info.effective_fee_bps,
+        FeeTierConfig::default_config().calm_fee_bps
+    );
+}
+
+#[test]
+fn test_dynamic_fee_split_between_lp_and_protocol_treasury_is_conserved() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    // First swap: pool starts in the calm tier (default 15 bps fee).
+    let info_before = client.get_market_fee_info(&market_id);
+    assert_eq!(info_before.tier, FeeTier::Calm);
+    let fee_bps = info_before.effective_fee_bps;
+
+    let swap_amount = 1_000_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    let treasury_before = client.get_treasury_balance();
+    let lp_fees_before = client.get_lp_position(&provider, &market_id).fees_earned;
+
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let treasury_after = client.get_treasury_balance();
+    let lp_fees_after = client.get_lp_position(&provider, &market_id).fees_earned;
+
+    let expected_total_fee = swap_amount * fee_bps as i128 / 10_000;
+    let protocol_share = treasury_after - treasury_before;
+    let lp_share = lp_fees_after - lp_fees_before;
+
+    assert!(expected_total_fee > 0);
+    // LP share + protocol share reconstructs the total fee exactly, to the last stroop.
+    assert_eq!(protocol_share + lp_share, expected_total_fee);
+
+    let cfg = FeeTierConfig::default_config();
+    let expected_protocol_share = expected_total_fee * cfg.protocol_share_bps as i128 / 10_000;
+    assert_eq!(protocol_share, expected_protocol_share);
+    assert_eq!(lp_share, expected_total_fee - expected_protocol_share);
+}
+
+#[test]
+fn test_swap_history_records_effective_fee_paid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 1_000_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    let fee_bps = client.get_market_fee_info(&market_id).effective_fee_bps;
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let history = client.get_swap_history(&market_id);
+    let record = history.get(0).unwrap();
+    let expected_fee = swap_amount * fee_bps as i128 / 10_000;
+    assert_eq!(record.fee_paid, expected_fee);
 }


### PR DESCRIPTION


Replaces the AMM's flat swap fee with a volatility-tiered dynamic fee, so LPs are better compensated during volatile periods and traders pay less during calm ones.

closes #1308 

- Tracks a rolling EMA of recent price movement per market (`VolatilityState` in `storage_types.rs`), updated on every swap.
- Derives the effective swap fee from an admin-configurable tiered schedule — calm / normal / volatile (`FeeTierConfig`) — based on that rolling measure.
- `swap_outcome` now prices each trade off the volatility observed *before* it (so a swap can't discount its own fee), then splits the collected fee between liquidity providers and the protocol treasury.
- Adds a read-only `get_market_fee_info` entry point exposing a market's current tier, effective fee, and volatility EMA.
- Adds admin entry points `get_fee_tier_config` / `update_fee_tier_config`, gated on the platform admin with input validation.

## Changes

**`contracts/open-market/src/storage_types.rs`**
- `VolatilityState`: per-market rolling EMA of price movement (`ema_bps`, `last_price_bps`, `sample_count`, `last_updated`).
- `FeeTier`: `Calm` / `Normal` / `Volatile`.
- `FeeTierConfig`: admin-configurable `calm_threshold_bps`, `volatile_threshold_bps`, per-tier fee rates, and `protocol_share_bps` (the split between LPs and treasury). Ships with sane defaults (`FeeTierConfig::default_config()`).
- `MarketFeeInfo`: read view returned by `get_market_fee_info`.
- Two new `DataKey` variants: `VolatilityState(u64)`, `FeeTierConfig`.

**`contracts/open-market/src/liquidity.rs`**
- Pure math helpers (independently unit-tested): `compute_price_bps`, `compute_ema`, `determine_fee_tier`, `fee_bps_for_tier`.
- `get_fee_tier_config` / `set_fee_tier_config`: lazily defaults until the admin customizes it; `set_fee_tier_config` requires admin auth and validates thresholds are strictly ordered, fees are monotonic (calm ≤ normal ≤ volatile) and ≤ 10,000 bps, and `protocol_share_bps` ≤ 10,000.
- `swap_outcome`: looks up the tier from the pre-trade `VolatilityState`, computes the effective fee, splits it into `protocol_fee_share` and `lp_fee_share` (the latter derived by subtraction so the two always sum exactly to the total fee — no stroop lost or double-counted), credits LPs as before, and routes the protocol share to the treasury via `escrow::add_to_treasury_balance`. Updates the market's `VolatilityState` from the post-trade reserves.
- `get_market_fee_info`: new read-only entry point.

**`contracts/open-market/src/lib.rs`**
- Exposes `get_market_fee_info`, `get_fee_tier_config`, `update_fee_tier_config`.
- Re-exports `FeeTier`, `FeeTierConfig`, `MarketFeeInfo`, `VolatilityState`.

**`contracts/open-market/tests/liquidity_tests.rs`**
- Unit tests for the volatility/tier math, including exact boundary checks (e.g. EMA of exactly `calm_threshold_bps` stays calm, one bps over tips to normal).
- Admin-config tests: defaults when unset, persistence after update, rejection of unauthorized callers, inverted thresholds, non-monotonic fees, and out-of-range protocol share.
- End-to-end integration tests: a burst of large same-direction swaps raises the tier Calm → Normal → Volatile; a subsequent quiet period of tiny swaps decays the EMA back to Calm; fee accounting is conserved (LP share + protocol share reconstructs the total fee to the last stroop, matching the configured split); swap history records the effective fee paid.



