### PR TITLE
test(open-market): batch payout distribution edge cases + pool accounting fix

### DIFF
--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
+use soroban_sdk::{symbol_short, Address, Env, Map, Symbol, Vec};
 
 use crate::config::{self, PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
 use crate::errors::InsightArenaError;
@@ -595,6 +595,17 @@ pub fn claim_payout(
 /// Batch distribute payouts for all unclaimed winning predictions in a resolved
 /// market. Callable only by admin or oracle.
 ///
+/// Iterates the market's predictor list and pays every winning prediction that
+/// has not been claimed yet. Losing predictions, predictions already claimed
+/// (individually via `claim_payout` or by a previous batch), and duplicate
+/// list entries are skipped without aborting the batch. Payout amounts are
+/// identical to what `claim_payout` would pay: the winning pool is computed
+/// over every winning stake — including already-claimed ones, whose records
+/// live in temporary storage — so entitlements do not depend on claim order,
+/// and each unique address is counted once.
+///
+/// At most 25 payouts are processed per invocation; call again to continue.
+///
 /// Returns the number of payouts processed in this invocation.
 pub fn batch_distribute_payouts(
     env: &Env,
@@ -624,18 +635,45 @@ pub fn batch_distribute_payouts(
         .clone()
         .ok_or(InsightArenaError::MarketNotResolved)?;
 
-    let predictions = list_market_predictions(env, market_id);
-    if predictions.is_empty() {
+    // Read the predictor list directly rather than via list_market_predictions:
+    // claimed predictions move to temporary storage, and the pool math below
+    // must see them (exactly as claim_payout does) or an already-claimed
+    // winning stake would be miscounted as loser pool and inflate the
+    // remaining winners' payouts.
+    let predictors: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::PredictorList(market_id))
+        .unwrap_or_else(|| Vec::new(env));
+
+    if predictors.is_empty() {
         emit_batch_payout_complete(env, market_id, &caller, 0);
         return Ok(0);
     }
+    bump_predictor_list(env, market_id);
 
+    // Each unique address contributes its winning stake exactly once, no
+    // matter how many times it appears in the list.
+    let mut seen: Map<Address, bool> = Map::new(env);
     let mut winning_pool: i128 = 0;
-    for prediction in predictions.iter() {
-        if prediction.chosen_outcome == resolved_outcome {
-            winning_pool = winning_pool
-                .checked_add(prediction.stake_amount)
-                .ok_or(InsightArenaError::Overflow)?;
+    for address in predictors.iter() {
+        if seen.contains_key(address.clone()) {
+            continue;
+        }
+        seen.set(address.clone(), true);
+
+        let key = DataKey::Prediction(market_id, address.clone());
+        if let Some(item) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Prediction>(&key)
+            .or_else(|| env.storage().temporary().get::<DataKey, Prediction>(&key))
+        {
+            if item.chosen_outcome == resolved_outcome {
+                winning_pool = winning_pool
+                    .checked_add(item.stake_amount)
+                    .ok_or(InsightArenaError::Overflow)?;
+            }
         }
     }
 
@@ -652,23 +690,28 @@ pub fn batch_distribute_payouts(
     const MAX_BATCH_PAYOUTS: u32 = 25;
     let mut processed: u32 = 0;
 
-    for prediction in predictions.iter() {
+    for address in predictors.iter() {
         if processed >= MAX_BATCH_PAYOUTS {
             break;
         }
 
-        if prediction.chosen_outcome != resolved_outcome || prediction.payout_claimed {
-            continue;
-        }
-
-        let prediction_key = DataKey::Prediction(market_id, prediction.predictor.clone());
-        let mut stored_prediction: Prediction = env
+        let prediction_key = DataKey::Prediction(market_id, address.clone());
+        // Claimed predictions live in temporary storage; loading from both
+        // stores lets the payout_claimed flag skip them (and any duplicate
+        // list entry) instead of aborting the batch. A missing record is
+        // skipped rather than treated as fatal.
+        let stored: Option<Prediction> = env
             .storage()
             .persistent()
             .get(&prediction_key)
-            .ok_or(InsightArenaError::PredictionNotFound)?;
+            .or_else(|| env.storage().temporary().get(&prediction_key));
+        let mut stored_prediction = match stored {
+            Some(prediction) => prediction,
+            None => continue,
+        };
 
-        if stored_prediction.payout_claimed {
+        if stored_prediction.chosen_outcome != resolved_outcome || stored_prediction.payout_claimed
+        {
             continue;
         }
 

--- a/contracts/open-market/tests/prediction_tests.rs
+++ b/contracts/open-market/tests/prediction_tests.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::testutils::{storage::Persistent as _, Address as _, Ledger};
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
-use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
+use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol, Vec};
 
 use insightarena_contract::config::LEDGER_BUMP_MARKET;
 use insightarena_contract::market::CreateMarketParams;
@@ -452,6 +452,256 @@ fn test_batch_distribute_payouts_skips_already_claimed() {
     // Second batch: all winning predictions already claimed — skips them, returns 0
     let second_run = client.batch_distribute_payouts(&oracle, &market_id);
     assert_eq!(second_run, 0);
+}
+
+// ── batch_distribute_payouts edge cases (#1263) ──────────────────────────────
+//
+// Shared arithmetic for the 3-winner / 2-loser fixture (stake 50 XLM each):
+//   total_pool   = 250_000_000
+//   winning_pool = 150_000_000, loser_pool = 100_000_000
+//   winner_share = 50M × 100M / 150M            = 33_333_333
+//   gross        = 50M + 33_333_333             = 83_333_333
+//   protocol fee = 83_333_333 × 200 / 10_000    =  1_666_666
+//   creator fee  = 83_333_333 × 100 / 10_000    =    833_333
+//   net payout   = 83_333_333 − 1_666_666 − 833_333 = 80_833_334
+const MIXED_STAKE: i128 = 50_000_000;
+const MIXED_NET_PAYOUT: i128 = 80_833_334;
+const MIXED_CREATOR_FEE: i128 = 833_333;
+
+/// Create a resolved 3-winner / 2-loser market. Every predictor stakes
+/// `MIXED_STAKE`; winners pick "yes", losers pick "no"; outcome is "yes".
+/// Returns (market_id, creator, [w1, w2, w3], [l1, l2]).
+#[allow(clippy::type_complexity)]
+fn setup_mixed_market(
+    env: &Env,
+    client: &InsightArenaContractClient<'_>,
+    xlm_token: &Address,
+    oracle: &Address,
+) -> (u64, Address, [Address; 3], [Address; 2]) {
+    let creator = Address::generate(env);
+    let winners = [
+        Address::generate(env),
+        Address::generate(env),
+        Address::generate(env),
+    ];
+    let losers = [Address::generate(env), Address::generate(env)];
+
+    let params = default_params(env);
+    let market_id = client.create_market(&creator, &params);
+
+    for winner in winners.iter() {
+        fund(env, xlm_token, winner, MIXED_STAKE);
+        client.submit_prediction(winner, &market_id, &symbol_short!("yes"), &MIXED_STAKE);
+    }
+    for loser in losers.iter() {
+        fund(env, xlm_token, loser, MIXED_STAKE);
+        client.submit_prediction(loser, &market_id, &symbol_short!("no"), &MIXED_STAKE);
+    }
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(oracle, &market_id, &symbol_short!("yes"));
+
+    (market_id, creator, winners, losers)
+}
+
+/// Requirement: a batch over a mixed predictor set (3 winners + 2 losers) pays
+/// each winner their exact entitlement, pays losers nothing, and does not
+/// abort. Token accounting is verified to the stroop, and a second batch
+/// proves no composition of repeat calls can double-pay.
+#[test]
+fn test_batch_mixed_winners_and_losers_exact_accounting() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, oracle) = deploy(&env);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let (market_id, creator, winners, losers) =
+        setup_mixed_market(&env, &client, &xlm_token, &oracle);
+
+    let contract_before = token.balance(&client.address);
+    assert_eq!(contract_before, 5 * MIXED_STAKE); // all stakes escrowed
+
+    let processed = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed, 3);
+
+    // Winners receive exactly their entitlement; losers receive nothing.
+    for winner in winners.iter() {
+        assert_eq!(token.balance(winner), MIXED_NET_PAYOUT);
+    }
+    for loser in losers.iter() {
+        assert_eq!(token.balance(loser), 0);
+    }
+
+    // Stroop-exact accounting: the contract released exactly
+    // 3 × (net payout + creator fee); protocol fees stay in escrow.
+    assert_eq!(token.balance(&creator), 3 * MIXED_CREATOR_FEE);
+    assert_eq!(
+        token.balance(&client.address),
+        contract_before - 3 * (MIXED_NET_PAYOUT + MIXED_CREATOR_FEE)
+    );
+
+    // A repeat batch is a no-op: nothing further is paid to anyone.
+    let processed_again = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed_again, 0);
+    for winner in winners.iter() {
+        assert_eq!(token.balance(winner), MIXED_NET_PAYOUT);
+    }
+    assert_eq!(token.balance(&creator), 3 * MIXED_CREATOR_FEE);
+}
+
+/// Requirement: a batch run after one winner already claimed individually via
+/// claim_payout must not double-pay that winner, must still pay the remaining
+/// winners, and must pay them the same entitlement they would have received in
+/// any other claim order (the already-claimed stake stays in the winning pool).
+#[test]
+fn test_batch_after_individual_claim_no_double_pay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, oracle) = deploy(&env);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let (market_id, creator, winners, losers) =
+        setup_mixed_market(&env, &client, &xlm_token, &oracle);
+
+    // Winner 0 claims individually first.
+    let individual_payout = client.claim_payout(&winners[0], &market_id);
+    assert_eq!(individual_payout, MIXED_NET_PAYOUT);
+
+    // Batch over the full predictor set: only the two unclaimed winners are
+    // processed; the already-claimed winner does not block them.
+    let processed = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed, 2);
+
+    // No double payment, and identical entitlements regardless of claim path.
+    assert_eq!(token.balance(&winners[0]), MIXED_NET_PAYOUT);
+    assert_eq!(token.balance(&winners[1]), MIXED_NET_PAYOUT);
+    assert_eq!(token.balance(&winners[2]), MIXED_NET_PAYOUT);
+    for loser in losers.iter() {
+        assert_eq!(token.balance(loser), 0);
+    }
+
+    // Total released across claim + batch equals the sum of the three
+    // individual entitlements plus creator fees — exact to the stroop.
+    assert_eq!(token.balance(&creator), 3 * MIXED_CREATOR_FEE);
+    assert_eq!(
+        token.balance(&client.address),
+        5 * MIXED_STAKE - 3 * (MIXED_NET_PAYOUT + MIXED_CREATOR_FEE)
+    );
+}
+
+/// Requirement: an address appearing twice in the predictor list is paid only
+/// on its first occurrence. The duplicate neither pays again nor aborts the
+/// batch, and pool math counts the duplicated stake exactly once.
+#[test]
+fn test_batch_duplicate_predictor_entry_pays_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, oracle) = deploy(&env);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let winner1 = Address::generate(&env);
+    let winner2 = Address::generate(&env);
+    let loser = Address::generate(&env);
+    let stake = 50_000_000_i128;
+
+    let creator = Address::generate(&env);
+    let params = default_params(&env);
+    let market_id = client.create_market(&creator, &params);
+
+    for (user, outcome) in [
+        (&winner1, symbol_short!("yes")),
+        (&winner2, symbol_short!("yes")),
+        (&loser, symbol_short!("no")),
+    ] {
+        fund(&env, &xlm_token, user, stake);
+        client.submit_prediction(user, &market_id, &outcome, &stake);
+    }
+
+    // Corrupt the predictor list with a duplicate entry for winner1.
+    // submit_prediction's AlreadyPredicted guard makes this unreachable via
+    // the public API, so inject it directly to pin the defensive behavior.
+    env.as_contract(&client.address, || {
+        let key = DataKey::PredictorList(market_id);
+        let mut list: Vec<Address> = env.storage().persistent().get(&key).unwrap();
+        list.push_back(winner1.clone());
+        env.storage().persistent().set(&key, &list);
+    });
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    // winning_pool = 100M (winner1 counted once), loser_pool = 50M:
+    // share = 25M, gross = 75M, fees 2% + 1% of gross, net = 72_750_000.
+    let processed = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed, 2);
+
+    assert_eq!(token.balance(&winner1), 72_750_000);
+    assert_eq!(token.balance(&winner2), 72_750_000);
+    assert_eq!(token.balance(&loser), 0);
+    assert_eq!(token.balance(&creator), 2 * 750_000);
+    assert_eq!(
+        token.balance(&client.address),
+        3 * stake - 2 * (72_750_000 + 750_000)
+    );
+
+    // Re-running cannot pay the duplicate either.
+    let processed_again = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed_again, 0);
+    assert_eq!(token.balance(&winner1), 72_750_000);
+}
+
+/// Requirement: a batch over a market with no predictions succeeds as a no-op.
+#[test]
+fn test_batch_empty_market_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, oracle) = deploy(&env);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let params = default_params(&env);
+    let market_id = client.create_market(&Address::generate(&env), &params);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    let processed = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed, 0);
+    assert_eq!(token.balance(&client.address), 0);
+}
+
+/// Requirement: a batch where every prediction lost pays nobody and succeeds.
+#[test]
+fn test_batch_all_losers_pays_nothing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, oracle) = deploy(&env);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let loser1 = Address::generate(&env);
+    let loser2 = Address::generate(&env);
+    let stake = 50_000_000_i128;
+
+    let params = default_params(&env);
+    let market_id = client.create_market(&Address::generate(&env), &params);
+
+    for loser in [&loser1, &loser2] {
+        fund(&env, &xlm_token, loser, stake);
+        client.submit_prediction(loser, &market_id, &symbol_short!("no"), &stake);
+    }
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    let processed = client.batch_distribute_payouts(&oracle, &market_id);
+    assert_eq!(processed, 0);
+    assert_eq!(token.balance(&loser1), 0);
+    assert_eq!(token.balance(&loser2), 0);
+    // Stakes remain escrowed in the contract.
+    assert_eq!(token.balance(&client.address), 2 * stake);
 }
 
 // ── payout_math tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the missing edge-case coverage for `batch_distribute_payouts` (`contracts/open-market/src/prediction.rs`) — and fixes a pool-accounting bug the new tests exposed. The acceptance criteria ("no double payment through any batch composition", "token balance accounting exact to the stroop") could not be satisfied by tests alone.

## Bug found and fixed

`claim_payout` moves a claimed prediction from **persistent** to **temporary** storage. But `batch_distribute_payouts` computed its winning pool via `list_market_predictions`, which reads persistent storage only. Consequence:

1. A winner claims individually via `claim_payout`.
2. A later batch no longer sees that prediction, so `winning_pool` drops the claimed stake and `loser_pool` is inflated by it.
3. Every remaining winner is **overpaid** — e.g. with 3 winners / 2 losers staking 50 XLM each, remaining winners would receive 121.25 XLM instead of their 80.83 XLM entitlement (total outflow 323 XLM from a 250 XLM pool), draining escrow held for protocol fees or other markets, or aborting with `EscrowEmpty` once the balance runs out.

`assert_escrow_solvent` does not catch this because it only sums stakes of *unresolved* markets.

**Fix:** the batch now iterates the predictor list directly and loads each prediction from persistent-**or**-temporary storage, exactly as `claim_payout` does. Entitlements are identical regardless of claim order. Already-claimed predictions and duplicate list entries are skipped via the `payout_claimed` flag (pinning the "skip bad entries, don't abort" behavior), a missing record is skipped rather than fatal, and each unique address is counted once in pool math.

## Tests added (`tests/prediction_tests.rs`)

| Requirement | Test |
|---|---|
| Mixed batch: 3 winners + 2 losers, exact amounts, no abort | `test_batch_mixed_winners_and_losers_exact_accounting` |
| Winner already claimed via `claim_payout` — no double pay | `test_batch_after_individual_claim_no_double_pay` |
| Duplicate address — second occurrence must not pay | `test_batch_duplicate_predictor_entry_pays_once` |
| Empty batch — no-op success | `test_batch_empty_market_is_noop` |
| All losers — pays nobody | `test_batch_all_losers_pays_nothing` |

Accounting is asserted to the stroop in each scenario: per-winner net payouts (`80_833_334` for the shared fixture), creator-fee transfers, and the contract's escrow balance before/after. Repeat batches are asserted to pay nothing more, proving no double payment through any composition. The duplicate-entry state is unreachable via the public API (`AlreadyPredicted` guard), so the test injects it directly into `PredictorList` to pin the defensive behavior.

## Verification

- `cargo test`: full open-market suite passes (470 tests, including 28 in `prediction_tests`)
- `cargo build --target wasm32-unknown-unknown --release`: passes

Closes #1263