### PR TITLE
feat(oracle): statistical anomaly detection for submissions

### DIFF
--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -77,6 +77,23 @@ class EnvironmentVariables {
 
   @IsNumber()
   LEADERBOARD_SNAPSHOT_RETENTION_DAYS: number = 30;
+
+  // Oracle submission anomaly detection (#1364)
+  @IsOptional()
+  @IsNumber()
+  ORACLE_ANOMALY_THRESHOLD?: number;
+
+  @IsOptional()
+  @IsNumber()
+  ORACLE_ANOMALY_MIN_SAMPLES?: number;
+
+  @IsOptional()
+  @IsNumber()
+  ORACLE_ANOMALY_WINDOW?: number;
+
+  @IsOptional()
+  @IsString()
+  ORACLE_ANOMALY_HOLD?: string;
 }
 
 export function validate(config: Record<string, unknown>) {

--- a/backend/src/migrations/1776700000000-AddOracleAnomalyDetection.ts
+++ b/backend/src/migrations/1776700000000-AddOracleAnomalyDetection.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Oracle submission anomaly detection (#1364).
+ *
+ * Adds anomaly/review columns to `oracle_submissions` and creates the
+ * `oracle_submission_flags` audit table.
+ */
+export class AddOracleAnomalyDetection1776700000000 implements MigrationInterface {
+  name = 'AddOracleAnomalyDetection1776700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "oracle_submissions_review_status_enum" AS ENUM (
+        'not_required', 'held', 'approved', 'rejected'
+      )
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "oracle_submissions"
+        ADD COLUMN "is_anomaly" boolean NOT NULL DEFAULT false,
+        ADD COLUMN "anomaly_score" double precision,
+        ADD COLUMN "review_status" "oracle_submissions_review_status_enum" NOT NULL DEFAULT 'not_required',
+        ADD COLUMN "reviewed_by" varchar(255),
+        ADD COLUMN "reviewed_at" TIMESTAMPTZ
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_submissions_is_anomaly" ON "oracle_submissions" ("is_anomaly")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_submissions_review_status" ON "oracle_submissions" ("review_status")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_submissions_data_source_created" ON "oracle_submissions" ("data_source", "created_at")
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "oracle_submission_flags" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "submission_id" uuid NOT NULL,
+        "match_id" varchar(255) NOT NULL,
+        "data_source" varchar(500) NOT NULL,
+        "observed_value" double precision NOT NULL,
+        "baseline_mean" double precision NOT NULL,
+        "baseline_stddev" double precision NOT NULL,
+        "deviation" double precision NOT NULL,
+        "threshold" double precision NOT NULL,
+        "sample_size" integer NOT NULL,
+        "held" boolean NOT NULL DEFAULT false,
+        "reason" varchar(500),
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "FK_oracle_submission_flags_submission" FOREIGN KEY ("submission_id") REFERENCES "oracle_submissions"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_submission_flags_submission" ON "oracle_submission_flags" ("submission_id")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_submission_flags_source_created" ON "oracle_submission_flags" ("data_source", "created_at")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_submission_flags_held" ON "oracle_submission_flags" ("held")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_oracle_submission_flags_held"`);
+    await queryRunner.query(
+      `DROP INDEX "IDX_oracle_submission_flags_source_created"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "IDX_oracle_submission_flags_submission"`,
+    );
+    await queryRunner.query(`DROP TABLE "oracle_submission_flags"`);
+
+    await queryRunner.query(
+      `DROP INDEX "IDX_oracle_submissions_data_source_created"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "IDX_oracle_submissions_review_status"`,
+    );
+    await queryRunner.query(`DROP INDEX "IDX_oracle_submissions_is_anomaly"`);
+    await queryRunner.query(`
+      ALTER TABLE "oracle_submissions"
+        DROP COLUMN "reviewed_at",
+        DROP COLUMN "reviewed_by",
+        DROP COLUMN "review_status",
+        DROP COLUMN "anomaly_score",
+        DROP COLUMN "is_anomaly"
+    `);
+    await queryRunner.query(
+      `DROP TYPE "oracle_submissions_review_status_enum"`,
+    );
+  }
+}

--- a/backend/src/oracle/dto/anomaly-detection.dto.ts
+++ b/backend/src/oracle/dto/anomaly-detection.dto.ts
@@ -1,0 +1,174 @@
+import {
+  IsOptional,
+  IsInt,
+  IsString,
+  IsBoolean,
+  IsEnum,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Result of evaluating a submission's confidence score against its data
+ * source's rolling baseline. Pure value object returned by
+ * `SubmissionHistoryService.evaluateAnomaly`.
+ */
+export interface AnomalyEvaluation {
+  /** Whether the value deviates beyond the configured threshold. */
+  isAnomaly: boolean;
+  /** Absolute z-score, or `null` when there were too few samples to evaluate. */
+  zScore: number | null;
+  /** Mean of the baseline window. */
+  mean: number;
+  /** Population standard deviation of the baseline window. */
+  stddev: number;
+  /** Number of prior submissions that formed the baseline. */
+  sampleSize: number;
+  /** The z-score threshold used for the decision. */
+  threshold: number;
+  /**
+   * Why the evaluation reached its verdict (e.g. `insufficient_samples`,
+   * `within_threshold`, `deviation_exceeds_threshold`, `zero_variance_outlier`).
+   */
+  reason: string;
+}
+
+export enum ReviewDecision {
+  APPROVE = 'approve',
+  REJECT = 'reject',
+}
+
+export class GetFlagsQueryDto {
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Results per page (max 100)',
+    default: 20,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ description: 'Filter by oracle data source' })
+  @IsOptional()
+  @IsString()
+  dataSource?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by match ID' })
+  @IsOptional()
+  @IsString()
+  matchId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter to only flags that held a submission for review',
+  })
+  @IsOptional()
+  @Transform(({ value }) => value === true || value === 'true')
+  @IsBoolean()
+  heldOnly?: boolean;
+}
+
+export class ReviewSubmissionDto {
+  @ApiProperty({
+    description: 'Whether to approve or reject the held submission',
+    enum: ReviewDecision,
+  })
+  @IsEnum(ReviewDecision)
+  decision: ReviewDecision;
+
+  @ApiPropertyOptional({
+    description: 'Identifier of the admin performing the review',
+  })
+  @IsOptional()
+  @IsString()
+  reviewer?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional note recorded with the review',
+  })
+  @IsOptional()
+  @IsString()
+  note?: string;
+}
+
+export class FlagResponse {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  submission_id: string;
+
+  @ApiProperty()
+  match_id: string;
+
+  @ApiProperty()
+  data_source: string;
+
+  @ApiProperty()
+  observed_value: number;
+
+  @ApiProperty()
+  baseline_mean: number;
+
+  @ApiProperty()
+  baseline_stddev: number;
+
+  @ApiProperty()
+  deviation: number;
+
+  @ApiProperty()
+  threshold: number;
+
+  @ApiProperty()
+  sample_size: number;
+
+  @ApiProperty()
+  held: boolean;
+
+  @ApiPropertyOptional()
+  reason?: string;
+
+  @ApiProperty()
+  created_at: string;
+}
+
+export class PaginatedFlagsResponse {
+  @ApiProperty({ type: [FlagResponse] })
+  data: FlagResponse[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+}
+
+export class ReviewResultResponse {
+  @ApiProperty()
+  submission_id: string;
+
+  @ApiProperty({ description: 'The submission review status after the review' })
+  review_status: string;
+
+  @ApiProperty({
+    description: 'Whether the approved submission was queued for on-chain use',
+  })
+  submitted: boolean;
+
+  @ApiProperty()
+  message: string;
+}

--- a/backend/src/oracle/dto/submission-history.dto.ts
+++ b/backend/src/oracle/dto/submission-history.dto.ts
@@ -110,6 +110,19 @@ export class SubmissionResponse {
   @ApiPropertyOptional()
   submission_time_ms?: number;
 
+  @ApiProperty({
+    description: 'Whether anomaly detection flagged this submission (#1364)',
+  })
+  is_anomaly: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Absolute z-score against the data source baseline',
+  })
+  anomaly_score?: number;
+
+  @ApiProperty({ description: 'Manual-review lifecycle status' })
+  review_status: string;
+
   @ApiProperty()
   created_at: string;
 }

--- a/backend/src/oracle/entities/oracle-submission-flag.entity.ts
+++ b/backend/src/oracle/entities/oracle-submission-flag.entity.ts
@@ -1,0 +1,91 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * An immutable audit record of a single anomaly-detection flag raised against an
+ * oracle submission (#1364).
+ *
+ * One row is written each time a submission's confidence score deviates beyond
+ * the configured threshold from its data source's rolling baseline. The row
+ * captures the full statistical evidence (baseline mean/stddev, deviation,
+ * threshold, sample size) so an admin can audit *why* a submission was flagged
+ * without recomputing anything. Flags are never mutated after creation; the
+ * hold/approve/reject lifecycle lives on the submission's `review_status`.
+ */
+@Entity('oracle_submission_flags')
+@Index(['data_source', 'created_at'])
+@Index(['submission_id'])
+@Index(['held'])
+export class OracleSubmissionFlag {
+  @PrimaryGeneratedColumn('uuid')
+  @ApiProperty()
+  id: string;
+
+  /** FK to the flagged `oracle_submissions.id`. */
+  @Column({ type: 'uuid' })
+  @Index()
+  @ApiProperty()
+  submission_id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  @ApiProperty()
+  match_id: string;
+
+  @Column({ type: 'varchar', length: 500 })
+  @ApiProperty()
+  data_source: string;
+
+  /** The confidence score that was evaluated against the baseline. */
+  @Column({ type: 'double precision' })
+  @ApiProperty()
+  observed_value: number;
+
+  /** Mean confidence score of the data source's rolling baseline window. */
+  @Column({ type: 'double precision' })
+  @ApiProperty()
+  baseline_mean: number;
+
+  /** Population standard deviation of the rolling baseline window. */
+  @Column({ type: 'double precision' })
+  @ApiProperty()
+  baseline_stddev: number;
+
+  /**
+   * Absolute deviation in standard deviations (z-score):
+   * `|observed_value - baseline_mean| / baseline_stddev`. When the baseline
+   * stddev is 0 and the observed value differs, this is stored as the
+   * sentinel value used by the detector (a large finite number).
+   */
+  @Column({ type: 'double precision' })
+  @ApiProperty()
+  deviation: number;
+
+  /** The configured z-score threshold in effect when the flag was raised. */
+  @Column({ type: 'double precision' })
+  @ApiProperty()
+  threshold: number;
+
+  /** Number of prior submissions that formed the baseline window. */
+  @Column({ type: 'int' })
+  @ApiProperty()
+  sample_size: number;
+
+  /** `true` when the flag caused the submission to be held for manual review. */
+  @Column({ type: 'boolean', default: false })
+  @ApiProperty()
+  held: boolean;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  @ApiPropertyOptional()
+  reason?: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  @ApiProperty()
+  created_at: Date;
+}

--- a/backend/src/oracle/entities/oracle-submission.entity.ts
+++ b/backend/src/oracle/entities/oracle-submission.entity.ts
@@ -13,6 +13,22 @@ export enum SubmissionStatus {
   FAILED = 'failed',
 }
 
+/**
+ * Governs the manual-review lifecycle for a submission flagged as a statistical
+ * anomaly (#1364).
+ *
+ * - `NOT_REQUIRED` — normal submission, no manual review needed (default).
+ * - `HELD` — flagged and withheld from on-chain submission pending admin review.
+ * - `APPROVED` — an admin approved a held submission; it may now be used.
+ * - `REJECTED` — an admin rejected a held submission; it must never be used.
+ */
+export enum SubmissionReviewStatus {
+  NOT_REQUIRED = 'not_required',
+  HELD = 'held',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
 export enum WinningTeam {
   TEAM_A = 'TEAM_A',
   TEAM_B = 'TEAM_B',
@@ -25,6 +41,8 @@ export enum WinningTeam {
 @Index(['created_at'])
 @Index(['match_id', 'status'])
 @Index(['created_at', 'status'])
+@Index(['data_source', 'created_at'])
+@Index(['review_status'])
 export class OracleSubmission {
   @PrimaryGeneratedColumn('uuid')
   @ApiProperty()
@@ -93,6 +111,40 @@ export class OracleSubmission {
   @Column({ type: 'bigint', nullable: true })
   @ApiPropertyOptional()
   submission_time_ms?: number;
+
+  /**
+   * `true` when anomaly detection flagged this submission's confidence score as
+   * a statistical outlier relative to its data source's rolling baseline (#1364).
+   */
+  @Column({ type: 'boolean', default: false })
+  @Index()
+  @ApiProperty()
+  is_anomaly: boolean;
+
+  /**
+   * Absolute z-score of the confidence score against the data source's rolling
+   * baseline at submission time. `null` when the baseline had too few samples
+   * to evaluate. Recorded for transparency even when below the flag threshold.
+   */
+  @Column({ type: 'double precision', nullable: true })
+  @ApiPropertyOptional()
+  anomaly_score?: number;
+
+  @Column({
+    type: 'enum',
+    enum: SubmissionReviewStatus,
+    default: SubmissionReviewStatus.NOT_REQUIRED,
+  })
+  @ApiProperty()
+  review_status: SubmissionReviewStatus;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  @ApiPropertyOptional()
+  reviewed_by?: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  @ApiPropertyOptional()
+  reviewed_at?: Date;
 
   @CreateDateColumn({ type: 'timestamptz' })
   @ApiProperty()

--- a/backend/src/oracle/oracle.controller.ts
+++ b/backend/src/oracle/oracle.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Param,
   Query,
   UseGuards,
   Body,
@@ -14,6 +15,7 @@ import {
   ApiResponse,
   ApiSecurity,
   ApiBody,
+  ApiParam,
 } from '@nestjs/swagger';
 import { OracleService } from './oracle.service';
 import { OracleAuthGuard } from './guards/oracle-auth.guard';
@@ -33,6 +35,12 @@ import {
   GetSubmissionsQueryDto,
   PaginatedSubmissionsResponse,
 } from './dto/submission-history.dto';
+import {
+  GetFlagsQueryDto,
+  PaginatedFlagsResponse,
+  ReviewSubmissionDto,
+  ReviewResultResponse,
+} from './dto/anomaly-detection.dto';
 
 @ApiTags('Oracle')
 @Controller('oracle')
@@ -107,5 +115,48 @@ export class OracleController {
     @Query() query: GetSubmissionsQueryDto,
   ): Promise<PaginatedSubmissionsResponse> {
     return this.submissionHistoryService.getSubmissions(query);
+  }
+
+  @Get('flags')
+  @UseGuards(OracleAuthGuard)
+  @ApiSecurity('api-key')
+  @ApiOperation({
+    summary: 'Get oracle submission anomaly flags for admin review',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of recorded anomaly flags',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized - invalid API key' })
+  async getFlags(
+    @Query() query: GetFlagsQueryDto,
+  ): Promise<PaginatedFlagsResponse> {
+    return this.submissionHistoryService.getFlags(query);
+  }
+
+  @Post('submissions/:id/review')
+  @UseGuards(OracleAuthGuard)
+  @ApiSecurity('api-key')
+  @ApiOperation({
+    summary: 'Approve or reject a submission held for manual review',
+  })
+  @ApiParam({ name: 'id', description: 'Oracle submission ID' })
+  @ApiBody({ type: ReviewSubmissionDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Review recorded',
+    type: ReviewResultResponse,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized - invalid API key' })
+  @ApiResponse({ status: 404, description: 'Submission not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Submission is not held for review',
+  })
+  async reviewSubmission(
+    @Param('id') id: string,
+    @Body() dto: ReviewSubmissionDto,
+  ): Promise<ReviewResultResponse> {
+    return this.webhookService.reviewSubmission(id, dto);
   }
 }

--- a/backend/src/oracle/oracle.module.ts
+++ b/backend/src/oracle/oracle.module.ts
@@ -9,6 +9,7 @@ import { WebhookService } from './webhook.service';
 import { WebhookAuthGuard } from './guards/webhook-auth.guard';
 import { SubmissionHistoryService } from './submission-history.service';
 import { OracleSubmission } from './entities/oracle-submission.entity';
+import { OracleSubmissionFlag } from './entities/oracle-submission-flag.entity';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { OracleSubmission } from './entities/oracle-submission.entity';
       CreatorEventMatch,
       CreatorEvent,
       OracleSubmission,
+      OracleSubmissionFlag,
     ]),
     ScheduleModule.forRoot(),
   ],

--- a/backend/src/oracle/submission-history.service.spec.ts
+++ b/backend/src/oracle/submission-history.service.spec.ts
@@ -1,16 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import { SubmissionHistoryService } from './submission-history.service';
 import {
   OracleSubmission,
   SubmissionStatus,
+  SubmissionReviewStatus,
 } from './entities/oracle-submission.entity';
+import { OracleSubmissionFlag } from './entities/oracle-submission-flag.entity';
 import { GetSubmissionsQueryDto } from './dto/submission-history.dto';
 
 describe('SubmissionHistoryService', () => {
   let service: SubmissionHistoryService;
   let submissionRepository: Repository<OracleSubmission>;
+  let flagRepository: Repository<OracleSubmissionFlag>;
+  let configValues: Record<string, string | number | undefined>;
 
   const mockSubmission: OracleSubmission = {
     id: 'sub-1',
@@ -28,16 +33,47 @@ describe('SubmissionHistoryService', () => {
     error_message: null,
     retry_count: 0,
     submission_time_ms: 150,
+    is_anomaly: false,
+    anomaly_score: null,
+    review_status: SubmissionReviewStatus.NOT_REQUIRED,
+    reviewed_by: null,
+    reviewed_at: null,
     created_at: new Date(),
-  };
+  } as OracleSubmission;
 
-  beforeEach(async () => {
+  /** Build `count` history rows for a data source, all with confidence `value`. */
+  const historyRows = (
+    value: number,
+    count: number,
+    source = 'https://api.example.com',
+  ): OracleSubmission[] =>
+    Array.from({ length: count }, (_, i) => ({
+      ...mockSubmission,
+      id: `hist-${i}`,
+      confidence_score: value,
+      data_source: source,
+    }));
+
+  const buildService = async (
+    config: Record<string, string | number | undefined> = {},
+  ) => {
+    configValues = config;
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SubmissionHistoryService,
         {
           provide: getRepositoryToken(OracleSubmission),
           useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(OracleSubmissionFlag),
+          useClass: Repository,
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => configValues[key]),
+          },
         },
       ],
     }).compile();
@@ -46,6 +82,13 @@ describe('SubmissionHistoryService', () => {
     submissionRepository = module.get<Repository<OracleSubmission>>(
       getRepositoryToken(OracleSubmission),
     );
+    flagRepository = module.get<Repository<OracleSubmissionFlag>>(
+      getRepositoryToken(OracleSubmissionFlag),
+    );
+  };
+
+  beforeEach(async () => {
+    await buildService();
   });
 
   it('should be defined', () => {
@@ -219,6 +262,301 @@ describe('SubmissionHistoryService', () => {
       const result = await service.getSubmissionById('non-existent');
 
       expect(result).toBeNull();
+    });
+  });
+
+  // ── Anomaly detection (#1364) ─────────────────────────────────────────────
+
+  describe('evaluateAnomaly', () => {
+    // Baseline of 10 samples at confidence 90 → mean 90, stddev 0. Add a small
+    // spread so stddev is a clean 2.0: five 88s and five 92s → mean 90, stddev 2.
+    const spreadBaseline = (): OracleSubmission[] => [
+      ...historyRows(88, 5),
+      ...historyRows(92, 5),
+    ];
+
+    it('does not flag a value within the threshold band (normal)', async () => {
+      await buildService({ ORACLE_ANOMALY_THRESHOLD: 3 });
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(spreadBaseline());
+
+      // mean 90, stddev 2. Value 93 → z = 1.5, well within threshold 3.
+      const result = await service.evaluateAnomaly(
+        'https://api.example.com',
+        93,
+      );
+
+      expect(result.mean).toBe(90);
+      expect(result.stddev).toBe(2);
+      expect(result.zScore).toBeCloseTo(1.5, 6);
+      expect(result.isAnomaly).toBe(false);
+      expect(result.reason).toBe('within_threshold');
+    });
+
+    it('flags a value deviating beyond the threshold (outlier)', async () => {
+      await buildService({ ORACLE_ANOMALY_THRESHOLD: 3 });
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(spreadBaseline());
+
+      // mean 90, stddev 2. Value 20 → z = 35, far beyond threshold 3.
+      const result = await service.evaluateAnomaly(
+        'https://api.example.com',
+        20,
+      );
+
+      expect(result.zScore).toBeCloseTo(35, 6);
+      expect(result.isAnomaly).toBe(true);
+      expect(result.reason).toBe('deviation_exceeds_threshold');
+    });
+
+    it('does not flag a value exactly at the threshold (edge)', async () => {
+      await buildService({ ORACLE_ANOMALY_THRESHOLD: 3 });
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(spreadBaseline());
+
+      // mean 90, stddev 2, threshold 3 → boundary value = 90 + 3*2 = 96 (z = 3).
+      const atThreshold = await service.evaluateAnomaly(
+        'https://api.example.com',
+        96,
+      );
+      expect(atThreshold.zScore).toBeCloseTo(3, 6);
+      expect(atThreshold.isAnomaly).toBe(false);
+
+      // Just beyond the boundary → flagged.
+      const justBeyond = await service.evaluateAnomaly(
+        'https://api.example.com',
+        96.01,
+      );
+      expect(justBeyond.zScore).toBeGreaterThan(3);
+      expect(justBeyond.isAnomaly).toBe(true);
+    });
+
+    it('does not flag when there are too few samples for a baseline', async () => {
+      await buildService({
+        ORACLE_ANOMALY_THRESHOLD: 3,
+        ORACLE_ANOMALY_MIN_SAMPLES: 5,
+      });
+      // Only 4 prior submissions — below the min-samples floor.
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(historyRows(90, 4));
+
+      const result = await service.evaluateAnomaly(
+        'https://api.example.com',
+        1,
+      );
+
+      expect(result.isAnomaly).toBe(false);
+      expect(result.zScore).toBeNull();
+      expect(result.reason).toBe('insufficient_samples');
+    });
+
+    it('flags a differing value against a zero-variance baseline', async () => {
+      await buildService({ ORACLE_ANOMALY_THRESHOLD: 3 });
+      // All prior submissions identical → stddev 0.
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(historyRows(90, 8));
+
+      const outlier = await service.evaluateAnomaly(
+        'https://api.example.com',
+        50,
+      );
+      expect(outlier.stddev).toBe(0);
+      expect(outlier.isAnomaly).toBe(true);
+      expect(outlier.reason).toBe('zero_variance_outlier');
+
+      const equal = await service.evaluateAnomaly(
+        'https://api.example.com',
+        90,
+      );
+      expect(equal.isAnomaly).toBe(false);
+      expect(equal.reason).toBe('within_threshold');
+    });
+
+    it('excludes the submission under evaluation from its own baseline', async () => {
+      await buildService({ ORACLE_ANOMALY_THRESHOLD: 3 });
+      const findSpy = jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(spreadBaseline());
+
+      await service.evaluateAnomaly('https://api.example.com', 93, 'sub-1');
+
+      expect(findSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            data_source: 'https://api.example.com',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('screenSubmission', () => {
+    const spreadBaseline = (): OracleSubmission[] => [
+      ...historyRows(88, 5),
+      ...historyRows(92, 5),
+    ];
+
+    it('flags and records an anomaly, holding when hold is enabled', async () => {
+      await buildService({
+        ORACLE_ANOMALY_THRESHOLD: 3,
+        ORACLE_ANOMALY_HOLD: 'true',
+      });
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(spreadBaseline());
+      const saveSub = jest
+        .spyOn(submissionRepository, 'save')
+        .mockImplementation((s) => Promise.resolve(s as OracleSubmission));
+      const createFlag = jest
+        .spyOn(flagRepository, 'create')
+        .mockImplementation((f) => f as OracleSubmissionFlag);
+      const saveFlag = jest
+        .spyOn(flagRepository, 'save')
+        .mockImplementation((f) => Promise.resolve(f as OracleSubmissionFlag));
+
+      const submission = {
+        ...mockSubmission,
+        id: 'sub-outlier',
+        confidence_score: 20,
+        review_status: SubmissionReviewStatus.NOT_REQUIRED,
+      } as OracleSubmission;
+
+      const result = await service.screenSubmission(submission);
+
+      expect(result.flagged).toBe(true);
+      expect(result.held).toBe(true);
+      expect(submission.is_anomaly).toBe(true);
+      expect(submission.review_status).toBe(SubmissionReviewStatus.HELD);
+      expect(createFlag).toHaveBeenCalledWith(
+        expect.objectContaining({
+          submission_id: 'sub-outlier',
+          observed_value: 20,
+          held: true,
+        }),
+      );
+      expect(saveFlag).toHaveBeenCalled();
+      expect(saveSub).toHaveBeenCalled();
+    });
+
+    it('flags without holding when hold is disabled', async () => {
+      await buildService({
+        ORACLE_ANOMALY_THRESHOLD: 3,
+        ORACLE_ANOMALY_HOLD: 'false',
+      });
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(spreadBaseline());
+      jest
+        .spyOn(submissionRepository, 'save')
+        .mockImplementation((s) => Promise.resolve(s as OracleSubmission));
+      jest
+        .spyOn(flagRepository, 'create')
+        .mockImplementation((f) => f as OracleSubmissionFlag);
+      jest
+        .spyOn(flagRepository, 'save')
+        .mockImplementation((f) => Promise.resolve(f as OracleSubmissionFlag));
+
+      const submission = {
+        ...mockSubmission,
+        id: 'sub-outlier',
+        confidence_score: 20,
+        review_status: SubmissionReviewStatus.NOT_REQUIRED,
+      } as OracleSubmission;
+
+      const result = await service.screenSubmission(submission);
+
+      expect(result.flagged).toBe(true);
+      expect(result.held).toBe(false);
+      expect(submission.review_status).toBe(
+        SubmissionReviewStatus.NOT_REQUIRED,
+      );
+    });
+
+    it('does not flag or hold a normal submission', async () => {
+      await buildService({
+        ORACLE_ANOMALY_THRESHOLD: 3,
+        ORACLE_ANOMALY_HOLD: 'true',
+      });
+      jest
+        .spyOn(submissionRepository, 'find')
+        .mockResolvedValue(spreadBaseline());
+      jest
+        .spyOn(submissionRepository, 'save')
+        .mockImplementation((s) => Promise.resolve(s as OracleSubmission));
+      const saveFlag = jest.spyOn(flagRepository, 'save');
+
+      const submission = {
+        ...mockSubmission,
+        id: 'sub-normal',
+        confidence_score: 91,
+        review_status: SubmissionReviewStatus.NOT_REQUIRED,
+      } as OracleSubmission;
+
+      const result = await service.screenSubmission(submission);
+
+      expect(result.flagged).toBe(false);
+      expect(result.held).toBe(false);
+      expect(submission.is_anomaly).toBe(false);
+      expect(saveFlag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getFlags', () => {
+    const mockFlag: OracleSubmissionFlag = {
+      id: 'flag-1',
+      submission_id: 'sub-1',
+      match_id: '123',
+      data_source: 'https://api.example.com',
+      observed_value: 20,
+      baseline_mean: 90,
+      baseline_stddev: 2,
+      deviation: 35,
+      threshold: 3,
+      sample_size: 10,
+      held: true,
+      reason: 'confidence 20 deviates 35.00σ from baseline mean 90.00',
+      created_at: new Date(),
+    };
+
+    it('returns paginated flags for admins', async () => {
+      jest
+        .spyOn(flagRepository, 'findAndCount')
+        .mockResolvedValue([[mockFlag], 1]);
+
+      const result = await service.getFlags({ page: 1, limit: 20 });
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        submission_id: 'sub-1',
+        observed_value: 20,
+        held: true,
+      });
+    });
+
+    it('filters flags by data source and held-only', async () => {
+      const findAndCount = jest
+        .spyOn(flagRepository, 'findAndCount')
+        .mockResolvedValue([[mockFlag], 1]);
+
+      await service.getFlags({
+        dataSource: 'https://api.example.com',
+        heldOnly: true,
+      });
+
+      expect(findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            data_source: 'https://api.example.com',
+            held: true,
+          },
+        }),
+      );
     });
   });
 });

--- a/backend/src/oracle/submission-history.service.ts
+++ b/backend/src/oracle/submission-history.service.ts
@@ -1,25 +1,84 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThanOrEqual, LessThanOrEqual, And } from 'typeorm';
+import {
+  Repository,
+  MoreThanOrEqual,
+  LessThanOrEqual,
+  And,
+  Not,
+} from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import {
   OracleSubmission,
   SubmissionStatus,
+  SubmissionReviewStatus,
 } from './entities/oracle-submission.entity';
+import { OracleSubmissionFlag } from './entities/oracle-submission-flag.entity';
 import {
   GetSubmissionsQueryDto,
   PaginatedSubmissionsResponse,
   SubmissionResponse,
   SubmissionStatistics,
 } from './dto/submission-history.dto';
+import {
+  AnomalyEvaluation,
+  GetFlagsQueryDto,
+  PaginatedFlagsResponse,
+  FlagResponse,
+} from './dto/anomaly-detection.dto';
+
+/**
+ * Sentinel deviation recorded when the baseline has zero variance but the
+ * observed value differs from the mean (an unambiguous outlier for which the
+ * z-score would be infinite). Kept finite so it can be stored and compared.
+ */
+const ZERO_VARIANCE_DEVIATION = Number.MAX_SAFE_INTEGER;
 
 @Injectable()
 export class SubmissionHistoryService {
   private readonly logger = new Logger(SubmissionHistoryService.name);
 
+  /** z-score beyond which a submission is flagged as an outlier. */
+  private readonly anomalyThreshold: number;
+  /** Minimum prior submissions per source before a baseline is trusted. */
+  private readonly anomalyMinSamples: number;
+  /** Max number of most-recent prior submissions used for the baseline. */
+  private readonly anomalyWindow: number;
+  /** When true, flagged submissions are held for manual review before use. */
+  private readonly anomalyHoldEnabled: boolean;
+
   constructor(
     @InjectRepository(OracleSubmission)
     private readonly submissionRepository: Repository<OracleSubmission>,
-  ) {}
+    @InjectRepository(OracleSubmissionFlag)
+    private readonly flagRepository: Repository<OracleSubmissionFlag>,
+    private readonly configService: ConfigService,
+  ) {
+    this.anomalyThreshold = this.readNumberConfig(
+      'ORACLE_ANOMALY_THRESHOLD',
+      3,
+    );
+    this.anomalyMinSamples = this.readNumberConfig(
+      'ORACLE_ANOMALY_MIN_SAMPLES',
+      5,
+    );
+    this.anomalyWindow = this.readNumberConfig('ORACLE_ANOMALY_WINDOW', 50);
+    this.anomalyHoldEnabled =
+      this.configService.get<string>('ORACLE_ANOMALY_HOLD') === 'true';
+  }
+
+  private readNumberConfig(key: string, fallback: number): number {
+    const raw = this.configService.get<string | number>(key);
+    if (raw === undefined || raw === null || raw === '') {
+      return fallback;
+    }
+    const parsed = typeof raw === 'number' ? raw : Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  get holdEnabled(): boolean {
+    return this.anomalyHoldEnabled;
+  }
 
   async getSubmissions(
     query: GetSubmissionsQueryDto,
@@ -154,6 +213,13 @@ export class SubmissionHistoryService {
       submission_time_ms: submission.submission_time_ms
         ? Number(submission.submission_time_ms)
         : undefined,
+      is_anomaly: submission.is_anomaly ?? false,
+      anomaly_score:
+        submission.anomaly_score !== null &&
+        submission.anomaly_score !== undefined
+          ? Number(submission.anomaly_score)
+          : undefined,
+      review_status: submission.review_status,
       created_at: submission.created_at.toISOString(),
     };
   }
@@ -168,5 +234,212 @@ export class SubmissionHistoryService {
     }
 
     return this.mapToResponse(submission);
+  }
+
+  // ── Anomaly detection (#1364) ─────────────────────────────────────────────
+
+  /**
+   * Evaluate a confidence score against the rolling baseline (mean/stddev) of
+   * its data source's most recent prior submissions.
+   *
+   * The baseline is the population mean and standard deviation over up to
+   * `ORACLE_ANOMALY_WINDOW` prior submissions for `dataSource`, optionally
+   * excluding one submission id (so a just-persisted row does not bias its own
+   * baseline). A value is an anomaly when its absolute z-score is strictly
+   * greater than `ORACLE_ANOMALY_THRESHOLD`; a value exactly at the threshold
+   * is not flagged (the threshold is the boundary of the accepted band).
+   *
+   * With fewer than `ORACLE_ANOMALY_MIN_SAMPLES` prior submissions the baseline
+   * is not yet trustworthy, so the value is never flagged. When the baseline has
+   * zero variance, any different value is an unambiguous outlier and an equal
+   * value is not.
+   *
+   * Pure and side-effect free: it only reads history and returns a verdict.
+   */
+  async evaluateAnomaly(
+    dataSource: string,
+    value: number,
+    excludeSubmissionId?: string,
+  ): Promise<AnomalyEvaluation> {
+    const history = await this.submissionRepository.find({
+      where: excludeSubmissionId
+        ? { data_source: dataSource, id: Not(excludeSubmissionId) }
+        : { data_source: dataSource },
+      order: { created_at: 'DESC' },
+      take: this.anomalyWindow,
+    });
+
+    const values = history
+      .map((s) => Number(s.confidence_score))
+      .filter((v) => Number.isFinite(v));
+
+    const sampleSize = values.length;
+
+    if (sampleSize < this.anomalyMinSamples) {
+      return {
+        isAnomaly: false,
+        zScore: null,
+        mean: sampleSize > 0 ? this.mean(values) : 0,
+        stddev: 0,
+        sampleSize,
+        threshold: this.anomalyThreshold,
+        reason: 'insufficient_samples',
+      };
+    }
+
+    const mean = this.mean(values);
+    const stddev = this.stddev(values, mean);
+
+    if (stddev === 0) {
+      const isAnomaly = value !== mean;
+      return {
+        isAnomaly,
+        zScore: isAnomaly ? ZERO_VARIANCE_DEVIATION : 0,
+        mean,
+        stddev,
+        sampleSize,
+        threshold: this.anomalyThreshold,
+        reason: isAnomaly ? 'zero_variance_outlier' : 'within_threshold',
+      };
+    }
+
+    const zScore = Math.abs(value - mean) / stddev;
+    const isAnomaly = zScore > this.anomalyThreshold;
+
+    return {
+      isAnomaly,
+      zScore,
+      mean,
+      stddev,
+      sampleSize,
+      threshold: this.anomalyThreshold,
+      reason: isAnomaly ? 'deviation_exceeds_threshold' : 'within_threshold',
+    };
+  }
+
+  /**
+   * Screen an already-persisted submission for anomalies, record a flag if it
+   * is an outlier, and hold it for manual review when holding is enabled.
+   *
+   * Always stamps `is_anomaly` and `anomaly_score` on the submission for
+   * transparency. When flagged: writes an immutable {@link OracleSubmissionFlag}
+   * audit row and, if `ORACLE_ANOMALY_HOLD=true`, sets the submission's
+   * `review_status` to `HELD`. Returns whether the caller should withhold the
+   * submission from on-chain use.
+   */
+  async screenSubmission(submission: OracleSubmission): Promise<{
+    flagged: boolean;
+    held: boolean;
+    evaluation: AnomalyEvaluation;
+  }> {
+    const evaluation = await this.evaluateAnomaly(
+      submission.data_source,
+      Number(submission.confidence_score),
+      submission.id,
+    );
+
+    const held = evaluation.isAnomaly && this.anomalyHoldEnabled;
+
+    submission.is_anomaly = evaluation.isAnomaly;
+    submission.anomaly_score = evaluation.zScore ?? undefined;
+    submission.review_status = held
+      ? SubmissionReviewStatus.HELD
+      : (submission.review_status ?? SubmissionReviewStatus.NOT_REQUIRED);
+    await this.submissionRepository.save(submission);
+
+    if (evaluation.isAnomaly) {
+      const reason = `confidence ${submission.confidence_score} deviates ${
+        evaluation.zScore === ZERO_VARIANCE_DEVIATION
+          ? '∞'
+          : evaluation.zScore?.toFixed(2)
+      }σ from baseline mean ${evaluation.mean.toFixed(2)} (threshold ${
+        evaluation.threshold
+      })`;
+
+      const flag = this.flagRepository.create({
+        submission_id: submission.id,
+        match_id: submission.match_id,
+        data_source: submission.data_source,
+        observed_value: Number(submission.confidence_score),
+        baseline_mean: evaluation.mean,
+        baseline_stddev: evaluation.stddev,
+        deviation: evaluation.zScore ?? 0,
+        threshold: evaluation.threshold,
+        sample_size: evaluation.sampleSize,
+        held,
+        reason,
+      });
+      await this.flagRepository.save(flag);
+
+      this.logger.warn(
+        `Oracle submission flagged as anomaly: submission_id=${submission.id}, ` +
+          `data_source=${submission.data_source}, ${reason}, held=${held}`,
+      );
+    }
+
+    return { flagged: evaluation.isAnomaly, held, evaluation };
+  }
+
+  /**
+   * List recorded anomaly flags for admin review, most recent first.
+   */
+  async getFlags(query: GetFlagsQueryDto): Promise<PaginatedFlagsResponse> {
+    const page = query.page ?? 1;
+    const limit = Math.min(query.limit ?? 20, 100);
+    const skip = (page - 1) * limit;
+
+    const where: Record<string, unknown> = {};
+    if (query.dataSource) {
+      where.data_source = query.dataSource;
+    }
+    if (query.matchId) {
+      where.match_id = query.matchId;
+    }
+    if (query.heldOnly) {
+      where.held = true;
+    }
+
+    const [flags, total] = await this.flagRepository.findAndCount({
+      where,
+      order: { created_at: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return {
+      data: flags.map((f) => this.mapFlagToResponse(f)),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  private mapFlagToResponse(flag: OracleSubmissionFlag): FlagResponse {
+    return {
+      id: flag.id,
+      submission_id: flag.submission_id,
+      match_id: flag.match_id,
+      data_source: flag.data_source,
+      observed_value: Number(flag.observed_value),
+      baseline_mean: Number(flag.baseline_mean),
+      baseline_stddev: Number(flag.baseline_stddev),
+      deviation: Number(flag.deviation),
+      threshold: Number(flag.threshold),
+      sample_size: flag.sample_size,
+      held: flag.held,
+      reason: flag.reason,
+      created_at: flag.created_at.toISOString(),
+    };
+  }
+
+  private mean(values: number[]): number {
+    return values.reduce((sum, v) => sum + v, 0) / values.length;
+  }
+
+  private stddev(values: number[], mean: number): number {
+    const variance =
+      values.reduce((sum, v) => sum + (v - mean) * (v - mean), 0) /
+      values.length;
+    return Math.sqrt(variance);
   }
 }

--- a/backend/src/oracle/webhook.service.spec.ts
+++ b/backend/src/oracle/webhook.service.spec.ts
@@ -2,12 +2,18 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { WebhookService } from './webhook.service';
 import { CreatorEventMatch } from '../creator-events/entities/creator-event-match.entity';
-import { OracleSubmission } from './entities/oracle-submission.entity';
+import {
+  OracleSubmission,
+  SubmissionReviewStatus,
+  SubmissionStatus,
+} from './entities/oracle-submission.entity';
 import { ConfigService } from '@nestjs/config';
+import { SubmissionHistoryService } from './submission-history.service';
 import {
   WebhookMatchResultDto,
   WinningTeam,
 } from './dto/webhook-match-result.dto';
+import { ReviewDecision } from './dto/anomaly-detection.dto';
 import { NotFoundException, ConflictException } from '@nestjs/common';
 
 describe('WebhookService', () => {
@@ -32,13 +38,31 @@ describe('WebhookService', () => {
 
   const mockSubmissionRepository = {
     create: jest.fn().mockReturnValue({}),
-    save: jest.fn().mockResolvedValue({}),
+    save: jest.fn().mockImplementation((s) => Promise.resolve(s)),
     findOne: jest.fn().mockResolvedValue(null),
     find: jest.fn().mockResolvedValue([]),
     findAndCount: jest.fn().mockResolvedValue([[], 0]),
   };
 
+  // Default screening: nothing flagged, nothing held. Individual tests override.
+  const mockSubmissionHistoryService = {
+    screenSubmission: jest.fn().mockResolvedValue({
+      flagged: false,
+      held: false,
+      evaluation: {},
+    }),
+  };
+
   beforeEach(async () => {
+    mockSubmissionHistoryService.screenSubmission.mockResolvedValue({
+      flagged: false,
+      held: false,
+      evaluation: {},
+    });
+    mockSubmissionRepository.create.mockReturnValue({});
+    mockSubmissionRepository.save.mockImplementation((s) => Promise.resolve(s));
+    mockMatchRepository.findOne.mockResolvedValue(mockMatch);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WebhookService,
@@ -58,6 +82,10 @@ describe('WebhookService', () => {
               return null;
             }),
           },
+        },
+        {
+          provide: SubmissionHistoryService,
+          useValue: mockSubmissionHistoryService,
         },
       ],
     }).compile();
@@ -254,6 +282,134 @@ describe('WebhookService', () => {
     it('should return null for non-existent job ID', () => {
       const job = service.getJobStatus('non-existent-job-id');
       expect(job).toBeNull();
+    });
+  });
+
+  // ── Anomaly hold & review (#1364) ─────────────────────────────────────────
+
+  describe('anomaly screening on intake', () => {
+    it('holds a flagged submission instead of submitting it', async () => {
+      const dto: WebhookMatchResultDto = {
+        match_id: '123',
+        winning_team: WinningTeam.TEAM_A,
+        confidence_score: 5,
+        data_source: 'https://api.example.com/match/123',
+        timestamp: new Date().toISOString(),
+      };
+
+      mockSubmissionRepository.save.mockResolvedValue({
+        id: 'sub-held',
+        review_status: SubmissionReviewStatus.NOT_REQUIRED,
+      });
+      mockSubmissionHistoryService.screenSubmission.mockResolvedValue({
+        flagged: true,
+        held: true,
+        evaluation: {},
+      });
+      const submitSpy = jest
+        .spyOn(service as any, 'simulateOracleSubmission')
+        .mockResolvedValue(undefined);
+
+      const result = await service.processMatchResult(dto);
+
+      expect(result.status).toBe('held');
+      expect(submitSpy).not.toHaveBeenCalled();
+      // A held submission is not left in the retry queue.
+      expect(service.getJobStatus(result.job_id)).toBeNull();
+    });
+
+    it('submits a flagged-but-not-held submission normally', async () => {
+      const dto: WebhookMatchResultDto = {
+        match_id: '123',
+        winning_team: WinningTeam.TEAM_A,
+        confidence_score: 5,
+        data_source: 'https://api.example.com/match/123',
+        timestamp: new Date().toISOString(),
+      };
+
+      mockSubmissionRepository.save.mockResolvedValue({ id: 'sub-flag-only' });
+      mockSubmissionHistoryService.screenSubmission.mockResolvedValue({
+        flagged: true,
+        held: false,
+        evaluation: {},
+      });
+      jest
+        .spyOn(service as any, 'simulateOracleSubmission')
+        .mockResolvedValue(undefined);
+
+      const result = await service.processMatchResult(dto);
+
+      expect(result.status).toBe('accepted');
+    });
+  });
+
+  describe('reviewSubmission', () => {
+    const heldSubmission = {
+      id: 'sub-held',
+      match_id: '123',
+      winning_team: WinningTeam.TEAM_A,
+      confidence_score: 5,
+      data_source: 'https://api.example.com/match/123',
+      result_timestamp: new Date(),
+      metadata: null,
+      status: SubmissionStatus.PENDING,
+      review_status: SubmissionReviewStatus.HELD,
+    };
+
+    it('approves a held submission and queues it for on-chain use', async () => {
+      mockSubmissionRepository.findOne.mockResolvedValue({ ...heldSubmission });
+      const submitSpy = jest
+        .spyOn(service as any, 'simulateOracleSubmission')
+        .mockResolvedValue(undefined);
+
+      const result = await service.reviewSubmission('sub-held', {
+        decision: ReviewDecision.APPROVE,
+        reviewer: 'admin-1',
+      });
+
+      expect(result.review_status).toBe(SubmissionReviewStatus.APPROVED);
+      expect(result.submitted).toBe(true);
+      expect(submitSpy).toHaveBeenCalled();
+    });
+
+    it('rejects a held submission without submitting it', async () => {
+      mockSubmissionRepository.findOne.mockResolvedValue({ ...heldSubmission });
+      const submitSpy = jest
+        .spyOn(service as any, 'simulateOracleSubmission')
+        .mockResolvedValue(undefined);
+
+      const result = await service.reviewSubmission('sub-held', {
+        decision: ReviewDecision.REJECT,
+        reviewer: 'admin-1',
+        note: 'value looks wrong',
+      });
+
+      expect(result.review_status).toBe(SubmissionReviewStatus.REJECTED);
+      expect(result.submitted).toBe(false);
+      expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound for an unknown submission', async () => {
+      mockSubmissionRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.reviewSubmission('missing', {
+          decision: ReviewDecision.APPROVE,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws Conflict when the submission is not held', async () => {
+      mockSubmissionRepository.findOne.mockResolvedValue({
+        ...heldSubmission,
+        review_status: SubmissionReviewStatus.NOT_REQUIRED,
+      });
+
+      await expect(
+        service.reviewSubmission('sub-held', {
+          decision: ReviewDecision.APPROVE,
+        }),
+      ).rejects.toThrow(ConflictException);
     });
   });
 });

--- a/backend/src/oracle/webhook.service.ts
+++ b/backend/src/oracle/webhook.service.ts
@@ -17,7 +17,14 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import {
   OracleSubmission,
   SubmissionStatus,
+  SubmissionReviewStatus,
 } from './entities/oracle-submission.entity';
+import { SubmissionHistoryService } from './submission-history.service';
+import {
+  ReviewSubmissionDto,
+  ReviewDecision,
+  ReviewResultResponse,
+} from './dto/anomaly-detection.dto';
 
 interface QueuedSubmission {
   id: string;
@@ -46,6 +53,7 @@ export class WebhookService {
     @InjectRepository(OracleSubmission)
     private readonly submissionRepository: Repository<OracleSubmission>,
     private readonly configService: ConfigService,
+    private readonly submissionHistoryService: SubmissionHistoryService,
   ) {
     this.startRetryProcessor();
   }
@@ -97,8 +105,33 @@ export class WebhookService {
 
     this.submissionQueue.set(jobId, submission);
 
-    // Save to database for history tracking
-    await this.saveSubmissionToDatabase(submission, match);
+    // Save to database for history tracking.
+    const savedSubmission = await this.saveSubmissionToDatabase(
+      submission,
+      match,
+    );
+
+    // Screen for statistical anomalies before any on-chain use (#1364). A
+    // flagged submission is recorded; when holding is enabled it is withheld
+    // from submission until an admin approves it via reviewSubmission.
+    if (savedSubmission) {
+      const screening =
+        await this.submissionHistoryService.screenSubmission(savedSubmission);
+
+      if (screening.held) {
+        // Do not auto-submit or retry — the submission awaits manual review.
+        this.submissionQueue.delete(jobId);
+        this.logger.warn(
+          `Match result held for manual review: job_id=${jobId}, match_id=${dto.match_id}, submission_id=${savedSubmission.id}`,
+        );
+        return {
+          job_id: jobId,
+          status: 'held',
+          message:
+            'Submission flagged as a statistical anomaly and held for manual review',
+        };
+      }
+    }
 
     this.logger.log(
       `Match result queued for submission: job_id=${jobId}, match_id=${dto.match_id}, winning_team=${dto.winning_team}`,
@@ -245,7 +278,7 @@ export class WebhookService {
   private async saveSubmissionToDatabase(
     submission: QueuedSubmission,
     match: CreatorEventMatch,
-  ): Promise<void> {
+  ): Promise<OracleSubmission | null> {
     try {
       const dbSubmission = this.submissionRepository.create({
         match_id: submission.matchId,
@@ -260,13 +293,96 @@ export class WebhookService {
         retry_count: 0,
       });
 
-      await this.submissionRepository.save(dbSubmission);
+      const saved = await this.submissionRepository.save(dbSubmission);
       this.logger.log(`Submission saved to database: job_id=${submission.id}`);
+      return saved;
     } catch (error) {
       this.logger.error(
         `Failed to save submission to database: ${error instanceof Error ? error.message : 'Unknown'}`,
       );
+      return null;
     }
+  }
+
+  /**
+   * Approve or reject a submission that anomaly detection held for manual
+   * review (#1364).
+   *
+   * Only a submission in `HELD` review status may be reviewed. Approving marks
+   * it `APPROVED` and queues it for on-chain submission — the manual approval
+   * is the gate that lets a flagged value be used. Rejecting marks it
+   * `REJECTED` and `FAILED` so it is never submitted.
+   */
+  async reviewSubmission(
+    submissionId: string,
+    dto: ReviewSubmissionDto,
+  ): Promise<ReviewResultResponse> {
+    const submission = await this.submissionRepository.findOne({
+      where: { id: submissionId },
+    });
+
+    if (!submission) {
+      throw new NotFoundException(`Submission ${submissionId} not found`);
+    }
+
+    if (submission.review_status !== SubmissionReviewStatus.HELD) {
+      throw new ConflictException(
+        `Submission ${submissionId} is not held for review (status: ${submission.review_status})`,
+      );
+    }
+
+    submission.reviewed_by = dto.reviewer;
+    submission.reviewed_at = new Date();
+
+    if (dto.decision === ReviewDecision.REJECT) {
+      submission.review_status = SubmissionReviewStatus.REJECTED;
+      submission.status = SubmissionStatus.FAILED;
+      submission.error_message = dto.note
+        ? `Rejected in manual review: ${dto.note}`
+        : 'Rejected in manual review';
+      await this.submissionRepository.save(submission);
+
+      this.logger.warn(
+        `Held submission rejected: submission_id=${submissionId}, reviewer=${dto.reviewer ?? 'unknown'}`,
+      );
+
+      return {
+        submission_id: submissionId,
+        review_status: submission.review_status,
+        submitted: false,
+        message: 'Submission rejected; it will not be submitted on-chain',
+      };
+    }
+
+    submission.review_status = SubmissionReviewStatus.APPROVED;
+    await this.submissionRepository.save(submission);
+
+    this.logger.log(
+      `Held submission approved: submission_id=${submissionId}, reviewer=${dto.reviewer ?? 'unknown'}`,
+    );
+
+    // Requeue the approved submission for on-chain use.
+    const requeued: QueuedSubmission = {
+      id: this.generateJobId(),
+      matchId: submission.match_id,
+      winningTeam: submission.winning_team,
+      confidenceScore: submission.confidence_score,
+      dataSource: submission.data_source,
+      timestamp: submission.result_timestamp.toISOString(),
+      metadata: submission.metadata,
+      retryCount: 0,
+      createdAt: new Date(),
+      nextRetryAt: new Date(),
+    };
+    this.submissionQueue.set(requeued.id, requeued);
+    await this.submitToOracle(requeued);
+
+    return {
+      submission_id: submissionId,
+      review_status: submission.review_status,
+      submitted: true,
+      message: 'Submission approved and queued for on-chain submission',
+    };
   }
 
   private async updateSubmissionRecord(


### PR DESCRIPTION
## Summary

Oracle submissions were accepted without any check for statistical outliers, so an erroneous or malicious confidence score could pass unnoticed until a dispute arose. This adds per-source outlier detection, a manual-review hold workflow, and admin visibility into flags.

The numeric value guarded is each submission's `confidence_score`; the "oracle source" is its `data_source`, so detection is computed per source.

## What it does

**1. Rolling baseline (mean/stddev per source)** — `SubmissionHistoryService.evaluateAnomaly` computes the population mean/standard deviation over a data source's most recent submissions. Window size, minimum samples, and the z-score threshold are all configurable via `ORACLE_ANOMALY_*` env vars (defaults: window 50, min samples 5, threshold 3). The submission under evaluation is excluded from its own baseline.

**2. Flag beyond a configurable threshold** — a confidence score is flagged when its absolute z-score is **strictly greater** than the threshold. Edge cases are handled deliberately:
- fewer than the minimum samples → never flagged (baseline not yet trustworthy)
- zero-variance baseline → any differing value is an unambiguous outlier; an equal value is not

**3. Record flags + admin endpoint** — each outlier writes an immutable `OracleSubmissionFlag` row capturing the full statistical evidence (baseline mean/stddev, deviation, threshold, sample size, reason). Queryable by admins via `GET /oracle/flags` (filterable by data source, match, or held-only). Submissions also carry `is_anomaly` / `anomaly_score` / `review_status` in the existing submission-history endpoint.

**4. Hold for manual review** — when `ORACLE_ANOMALY_HOLD=true`, a flagged submission is withheld from on-chain submission (`review_status=HELD`) instead of being auto-submitted. `POST /oracle/submissions/:id/review` lets an admin approve (which queues it for submission — approval is the gate before use) or reject it. Resolve/submit paths never use a held submission until it is approved.

## Files

New:
- `oracle/dto/anomaly-detection.dto.ts` — evaluation result, flag query/response, review DTOs
- `oracle/entities/oracle-submission-flag.entity.ts` — immutable flag audit record
- `migrations/1776700000000-AddOracleAnomalyDetection.ts` — anomaly/review columns + flags table with indexes

Modified: `submission-history.service.ts` (detection, flag recording, flag query), `webhook.service.ts` (screening on intake + approve/reject workflow), `entities/oracle-submission.entity.ts`, `oracle.controller.ts`, `oracle.module.ts`, `dto/submission-history.dto.ts`, `config/env.validation.ts`.

## Tests

Extended `submission-history.service.spec.ts` and `webhook.service.spec.ts` to cover:
- **normal**, **outlier**, and **threshold-edge** submissions (value exactly at the threshold is not flagged; just beyond is)
- insufficient-samples and zero-variance baselines
- flag recording and the admin flag query (with filters)
- the full hold → approve / reject lifecycle, including that a held submission is not auto-submitted and that approval queues it for use

## Verification

- Oracle test suite: 58 tests passing
- `eslint` clean on all changed files (0 errors)
- `nest build` succeeds

Closes #1364