### PR TITLE
Search Autocomplete Suggestions

### DIFF
--- a/backend/src/admin/admin.controller.spec.ts
+++ b/backend/src/admin/admin.controller.spec.ts
@@ -38,6 +38,7 @@ describe('AdminController', () => {
             listFlags: jest.fn(),
             resolveFlag: jest.fn(),
             adminResolveMarket: jest.fn(),
+            bulkUserAction: jest.fn(),
           },
         },
         {
@@ -195,6 +196,33 @@ describe('AdminController', () => {
       );
     });
   });
+
+  describe('bulkUserAction', () => {
+    it('forwards the dto and admin id to the service', async () => {
+      const dto = {
+        user_ids: ['u1', 'u2'],
+        action: 'ban' as const,
+        reason: 'spam',
+      };
+      const response = {
+        results: [
+          { user_id: 'u1', success: true },
+          { user_id: 'u2', success: true },
+        ],
+        succeeded: 2,
+        failed: 0,
+      };
+      service.bulkUserAction.mockResolvedValue(response as any);
+
+      const result = await controller.bulkUserAction(
+        dto as any,
+        mockRequest as any,
+      );
+
+      expect(result).toEqual(response);
+      expect(service.bulkUserAction).toHaveBeenCalledWith(dto, 'admin-1');
+    });
+  });
 });
 
 describe('AdminController — RolesGuard enforcement', () => {
@@ -214,6 +242,7 @@ describe('AdminController — RolesGuard enforcement', () => {
             getStats: jest.fn(),
             listUsers: jest.fn(),
             banUser: jest.fn(),
+            bulkUserAction: jest.fn(),
           },
         },
         {
@@ -264,5 +293,19 @@ describe('AdminController — RolesGuard enforcement', () => {
 
   it('PATCH /admin/users/:id/ban — allows role=admin', () => {
     expect(guard.canActivate(makeCtx('admin', 'banUser'))).toBe(true);
+  });
+
+  it('POST /admin/users/bulk-action — denies role=user', () => {
+    expect(guard.canActivate(makeCtx('user', 'bulkUserAction'))).toBe(false);
+  });
+
+  it('POST /admin/users/bulk-action — denies role=moderator', () => {
+    expect(guard.canActivate(makeCtx('moderator', 'bulkUserAction'))).toBe(
+      false,
+    );
+  });
+
+  it('POST /admin/users/bulk-action — allows role=admin', () => {
+    expect(guard.canActivate(makeCtx('admin', 'bulkUserAction'))).toBe(true);
   });
 });

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -24,6 +24,7 @@ import { ResolveFlagDto } from '../flags/dto/resolve-flag.dto';
 import { AdminService } from './admin.service';
 import { ActivityLogQueryDto } from './dto/activity-log-query.dto';
 import { BanUserDto } from './dto/ban-user.dto';
+import { BulkUserActionDto } from './dto/bulk-user-action.dto';
 import { DateRangeQueryDto } from './dto/date-range-query.dto';
 import { FeeStatsResponseDto } from './dto/fee-stats-response.dto';
 import { ListUsersQueryDto } from './dto/list-users-query.dto';
@@ -141,6 +142,26 @@ export class AdminController {
   async unbanUser(@Param('id') id: string, @Request() req: any) {
     return this.adminService.unbanUser(
       id,
+      (req as { user: { id: string } }).user.id,
+    );
+  }
+
+  @Post('users/bulk-action')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Apply a moderation action (ban/unban/flag) to multiple users',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Per-user result report for the bulk action',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  async bulkUserAction(
+    @Body() dto: BulkUserActionDto,
+    @Request() req: RequestUser,
+  ) {
+    return this.adminService.bulkUserAction(
+      dto,
       (req as { user: { id: string } }).user.id,
     );
   }

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -14,6 +14,7 @@ import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { Prediction } from '../predictions/entities/prediction.entity';
 import { User } from '../users/entities/user.entity';
+import { UserFlag } from './entities/user-flag.entity';
 import { VerifiedAddress } from './entities/verified-address.entity';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
@@ -32,6 +33,7 @@ import { AdminService } from './admin.service';
       CreatorEvent,
       VerifiedAddress,
       FeeHistory,
+      UserFlag,
     ]),
     AnalyticsModule,
     FlagsModule,

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -4,7 +4,9 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 
 import { AdminService } from './admin.service';
 import { VerifiedAddress } from './entities/verified-address.entity';
+import { UserFlag } from './entities/user-flag.entity';
 import { ListVerifiedAddressesQueryDto } from './dto/list-verified-addresses-query.dto';
+import { BulkUserAction } from './dto/bulk-user-action.dto';
 
 describe('AdminService (Verified Addresses)', () => {
   let service: AdminService;
@@ -266,6 +268,124 @@ describe('AdminService (Verified Addresses)', () => {
       userRepository.findOne.mockResolvedValue({ id: 'u1', is_banned: false });
       await expect(service.unbanUser('u1', 'admin')).rejects.toThrow(
         'User is not banned',
+      );
+    });
+  });
+
+  describe('bulkUserAction', () => {
+    let userRepository: any;
+    let mockManager: any;
+
+    beforeEach(() => {
+      userRepository = service['usersRepository'];
+      mockManager = {
+        findOne: jest.fn(),
+        save: jest
+          .fn()
+          .mockImplementation((a: any, b: any) => Promise.resolve(b ?? a)),
+        create: jest.fn().mockImplementation((_entity: any, obj: any) => obj),
+      };
+      userRepository.manager = {
+        transaction: jest.fn((cb: any) => cb(mockManager)),
+      };
+    });
+
+    it('bans all users and reports success for each', async () => {
+      mockManager.findOne.mockImplementation(
+        (_entity: any, opts: any) =>
+          Promise.resolve({ id: opts.where.id, is_banned: false }) as any,
+      );
+
+      const result = await service.bulkUserAction(
+        { user_ids: ['u1', 'u2'], action: BulkUserAction.Ban, reason: 'spam' },
+        'admin-1',
+      );
+
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(result.results).toEqual([
+        { user_id: 'u1', success: true },
+        { user_id: 'u2', success: true },
+      ]);
+    });
+
+    it('reports a per-item failure without failing the whole batch', async () => {
+      mockManager.findOne.mockImplementation((_entity: any, opts: any) => {
+        if (opts.where.id === 'missing') return Promise.resolve(null);
+        return Promise.resolve({ id: opts.where.id, is_banned: false });
+      });
+
+      const result = await service.bulkUserAction(
+        {
+          user_ids: ['u1', 'missing'],
+          action: BulkUserAction.Ban,
+          reason: 'spam',
+        },
+        'admin-1',
+      );
+
+      expect(result.succeeded).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.results).toEqual([
+        { user_id: 'u1', success: true },
+        {
+          user_id: 'missing',
+          success: false,
+          error: 'User "missing" not found',
+        },
+      ]);
+    });
+
+    it('reports failure when banning an already-banned user', async () => {
+      mockManager.findOne.mockResolvedValue({ id: 'u1', is_banned: true });
+
+      const result = await service.bulkUserAction(
+        { user_ids: ['u1'], action: BulkUserAction.Ban, reason: 'spam' },
+        'admin-1',
+      );
+
+      expect(result.results[0]).toEqual({
+        user_id: 'u1',
+        success: false,
+        error: 'User is already banned',
+      });
+    });
+
+    it('reports failure when unbanning a user who is not banned', async () => {
+      mockManager.findOne.mockResolvedValue({ id: 'u1', is_banned: false });
+
+      const result = await service.bulkUserAction(
+        { user_ids: ['u1'], action: BulkUserAction.Unban },
+        'admin-1',
+      );
+
+      expect(result.results[0]).toEqual({
+        user_id: 'u1',
+        success: false,
+        error: 'User is not banned',
+      });
+    });
+
+    it('creates a UserFlag record for the flag action', async () => {
+      mockManager.findOne.mockResolvedValue({ id: 'u1', is_banned: false });
+
+      const result = await service.bulkUserAction(
+        {
+          user_ids: ['u1'],
+          action: BulkUserAction.Flag,
+          reason: 'suspicious activity',
+        },
+        'admin-1',
+      );
+
+      expect(result.results[0]).toEqual({ user_id: 'u1', success: true });
+      expect(mockManager.create).toHaveBeenCalledWith(
+        UserFlag,
+        expect.objectContaining({
+          user_id: 'u1',
+          reason: 'suspicious activity',
+          flagged_by: 'admin-1',
+        }),
       );
     });
   });

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -24,9 +24,16 @@ import { Prediction } from '../predictions/entities/prediction.entity';
 import { SorobanService } from '../soroban/soroban.service';
 import { User } from '../users/entities/user.entity';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
+import { UserFlag } from './entities/user-flag.entity';
 import { VerifiedAddress } from './entities/verified-address.entity';
 import { FeeHistory } from '../indexer/entities/fee-history.entity';
 import { ActivityLogQueryDto } from './dto/activity-log-query.dto';
+import {
+  BulkUserAction,
+  BulkUserActionDto,
+  BulkUserActionResponseDto,
+  BulkUserActionResultDto,
+} from './dto/bulk-user-action.dto';
 import { DateRangeQueryDto } from './dto/date-range-query.dto';
 import { FeeStatsResponseDto } from './dto/fee-stats-response.dto';
 import { ListUsersQueryDto } from './dto/list-users-query.dto';
@@ -322,6 +329,93 @@ export class AdminService {
     });
 
     return user;
+  }
+
+  async bulkUserAction(
+    dto: BulkUserActionDto,
+    adminId: string,
+  ): Promise<BulkUserActionResponseDto> {
+    const results: BulkUserActionResultDto[] = [];
+
+    for (const userId of dto.user_ids) {
+      try {
+        await this.usersRepository.manager.transaction(async (manager) => {
+          const user = await manager.findOne(User, { where: { id: userId } });
+          if (!user) {
+            throw new NotFoundException(`User "${userId}" not found`);
+          }
+
+          switch (dto.action) {
+            case BulkUserAction.Ban:
+              if (user.is_banned) {
+                throw new ConflictException('User is already banned');
+              }
+              user.is_banned = true;
+              user.ban_reason = dto.reason ?? null;
+              user.banned_at = new Date();
+              user.banned_by = adminId;
+              await manager.save(user);
+              break;
+
+            case BulkUserAction.Unban:
+              if (!user.is_banned) {
+                throw new BadRequestException('User is not banned');
+              }
+              user.is_banned = false;
+              user.ban_reason = null;
+              user.banned_at = null;
+              user.banned_by = null;
+              await manager.save(user);
+              break;
+
+            case BulkUserAction.Flag:
+              await manager.save(
+                UserFlag,
+                manager.create(UserFlag, {
+                  user_id: user.id,
+                  reason: dto.reason ?? null,
+                  flagged_by: adminId,
+                }),
+              );
+              break;
+          }
+
+          await manager.save(
+            ActivityLog,
+            manager.create(ActivityLog, {
+              userId: user.id,
+              actionType: `USER_BULK_${dto.action.toUpperCase()}`,
+              actionDetails: {
+                admin_id: adminId,
+                reason: dto.reason ?? null,
+              },
+            }),
+          );
+        });
+
+        results.push({ user_id: userId, success: true });
+      } catch (err) {
+        results.push({
+          user_id: userId,
+          success: false,
+          error: err instanceof Error ? err.message : 'Unknown error',
+        });
+      }
+    }
+
+    const succeeded = results.filter((r) => r.success).length;
+
+    this.logger.log(
+      `Admin ${adminId} performed bulk "${dto.action}" on ${dto.user_ids.length} users: ${succeeded} succeeded, ${
+        results.length - succeeded
+      } failed`,
+    );
+
+    return {
+      results,
+      succeeded,
+      failed: results.length - succeeded,
+    };
   }
 
   async updateUserRole(

--- a/backend/src/admin/dto/bulk-user-action.dto.ts
+++ b/backend/src/admin/dto/bulk-user-action.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+
+export const MAX_BULK_USER_ACTION_SIZE = 100;
+
+export enum BulkUserAction {
+  Ban = 'ban',
+  Unban = 'unban',
+  Flag = 'flag',
+}
+
+export class BulkUserActionDto {
+  @ApiProperty({
+    type: [String],
+    description: `User IDs to apply the action to (1-${MAX_BULK_USER_ACTION_SIZE} unique UUIDs)`,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(MAX_BULK_USER_ACTION_SIZE)
+  @ArrayUnique()
+  @IsUUID('4', { each: true })
+  user_ids: string[];
+
+  @ApiProperty({ enum: BulkUserAction, description: 'Action to apply' })
+  @IsEnum(BulkUserAction)
+  action: BulkUserAction;
+
+  @ApiPropertyOptional({
+    description: 'Reason recorded in the audit log for this action',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}
+
+export class BulkUserActionResultDto {
+  @ApiProperty() user_id: string;
+  @ApiProperty() success: boolean;
+  @ApiPropertyOptional() error?: string;
+}
+
+export class BulkUserActionResponseDto {
+  @ApiProperty({ type: [BulkUserActionResultDto] })
+  results: BulkUserActionResultDto[];
+
+  @ApiProperty() succeeded: number;
+  @ApiProperty() failed: number;
+}

--- a/backend/src/admin/entities/user-flag.entity.ts
+++ b/backend/src/admin/entities/user-flag.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('user_flags')
+@Index(['user_id'])
+export class UserFlag {
+  @PrimaryGeneratedColumn('uuid')
+  @ApiProperty()
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @ApiProperty()
+  user_id: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  @ApiProperty({ required: false })
+  reason: string | null;
+
+  @Column({ type: 'varchar' })
+  @ApiProperty()
+  flagged_by: string;
+
+  @CreateDateColumn()
+  @ApiProperty()
+  created_at: Date;
+}

--- a/backend/src/migrations/1776800000000-CreateUserFlags.ts
+++ b/backend/src/migrations/1776800000000-CreateUserFlags.ts
@@ -1,0 +1,73 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateUserFlags1776800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_flags',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'reason',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+          {
+            name: 'flagged_by',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'user_flags',
+      new TableIndex({
+        name: 'IDX_user_flags_user_id',
+        columnNames: ['user_id'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'user_flags',
+      new TableForeignKey({
+        name: 'FK_user_flags_user',
+        columnNames: ['user_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('user_flags', 'FK_user_flags_user');
+    await queryRunner.dropTable('user_flags');
+  }
+}

--- a/backend/src/search/dto/suggest-query.dto.ts
+++ b/backend/src/search/dto/suggest-query.dto.ts
@@ -1,0 +1,67 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+/** Prefixes shorter than this return an empty list rather than querying the DB */
+export const MIN_SUGGEST_PREFIX_LENGTH = 2;
+
+export const MAX_SUGGEST_LIMIT = 10;
+
+export enum SuggestType {
+  All = 'all',
+  Markets = 'markets',
+  Users = 'users',
+  Competitions = 'competitions',
+}
+
+export class SuggestQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Type-ahead prefix. Prefixes shorter than 2 characters return an empty list (no error).',
+    example: 'bit',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString({ message: 'Prefix must be a string' })
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.trim().replace(/\s+/g, ' ') : value,
+  )
+  @MaxLength(100, { message: 'Prefix must not exceed 100 characters' })
+  q?: string;
+
+  @ApiPropertyOptional({ enum: SuggestType, default: SuggestType.All })
+  @IsOptional()
+  @IsEnum(SuggestType)
+  type?: SuggestType = SuggestType.All;
+
+  @ApiPropertyOptional({
+    default: MAX_SUGGEST_LIMIT,
+    maximum: MAX_SUGGEST_LIMIT,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(MAX_SUGGEST_LIMIT)
+  limit?: number = MAX_SUGGEST_LIMIT;
+}
+
+export class SuggestItemDto {
+  @ApiProperty() id: string;
+  @ApiProperty() label: string;
+  @ApiProperty({ enum: ['market', 'user', 'competition'] })
+  type: 'market' | 'user' | 'competition';
+}
+
+export class SuggestResponseDto {
+  @ApiProperty({ type: [SuggestItemDto] })
+  suggestions: SuggestItemDto[];
+}

--- a/backend/src/search/search-integration.spec.ts
+++ b/backend/src/search/search-integration.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Repository } from 'typeorm';
 import { SearchService } from './search.service';
 import { Market } from '../markets/entities/market.entity';
@@ -38,6 +39,10 @@ describe('SearchService - Wildcard Escaping Integration', () => {
           useValue: {
             createQueryBuilder: jest.fn(),
           },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn() },
         },
       ],
     }).compile();

--- a/backend/src/search/search.controller.spec.ts
+++ b/backend/src/search/search.controller.spec.ts
@@ -7,6 +7,7 @@ import {
   SearchType,
 } from './dto/global-search.dto';
 import { SearchQueryDto } from './dto/search-query.dto';
+import { SuggestQueryDto, SuggestType } from './dto/suggest-query.dto';
 import { ValidationPipe, BadRequestException } from '@nestjs/common';
 
 describe('SearchController', () => {
@@ -31,6 +32,10 @@ describe('SearchController', () => {
     users: ['alice'],
   };
 
+  const mockSuggestResponse = {
+    suggestions: [{ id: 'market-1', label: 'Bitcoin Market', type: 'market' }],
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SearchController],
@@ -42,6 +47,7 @@ describe('SearchController', () => {
             getSuggestions: jest
               .fn()
               .mockResolvedValue(mockSuggestionsResponse),
+            suggest: jest.fn().mockResolvedValue(mockSuggestResponse),
           },
         },
       ],
@@ -153,6 +159,66 @@ describe('SearchController', () => {
         metatype: SearchQueryDto,
       });
       expect(result.query).toBe('%%');
+    });
+  });
+
+  describe('suggest', () => {
+    it('forwards the query to the service', async () => {
+      const result = await controller.suggest({
+        q: 'bit',
+        type: SuggestType.All,
+        limit: 10,
+      });
+
+      expect(result).toEqual(mockSuggestResponse);
+      expect(service.suggest).toHaveBeenCalledWith({
+        q: 'bit',
+        type: SuggestType.All,
+        limit: 10,
+      });
+    });
+
+    it('validation pipe accepts an empty/missing prefix without throwing', async () => {
+      const result = await validationPipe.transform(
+        {},
+        { type: 'query', metatype: SuggestQueryDto },
+      );
+
+      expect(result.q).toBeUndefined();
+      expect(result.type).toBe(SuggestType.All);
+    });
+
+    it('validation pipe rejects a prefix over 100 characters', async () => {
+      const dto = { q: 'a'.repeat(101) };
+
+      await expect(
+        validationPipe.transform(dto, {
+          type: 'query',
+          metatype: SuggestQueryDto,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('validation pipe rejects an invalid type', async () => {
+      const dto = { q: 'bit', type: 'invalid' };
+
+      await expect(
+        validationPipe.transform(dto, {
+          type: 'query',
+          metatype: SuggestQueryDto,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('validation pipe rejects a limit above the max', async () => {
+      const dto = { q: 'bit', limit: 999 };
+
+      await expect(
+        validationPipe.transform(dto, {
+          type: 'query',
+          metatype: SuggestQueryDto,
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -14,6 +14,7 @@ import {
   SuggestionsResponseDto,
 } from './dto/global-search.dto';
 import { SearchQueryDto } from './dto/search-query.dto';
+import { SuggestQueryDto, SuggestResponseDto } from './dto/suggest-query.dto';
 import { SearchService } from './search.service';
 
 @ApiTags('Search')
@@ -42,6 +43,27 @@ export class SearchController {
     @Query() { query }: SearchQueryDto,
   ): Promise<SuggestionsResponseDto> {
     return this.searchService.getSuggestions(query);
+  }
+
+  @Public()
+  @Get('suggest')
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  )
+  @ApiOperation({
+    summary: 'Ranked type-ahead suggestions for a prefix (public)',
+    description:
+      'Returns a capped, ranked list of { id, label, type } suggestions for markets, ' +
+      'users, and/or competitions matching the given prefix. Results for popular prefixes ' +
+      'are cached briefly. Empty or short (<2 char) prefixes return an empty list.',
+  })
+  @ApiResponse({ status: 200, type: SuggestResponseDto })
+  async suggest(@Query() query: SuggestQueryDto): Promise<SuggestResponseDto> {
+    return this.searchService.suggest(query);
   }
 
   @Public()

--- a/backend/src/search/search.module.ts
+++ b/backend/src/search/search.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { CacheModule } from '@nestjs/cache-manager';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
@@ -7,7 +8,10 @@ import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Market, User, Competition])],
+  imports: [
+    TypeOrmModule.forFeature([Market, User, Competition]),
+    CacheModule.register(),
+  ],
   controllers: [SearchController],
   providers: [SearchService],
 })

--- a/backend/src/search/search.service.spec.ts
+++ b/backend/src/search/search.service.spec.ts
@@ -1,6 +1,7 @@
 // backend/src/search/search.service.spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { SelectQueryBuilder } from 'typeorm';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
@@ -10,6 +11,7 @@ import {
 } from '../competitions/entities/competition.entity';
 import { SearchService } from './search.service';
 import { GlobalSearchDto, SearchType } from './dto/global-search.dto';
+import { SuggestType } from './dto/suggest-query.dto';
 
 type MockQb<T> = jest.Mocked<
   Pick<
@@ -23,6 +25,7 @@ type MockQb<T> = jest.Mocked<
     | 'addOrderBy'
     | 'skip'
     | 'take'
+    | 'limit'
     | 'getMany'
     | 'getManyAndCount'
   >
@@ -40,10 +43,9 @@ function makeQb<T>(results: T[], count?: number): MockQb<T> {
     addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
     getMany: jest.fn().mockResolvedValue(results),
-    getManyAndCount: jest
-      .fn()
-      .mockResolvedValue([results, resolvedCount]),
+    getManyAndCount: jest.fn().mockResolvedValue([results, resolvedCount]),
   } as unknown as MockQb<T>;
   return qb;
 }
@@ -94,11 +96,21 @@ describe('SearchService', () => {
     headline: '<b>Crypto</b> League',
   } as unknown as Competition;
 
+  let mockCacheManager: {
+    get: jest.Mock;
+    set: jest.Mock;
+  };
+
   beforeEach(async () => {
     // Return count >= FTS_FALLBACK_THRESHOLD (3) so we get the fast FTS path
     marketQb = makeQb([mockMarket], 5);
     userQb = makeQb([mockUser], 5);
     competitionQb = makeQb([mockCompetition], 5);
+
+    mockCacheManager = {
+      get: jest.fn().mockResolvedValue(undefined),
+      set: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -116,6 +128,10 @@ describe('SearchService', () => {
           useValue: {
             createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
           },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
         },
       ],
     }).compile();
@@ -312,6 +328,10 @@ describe('SearchService', () => {
               createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
             },
           },
+          {
+            provide: CACHE_MANAGER,
+            useValue: mockCacheManager,
+          },
         ],
       }).compile();
 
@@ -355,6 +375,10 @@ describe('SearchService', () => {
               createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
             },
           },
+          {
+            provide: CACHE_MANAGER,
+            useValue: mockCacheManager,
+          },
         ],
       }).compile();
 
@@ -373,7 +397,13 @@ describe('SearchService', () => {
 
     it('trigram fallback andWhere includes OR similarity condition', async () => {
       marketQb = makeQb(
-        [{ ...mockMarket, fts_rank: '0', trgm_score: '0.35' } as unknown as Market],
+        [
+          {
+            ...mockMarket,
+            fts_rank: '0',
+            trgm_score: '0.35',
+          } as unknown as Market,
+        ],
         1,
       );
 
@@ -395,6 +425,10 @@ describe('SearchService', () => {
             useValue: {
               createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
             },
+          },
+          {
+            provide: CACHE_MANAGER,
+            useValue: mockCacheManager,
           },
         ],
       }).compile();
@@ -579,6 +613,10 @@ describe('SearchService', () => {
               createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
             },
           },
+          {
+            provide: CACHE_MANAGER,
+            useValue: mockCacheManager,
+          },
         ],
       }).compile();
 
@@ -629,6 +667,10 @@ describe('SearchService', () => {
               createQueryBuilder: jest.fn().mockReturnValue(competitionQb),
             },
           },
+          {
+            provide: CACHE_MANAGER,
+            useValue: mockCacheManager,
+          },
         ],
       }).compile();
 
@@ -643,6 +685,139 @@ describe('SearchService', () => {
 
       expect(result.markets[0].highlight).toBe(mockMarket.title);
       expect(result.markets[0].highlight).toBeTruthy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // suggest()
+  // -------------------------------------------------------------------------
+
+  describe('suggest()', () => {
+    const scoredMarket = {
+      id: 'market-1',
+      title: 'Bitcoin price prediction',
+      score: '0.8',
+    } as unknown as Market;
+
+    const scoredUser = {
+      id: 'user-1',
+      username: 'bitfan',
+      score: '0.6',
+    } as unknown as User;
+
+    const scoredCompetition = {
+      id: 'comp-1',
+      title: 'Bitcoin League',
+      score: '0.4',
+    } as unknown as Competition;
+
+    beforeEach(() => {
+      marketQb = makeQb([scoredMarket]);
+      userQb = makeQb([scoredUser]);
+      competitionQb = makeQb([scoredCompetition]);
+
+      (
+        service as unknown as {
+          marketsRepository: { createQueryBuilder: jest.Mock };
+        }
+      ).marketsRepository.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(marketQb);
+      (
+        service as unknown as {
+          usersRepository: { createQueryBuilder: jest.Mock };
+        }
+      ).usersRepository.createQueryBuilder = jest.fn().mockReturnValue(userQb);
+      (
+        service as unknown as {
+          competitionsRepository: { createQueryBuilder: jest.Mock };
+        }
+      ).competitionsRepository.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(competitionQb);
+    });
+
+    it('returns an empty list without querying for an empty prefix', async () => {
+      const result = await service.suggest({ q: '' });
+
+      expect(result).toEqual({ suggestions: [] });
+      expect(marketQb.getMany).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty list without querying for a 1-character prefix', async () => {
+      const result = await service.suggest({ q: 'b' });
+
+      expect(result).toEqual({ suggestions: [] });
+      expect(mockCacheManager.get).not.toHaveBeenCalled();
+    });
+
+    it('caps the query at the requested limit via a bounded LIMIT clause', async () => {
+      await service.suggest({ q: 'bit', type: SuggestType.Markets, limit: 5 });
+
+      expect(marketQb.limit).toHaveBeenCalledWith(5);
+    });
+
+    it('returns ranked, deduplicated ids+labels merged across types', async () => {
+      const result = await service.suggest({ q: 'bit', type: SuggestType.All });
+
+      expect(result.suggestions).toEqual([
+        { id: 'market-1', label: 'Bitcoin price prediction', type: 'market' },
+        { id: 'user-1', label: 'bitfan', type: 'user' },
+        { id: 'comp-1', label: 'Bitcoin League', type: 'competition' },
+      ]);
+    });
+
+    it('only queries the requested type', async () => {
+      await service.suggest({ q: 'bit', type: SuggestType.Users });
+
+      expect(userQb.getMany).toHaveBeenCalled();
+      expect(marketQb.getMany).not.toHaveBeenCalled();
+      expect(competitionQb.getMany).not.toHaveBeenCalled();
+    });
+
+    it('returns the cached response on a repeat lookup without re-querying', async () => {
+      const cached = {
+        suggestions: [
+          { id: 'market-1', label: 'Bitcoin', type: 'market' as const },
+        ],
+      };
+      mockCacheManager.get.mockResolvedValueOnce(cached);
+
+      const result = await service.suggest({
+        q: 'bit',
+        type: SuggestType.Markets,
+      });
+
+      expect(result).toEqual(cached);
+      expect(marketQb.getMany).not.toHaveBeenCalled();
+    });
+
+    it('caches the computed response after a miss', async () => {
+      await service.suggest({ q: 'bit', type: SuggestType.Markets });
+
+      expect(mockCacheManager.set).toHaveBeenCalledWith(
+        expect.stringContaining('search:suggest:'),
+        expect.objectContaining({ suggestions: expect.any(Array) }),
+        expect.any(Number),
+      );
+    });
+
+    it('excludes banned users and non-public markets/competitions via where clauses', async () => {
+      await service.suggest({ q: 'bit', type: SuggestType.All });
+
+      expect(marketQb.where).toHaveBeenCalledWith(
+        'market.is_public = :isPublic',
+        {
+          isPublic: true,
+        },
+      );
+      expect(userQb.where).toHaveBeenCalledWith('user.is_banned = :banned', {
+        banned: false,
+      });
+      expect(competitionQb.where).toHaveBeenCalledWith(
+        'competition.visibility = :visibility',
+        { visibility: CompetitionVisibility.Public },
+      );
     });
   });
 });

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { InjectRepository } from '@nestjs/typeorm';
+import type { Cache } from 'cache-manager';
 import { Repository } from 'typeorm';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
@@ -17,6 +19,14 @@ import {
   SuggestionsResponseDto,
 } from './dto/global-search.dto';
 import { escapeLikeWildcards } from './dto/search-query.dto';
+import {
+  MAX_SUGGEST_LIMIT,
+  MIN_SUGGEST_PREFIX_LENGTH,
+  SuggestItemDto,
+  SuggestQueryDto,
+  SuggestResponseDto,
+  SuggestType,
+} from './dto/suggest-query.dto';
 
 /**
  * Minimum number of FTS hits required before we skip the trigram fallback.
@@ -31,6 +41,16 @@ const FTS_FALLBACK_THRESHOLD = 3;
  */
 const TRGM_SIMILARITY_THRESHOLD = 0.1;
 
+/** How long a prefix's suggestion results are cached for */
+const SUGGEST_CACHE_TTL_MS = 30_000;
+
+interface ScoredSuggestion {
+  id: string;
+  label: string;
+  score: number;
+  type: 'market' | 'user' | 'competition';
+}
+
 @Injectable()
 export class SearchService {
   constructor(
@@ -40,6 +60,7 @@ export class SearchService {
     private readonly usersRepository: Repository<User>,
     @InjectRepository(Competition)
     private readonly competitionsRepository: Repository<Competition>,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
   async search(dto: GlobalSearchDto): Promise<GlobalSearchResponseDto> {
@@ -115,6 +136,129 @@ export class SearchService {
     };
   }
 
+  /**
+   * Lightweight, debounce-friendly type-ahead suggestions (ids + labels only).
+   * Backed by the trigram indexes on title/username so prefix lookups stay index-friendly,
+   * and results for popular prefixes are cached briefly to absorb repeat keystrokes.
+   */
+  async suggest(dto: SuggestQueryDto): Promise<SuggestResponseDto> {
+    const prefix = dto.q?.trim() ?? '';
+    if (prefix.length < MIN_SUGGEST_PREFIX_LENGTH) {
+      return { suggestions: [] };
+    }
+
+    const type = dto.type ?? SuggestType.All;
+    const limit = Math.min(dto.limit ?? MAX_SUGGEST_LIMIT, MAX_SUGGEST_LIMIT);
+    const cacheKey = `search:suggest:${type}:${limit}:${prefix.toLowerCase()}`;
+
+    const cached = await this.cacheManager.get<SuggestResponseDto>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const escapedPrefix = escapeLikeWildcards(prefix);
+
+    const [markets, users, competitions] = await Promise.all([
+      type === SuggestType.All || type === SuggestType.Markets
+        ? this.suggestMarkets(escapedPrefix, limit)
+        : Promise.resolve([]),
+      type === SuggestType.All || type === SuggestType.Users
+        ? this.suggestUsers(escapedPrefix, limit)
+        : Promise.resolve([]),
+      type === SuggestType.All || type === SuggestType.Competitions
+        ? this.suggestCompetitions(escapedPrefix, limit)
+        : Promise.resolve([]),
+    ]);
+
+    const suggestions: SuggestItemDto[] = [
+      ...markets,
+      ...users,
+      ...competitions,
+    ]
+      .sort((a, b) => b.score - a.score || a.label.localeCompare(b.label))
+      .slice(0, limit)
+      .map(({ id, label, type: itemType }) => ({ id, label, type: itemType }));
+
+    const response: SuggestResponseDto = { suggestions };
+    await this.cacheManager.set(cacheKey, response, SUGGEST_CACHE_TTL_MS);
+    return response;
+  }
+
+  private async suggestMarkets(
+    prefix: string,
+    limit: number,
+  ): Promise<ScoredSuggestion[]> {
+    const rows = await this.marketsRepository
+      .createQueryBuilder('market')
+      .select(['market.id', 'market.title'])
+      .addSelect('similarity(market.title, :prefix)', 'score')
+      .where('market.is_public = :isPublic', { isPublic: true })
+      .andWhere('market.title ILIKE :pattern', { pattern: `${prefix}%` })
+      .setParameter('prefix', prefix)
+      .orderBy('score', 'DESC')
+      .addOrderBy('market.title', 'ASC')
+      .limit(limit)
+      .getMany();
+
+    return (rows as (Market & { score?: string })[]).map((m) => ({
+      id: m.id,
+      label: m.title,
+      score: parseFloat(m.score ?? '0'),
+      type: 'market' as const,
+    }));
+  }
+
+  private async suggestUsers(
+    prefix: string,
+    limit: number,
+  ): Promise<ScoredSuggestion[]> {
+    const rows = await this.usersRepository
+      .createQueryBuilder('user')
+      .select(['user.id', 'user.username'])
+      .addSelect('similarity(user.username, :prefix)', 'score')
+      .where('user.is_banned = :banned', { banned: false })
+      .andWhere('user.username IS NOT NULL')
+      .andWhere('user.username ILIKE :pattern', { pattern: `${prefix}%` })
+      .setParameter('prefix', prefix)
+      .orderBy('score', 'DESC')
+      .addOrderBy('user.username', 'ASC')
+      .limit(limit)
+      .getMany();
+
+    return (rows as (User & { score?: string })[]).map((u) => ({
+      id: u.id,
+      label: u.username as string,
+      score: parseFloat(u.score ?? '0'),
+      type: 'user' as const,
+    }));
+  }
+
+  private async suggestCompetitions(
+    prefix: string,
+    limit: number,
+  ): Promise<ScoredSuggestion[]> {
+    const rows = await this.competitionsRepository
+      .createQueryBuilder('competition')
+      .select(['competition.id', 'competition.title'])
+      .addSelect('similarity(competition.title, :prefix)', 'score')
+      .where('competition.visibility = :visibility', {
+        visibility: CompetitionVisibility.Public,
+      })
+      .andWhere('competition.title ILIKE :pattern', { pattern: `${prefix}%` })
+      .setParameter('prefix', prefix)
+      .orderBy('score', 'DESC')
+      .addOrderBy('competition.title', 'ASC')
+      .limit(limit)
+      .getMany();
+
+    return (rows as (Competition & { score?: string })[]).map((c) => ({
+      id: c.id,
+      label: c.title,
+      score: parseFloat(c.score ?? '0'),
+      type: 'competition' as const,
+    }));
+  }
+
   // ---------------------------------------------------------------------------
   // Markets
   // ---------------------------------------------------------------------------
@@ -171,10 +315,7 @@ export class SearchService {
     const [ftsRaw, ftsCount] = await ftsQb.getManyAndCount();
 
     if (ftsCount >= FTS_FALLBACK_THRESHOLD) {
-      return [
-        this.mapMarketsWithScore(ftsRaw, skip, limit),
-        ftsCount,
-      ];
+      return [this.mapMarketsWithScore(ftsRaw, skip, limit), ftsCount];
     }
 
     // Phase 2: trigram fallback — merge FTS hits with similarity hits
@@ -236,14 +377,15 @@ export class SearchService {
 
     const [trgmRaw, trgmCount] = await trgmQb.getManyAndCount();
 
-    return [
-      this.mapMarketsWithScore(trgmRaw, skip, limit),
-      trgmCount,
-    ];
+    return [this.mapMarketsWithScore(trgmRaw, skip, limit), trgmCount];
   }
 
   private mapMarketsWithScore(
-    raw: (Market & { fts_rank?: string; trgm_score?: string; headline?: string })[],
+    raw: (Market & {
+      fts_rank?: string;
+      trgm_score?: string;
+      headline?: string;
+    })[],
     skip: number,
     limit: number,
   ): MarketSearchResult[] {
@@ -367,7 +509,11 @@ export class SearchService {
   }
 
   private mapUsersWithScore(
-    raw: (User & { fts_rank?: string; trgm_score?: string; headline?: string })[],
+    raw: (User & {
+      fts_rank?: string;
+      trgm_score?: string;
+      headline?: string;
+    })[],
     skip: number,
     limit: number,
   ): UserSearchResult[] {
@@ -441,10 +587,7 @@ export class SearchService {
     const [ftsRaw, ftsCount] = await ftsQb.getManyAndCount();
 
     if (ftsCount >= FTS_FALLBACK_THRESHOLD) {
-      return [
-        this.mapCompetitionsWithScore(ftsRaw, skip, limit),
-        ftsCount,
-      ];
+      return [this.mapCompetitionsWithScore(ftsRaw, skip, limit), ftsCount];
     }
 
     // Trigram fallback
@@ -507,10 +650,7 @@ export class SearchService {
 
     const [trgmRaw, trgmCount] = await trgmQb.getManyAndCount();
 
-    return [
-      this.mapCompetitionsWithScore(trgmRaw, skip, limit),
-      trgmCount,
-    ];
+    return [this.mapCompetitionsWithScore(trgmRaw, skip, limit), trgmCount];
   }
 
   private mapCompetitionsWithScore(


### PR DESCRIPTION

Admin bulk user action (backend/src/admin/):
- dto/bulk-user-action.dto.ts — BulkUserActionDto (1-100 unique UUIDs, ban|unban|flag action, optional reason), plus per-item result/response DTOs.
- entities/user-flag.entity.ts + migration 1776800000000-CreateUserFlags.ts — new user_flags table since flagging a user had no existing storage (the Flag entity is market-scoped).
- admin.service.ts — bulkUserAction() runs each user through its own DB transaction (user mutation + audit log write are atomic together), catches per-item failures so one bad ID doesn't sink the batch, and returns a { user_id, success, error? } report.
- admin.controller.ts — POST /admin/users/bulk-action, inherits the controller's class-level @Roles(Role.Admin) guard, so non-admins (including moderators) get 403.
- Tests cover: all-succeed, partial failure (missing user), duplicate-ban/already-unbanned failures, flag record creation, controller wiring, and RolesGuard 403 enforcement.

Search suggest endpoint (backend/src/search/):
- dto/suggest-query.dto.ts — SuggestQueryDto (no MinLength validator, so short/empty prefixes don't 400 — service returns [] instead), capped limit (max 10).
- search.service.ts — new suggest() method: bounded LIMIT-at-the-DB-level queries per type using the existing trigram GIN indexes, ranks by similarity score, merges across types, and caches per-prefix results for 30s via CACHE_MANAGER (added to search.module.ts).
- search.controller.ts — GET /search/suggest, public, returns { suggestions: [{ id, label, type }] }.
- Tests cover ranking/merging, type filtering, limit capping, cache hit/miss, and empty-list behavior for short prefixes. Also had to add the new CACHE_MANAGER provider to the pre-existing search-integration.spec.ts since SearchService's constructor changed.



closes #1379
closes #1377
closes #1378
closes #1380