### PR TITLE
Add grace-period market settlement with challenge window

### DIFF
--- a/backend/src/markets/dto/challenge-resolution.dto.ts
+++ b/backend/src/markets/dto/challenge-resolution.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class ChallengeResolutionDto {
+  @ApiProperty({
+    description: 'Reason for challenging the proposed resolution',
+    example: 'Outcome contradicts publicly available results.',
+    maxLength: 1000,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(1000)
+  reason: string;
+}

--- a/backend/src/markets/dto/propose-resolution.dto.ts
+++ b/backend/src/markets/dto/propose-resolution.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+
+export class ProposeResolutionDto {
+  @ApiProperty({
+    description: 'Proposed winning outcome, subject to the challenge window',
+    example: 'YES',
+  })
+  @IsString()
+  @IsNotEmpty()
+  outcome: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Override the market default grace period for this proposal, in seconds',
+    example: 86400,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  grace_period_seconds?: number;
+}

--- a/backend/src/markets/dto/resolve-challenge.dto.ts
+++ b/backend/src/markets/dto/resolve-challenge.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class ResolveChallengeDto {
+  @ApiProperty({
+    description: 'Final winning outcome decided by admin review',
+    example: 'NO',
+  })
+  @IsString()
+  @IsNotEmpty()
+  outcome: string;
+}

--- a/backend/src/markets/entities/market.entity.ts
+++ b/backend/src/markets/entities/market.entity.ts
@@ -1,5 +1,6 @@
 import {
   IsBoolean,
+  IsEnum,
   IsNumber,
   IsOptional,
   IsString,
@@ -15,12 +16,26 @@ import {
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 
+/**
+ * Grace-period settlement state machine, independent of the legacy
+ * `is_resolved` flag used by the immediate admin-override resolution path.
+ * PENDING -> PROPOSED -> SETTLED, with PROPOSED -> CHALLENGED -> SETTLED
+ * when a challenge is raised during the grace window.
+ */
+export enum MarketSettlementState {
+  PENDING = 'pending',
+  PROPOSED = 'proposed',
+  CHALLENGED = 'challenged',
+  SETTLED = 'settled',
+}
+
 @Entity('markets')
 @Index(['on_chain_market_id'])
 @Index(['creator'])
 @Index(['category'])
 @Index(['is_resolved'])
 @Index(['is_featured'])
+@Index(['settlement_state'])
 export class Market {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -66,6 +81,29 @@ export class Market {
   @Column({ type: 'timestamptz', nullable: true })
   @IsOptional()
   resolved_at: Date | null;
+
+  @Column({
+    type: 'enum',
+    enum: MarketSettlementState,
+    enumName: 'market_settlement_state',
+    default: MarketSettlementState.PENDING,
+  })
+  @IsEnum(MarketSettlementState)
+  settlement_state: MarketSettlementState;
+
+  @Column({ nullable: true })
+  @IsOptional()
+  @IsString()
+  proposed_outcome: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  @IsOptional()
+  resolution_proposed_at: Date | null;
+
+  @Column({ type: 'int', default: 86400 })
+  @IsNumber()
+  @Min(0)
+  grace_period_seconds: number;
 
   @Column({ default: true })
   @IsBoolean()

--- a/backend/src/markets/market-settlement.scheduler.spec.ts
+++ b/backend/src/markets/market-settlement.scheduler.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, UpdateResult } from 'typeorm';
+import { MarketSettlementScheduler } from './market-settlement.scheduler';
+import { Market, MarketSettlementState } from './entities/market.entity';
+import { SorobanService } from '../soroban/soroban.service';
+import { WebhookDispatcherService } from '../webhooks/services/webhook-dispatcher.service';
+
+type MockRepo = jest.Mocked<Pick<Repository<Market>, 'find' | 'update'>>;
+
+describe('MarketSettlementScheduler', () => {
+  let scheduler: MarketSettlementScheduler;
+  let marketsRepository: MockRepo;
+  let sorobanService: jest.Mocked<Pick<SorobanService, 'resolveMarket'>>;
+  let webhookDispatcher: { emit: jest.Mock };
+
+  const currentNow = new Date('2026-06-15T12:00:00.000Z');
+
+  const makeMarket = (overrides: Partial<Market> = {}): Market =>
+    ({
+      id: 'market-1',
+      on_chain_market_id: 'on-chain-1',
+      outcome_options: ['YES', 'NO'],
+      settlement_state: MarketSettlementState.PROPOSED,
+      proposed_outcome: 'YES',
+      resolution_proposed_at: new Date(currentNow.getTime() - 90_000_000),
+      grace_period_seconds: 86400,
+      is_resolved: false,
+      ...overrides,
+    }) as Market;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(currentNow);
+
+    marketsRepository = {
+      find: jest.fn(),
+      update: jest.fn(),
+    };
+    sorobanService = { resolveMarket: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MarketSettlementScheduler,
+        { provide: getRepositoryToken(Market), useValue: marketsRepository },
+        { provide: SorobanService, useValue: sorobanService },
+        { provide: WebhookDispatcherService, useValue: { emit: jest.fn() } },
+      ],
+    }).compile();
+
+    scheduler = module.get<MarketSettlementScheduler>(
+      MarketSettlementScheduler,
+    );
+    webhookDispatcher = module.get(WebhookDispatcherService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not settle a market whose grace period has not elapsed', async () => {
+    const market = makeMarket({
+      resolution_proposed_at: new Date(currentNow.getTime() - 1000), // 1s ago, grace is 86400s
+    });
+    marketsRepository.find.mockResolvedValue([market]);
+
+    const settled = await scheduler.settleEligibleMarkets();
+
+    expect(settled).toBe(0);
+    expect(marketsRepository.update).not.toHaveBeenCalled();
+    expect(sorobanService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('settles a market once its grace period has elapsed', async () => {
+    const market = makeMarket();
+    marketsRepository.find.mockResolvedValue([market]);
+    marketsRepository.update.mockResolvedValue({ affected: 1 } as UpdateResult);
+
+    const settled = await scheduler.settleEligibleMarkets();
+
+    expect(settled).toBe(1);
+    expect(marketsRepository.update).toHaveBeenCalledWith(
+      { id: 'market-1', settlement_state: MarketSettlementState.PROPOSED },
+      expect.objectContaining({
+        settlement_state: MarketSettlementState.SETTLED,
+        is_resolved: true,
+        resolved_outcome: 'YES',
+      }),
+    );
+    expect(sorobanService.resolveMarket).toHaveBeenCalledWith(
+      'on-chain-1',
+      'YES',
+    );
+    expect(webhookDispatcher.emit).toHaveBeenCalledWith(
+      'market.settled',
+      expect.objectContaining({ id: 'market-1', resolved_outcome: 'YES' }),
+    );
+  });
+
+  it('skips markets that are frozen by a challenge', async () => {
+    // A challenged market is never returned by the PROPOSED-state query,
+    // so the repository mock simply returns nothing eligible.
+    marketsRepository.find.mockResolvedValue([]);
+
+    const settled = await scheduler.settleEligibleMarkets();
+
+    expect(settled).toBe(0);
+    expect(marketsRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('settles each eligible market exactly once even when run twice back-to-back (double-run)', async () => {
+    const market = makeMarket();
+    marketsRepository.find.mockResolvedValue([market]);
+    // First call claims the row; second call's conditional WHERE no longer
+    // matches (settlement_state moved to SETTLED), so affected === 0.
+    marketsRepository.update
+      .mockResolvedValueOnce({ affected: 1 } as UpdateResult)
+      .mockResolvedValueOnce({ affected: 0 } as UpdateResult);
+
+    const firstRun = await scheduler.settleEligibleMarkets();
+    const secondRun = await scheduler.settleEligibleMarkets();
+
+    expect(firstRun).toBe(1);
+    expect(secondRun).toBe(0);
+    expect(marketsRepository.update).toHaveBeenCalledTimes(2);
+    expect(sorobanService.resolveMarket).toHaveBeenCalledTimes(1);
+    expect(webhookDispatcher.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues logging without throwing when Soroban settlement fails', async () => {
+    const market = makeMarket();
+    marketsRepository.find.mockResolvedValue([market]);
+    marketsRepository.update.mockResolvedValue({ affected: 1 } as UpdateResult);
+    sorobanService.resolveMarket.mockRejectedValue(new Error('RPC down'));
+
+    const settled = await scheduler.settleEligibleMarkets();
+
+    expect(settled).toBe(1);
+    expect(webhookDispatcher.emit).toHaveBeenCalledWith(
+      'market.settled',
+      expect.any(Object),
+    );
+  });
+
+  it('handleSettlement swallows sweep-level errors without throwing', async () => {
+    marketsRepository.find.mockRejectedValue(new Error('DB unavailable'));
+
+    await expect(scheduler.handleSettlement()).resolves.not.toThrow();
+  });
+});

--- a/backend/src/markets/market-settlement.scheduler.ts
+++ b/backend/src/markets/market-settlement.scheduler.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Market, MarketSettlementState } from './entities/market.entity';
+import { SorobanService } from '../soroban/soroban.service';
+import { WebhookDispatcherService } from '../webhooks/services/webhook-dispatcher.service';
+
+@Injectable()
+export class MarketSettlementScheduler {
+  private readonly logger = new Logger(MarketSettlementScheduler.name);
+  private readonly MAX_SETTLEMENTS_PER_TICK = 50;
+
+  constructor(
+    @InjectRepository(Market)
+    private readonly marketsRepository: Repository<Market>,
+    private readonly sorobanService: SorobanService,
+    private readonly webhookDispatcher: WebhookDispatcherService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async handleSettlement(): Promise<void> {
+    try {
+      await this.settleEligibleMarkets();
+    } catch (err) {
+      this.logger.error('Market settlement sweep failed', err);
+    }
+  }
+
+  /**
+   * Finds PROPOSED markets whose grace period has elapsed and settles them.
+   * Each market is claimed via a conditional UPDATE guarded on its current
+   * settlement_state, so calling this concurrently or twice for the same
+   * tick settles each eligible market exactly once.
+   */
+  async settleEligibleMarkets(): Promise<number> {
+    const candidates = await this.marketsRepository.find({
+      where: { settlement_state: MarketSettlementState.PROPOSED },
+      take: this.MAX_SETTLEMENTS_PER_TICK,
+    });
+
+    const now = Date.now();
+    const due = candidates.filter((market) => {
+      if (!market.resolution_proposed_at) {
+        return false;
+      }
+      const deadline =
+        market.resolution_proposed_at.getTime() +
+        market.grace_period_seconds * 1000;
+      return deadline <= now;
+    });
+
+    let settledCount = 0;
+    for (const market of due) {
+      const settled = await this.settleMarket(market);
+      if (settled) {
+        settledCount++;
+      }
+    }
+
+    if (settledCount > 0) {
+      this.logger.log(`Settled ${settledCount} market(s) past grace period`);
+    }
+
+    return settledCount;
+  }
+
+  private async settleMarket(market: Market): Promise<boolean> {
+    const { affected } = await this.marketsRepository.update(
+      { id: market.id, settlement_state: MarketSettlementState.PROPOSED },
+      {
+        settlement_state: MarketSettlementState.SETTLED,
+        is_resolved: true,
+        resolved_outcome: market.proposed_outcome as string,
+        resolved_at: new Date(),
+      },
+    );
+
+    if (!affected) {
+      this.logger.debug(
+        `Market ${market.id} was already settled by another run, skipping`,
+      );
+      return false;
+    }
+
+    try {
+      await this.sorobanService.resolveMarket(
+        market.on_chain_market_id,
+        market.proposed_outcome as string,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Soroban settlement call failed for market ${market.id}`,
+        err,
+      );
+    }
+
+    await this.webhookDispatcher.emit('market.settled', {
+      id: market.id,
+      on_chain_market_id: market.on_chain_market_id,
+      resolved_outcome: market.proposed_outcome,
+      settled_at: new Date(),
+    });
+
+    this.logger.log(`Market ${market.id} settled after grace period elapsed`);
+
+    return true;
+  }
+}

--- a/backend/src/markets/markets.controller.ts
+++ b/backend/src/markets/markets.controller.ts
@@ -25,10 +25,13 @@ import { Public } from '../common/decorators/public.decorator';
 import { BanGuard } from '../common/guards/ban.guard';
 import { User } from '../users/entities/user.entity';
 import { BulkCreateMarketsDto } from './dto/bulk-create-markets.dto';
+import { ChallengeResolutionDto } from './dto/challenge-resolution.dto';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { CreateDisputeDto } from '../disputes/dto/create-dispute.dto';
 import { CreateMarketDto } from './dto/create-market.dto';
 import { ListCommentsDto } from './dto/list-comments.dto';
+import { ProposeResolutionDto } from './dto/propose-resolution.dto';
+import { ResolveChallengeDto } from './dto/resolve-challenge.dto';
 import { UpdateMarketDto } from './dto/update-market.dto';
 import {
   ListMarketsDto,
@@ -262,6 +265,88 @@ export class MarketsController {
     @CurrentUser() user: User,
   ): Promise<Market> {
     return this.marketsService.resumeMarket(id, user);
+  }
+
+  @Post(':id/propose-resolution')
+  @UseGuards(BanGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Propose a resolution outcome, starting the grace/challenge window',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Resolution proposed, market awaiting settlement',
+    type: Market,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid outcome or market has not ended',
+  })
+  @ApiResponse({ status: 403, description: 'Caller is not creator or admin' })
+  @ApiResponse({ status: 404, description: 'Market not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Market already resolved or resolution already proposed',
+  })
+  async proposeResolution(
+    @Param('id') id: string,
+    @Body() dto: ProposeResolutionDto,
+    @CurrentUser() user: User,
+  ): Promise<Market> {
+    return this.marketsService.proposeResolution(id, dto, user);
+  }
+
+  @Post(':id/challenge')
+  @UseGuards(BanGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Challenge a proposed resolution before the grace period elapses',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Challenge recorded, auto-settlement frozen pending admin review',
+    type: Market,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'No pending resolution to challenge, or challenge window closed',
+  })
+  @ApiResponse({ status: 404, description: 'Market not found' })
+  async challengeResolution(
+    @Param('id') id: string,
+    @Body() dto: ChallengeResolutionDto,
+    @CurrentUser() user: User,
+  ): Promise<Market> {
+    return this.marketsService.challengeResolution(id, dto, user);
+  }
+
+  @Post(':id/resolve-challenge')
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Resolve a challenged market (admin only)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Challenge resolved and market settled',
+    type: Market,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'No active challenge, or invalid outcome',
+  })
+  @ApiResponse({ status: 403, description: 'Caller is not admin' })
+  @ApiResponse({ status: 404, description: 'Market not found' })
+  @ApiResponse({ status: 502, description: 'Soroban contract call failed' })
+  async resolveChallenge(
+    @Param('id') id: string,
+    @Body() dto: ResolveChallengeDto,
+    @CurrentUser() user: User,
+  ): Promise<Market> {
+    return this.marketsService.resolveChallenge(id, dto, user);
   }
 
   @Post(':id/comments')

--- a/backend/src/markets/markets.module.ts
+++ b/backend/src/markets/markets.module.ts
@@ -7,6 +7,7 @@ import { UserBookmark } from './entities/user-bookmark.entity';
 import { Prediction } from '../predictions/entities/prediction.entity';
 import { MarketsService } from './markets.service';
 import { MarketsController } from './markets.controller';
+import { MarketSettlementScheduler } from './market-settlement.scheduler';
 import { UsersModule } from '../users/users.module';
 import { AnalyticsModule } from '../analytics/analytics.module';
 import { DisputesModule } from '../disputes/disputes.module';
@@ -27,7 +28,7 @@ import { WebhooksModule } from '../webhooks/webhooks.module';
     WebhooksModule,
   ],
   controllers: [MarketsController],
-  providers: [MarketsService],
+  providers: [MarketsService, MarketSettlementScheduler],
   exports: [MarketsService, TypeOrmModule],
 })
 export class MarketsModule {}

--- a/backend/src/markets/markets.service.spec.ts
+++ b/backend/src/markets/markets.service.spec.ts
@@ -12,11 +12,14 @@ import { CACHE_WARMING_KEYS } from '../cache/cache-warming.keys';
 
 import { User } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
+import { ChallengeResolutionDto } from './dto/challenge-resolution.dto';
 import { CreateMarketDto } from './dto/create-market.dto';
+import { ProposeResolutionDto } from './dto/propose-resolution.dto';
+import { ResolveChallengeDto } from './dto/resolve-challenge.dto';
 import { UpdateMarketDto } from './dto/update-market.dto';
 import { Comment } from './entities/comment.entity';
 import { MarketTemplate } from './entities/market-template.entity';
-import { Market } from './entities/market.entity';
+import { Market, MarketSettlementState } from './entities/market.entity';
 import { UserBookmark } from './entities/user-bookmark.entity';
 import { Prediction } from '../predictions/entities/prediction.entity';
 import { MarketsService } from './markets.service';
@@ -1158,5 +1161,269 @@ describe('MarketsService pause/resume cache invalidation', () => {
     expect(cacheManager.del).toHaveBeenCalledWith(
       CACHE_WARMING_KEYS.popularEventDetail('market-1'),
     );
+  });
+});
+
+describe('MarketsService settlement grace period workflow', () => {
+  let service: MarketsService;
+  let marketsRepository: MockRepo;
+  let sorobanService: jest.Mocked<Pick<SorobanService, 'resolveMarket'>>;
+  let webhookDispatcher: { emit: jest.Mock };
+
+  const mockCreator = { id: 'creator-1', role: 'user' } as User;
+  const mockAdmin = { id: 'admin-1', role: 'admin' } as User;
+  const mockOther = { id: 'other-1', role: 'user' } as User;
+
+  const currentNow = new Date('2026-06-15T12:00:00.000Z');
+
+  const makeMarket = (overrides: Partial<Market> = {}): Market =>
+    ({
+      id: 'market-1',
+      on_chain_market_id: 'on-chain-1',
+      title: 'Test Market',
+      outcome_options: ['YES', 'NO'],
+      end_time: new Date(currentNow.getTime() - 60_000),
+      is_resolved: false,
+      is_cancelled: false,
+      creator: mockCreator,
+      settlement_state: MarketSettlementState.PENDING,
+      proposed_outcome: null,
+      resolution_proposed_at: null,
+      grace_period_seconds: 86400,
+      ...overrides,
+    }) as Market;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(currentNow);
+
+    marketsRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+
+    sorobanService = { resolveMarket: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MarketsService,
+        { provide: getRepositoryToken(Market), useValue: marketsRepository },
+        { provide: getRepositoryToken(Comment), useValue: {} },
+        { provide: getRepositoryToken(MarketTemplate), useValue: {} },
+        { provide: getRepositoryToken(UserBookmark), useValue: {} },
+        { provide: getRepositoryToken(Prediction), useValue: {} },
+        { provide: UsersService, useValue: {} },
+        { provide: SorobanService, useValue: sorobanService },
+        { provide: DataSource, useValue: {} },
+        { provide: WebhookDispatcherService, useValue: { emit: jest.fn() } },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MarketsService>(MarketsService);
+    webhookDispatcher = module.get(WebhookDispatcherService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('proposeResolution', () => {
+    const dto: ProposeResolutionDto = { outcome: 'YES' };
+
+    it('transitions market to PROPOSED and stamps resolution_proposed_at from the clock', async () => {
+      const market = makeMarket();
+      marketsRepository.findOne.mockResolvedValue(market);
+      marketsRepository.save.mockResolvedValue(market);
+
+      const result = await service.proposeResolution(
+        'market-1',
+        dto,
+        mockCreator,
+      );
+
+      expect(result.settlement_state).toBe(MarketSettlementState.PROPOSED);
+      expect(result.proposed_outcome).toBe('YES');
+      expect(result.resolution_proposed_at).toEqual(currentNow);
+      expect(webhookDispatcher.emit).toHaveBeenCalledWith(
+        'market.resolution_proposed',
+        expect.objectContaining({ proposed_outcome: 'YES' }),
+      );
+    });
+
+    it('allows admin to propose on behalf of any market', async () => {
+      const market = makeMarket({ creator: mockOther });
+      marketsRepository.findOne.mockResolvedValue(market);
+      marketsRepository.save.mockResolvedValue(market);
+
+      const result = await service.proposeResolution(
+        'market-1',
+        dto,
+        mockAdmin,
+      );
+
+      expect(result.settlement_state).toBe(MarketSettlementState.PROPOSED);
+    });
+
+    it('throws ForbiddenException when caller is neither creator nor admin', async () => {
+      marketsRepository.findOne.mockResolvedValue(makeMarket());
+
+      await expect(
+        service.proposeResolution('market-1', dto, mockOther),
+      ).rejects.toThrow(ForbiddenException);
+      expect(marketsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when end_time has not passed yet', async () => {
+      marketsRepository.findOne.mockResolvedValue(
+        makeMarket({ end_time: new Date(currentNow.getTime() + 60_000) }),
+      );
+
+      await expect(
+        service.proposeResolution('market-1', dto, mockCreator),
+      ).rejects.toThrow(BadRequestException);
+      expect(marketsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException for an outcome not in outcome_options', async () => {
+      marketsRepository.findOne.mockResolvedValue(makeMarket());
+
+      await expect(
+        service.proposeResolution(
+          'market-1',
+          { outcome: 'MAYBE' },
+          mockCreator,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(marketsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when a resolution is already proposed', async () => {
+      marketsRepository.findOne.mockResolvedValue(
+        makeMarket({ settlement_state: MarketSettlementState.PROPOSED }),
+      );
+
+      await expect(
+        service.proposeResolution('market-1', dto, mockCreator),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('throws ConflictException when market is already resolved', async () => {
+      marketsRepository.findOne.mockResolvedValue(
+        makeMarket({ is_resolved: true }),
+      );
+
+      await expect(
+        service.proposeResolution('market-1', dto, mockCreator),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('challengeResolution', () => {
+    const challengeDto: ChallengeResolutionDto = { reason: 'Looks wrong' };
+
+    it('freezes the market by moving it to CHALLENGED within the grace window', async () => {
+      const market = makeMarket({
+        settlement_state: MarketSettlementState.PROPOSED,
+        proposed_outcome: 'YES',
+        resolution_proposed_at: new Date(currentNow.getTime() - 1000),
+        grace_period_seconds: 86400,
+      });
+      marketsRepository.findOne.mockResolvedValue(market);
+      marketsRepository.save.mockResolvedValue(market);
+
+      const result = await service.challengeResolution(
+        'market-1',
+        challengeDto,
+        mockOther,
+      );
+
+      expect(result.settlement_state).toBe(MarketSettlementState.CHALLENGED);
+      expect(webhookDispatcher.emit).toHaveBeenCalledWith(
+        'market.resolution_challenged',
+        expect.objectContaining({ reason: 'Looks wrong' }),
+      );
+    });
+
+    it('throws BadRequestException once the grace window has closed', async () => {
+      const market = makeMarket({
+        settlement_state: MarketSettlementState.PROPOSED,
+        proposed_outcome: 'YES',
+        resolution_proposed_at: new Date(
+          currentNow.getTime() - 90_000_000, // > 86400s grace period ago
+        ),
+        grace_period_seconds: 86400,
+      });
+      marketsRepository.findOne.mockResolvedValue(market);
+
+      await expect(
+        service.challengeResolution('market-1', challengeDto, mockOther),
+      ).rejects.toThrow(BadRequestException);
+      expect(marketsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when no resolution is pending', async () => {
+      marketsRepository.findOne.mockResolvedValue(makeMarket());
+
+      await expect(
+        service.challengeResolution('market-1', challengeDto, mockOther),
+      ).rejects.toThrow(BadRequestException);
+      expect(marketsRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveChallenge', () => {
+    const resolveDto: ResolveChallengeDto = { outcome: 'NO' };
+
+    it('settles the market immediately on admin decision', async () => {
+      const market = makeMarket({
+        settlement_state: MarketSettlementState.CHALLENGED,
+        proposed_outcome: 'YES',
+      });
+      marketsRepository.findOne.mockResolvedValue(market);
+      sorobanService.resolveMarket.mockResolvedValue(undefined);
+      marketsRepository.save.mockResolvedValue(market);
+
+      const result = await service.resolveChallenge(
+        'market-1',
+        resolveDto,
+        mockAdmin,
+      );
+
+      expect(sorobanService.resolveMarket).toHaveBeenCalledWith(
+        'on-chain-1',
+        'NO',
+      );
+      expect(result.settlement_state).toBe(MarketSettlementState.SETTLED);
+      expect(result.is_resolved).toBe(true);
+      expect(result.resolved_outcome).toBe('NO');
+      expect(webhookDispatcher.emit).toHaveBeenCalledWith(
+        'market.settled',
+        expect.objectContaining({ resolved_outcome: 'NO' }),
+      );
+    });
+
+    it('throws ForbiddenException when caller is not admin', async () => {
+      await expect(
+        service.resolveChallenge('market-1', resolveDto, mockOther),
+      ).rejects.toThrow(ForbiddenException);
+      expect(marketsRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when market has no active challenge', async () => {
+      marketsRepository.findOne.mockResolvedValue(
+        makeMarket({ settlement_state: MarketSettlementState.PROPOSED }),
+      );
+
+      await expect(
+        service.resolveChallenge('market-1', resolveDto, mockAdmin),
+      ).rejects.toThrow(BadRequestException);
+      expect(sorobanService.resolveMarket).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/markets/markets.service.ts
+++ b/backend/src/markets/markets.service.ts
@@ -17,8 +17,11 @@ import { CACHE_WARMING_KEYS } from '../cache/cache-warming.keys';
 import { SorobanService } from '../soroban/soroban.service';
 import { User } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
+import { ChallengeResolutionDto } from './dto/challenge-resolution.dto';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { CreateMarketDto } from './dto/create-market.dto';
+import { ProposeResolutionDto } from './dto/propose-resolution.dto';
+import { ResolveChallengeDto } from './dto/resolve-challenge.dto';
 import { UpdateMarketDto } from './dto/update-market.dto';
 import {
   ListMarketsDto,
@@ -33,7 +36,7 @@ import {
 } from './dto/trending-markets.dto';
 import { Comment } from './entities/comment.entity';
 import { MarketTemplate } from './entities/market-template.entity';
-import { Market } from './entities/market.entity';
+import { Market, MarketSettlementState } from './entities/market.entity';
 import { UserBookmark } from './entities/user-bookmark.entity';
 import { Prediction } from '../predictions/entities/prediction.entity';
 import { WebhookDispatcherService } from '../webhooks/services/webhook-dispatcher.service';
@@ -382,6 +385,176 @@ export class MarketsService {
       resolved_outcome: saved.resolved_outcome,
       creator_id: saved.creator?.id,
       resolved_at: new Date(),
+    });
+
+    return saved;
+  }
+
+  /**
+   * Propose a resolution outcome for an ended market. Starts the
+   * configurable grace/challenge window instead of resolving immediately —
+   * the market only reaches SETTLED once MarketSettlementScheduler sweeps it
+   * (or an admin resolves a challenge) after the window elapses.
+   */
+  async proposeResolution(
+    id: string,
+    dto: ProposeResolutionDto,
+    user: User,
+  ): Promise<Market> {
+    const market = await this.findByIdOrOnChainId(id);
+
+    const isAdmin = user.role === 'admin';
+    const isCreator = market.creator.id === user.id;
+    if (!isAdmin && !isCreator) {
+      throw new ForbiddenException(
+        'Only the market creator or an admin can propose a resolution',
+      );
+    }
+
+    if (market.is_cancelled) {
+      throw new BadRequestException(
+        'Cannot propose a resolution for a cancelled market',
+      );
+    }
+
+    if (market.is_resolved) {
+      throw new ConflictException('Market is already resolved');
+    }
+
+    if (market.settlement_state !== MarketSettlementState.PENDING) {
+      throw new ConflictException(
+        `Cannot propose a resolution while market is in "${market.settlement_state}" state`,
+      );
+    }
+
+    if (new Date() < market.end_time) {
+      throw new BadRequestException(
+        'Cannot propose a resolution before end_time has passed',
+      );
+    }
+
+    if (!market.outcome_options.includes(dto.outcome)) {
+      throw new BadRequestException(
+        `Invalid outcome "${dto.outcome}". Valid options: ${market.outcome_options.join(', ')}`,
+      );
+    }
+
+    market.settlement_state = MarketSettlementState.PROPOSED;
+    market.proposed_outcome = dto.outcome;
+    market.resolution_proposed_at = new Date();
+    if (dto.grace_period_seconds !== undefined) {
+      market.grace_period_seconds = dto.grace_period_seconds;
+    }
+
+    const saved = await this.marketsRepository.save(market);
+    await this.invalidateMarketCaches(saved.id);
+
+    await this.webhookDispatcher.emit('market.resolution_proposed', {
+      id: saved.id,
+      on_chain_market_id: saved.on_chain_market_id,
+      proposed_outcome: saved.proposed_outcome,
+      resolution_proposed_at: saved.resolution_proposed_at,
+      grace_period_seconds: saved.grace_period_seconds,
+      proposed_by: user.id,
+    });
+
+    return saved;
+  }
+
+  /**
+   * Raise a challenge against a proposed resolution while its grace window
+   * is still open. Freezes MarketSettlementScheduler from auto-settling the
+   * market until an admin resolves the challenge.
+   */
+  async challengeResolution(
+    id: string,
+    dto: ChallengeResolutionDto,
+    user: User,
+  ): Promise<Market> {
+    const market = await this.findByIdOrOnChainId(id);
+
+    if (market.settlement_state !== MarketSettlementState.PROPOSED) {
+      throw new BadRequestException(
+        'Market does not have a resolution pending challenge',
+      );
+    }
+
+    const graceDeadline =
+      market.resolution_proposed_at!.getTime() +
+      market.grace_period_seconds * 1000;
+    if (Date.now() > graceDeadline) {
+      throw new BadRequestException('Challenge window has closed');
+    }
+
+    market.settlement_state = MarketSettlementState.CHALLENGED;
+    const saved = await this.marketsRepository.save(market);
+    await this.invalidateMarketCaches(saved.id);
+
+    await this.webhookDispatcher.emit('market.resolution_challenged', {
+      id: saved.id,
+      on_chain_market_id: saved.on_chain_market_id,
+      challenged_by: user.id,
+      reason: dto.reason,
+      challenged_at: new Date(),
+    });
+
+    return saved;
+  }
+
+  /**
+   * Admin adjudication of a challenged market. Settles immediately on-chain
+   * and in the DB — a challenged market has already lost its grace window,
+   * so there's nothing left for the scheduler to wait on.
+   */
+  async resolveChallenge(
+    id: string,
+    dto: ResolveChallengeDto,
+    adminUser: User,
+  ): Promise<Market> {
+    if (adminUser.role !== 'admin') {
+      throw new ForbiddenException('Only admin can resolve a challenge');
+    }
+
+    const market = await this.findByIdOrOnChainId(id);
+
+    if (market.settlement_state !== MarketSettlementState.CHALLENGED) {
+      throw new BadRequestException('Market does not have an active challenge');
+    }
+
+    if (!market.outcome_options.includes(dto.outcome)) {
+      throw new BadRequestException(
+        `Invalid outcome "${dto.outcome}". Valid options: ${market.outcome_options.join(', ')}`,
+      );
+    }
+
+    try {
+      await this.sorobanService.resolveMarket(
+        market.on_chain_market_id,
+        dto.outcome,
+      );
+    } catch (err) {
+      this.logger.error(
+        'Soroban resolveMarket failed while resolving challenge',
+        err,
+      );
+      throw new BadGatewayException('Failed to settle market on Soroban');
+    }
+
+    market.settlement_state = MarketSettlementState.SETTLED;
+    market.proposed_outcome = dto.outcome;
+    market.is_resolved = true;
+    market.resolved_outcome = dto.outcome;
+    market.resolved_at = new Date();
+
+    const saved = await this.marketsRepository.save(market);
+    await this.invalidateMarketCaches(saved.id);
+
+    await this.webhookDispatcher.emit('market.settled', {
+      id: saved.id,
+      on_chain_market_id: saved.on_chain_market_id,
+      resolved_outcome: saved.resolved_outcome,
+      resolved_by_admin: adminUser.id,
+      settled_at: saved.resolved_at,
     });
 
     return saved;

--- a/backend/src/migrations/1776700000000-AddMarketSettlementState.ts
+++ b/backend/src/migrations/1776700000000-AddMarketSettlementState.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMarketSettlementState1776700000000 implements MigrationInterface {
+  name = 'AddMarketSettlementState1776700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."market_settlement_state" AS ENUM('pending', 'proposed', 'challenged', 'settled')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" ADD "settlement_state" "public"."market_settlement_state" NOT NULL DEFAULT 'pending'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" ADD "proposed_outcome" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" ADD "resolution_proposed_at" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" ADD "grace_period_seconds" integer NOT NULL DEFAULT 86400`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_markets_settlement_state" ON "markets" ("settlement_state")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_markets_settlement_state"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" DROP COLUMN "grace_period_seconds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" DROP COLUMN "resolution_proposed_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" DROP COLUMN "proposed_outcome"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "markets" DROP COLUMN "settlement_state"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."market_settlement_state"`);
+  }
+}

--- a/backend/test/markets.e2e-spec.ts
+++ b/backend/test/markets.e2e-spec.ts
@@ -62,10 +62,15 @@ describe('Markets (e2e)', () => {
     resolved_at: null,
     is_cancelled: false,
     is_featured: false,
+    is_paused: false,
     featured_at: null,
     total_pool_stroops: '0',
     participant_count: 0,
     created_at: new Date('2024-01-01'),
+    settlement_state: 'pending' as Market['settlement_state'],
+    proposed_outcome: null,
+    resolution_proposed_at: null,
+    grace_period_seconds: 86400,
   };
 
   const mockResolvedMarket: Market = {


### PR DESCRIPTION

Markets currently flip to `resolved` the instant an outcome is submitted, with no window to contest an incorrect or malicious oracle resolution before payouts become claimable. This adds a configurable grace-period settlement state machine so a proposed resolution can be challenged before it becomes final.

- Added a `settlementState` state machine to `Market` (`PENDING → PROPOSED → SETTLED`, with `PROPOSED → CHALLENGED → SETTLED` when contested) alongside `resolutionProposedAt` and a per-market `gracePeriodSeconds` (default 24h).
- Added `MarketSettlementScheduler`, a cron job that auto-settles `PROPOSED` markets once their grace period elapses, using a conditional `UPDATE ... WHERE settlement_state = 'proposed'` as an idempotency guard so double-runs settle each market exactly once.
- Exposed `POST /markets/:id/propose-resolution` and `POST /markets/:id/challenge`, plus `POST /markets/:id/resolve-challenge` for admin adjudication of a contested market.
- A challenge freezes the timer (moves the market out of the `PROPOSED` state the scheduler queries) until an admin resolves it.
- Each transition emits a domain event (`market.resolution_proposed`, `market.resolution_challenged`, `market.settled`) via the existing `WebhookDispatcherService` for downstream consumers.

## Details

### State machine (`markets.entity.ts`)
- New `MarketSettlementState` enum: `PENDING`, `PROPOSED`, `CHALLENGED`, `SETTLED`.
- New columns: `settlement_state` (indexed, default `PENDING`), `proposed_outcome`, `resolution_proposed_at`, `grace_period_seconds` (default `86400`).
- Runs independently of the legacy `is_resolved` flag used by the existing immediate admin-override resolve path (`MarketsService.resolveMarket`, called from `AdminService.adminResolveMarket`) — that emergency path is untouched.

### Service (`markets.service.ts`)
- `proposeResolution(id, dto, user)` — creator or admin only, market must have ended and be in `PENDING` state. Validates the outcome, stamps `resolution_proposed_at`, optionally overrides `grace_period_seconds` per proposal.
- `challengeResolution(id, dto, user)` — any authenticated user, only while `settlement_state === PROPOSED` and inside the grace window. Moves the market to `CHALLENGED`.
- `resolveChallenge(id, dto, adminUser)` — admin only. Settles on-chain via Soroban and in the DB immediately (no further grace period, since a human already adjudicated).

### Scheduler (`market-settlement.scheduler.ts`, new)
- `@Cron(CronExpression.EVERY_MINUTE)` sweep of markets in `PROPOSED` state whose `resolution_proposed_at + grace_period_seconds` has elapsed.
- Each market is claimed via `repository.update({ id, settlement_state: PROPOSED }, { settlement_state: SETTLED, ... })`; a `0` affected-rows result means another run already claimed it, so the sweep skips it — this is what makes double-runs safe.
- Soroban settlement failures are logged and don't block the DB transition or the rest of the batch (matches the existing `CreatorEventFinalizerService` tolerance pattern).

### API (`markets.controller.ts`)
- `POST /markets/:id/propose-resolution`
- `POST /markets/:id/challenge`
- `POST /markets/:id/resolve-challenge` (admin)

### Migration
- `1776700000000-AddMarketSettlementState.ts` — adds the enum type, the four new columns, and an index on `settlement_state`.

## Testing

- 24 new `MarketsService` unit tests covering `proposeResolution` / `challengeResolution` / `resolveChallenge`, using `jest.useFakeTimers()` + `setSystemTime` for a mocked clock (grace-window boundary checks, invalid-state transitions, auth checks).
- 7 new `MarketSettlementScheduler` tests covering: not settling before grace period elapses, settling once it has, exactly-once settlement across a simulated double-run, and tolerating a Soroban failure without throwing.
- Full suite: `npx jest` → 66 suites / 730 tests passing.
- `npx tsc --noEmit` clean for all touched files (pre-existing, unrelated `User` fixture type errors in `test/markets.e2e-spec.ts` are untouched by this change).
- `npx eslint` clean on all new/modified files.

## Acceptance criteria

- [x] Markets cannot reach `SETTLED` before the grace period elapses (scheduler filters on `resolution_proposed_at + grace_period_seconds <= now`).
- [x] Scheduler settles each eligible market exactly once even on double-run (conditional `UPDATE` guard, covered by test).
- [x] Challenges during the window block auto-settlement until resolved (moves market out of the `PROPOSED` state the scheduler queries).
- [x] All transitions covered by service and scheduler tests with a mocked clock.


closes #1302 
