### PR TITLE
feat(health): probe DB, cache, and Soroban RPC independently

### DIFF
--- a/backend/src/health/dto/detailed-health.dto.ts
+++ b/backend/src/health/dto/detailed-health.dto.ts
@@ -20,14 +20,19 @@ export class CacheStatusDto {
   @ApiProperty({ example: 'up' })
   status: string;
 
-  @ApiProperty({ example: 0.85 })
-  hit_rate: number;
+  @ApiProperty({ example: 1 })
+  latency_ms: number;
 }
 
-export class DetailedHealthDto {
+export class HealthSummaryDto {
   @ApiProperty({ enum: ['healthy', 'degraded', 'down'], example: 'healthy' })
   status: 'healthy' | 'degraded' | 'down';
 
+  @ApiProperty({ example: 3600 })
+  uptime_seconds: number;
+}
+
+export class DetailedHealthDto extends HealthSummaryDto {
   @ApiProperty({ type: DatabaseStatusDto })
   database: DatabaseStatusDto;
 
@@ -36,7 +41,4 @@ export class DetailedHealthDto {
 
   @ApiProperty({ type: CacheStatusDto })
   cache: CacheStatusDto;
-
-  @ApiProperty({ example: 3600 })
-  uptime_seconds: number;
 }

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -11,6 +11,7 @@ describe('HealthController', () => {
   let healthService: {
     checkHealth: jest.Mock;
     checkPing: jest.Mock;
+    checkDetailed: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -21,6 +22,7 @@ describe('HealthController', () => {
         type: 'ping',
         timestamp: new Date().toISOString(),
       }),
+      checkDetailed: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -102,6 +104,47 @@ describe('HealthController', () => {
       const timestamp = new Date(result.timestamp);
       expect(timestamp instanceof Date).toBe(true);
       expect(!Number.isNaN(timestamp.getTime())).toBe(true);
+    });
+  });
+
+  describe('checkDetailed', () => {
+    it('requests a compact summary when verbose is omitted', async () => {
+      healthService.checkDetailed.mockResolvedValue({
+        status: 'healthy',
+        uptime_seconds: 42,
+      });
+
+      const result = await controller.checkDetailed();
+
+      expect(healthService.checkDetailed).toHaveBeenCalledWith(false);
+      expect(result).toEqual({ status: 'healthy', uptime_seconds: 42 });
+    });
+
+    it('requests full detail when verbose=true', async () => {
+      const detailed = {
+        status: 'degraded',
+        database: { status: 'up', latency_ms: 3 },
+        soroban: { status: 'down', latency_ms: 5000 },
+        cache: { status: 'up', latency_ms: 1 },
+        uptime_seconds: 42,
+      };
+      healthService.checkDetailed.mockResolvedValue(detailed);
+
+      const result = await controller.checkDetailed('true');
+
+      expect(healthService.checkDetailed).toHaveBeenCalledWith(true);
+      expect(result).toEqual(detailed);
+    });
+
+    it('treats any non-"true" value as non-verbose', async () => {
+      healthService.checkDetailed.mockResolvedValue({
+        status: 'healthy',
+        uptime_seconds: 1,
+      });
+
+      await controller.checkDetailed('yes');
+
+      expect(healthService.checkDetailed).toHaveBeenCalledWith(false);
     });
   });
 

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,9 +1,9 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { HealthCheckResult } from '@nestjs/terminus';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Public } from '../common/decorators/public.decorator';
 import { HealthService } from './health.service';
-import { DetailedHealthDto } from './dto/detailed-health.dto';
+import { DetailedHealthDto, HealthSummaryDto } from './dto/detailed-health.dto';
 
 @ApiTags('Health')
 @Controller('health')
@@ -39,12 +39,21 @@ export class HealthController {
   @Get('detailed')
   @Public()
   @ApiOperation({ summary: 'Detailed health status for monitoring' })
+  @ApiQuery({
+    name: 'verbose',
+    required: false,
+    type: Boolean,
+    description:
+      'When true, includes per-dependency status and latency. Defaults to a compact summary.',
+  })
   @ApiResponse({
     status: 200,
-    description: 'Detailed health status of all components',
+    description: 'Health status, compact by default or detailed when verbose',
     type: DetailedHealthDto,
   })
-  async checkDetailed(): Promise<DetailedHealthDto> {
-    return this.healthService.checkDetailed();
+  async checkDetailed(
+    @Query('verbose') verbose?: string,
+  ): Promise<DetailedHealthDto | HealthSummaryDto> {
+    return this.healthService.checkDetailed(verbose === 'true');
   }
 }

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,11 +1,12 @@
 import { HttpModule } from '@nestjs/axios';
+import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 
 @Module({
-  imports: [TerminusModule, HttpModule],
+  imports: [TerminusModule, HttpModule, CacheModule.register()],
   controllers: [HealthController],
   providers: [HealthService],
 })

--- a/backend/src/health/health.service.spec.ts
+++ b/backend/src/health/health.service.spec.ts
@@ -1,0 +1,115 @@
+import { HealthService } from './health.service';
+
+describe('HealthService - checkDetailed', () => {
+  let dataSource: { query: jest.Mock };
+  let cacheManager: { set: jest.Mock; get: jest.Mock };
+  let service: HealthService;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    dataSource = { query: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+    cacheManager = {
+      set: jest.fn().mockResolvedValue(undefined),
+      get: jest.fn().mockResolvedValue('ok'),
+    };
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    service = new HealthService(
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      dataSource as never,
+      cacheManager as never,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports healthy when database, soroban, and cache are all up', async () => {
+    const result = await service.checkDetailed(true);
+
+    expect(result.status).toBe('healthy');
+    expect('database' in result && result.database.status).toBe('up');
+    expect('soroban' in result && result.soroban.status).toBe('up');
+    expect('cache' in result && result.cache.status).toBe('up');
+  });
+
+  it('reports down when the database is unreachable', async () => {
+    dataSource.query.mockRejectedValue(new Error('connection refused'));
+
+    const result = await service.checkDetailed(true);
+
+    expect(result.status).toBe('down');
+    expect('database' in result && result.database.status).toBe('down');
+  });
+
+  it('reports degraded when soroban RPC fails but the database is up', async () => {
+    fetchMock.mockRejectedValue(new Error('timeout'));
+
+    const result = await service.checkDetailed(true);
+
+    expect(result.status).toBe('degraded');
+    expect('soroban' in result && result.soroban.status).toBe('down');
+    expect('database' in result && result.database.status).toBe('up');
+  });
+
+  it('reports degraded when soroban RPC responds with a non-ok status', async () => {
+    fetchMock.mockResolvedValue({ ok: false });
+
+    const result = await service.checkDetailed(true);
+
+    expect(result.status).toBe('degraded');
+    expect('soroban' in result && result.soroban.status).toBe('degraded');
+  });
+
+  it('reports degraded when the cache is unreachable but the database is up', async () => {
+    cacheManager.get.mockResolvedValue(undefined);
+
+    const result = await service.checkDetailed(true);
+
+    expect(result.status).toBe('degraded');
+    expect('cache' in result && result.cache.status).toBe('down');
+  });
+
+  it('prioritizes down over degraded when both the database and a non-critical dependency fail', async () => {
+    dataSource.query.mockRejectedValue(new Error('connection refused'));
+    fetchMock.mockRejectedValue(new Error('timeout'));
+
+    const result = await service.checkDetailed(true);
+
+    expect(result.status).toBe('down');
+  });
+
+  it('omits per-dependency detail when verbose is not requested', async () => {
+    const result = await service.checkDetailed();
+
+    expect(result).toEqual({
+      status: 'healthy',
+      uptime_seconds: expect.any(Number),
+    });
+    expect('database' in result).toBe(false);
+    expect('soroban' in result).toBe(false);
+    expect('cache' in result).toBe(false);
+  });
+
+  it('includes per-dependency status and latency when verbose is requested', async () => {
+    const result = await service.checkDetailed(true);
+
+    expect('database' in result && result.database).toEqual({
+      status: 'up',
+      latency_ms: expect.any(Number),
+    });
+    expect('soroban' in result && result.soroban).toEqual({
+      status: 'up',
+      latency_ms: expect.any(Number),
+    });
+    expect('cache' in result && result.cache).toEqual({
+      status: 'up',
+      latency_ms: expect.any(Number),
+    });
+  });
+});

--- a/backend/src/health/health.service.ts
+++ b/backend/src/health/health.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable } from '@nestjs/common';
 import {
   DiskHealthIndicator,
   HealthCheck,
@@ -8,11 +9,15 @@ import {
   TypeOrmHealthIndicator,
 } from '@nestjs/terminus';
 import { InjectDataSource } from '@nestjs/typeorm';
+import type { Cache } from 'cache-manager';
 import * as os from 'os';
 import { DataSource } from 'typeorm';
-import { DetailedHealthDto } from './dto/detailed-health.dto';
+import { DetailedHealthDto, HealthSummaryDto } from './dto/detailed-health.dto';
 
 const START_TIME = Date.now();
+const CACHE_PROBE_KEY = '__health_check_probe__';
+
+type DependencyStatus = { status: string; latency_ms: number };
 
 @Injectable()
 export class HealthService {
@@ -23,6 +28,8 @@ export class HealthService {
     private readonly disk: DiskHealthIndicator,
     @InjectDataSource()
     private readonly dataSource: DataSource,
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager: Cache,
   ) {}
 
   /**
@@ -67,34 +74,60 @@ export class HealthService {
 
   /**
    * Detailed health check with individual component status and latency for monitoring.
-   * Checks database connectivity, Soroban RPC reachability, and cache status.
+   * Probes the database, Soroban RPC, and cache independently and in parallel.
+   *
+   * The database is treated as a critical dependency: its failure brings the
+   * overall status to 'down'. Soroban RPC and cache are non-critical: their
+   * failure only degrades the overall status, since the API can still serve
+   * most traffic without them.
+   *
+   * @param verbose When false (default), returns only the overall status and
+   * uptime. When true, includes per-dependency status and latency.
    */
-  async checkDetailed(): Promise<DetailedHealthDto> {
-    const [dbResult, sorobanResult] = await Promise.all([
+  async checkDetailed(
+    verbose = false,
+  ): Promise<DetailedHealthDto | HealthSummaryDto> {
+    const [dbResult, sorobanResult, cacheResult] = await Promise.all([
       this.checkDatabase(),
       this.checkSoroban(),
+      this.checkCache(),
     ]);
 
-    const overallStatus =
-      dbResult.status === 'down'
-        ? 'down'
-        : dbResult.status === 'degraded' || sorobanResult.status === 'degraded'
-          ? 'degraded'
-          : 'healthy';
+    const status = this.computeOverallStatus(
+      dbResult,
+      sorobanResult,
+      cacheResult,
+    );
+    const uptime_seconds = Math.floor((Date.now() - START_TIME) / 1000);
+
+    if (!verbose) {
+      return { status, uptime_seconds };
+    }
 
     return {
-      status: overallStatus,
+      status,
       database: dbResult,
       soroban: sorobanResult,
-      cache: this.getCacheStatus(),
-      uptime_seconds: Math.floor((Date.now() - START_TIME) / 1000),
+      cache: cacheResult,
+      uptime_seconds,
     };
   }
 
-  private async checkDatabase(): Promise<{
-    status: string;
-    latency_ms: number;
-  }> {
+  private computeOverallStatus(
+    database: DependencyStatus,
+    soroban: DependencyStatus,
+    cache: DependencyStatus,
+  ): 'healthy' | 'degraded' | 'down' {
+    if (database.status !== 'up') {
+      return 'down';
+    }
+    if (soroban.status !== 'up' || cache.status !== 'up') {
+      return 'degraded';
+    }
+    return 'healthy';
+  }
+
+  private async checkDatabase(): Promise<DependencyStatus> {
     const start = Date.now();
     try {
       await this.dataSource.query('SELECT 1');
@@ -104,10 +137,7 @@ export class HealthService {
     }
   }
 
-  private async checkSoroban(): Promise<{
-    status: string;
-    latency_ms: number;
-  }> {
+  private async checkSoroban(): Promise<DependencyStatus> {
     const rpcUrl =
       process.env.SOROBAN_RPC_URL ?? 'https://soroban-testnet.stellar.org';
     const start = Date.now();
@@ -133,8 +163,18 @@ export class HealthService {
     }
   }
 
-  /** Cache is in-memory (challenge cache); always 'up'. Hit rate is not tracked externally. */
-  private getCacheStatus(): { status: string; hit_rate: number } {
-    return { status: 'up', hit_rate: 0 };
+  /** Round-trips a probe value through the cache to verify it is reachable. */
+  private async checkCache(): Promise<DependencyStatus> {
+    const start = Date.now();
+    try {
+      await this.cacheManager.set(CACHE_PROBE_KEY, 'ok', 5000);
+      const value = await this.cacheManager.get(CACHE_PROBE_KEY);
+      return {
+        status: value === 'ok' ? 'up' : 'down',
+        latency_ms: Date.now() - start,
+      };
+    } catch {
+      return { status: 'down', latency_ms: Date.now() - start };
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Extend the detailed health check to probe DB, Soroban RPC, and cache independently, in parallel, each reporting `status` and `latency_ms`.
- Replace the hardcoded cache status with a real probe (set/get roundtrip) via the existing `CACHE_MANAGER`.
- Add a `?verbose` query flag on `GET /health/detailed` — compact `{status, uptime_seconds}` by default, full per-dependency breakdown when `verbose=true`.
- Fix overall status computation: DB is treated as critical (`down` → overall `down`); Soroban and cache are non-critical (failure → overall `degraded` only). Previously a fully-down Soroban RPC was not reflected in overall status at all.

Closes #1384

## Test plan
- [x] `npx jest src/health` — 18/18 passing (new `health.service.spec.ts` covers all-healthy, DB-down, Soroban-down/degraded, cache-down, and combined-failure precedence; extended `health.controller.spec.ts` for the verbose flag)
- [x] `npx eslint src/health --ext .ts` — clean
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated errors in other modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)