### PR TITLE
feat: Governance Timelock with Veto Window

### DIFF
--- a/contracts/open-market/src/config.rs
+++ b/contracts/open-market/src/config.rs
@@ -10,6 +10,12 @@ use crate::storage_types::DataKey;
 pub const PERSISTENT_BUMP: u32 = 518_400;
 pub const PERSISTENT_THRESHOLD: u32 = 501_120; // PERSISTENT_BUMP − 1 day
 
+// ── Governance timelock defaults ──────────────────────────────────────────────
+/// Default delay (seconds) a passed governance proposal must sit in the queue
+/// before it becomes executable. ~2 days at real time. Admin-configurable via
+/// [`set_timelock_delay`].
+pub const DEFAULT_TIMELOCK_DELAY: u64 = 172_800;
+
 // ── Storage-specific TTL constants (merged from ttl.rs) ───────────────────────
 // ~30 days at ~6s/ledger for frequently accessed market state.
 pub const LEDGER_BUMP_MARKET: u32 = 432_000;
@@ -113,6 +119,15 @@ pub struct Config {
     pub xlm_token: Address,
     /// When `true`, all non-admin entry points must revert with `Paused`.
     pub is_paused: bool,
+    /// Address authorized to veto a queued governance proposal during its
+    /// timelock window. Defaults to `admin` at initialization.
+    pub guardian: Address,
+    /// Delay (seconds) a passed governance proposal must wait in the queue
+    /// before `execute_proposal` will apply it. This value — and `guardian`
+    /// above — are only mutable via the admin-only setters in this module;
+    /// no `ProposalType` variant may change them, so a proposal can never
+    /// vote itself a shorter timelock or a friendlier guardian.
+    pub timelock_delay: u64,
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────
@@ -160,6 +175,7 @@ pub fn initialize(
     validate_protocol_fee(fee_bps)?;
 
     let config = Config {
+        guardian: admin.clone(),
         admin,
         protocol_fee_bps: fee_bps,
         max_creator_fee_bps: 500,  // 5 % absolute cap for market creators
@@ -167,6 +183,7 @@ pub fn initialize(
         oracle_address: oracle,
         xlm_token,
         is_paused: false,
+        timelock_delay: DEFAULT_TIMELOCK_DELAY,
     };
 
     env.storage().persistent().set(&DataKey::Config, &config);
@@ -295,6 +312,74 @@ fn emit_oracle_updated(env: &Env, old_oracle: &Address, new_oracle: &Address) {
     env.events().publish(
         (symbol_short!("cfg"), symbol_short!("ora_upd")),
         (old_oracle.clone(), new_oracle.clone()),
+    );
+}
+
+/// Update the governance timelock delay. Caller must be the stored admin.
+///
+/// This is intentionally only reachable through the admin path — no
+/// `ProposalType` exists to change it via governance — so a proposal can
+/// never shorten its own timelock to bypass the veto window.
+pub fn set_timelock_delay(
+    env: &Env,
+    admin: Address,
+    new_delay: u64,
+) -> Result<(), InsightArenaError> {
+    let mut config = load_config(env)?;
+
+    admin.require_auth();
+    if admin != config.admin {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    let old_delay = config.timelock_delay;
+    config.timelock_delay = new_delay;
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    emit_timelock_delay_updated(env, old_delay, new_delay);
+
+    Ok(())
+}
+
+fn emit_timelock_delay_updated(env: &Env, old_delay: u64, new_delay: u64) {
+    env.events().publish(
+        (symbol_short!("cfg"), symbol_short!("tl_upd")),
+        (old_delay, new_delay),
+    );
+}
+
+/// Update the governance guardian address. Caller must be the stored admin.
+///
+/// Like `timelock_delay`, this is only reachable through the admin path —
+/// no `ProposalType` exists to change it via governance — so a proposal can
+/// never appoint a friendly guardian to neutralize the veto safeguard.
+pub fn set_guardian(
+    env: &Env,
+    admin: Address,
+    new_guardian: Address,
+) -> Result<(), InsightArenaError> {
+    let mut config = load_config(env)?;
+
+    admin.require_auth();
+    if admin != config.admin {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    let old_guardian = config.guardian;
+    config.guardian = new_guardian.clone();
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    emit_guardian_updated(env, &old_guardian, &new_guardian);
+
+    Ok(())
+}
+
+fn emit_guardian_updated(env: &Env, old_guardian: &Address, new_guardian: &Address) {
+    env.events().publish(
+        (symbol_short!("cfg"), symbol_short!("grd_upd")),
+        (old_guardian.clone(), new_guardian.clone()),
     );
 }
 

--- a/contracts/open-market/src/errors.rs
+++ b/contracts/open-market/src/errors.rs
@@ -138,4 +138,9 @@ pub enum InsightArenaError {
     // ── Conditional Markets ───────────────────────────────────────────────────
     /// The maximum allowed depth for nested conditional markets has been exceeded.
     ConditionalDepthExceeded = 103,
+
+    // ── Governance Timelock ───────────────────────────────────────────────────
+    /// A passed proposal was queued but its timelock `ready_at` timestamp has not
+    /// yet elapsed. Raised when `execute_proposal` is called too early.
+    TimelockNotElapsed = 104,
 }

--- a/contracts/open-market/src/governance.rs
+++ b/contracts/open-market/src/governance.rs
@@ -3,9 +3,16 @@ use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 use crate::config;
 use crate::errors::InsightArenaError;
 use crate::market;
-use crate::storage_types::DataKey;
+use crate::storage_types::{DataKey, ProposalState};
 use crate::Config;
 
+/// Parameter changes a passed governance proposal may apply.
+///
+/// Notably absent: anything touching `Config::timelock_delay` or
+/// `Config::guardian`. Those are intentionally admin-only (see
+/// `config::set_timelock_delay` / `config::set_guardian`) so that no
+/// proposal can ever vote itself a shorter timelock or a friendlier
+/// guardian to bypass the veto safety net.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProposalType {
@@ -27,6 +34,11 @@ pub struct Proposal {
     pub voting_end: u64,
     pub executed: bool,
     pub cancelled: bool,
+    /// Set once voting has passed quorum/majority: `now + timelock_delay` at
+    /// that moment. `None` while still voting (or if it never passed).
+    pub ready_at: Option<u64>,
+    /// Set by the guardian during the timelock window; blocks execution.
+    pub vetoed: bool,
 }
 
 
@@ -88,6 +100,18 @@ fn emit_proposal_cancelled(env: &Env, proposal_id: u32) {
     );
 }
 
+fn emit_proposal_queued(env: &Env, proposal_id: u32, ready_at: u64) {
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("queued")),
+        (proposal_id, ready_at),
+    );
+}
+
+fn emit_proposal_vetoed(env: &Env, proposal_id: u32) {
+    env.events()
+        .publish((symbol_short!("gov"), symbol_short!("vetoed")), proposal_id);
+}
+
 pub fn create_proposal(
     env: &Env,
     proposer: Address,
@@ -124,6 +148,8 @@ pub fn create_proposal(
         voting_end,
         executed: false,
         cancelled: false,
+        ready_at: None,
+        vetoed: false,
     };
 
 
@@ -172,6 +198,17 @@ pub fn vote(
     Ok(())
 }
 
+/// Execute a passed proposal, subject to the governance timelock.
+///
+/// A contract call that returns `Err` reverts every write it made, so
+/// "queue" and "execute" cannot share one call the way a single fallthrough
+/// function would suggest: this needs two separate calls to `execute_proposal`.
+/// The first call after voting ends does the "queueing": if quorum and
+/// majority were met, it records `ready_at = now + timelock_delay` and
+/// returns `Ok(())`, persisting the queued state. Any call made before
+/// `ready_at` (including a queued proposal's own queuing check re-run) then
+/// returns `TimelockNotElapsed`. Once `ready_at` is reached, a further call
+/// actually applies the effect.
 pub fn execute_proposal(
     env: &Env,
     executor: Address,
@@ -181,20 +218,45 @@ pub fn execute_proposal(
     executor.require_auth();
 
     let mut proposal = load_proposal(env, proposal_id)?;
-    if proposal.executed || env.ledger().timestamp() < proposal.voting_end {
+
+    if proposal.executed || proposal.cancelled || proposal.vetoed {
         return Err(InsightArenaError::InvalidInput);
     }
 
-    let users = load_registered_users(env);
-    let total_users = users.len();
-    let total_votes = proposal
-        .votes_for
-        .checked_add(proposal.votes_against)
-        .ok_or(InsightArenaError::Overflow)?;
+    let now = env.ledger().timestamp();
 
-    let quorum = proposal_quorum(total_users);
-    if total_votes < quorum || proposal.votes_for <= proposal.votes_against {
-        return Err(InsightArenaError::Unauthorized);
+    if proposal.ready_at.is_none() {
+        if now < proposal.voting_end {
+            return Err(InsightArenaError::InvalidInput);
+        }
+
+        let users = load_registered_users(env);
+        let total_users = users.len();
+        let total_votes = proposal
+            .votes_for
+            .checked_add(proposal.votes_against)
+            .ok_or(InsightArenaError::Overflow)?;
+
+        let quorum = proposal_quorum(total_users);
+        if total_votes < quorum || proposal.votes_for <= proposal.votes_against {
+            return Err(InsightArenaError::Unauthorized);
+        }
+
+        let cfg = config::get_config(env)?;
+        let ready_at = now
+            .checked_add(cfg.timelock_delay)
+            .ok_or(InsightArenaError::Overflow)?;
+        proposal.ready_at = Some(ready_at);
+        store_proposal(env, &proposal);
+        emit_proposal_queued(env, proposal_id, ready_at);
+
+        // Persist the queued state now — a subsequent call re-checks readiness.
+        return Ok(());
+    }
+
+    let ready_at = proposal.ready_at.unwrap();
+    if now < ready_at {
+        return Err(InsightArenaError::TimelockNotElapsed);
     }
 
     let summary = match proposal.proposal_type.clone() {
@@ -238,7 +300,7 @@ pub fn execute_proposal(
 /// Cancel a proposal before it is executed.
 ///
 /// Only the original proposer or the platform admin may cancel. Proposals that
-/// have already been executed cannot be cancelled.
+/// have already been executed, vetoed, or cancelled cannot be cancelled again.
 pub fn cancel_proposal(
     env: &Env,
     caller: Address,
@@ -248,7 +310,7 @@ pub fn cancel_proposal(
 
     let mut proposal = load_proposal(env, proposal_id)?;
 
-    if proposal.executed || proposal.cancelled {
+    if proposal.executed || proposal.cancelled || proposal.vetoed {
         return Err(InsightArenaError::InvalidInput);
     }
 
@@ -265,6 +327,66 @@ pub fn cancel_proposal(
 
 
     Ok(())
+}
+
+/// Guardian-only veto of a queued proposal, valid any time between it entering
+/// the queue (`ready_at` set) and it actually being executed. Once executed,
+/// cancelled, or already vetoed, this errors rather than re-applying the veto.
+pub fn veto_proposal(
+    env: &Env,
+    guardian: Address,
+    proposal_id: u32,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
+    guardian.require_auth();
+
+    let cfg = config::get_config(env)?;
+    if guardian != cfg.guardian {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    let mut proposal = load_proposal(env, proposal_id)?;
+
+    if proposal.executed || proposal.cancelled || proposal.vetoed {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    // Nothing queued yet — vetoing only applies to the timelock window.
+    if proposal.ready_at.is_none() {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    proposal.vetoed = true;
+    store_proposal(env, &proposal);
+
+    emit_proposal_vetoed(env, proposal_id);
+
+    Ok(())
+}
+
+/// Derive the current lifecycle state of a proposal from its stored flags and
+/// the ledger clock. See [`ProposalState`] for the full transition diagram.
+pub fn get_proposal_state(
+    env: &Env,
+    proposal_id: u32,
+) -> Result<ProposalState, InsightArenaError> {
+    let proposal = load_proposal(env, proposal_id)?;
+
+    if proposal.executed {
+        return Ok(ProposalState::Executed);
+    }
+    if proposal.vetoed {
+        return Ok(ProposalState::Vetoed);
+    }
+    if proposal.cancelled {
+        return Ok(ProposalState::Cancelled);
+    }
+
+    Ok(match proposal.ready_at {
+        Some(ready_at) if env.ledger().timestamp() >= ready_at => ProposalState::Executable,
+        Some(_) => ProposalState::Queued,
+        None => ProposalState::Voting,
+    })
 }
 
 /// Return a single proposal by ID, extending its TTL on read.

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -22,6 +22,7 @@ pub mod storage_types;
 pub use crate::config::Config;
 pub use crate::errors::InsightArenaError;
 pub use crate::governance::{Proposal, ProposalType};
+pub use crate::storage_types::ProposalState;
 pub use crate::liquidity::{calculate_liquidity_value, calculate_lp_tokens, calculate_swap_output};
 pub use crate::market::CreateMarketParams;
 pub use crate::storage_types::{
@@ -381,6 +382,41 @@ impl InsightArenaContract {
         proposal_id: u32,
     ) -> Result<(), InsightArenaError> {
         governance::cancel_proposal(&env, caller, proposal_id)
+    }
+
+    /// Guardian-only veto of a queued proposal during its timelock window.
+    pub fn veto_proposal(
+        env: Env,
+        guardian: Address,
+        proposal_id: u32,
+    ) -> Result<(), InsightArenaError> {
+        governance::veto_proposal(&env, guardian, proposal_id)
+    }
+
+    /// Return the current lifecycle state of a proposal (Voting/Queued/Executable/Executed/Cancelled/Vetoed).
+    pub fn get_proposal_state(
+        env: Env,
+        proposal_id: u32,
+    ) -> Result<ProposalState, InsightArenaError> {
+        governance::get_proposal_state(&env, proposal_id)
+    }
+
+    /// Update the governance timelock delay (seconds). Caller must be the current admin.
+    pub fn set_timelock_delay(
+        env: Env,
+        admin: Address,
+        new_delay: u64,
+    ) -> Result<(), InsightArenaError> {
+        config::set_timelock_delay(&env, admin, new_delay)
+    }
+
+    /// Update the governance guardian address. Caller must be the current admin.
+    pub fn set_guardian(
+        env: Env,
+        admin: Address,
+        new_guardian: Address,
+    ) -> Result<(), InsightArenaError> {
+        config::set_guardian(&env, admin, new_guardian)
     }
 
     /// Return the total protocol fees accumulated in the treasury.

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -106,6 +106,27 @@ pub enum DataKey {
     TreasuryBalance,
 }
 
+/// Lifecycle state of a governance proposal, derived from its stored flags and
+/// the current ledger time rather than persisted directly.
+///
+/// `Voting -> Queued -> Executable -> (Executed | Vetoed | Cancelled)`
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalState {
+    /// Voting window is still open.
+    Voting,
+    /// Voting passed and `ready_at` has been recorded, but the timelock has not elapsed.
+    Queued,
+    /// The timelock has elapsed; the proposal may now be executed.
+    Executable,
+    /// The proposal's effect has been applied.
+    Executed,
+    /// The proposer or admin withdrew the proposal before execution.
+    Cancelled,
+    /// The guardian vetoed the proposal during the timelock window.
+    Vetoed,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Dispute {

--- a/contracts/open-market/tests/governance_tests.rs
+++ b/contracts/open-market/tests/governance_tests.rs
@@ -1,6 +1,9 @@
+use insightarena_contract::config::DEFAULT_TIMELOCK_DELAY;
 use insightarena_contract::governance::ProposalType;
 
-use insightarena_contract::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
+use insightarena_contract::{
+    InsightArenaContract, InsightArenaContractClient, InsightArenaError, ProposalState,
+};
 use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
@@ -32,6 +35,10 @@ fn seed_users(env: &Env, _client: &InsightArenaContractClient, count: u32) -> Ve
     users
 }
 
+/// Runs a proposal through voting, queues it (first `execute_proposal` call
+/// after voting ends), then fast-forwards past the default timelock so the
+/// returned id is immediately executable by a single follow-up call — keeping
+/// pre-existing callers of this helper unchanged.
 fn pass_proposal(
     env: &Env,
     client: &InsightArenaContractClient,
@@ -47,6 +54,11 @@ fn pass_proposal(
     }
 
     env.ledger().with_mut(|l| l.timestamp += duration + 1);
+
+    let queuer = Address::generate(env);
+    let _ = client.try_execute_proposal(&queuer, &id);
+
+    env.ledger().with_mut(|l| l.timestamp += DEFAULT_TIMELOCK_DELAY);
     id
 }
 
@@ -222,5 +234,229 @@ fn test_cancel_proposal_by_non_proposer_fails() {
     let id = client.create_proposal(&proposer, &ProposalType::UpdateProtocolFee(400), &duration);
 
     let result = client.try_cancel_proposal(&non_proposer, &id);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+// ── Timelock / veto tests ─────────────────────────────────────────────────────
+
+/// Advances voting to completion and quorum without touching the timelock clock,
+/// returning the proposal id right after voting has ended (not yet queued).
+fn pass_vote_only(
+    env: &Env,
+    client: &InsightArenaContractClient,
+    action: &ProposalType,
+    voters: &Vec<Address>,
+) -> u32 {
+    let proposer = Address::generate(env);
+    let duration = 3_600_u64;
+    let id = client.create_proposal(&proposer, action, &duration);
+
+    for voter in voters.iter() {
+        client.vote(&voter, &id, &true);
+    }
+
+    env.ledger().with_mut(|l| l.timestamp += duration + 1);
+    id
+}
+
+#[test]
+fn test_execute_proposal_queues_and_blocks_before_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let id = pass_vote_only(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+
+    let executor = Address::generate(&env);
+
+    // First call after voting ends just queues the proposal (persists ready_at);
+    // it does not execute yet.
+    client.execute_proposal(&executor, &id);
+
+    let proposal = client.get_proposal(&id);
+    assert!(!proposal.executed);
+    assert!(proposal.ready_at.is_some());
+    assert_eq!(client.get_proposal_state(&id), ProposalState::Queued);
+
+    // Config must not have changed yet.
+    assert_eq!(client.get_config().protocol_fee_bps, 200);
+
+    // A second call before ready_at errors with the typed timelock error.
+    let result = client.try_execute_proposal(&executor, &id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TimelockNotElapsed))
+    ));
+
+    // Still too early one second before ready_at.
+    let ready_at = proposal.ready_at.unwrap();
+    env.ledger().with_mut(|l| l.timestamp = ready_at - 1);
+    let result = client.try_execute_proposal(&executor, &id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TimelockNotElapsed))
+    ));
+}
+
+#[test]
+fn test_execute_proposal_succeeds_at_ready_at_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let id = pass_vote_only(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+
+    let executor = Address::generate(&env);
+    let _ = client.try_execute_proposal(&executor, &id); // queue
+    let ready_at = client.get_proposal(&id).ready_at.unwrap();
+
+    // Exactly at ready_at succeeds.
+    env.ledger().with_mut(|l| l.timestamp = ready_at);
+    client.execute_proposal(&executor, &id);
+
+    let proposal = client.get_proposal(&id);
+    assert!(proposal.executed);
+    assert_eq!(client.get_proposal_state(&id), ProposalState::Executed);
+    assert_eq!(client.get_config().protocol_fee_bps, 500);
+}
+
+#[test]
+fn test_veto_proposal_cancels_before_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let id = pass_vote_only(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+
+    let executor = Address::generate(&env);
+    let _ = client.try_execute_proposal(&executor, &id); // queue
+
+    // Default guardian is the admin.
+    client.veto_proposal(&admin, &id);
+
+    let proposal = client.get_proposal(&id);
+    assert!(proposal.vetoed);
+    assert_eq!(client.get_proposal_state(&id), ProposalState::Vetoed);
+
+    // Execution after veto errors even once the timelock has elapsed.
+    let ready_at = proposal.ready_at.unwrap();
+    env.ledger().with_mut(|l| l.timestamp = ready_at);
+    let result = client.try_execute_proposal(&executor, &id);
+    assert!(result.is_err());
+
+    // The change never applied.
+    assert_eq!(client.get_config().protocol_fee_bps, 200);
+}
+
+#[test]
+fn test_veto_proposal_after_execution_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let id = pass_proposal(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+    let executor = Address::generate(&env);
+    client.execute_proposal(&executor, &id);
+
+    let result = client.try_veto_proposal(&admin, &id);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn test_veto_proposal_before_queued_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = deploy(&env);
+
+    let proposer = Address::generate(&env);
+    let duration = 3_600_u64;
+    let id = client.create_proposal(&proposer, &ProposalType::UpdateProtocolFee(500), &duration);
+
+    // Still in the voting window — never queued.
+    let result = client.try_veto_proposal(&admin, &id);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn test_veto_proposal_unauthorized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let id = pass_vote_only(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+    let executor = Address::generate(&env);
+    let _ = client.try_execute_proposal(&executor, &id); // queue
+
+    let not_guardian = Address::generate(&env);
+    let result = client.try_veto_proposal(&not_guardian, &id);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+#[test]
+fn test_set_guardian_allows_new_guardian_to_veto() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let new_guardian = Address::generate(&env);
+    client.set_guardian(&admin, &new_guardian);
+
+    let id = pass_vote_only(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+    let executor = Address::generate(&env);
+    let _ = client.try_execute_proposal(&executor, &id); // queue
+
+    // The old admin/guardian can no longer veto.
+    let result = client.try_veto_proposal(&admin, &id);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+
+    client.veto_proposal(&new_guardian, &id);
+    assert!(client.get_proposal(&id).vetoed);
+}
+
+#[test]
+fn test_set_timelock_delay_changes_ready_at() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = deploy(&env);
+    let voters = seed_users(&env, &client, 5);
+
+    let short_delay = 10_u64;
+    client.set_timelock_delay(&admin, &short_delay);
+
+    let id = pass_vote_only(&env, &client, &ProposalType::UpdateProtocolFee(500), &voters);
+    let queued_at = env.ledger().timestamp();
+    let executor = Address::generate(&env);
+    let _ = client.try_execute_proposal(&executor, &id); // queue
+
+    let proposal = client.get_proposal(&id);
+    assert_eq!(proposal.ready_at, Some(queued_at + short_delay));
+}
+
+#[test]
+fn test_set_timelock_delay_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = deploy(&env);
+
+    let not_admin = Address::generate(&env);
+    let result = client.try_set_timelock_delay(&not_admin, &10_u64);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+#[test]
+fn test_set_guardian_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = deploy(&env);
+
+    let not_admin = Address::generate(&env);
+    let new_guardian = Address::generate(&env);
+    let result = client.try_set_guardian(&not_admin, &new_guardian);
     assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
 }


### PR DESCRIPTION

Passed governance proposals used to execute immediately, giving zero reaction time to catch a malicious or mistaken parameter change. This adds a mandatory timelock between a proposal passing and it taking effect, plus a guardian who can veto a queued proposal during that window.

- `execute_proposal` now queues a passed proposal (`ready_at = now + timelock_delay`) instead of applying it immediately, and blocks execution until `ready_at` with a typed error.
- New `veto_proposal` lets a guardian address cancel a queued proposal any time before it executes.
- `timelock_delay` and `guardian` are new admin-configurable `Config` fields, defaulted at `initialize` so no existing deployment/test breaks.
- Neither field is reachable from any `ProposalType`, so a proposal can never vote itself a shorter timelock or a friendlier guardian.

## Changes

**`contracts/open-market/src/errors.rs`**
- Added `TimelockNotElapsed = 104`.

**`contracts/open-market/src/config.rs`**
- Added `Config::guardian: Address` and `Config::timelock_delay: u64`.
- `initialize` defaults `guardian = admin` and `timelock_delay = DEFAULT_TIMELOCK_DELAY` (172,800s / 2 days).
- Added `set_timelock_delay(admin, new_delay)` and `set_guardian(admin, new_guardian)` — both admin-only, each emitting a config-updated event.

**`contracts/open-market/src/storage_types.rs`**
- Added `ProposalState` enum: `Voting → Queued → Executable → {Executed | Cancelled | Vetoed}`. Derived on read from a proposal's stored flags and the current ledger time — not persisted itself.

**`contracts/open-market/src/governance.rs`**
- `Proposal` gained `ready_at: Option<u64>` and `vetoed: bool`.
- `execute_proposal`: first call after voting passes quorum/majority sets `ready_at` and returns `Ok` (queued); any call before `ready_at` returns `TimelockNotElapsed`; a call at/after `ready_at` applies the effect as before.
  - Note: Soroban reverts all storage writes when a call returns `Err`, so "queue" and "block" can't happen atomically in one call — the queuing call must succeed (`Ok`) to persist `ready_at`, and a *subsequent* call is what actually enforces the block.
- Added `veto_proposal(guardian, id)` — only the configured guardian, only once queued, only before execution.
- Added `get_proposal_state(id)` view function.
- `cancel_proposal` guard extended to also reject already-vetoed proposals.

**`contracts/open-market/src/lib.rs`**
- Exposed `veto_proposal`, `get_proposal_state`, `set_timelock_delay`, `set_guardian` as contract entry points.

**`contracts/open-market/tests/governance_tests.rs`**
- Updated the `pass_proposal` helper to queue-then-fast-forward past the default timelock, so all pre-existing single-call execute tests keep working unchanged.
- Added 10 new tests: blocked-before-timelock, exact `ready_at` boundary success, veto during window, veto-after-execution failure, veto-before-queued failure, unauthorized veto, guardian rotation, and admin-only gating on both new setters.

## Acceptance criteria

- [x] Execution before `ready_at` errors (`TimelockNotElapsed`); at/after succeeds — boundary-tested at exactly `ready_at`.
- [x] Veto during the timelock window cancels execution; veto after execution errors.
- [x] Only the guardian can veto; unauthorized attempts return `Unauthorized`.
- [x] Timelock queueing, veto, and execution covered by unit and integration tests.

## Test plan

- `cargo test` — full workspace suite (400+ tests) passes, including 19 governance tests.
- `cargo clippy --lib --tests` — no new warnings introduced.





closes #1313