### PR TITLE
Fix/1341 market cancellation refund

### DIFF
--- a/contracts/open-market/src/errors.rs
+++ b/contracts/open-market/src/errors.rs
@@ -44,6 +44,10 @@ pub enum InsightArenaError {
     /// Raised when cancel_market is called a second time or when any post-cancel
     /// mutation (prediction, resolution) is attempted.
     MarketAlreadyCancelled = 19,
+    /// The market is not in the cancelled state.
+    /// Raised by `claim_cancel_refund` when the market has not been cancelled and
+    /// therefore no cancellation refund is available.
+    MarketNotCancelled = 28,
     /// The predicted outcome symbol is not present in `outcome_options`.
     /// Raised when a user submits a prediction with an unrecognised outcome.
     InvalidOutcome = 16,
@@ -81,6 +85,12 @@ pub enum InsightArenaError {
     /// The market has already been closed and is no longer accepting changes.
     /// Raised when a mutation (fee update, end_time extension) is attempted after close.
     MarketAlreadyClosed = 25,
+    /// The participant has already claimed their cancellation refund for this market.
+    /// Raised by `claim_cancel_refund` to prevent double-claiming on cancelled markets.
+    RefundAlreadyClaimed = 26,
+    /// The caller has no stake in this market and is therefore not entitled to a refund.
+    /// Raised by `claim_cancel_refund` when the address never submitted a prediction.
+    NotAParticipant = 27,
 
     // ── Escrow ────────────────────────────────────────────────────────────────
     /// The contract's escrow balance is insufficient to complete the transfer.
@@ -154,5 +164,5 @@ pub enum InsightArenaError {
     /// `DataKey::TrustedCreator` allowlist. Raised by `market::create_market`
     /// before any market state is persisted; a `MarketCreationDenied` event is
     /// emitted with the attempted creator's address before this error returns.
-    InsufficientReputation = 105,
+    InsufficientReputation = 106,
 }

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -342,6 +342,21 @@ impl InsightArenaContract {
         prediction::claim_payout(&env, predictor, market_id)
     }
 
+    /// Pull-based cancellation refund: transfer the caller's full staked amount
+    /// back to them from escrow.
+    ///
+    /// The market must be cancelled. Each participant calls this once for
+    /// themselves; a second call reverts with `RefundAlreadyClaimed`.
+    /// A caller with no stake in the market reverts with `NotAParticipant`.
+    /// Returns the refund amount in stroops.
+    pub fn claim_cancel_refund(
+        env: Env,
+        predictor: Address,
+        market_id: u64,
+    ) -> Result<i128, InsightArenaError> {
+        prediction::claim_cancel_refund(&env, predictor, market_id)
+    }
+
     /// Return the current XLM balance held by the contract escrow in stroops.
     pub fn get_contract_balance(env: Env) -> i128 {
         escrow::get_contract_balance(&env)

--- a/contracts/open-market/src/market.rs
+++ b/contracts/open-market/src/market.rs
@@ -2,7 +2,6 @@ use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol, Vec}
 
 use crate::config::{self, PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
 use crate::errors::InsightArenaError;
-use crate::escrow;
 use crate::reputation;
 use crate::storage_types::{
     ConditionalMarket, DataKey, DependencyStatus, Market, MarketStats, PlatformStats, Prediction,
@@ -615,19 +614,24 @@ pub fn extend_market_end_time(
 
 /// Cancel a market that could not be resolved (oracle failure, creator error, etc.).
 ///
-/// Upon cancellation every predictor's full stake is refunded via the escrow
-/// module. No payouts or fees are processed.
+/// Marks the market as cancelled and freezes all further mutations (predictions,
+/// resolution, fee updates). Funds are NOT pushed in this call. Instead, each
+/// participant must call `claim_cancel_refund` to pull their stake back. This
+/// pull pattern keeps this function O(1) and gas-bounded regardless of participant
+/// count, and each individual transfer is isolated so one failing recipient cannot
+/// block the rest.
 ///
 /// Validation order:
-/// 1. Market exists
-/// 2. Market has not already been resolved
-/// 3. Market has not already been cancelled
-/// 4. `caller` must be the platform admin
+/// 1. Platform not paused
+/// 2. Market exists
+/// 3. Market has not already been resolved
+/// 4. Market has not already been cancelled
+/// 5. `caller` must be the platform admin
 ///
 /// On success:
 /// - `market.is_cancelled` is set to `true` and persisted.
-/// - All entries in `PredictorList(market_id)` are iterated; for each, the
-///   corresponding `Prediction` record is loaded and `escrow::refund` is called.
+/// - Conditional children are deactivated (their own stakes remain claimable per
+///   participant via `claim_cancel_refund` on each child market).
 /// - A `MarketCancelled` event is emitted.
 pub fn cancel_market(env: &Env, caller: Address, market_id: u64) -> Result<(), InsightArenaError> {
     config::ensure_not_paused(env)?;
@@ -659,20 +663,9 @@ pub fn cancel_market(env: &Env, caller: Address, market_id: u64) -> Result<(), I
         .set(&DataKey::Market(market_id), &market);
     bump_market(env, market_id);
 
-    let predictors = env
-        .storage()
-        .persistent()
-        .get::<DataKey, Vec<Address>>(&DataKey::PredictorList(market_id))
-        .unwrap_or_else(|| Vec::new(env));
-
-    for predictor in predictors.iter() {
-        let key = DataKey::Prediction(market_id, predictor.clone());
-        if let Some(prediction) = env.storage().persistent().get::<DataKey, Prediction>(&key) {
-            escrow::refund(env, &predictor, prediction.stake_amount)?;
-        }
-    }
-
     // Deactivate all conditional children so no orphaned markets remain.
+    // Each child market is also marked cancelled; its participants may call
+    // claim_cancel_refund on the child market independently.
     let child_ids: Vec<u64> = env
         .storage()
         .persistent()
@@ -1078,8 +1071,11 @@ fn emit_conditional_deactivated(env: &Env, market_id: u64) {
 
 /// Deactivate a conditional market whose parent was cancelled or resolved to a
 /// non-matching outcome. Sets `is_activated = false`, marks the underlying
-/// `Market` as `is_cancelled = true`, refunds any stakes already placed, and
-/// emits a deactivation event.
+/// `Market` as `is_cancelled = true` so `submit_prediction` rejects new entries,
+/// and emits a deactivation event.
+///
+/// Stakes already placed in the child market are claimable by each participant
+/// via `claim_cancel_refund` — the pull pattern keeps this function O(1).
 pub fn deactivate_conditional_market(env: &Env, market_id: u64) -> Result<(), InsightArenaError> {
     // Load and update the ConditionalMarket record.
     let mut conditional: ConditionalMarket = env
@@ -1094,7 +1090,8 @@ pub fn deactivate_conditional_market(env: &Env, market_id: u64) -> Result<(), In
         .persistent()
         .set(&DataKey::ConditionalMarket(market_id), &conditional);
 
-    // Mark the underlying Market as cancelled and refund any stakes.
+    // Mark the underlying Market as cancelled. Stakes remain in escrow and are
+    // individually claimable via claim_cancel_refund.
     let mut market = get_market(env, market_id)?;
 
     if !market.is_cancelled && !market.is_resolved {
@@ -1103,19 +1100,6 @@ pub fn deactivate_conditional_market(env: &Env, market_id: u64) -> Result<(), In
             .persistent()
             .set(&DataKey::Market(market_id), &market);
         bump_market(env, market_id);
-
-        let predictors = env
-            .storage()
-            .persistent()
-            .get::<DataKey, Vec<Address>>(&DataKey::PredictorList(market_id))
-            .unwrap_or_else(|| Vec::new(env));
-
-        for predictor in predictors.iter() {
-            let key = DataKey::Prediction(market_id, predictor.clone());
-            if let Some(prediction) = env.storage().persistent().get::<DataKey, Prediction>(&key) {
-                escrow::refund(env, &predictor, prediction.stake_amount)?;
-            }
-        }
     }
 
     emit_conditional_deactivated(env, market_id);

--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -759,3 +759,107 @@ pub fn batch_distribute_payouts(
 
     Ok(processed)
 }
+
+// ── Cancellation refund (pull pattern) ───────────────────────────────────────
+
+/// Emit one refund event per individual claim, matching the emit_* style used
+/// elsewhere in this module.
+fn emit_refund_claimed(env: &Env, market_id: u64, predictor: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("pred"), symbol_short!("refndcld")),
+        (market_id, predictor.clone(), amount),
+    );
+}
+
+/// Claim a cancellation refund for a staked prediction on a cancelled market.
+///
+/// This implements a **pull** pattern: each participant calls this function
+/// independently to withdraw their own stake. The function is O(1) — it
+/// touches only the caller's records and does not iterate any participant list.
+///
+/// Accounting guarantee: because no fees are deducted before resolution, the
+/// full `stake_amount` is still held in escrow at cancellation time. Each
+/// participant therefore receives exactly what they deposited, and the sum of
+/// all individual refunds equals `market.total_pool` — the total held in
+/// escrow for that market.
+///
+/// # Validation order
+/// 1. Platform not paused
+/// 2. Market exists
+/// 3. Market is cancelled (`is_cancelled == true`)
+/// 4. Caller has an unclaimed prediction for this market (`NotAParticipant`)
+/// 5. Refund has not already been claimed (`RefundAlreadyClaimed`)
+///
+/// # On success
+/// - `stake_amount` is transferred from escrow to `predictor` via
+///   `escrow::refund`.
+/// - The prediction record is moved from persistent to temporary storage,
+///   preventing any second claim (same tombstone pattern as `claim_payout`).
+/// - A `RefundClaimed` event is emitted carrying
+///   `(market_id, predictor, amount)`.
+///
+/// # Returns
+/// The refund amount in stroops (equal to the original `stake_amount`).
+pub fn claim_cancel_refund(
+    env: &Env,
+    predictor: Address,
+    market_id: u64,
+) -> Result<i128, InsightArenaError> {
+    // ── Guard 1: platform not paused ─────────────────────────────────────────
+    config::ensure_not_paused(env)?;
+
+    // Require the caller's authorisation before reading any state so the
+    // auth check can never be bypassed by an early error return.
+    predictor.require_auth();
+
+    // ── Guard 2: market must exist ────────────────────────────────────────────
+    let market: Market = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Market(market_id))
+        .ok_or(InsightArenaError::MarketNotFound)?;
+
+    // ── Guard 3: market must be cancelled ─────────────────────────────────────
+    if !market.is_cancelled {
+        return Err(InsightArenaError::MarketNotCancelled);
+    }
+
+    // ── Guard 4: caller must have a prediction record ─────────────────────────
+    // Presence in persistent storage means the refund has not yet been claimed.
+    // After a successful claim the record is moved to temporary storage (tombstone),
+    // exactly mirroring what claim_payout does — so the same "is it in persistent?"
+    // check doubles as the double-claim guard with no new storage keys required.
+    let prediction_key = DataKey::Prediction(market_id, predictor.clone());
+
+    // Check temporary storage first: if the record is there it was already processed.
+    if env.storage().temporary().has(&prediction_key) {
+        return Err(InsightArenaError::RefundAlreadyClaimed);
+    }
+
+    let prediction: Prediction = env
+        .storage()
+        .persistent()
+        .get(&prediction_key)
+        .ok_or(InsightArenaError::NotAParticipant)?;
+
+    let refund_amount = prediction.stake_amount;
+
+    // ── Checks-Effects-Interactions: move record to temporary before transfer ─
+    // Removing from persistent and writing a tombstone to temporary makes the
+    // double-claim guard above fire on any subsequent call, even if the transfer
+    // below were somehow to revert (it cannot in Soroban, but the pattern is
+    // correct regardless).
+    let mut tombstone = prediction.clone();
+    tombstone.payout_claimed = true; // reuse flag to signal "refund claimed"
+    env.storage().persistent().remove(&prediction_key);
+    env.storage().temporary().set(&prediction_key, &tombstone);
+    config::shorten_prediction_ttl_after_claim(env, market_id, &predictor);
+
+    // ── Transfer stake from escrow back to predictor ──────────────────────────
+    escrow::refund(env, &predictor, refund_amount)?;
+
+    // ── Emit one RefundClaimed event for this individual claim ────────────────
+    emit_refund_claimed(env, market_id, &predictor, refund_amount);
+
+    Ok(refund_amount)
+}

--- a/contracts/open-market/tests/cancel_refund_tests.rs
+++ b/contracts/open-market/tests/cancel_refund_tests.rs
@@ -1,0 +1,501 @@
+//! Tests for issue #1341: Automated Refund on Market Cancellation (pull pattern).
+//!
+//! Acceptance criteria covered:
+//! 1. `cancel_market` transitions to Cancelled state and blocks new predictions.
+//! 2. A single participant can successfully claim their full stake back.
+//! 3. A participant claiming twice is rejected with `RefundAlreadyClaimed`.
+//! 4. Multiple participants can each independently claim their correct amounts.
+//! 5. Sum of all refunds equals total staked (escrow-invariant test).
+
+use insightarena_contract::market::CreateMarketParams;
+use insightarena_contract::storage_types::{DataKey, Prediction};
+use insightarena_contract::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn register_token(env: &Env) -> Address {
+    let token_admin = Address::generate(env);
+    env.register_stellar_asset_contract_v2(token_admin)
+        .address()
+}
+
+/// Deploy the contract and return (client, admin, oracle, xlm_token).
+fn deploy(env: &Env) -> (InsightArenaContractClient<'_>, Address, Address, Address) {
+    let id = env.register(InsightArenaContract, ());
+    let client = InsightArenaContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+    let xlm_token = register_token(env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle, &200_u32, &xlm_token);
+    (client, admin, oracle, xlm_token)
+}
+
+fn default_params(env: &Env) -> CreateMarketParams {
+    let now = env.ledger().timestamp();
+    CreateMarketParams {
+        title: String::from_str(env, "Test market"),
+        description: String::from_str(env, "Refund test"),
+        category: Symbol::new(env, "Sports"),
+        outcomes: vec![env, symbol_short!("yes"), symbol_short!("no")],
+        end_time: now + 1_000,
+        resolution_time: now + 2_000,
+        dispute_window: 86_400,
+        creator_fee_bps: 100,
+        min_stake: 10_000_000,
+        max_stake: 500_000_000,
+        is_public: true,
+    }
+}
+
+fn fund(env: &Env, token: &Address, recipient: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(recipient, &amount);
+}
+
+// ── AC-1: Cancel transitions state and blocks predictions ─────────────────────
+
+/// Cancellation flips `is_cancelled` to true and `submit_prediction` on a
+/// cancelled market returns `MarketAlreadyCancelled`.
+#[test]
+fn ac1_cancel_transitions_state_and_blocks_predictions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    // Confirm open before cancel.
+    let before = client.get_market(&market_id);
+    assert!(!before.is_cancelled);
+    assert!(!before.is_resolved);
+
+    client.cancel_market(&admin, &market_id);
+
+    // State is now cancelled.
+    let after = client.get_market(&market_id);
+    assert!(after.is_cancelled);
+    assert!(!after.is_resolved);
+
+    // Predictions are blocked.
+    fund(&env, &xlm_token, &predictor, stake);
+    let result =
+        client.try_submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyCancelled))
+    ));
+}
+
+/// `cancel_market` itself is idempotent-blocked: a second call returns
+/// `MarketAlreadyCancelled`.
+#[test]
+fn ac1_double_cancel_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, _xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    client.cancel_market(&admin, &market_id);
+
+    let result = client.try_cancel_market(&admin, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyCancelled))
+    ));
+}
+
+/// A resolved market cannot be cancelled.
+#[test]
+fn ac1_resolved_market_cannot_be_cancelled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, _xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let params = default_params(&env);
+    let market_id = client.create_market(&creator, &params);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    let result = client.try_cancel_market(&admin, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyResolved))
+    ));
+}
+
+/// Only the platform admin may cancel — a random caller is rejected.
+#[test]
+fn ac1_non_admin_cannot_cancel() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let random = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    let result = client.try_cancel_market(&random, &market_id);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+// ── AC-2: Single participant claims full stake ────────────────────────────────
+
+/// One predictor stakes, market is cancelled, predictor claims and receives
+/// exactly `stake_amount` back.
+#[test]
+fn ac2_single_participant_claims_full_stake() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 30_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    // Stake is in escrow.
+    assert_eq!(token.balance(&predictor), 0);
+
+    client.cancel_market(&admin, &market_id);
+
+    // Funds still in escrow after cancel.
+    assert_eq!(token.balance(&predictor), 0);
+    assert_eq!(token.balance(&client.address), stake);
+
+    let refunded = client.claim_cancel_refund(&predictor, &market_id);
+
+    // Returned value equals stake.
+    assert_eq!(refunded, stake);
+    // Predictor is whole.
+    assert_eq!(token.balance(&predictor), stake);
+    // Escrow is empty.
+    assert_eq!(token.balance(&client.address), 0);
+}
+
+/// `claim_cancel_refund` on a market that is not cancelled returns
+/// `MarketNotCancelled`.
+#[test]
+fn ac2_claim_on_live_market_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 10_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    // Market is still live — refund must fail.
+    let result = client.try_claim_cancel_refund(&predictor, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketNotCancelled))
+    ));
+}
+
+// ── AC-3: Double-claim prevention ────────────────────────────────────────────
+
+/// A predictor who calls `claim_cancel_refund` twice gets `RefundAlreadyClaimed`
+/// on the second call and receives no extra tokens.
+#[test]
+fn ac3_double_claim_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    client.cancel_market(&admin, &market_id);
+
+    // First claim succeeds.
+    client.claim_cancel_refund(&predictor, &market_id);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    let balance_after_first = token.balance(&predictor);
+    assert_eq!(balance_after_first, stake);
+
+    // Second claim is rejected.
+    let result = client.try_claim_cancel_refund(&predictor, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::RefundAlreadyClaimed))
+    ));
+
+    // Balance unchanged — no double-payment.
+    assert_eq!(token.balance(&predictor), stake);
+}
+
+// ── AC-4: Multiple independent participants ───────────────────────────────────
+
+/// Five predictors with different stakes on both outcomes each claim in
+/// arbitrary order and each receive exactly their deposited amount.
+#[test]
+fn ac4_multiple_participants_claim_independently_in_any_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    let stakes = [12_000_000_i128, 25_000_000, 40_000_000, 60_000_000, 100_000_000];
+    let outcomes = [
+        symbol_short!("yes"),
+        symbol_short!("no"),
+        symbol_short!("yes"),
+        symbol_short!("no"),
+        symbol_short!("yes"),
+    ];
+    let predictors: Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+
+    let token = TokenClient::new(&env, &xlm_token);
+
+    for (i, predictor) in predictors.iter().enumerate() {
+        fund(&env, &xlm_token, predictor, stakes[i]);
+        client.submit_prediction(predictor, &market_id, &outcomes[i], &stakes[i]);
+    }
+
+    client.cancel_market(&admin, &market_id);
+
+    // Claim in reverse order to show independence.
+    for (i, predictor) in predictors.iter().enumerate().rev() {
+        let result = client.claim_cancel_refund(predictor, &market_id);
+        assert_eq!(result, stakes[i], "predictor {i} got wrong refund amount");
+        assert_eq!(
+            token.balance(predictor),
+            stakes[i],
+            "predictor {i} final balance wrong"
+        );
+    }
+}
+
+/// A non-participant calling `claim_cancel_refund` receives `NotAParticipant`.
+#[test]
+fn ac4_non_participant_cannot_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let stake = 15_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    client.cancel_market(&admin, &market_id);
+
+    let result = client.try_claim_cancel_refund(&outsider, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::NotAParticipant))
+    ));
+
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&outsider), 0);
+}
+
+// ── AC-5: Escrow invariant — sum of all refunds == total staked ───────────────
+
+/// Invariant: after all participants claim, the escrow balance is exactly zero
+/// and each participant received exactly their deposited stake. No rounding
+/// errors, no dust, no over-payment.
+#[test]
+fn ac5_sum_of_all_refunds_equals_total_staked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    // Deliberately unequal stakes across both outcomes to stress the accounting.
+    let stakes = [
+        10_000_000_i128,
+        17_500_000,
+        33_333_333,
+        99_999_999,
+        200_000_001,
+    ];
+    let outcomes = [
+        symbol_short!("yes"),
+        symbol_short!("yes"),
+        symbol_short!("no"),
+        symbol_short!("yes"),
+        symbol_short!("no"),
+    ];
+    let predictors: Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+
+    let token = TokenClient::new(&env, &xlm_token);
+    let total_staked: i128 = stakes.iter().sum();
+
+    for (i, predictor) in predictors.iter().enumerate() {
+        fund(&env, &xlm_token, predictor, stakes[i]);
+        client.submit_prediction(predictor, &market_id, &outcomes[i], &stakes[i]);
+    }
+
+    // All stakes are now in escrow.
+    assert_eq!(token.balance(&client.address), total_staked);
+
+    client.cancel_market(&admin, &market_id);
+
+    // Escrow unchanged after cancel — pull pattern.
+    assert_eq!(token.balance(&client.address), total_staked);
+
+    // Each participant claims; track cumulative refunds.
+    let mut total_refunded: i128 = 0;
+    for (i, predictor) in predictors.iter().enumerate() {
+        let got = client.claim_cancel_refund(predictor, &market_id);
+        assert_eq!(got, stakes[i], "predictor {i}: refund amount mismatch");
+        total_refunded += got;
+    }
+
+    // Invariant: sum of individual refunds == total staked.
+    assert_eq!(
+        total_refunded, total_staked,
+        "sum of refunds must equal total staked"
+    );
+
+    // Escrow must be exactly zero — no dust remaining.
+    assert_eq!(
+        token.balance(&client.address),
+        0,
+        "escrow must be empty after all claims"
+    );
+}
+
+/// Partial-claim invariant: after N of M participants claim, escrow holds
+/// exactly the stakes of the M-N unclaimed participants.
+#[test]
+fn ac5_escrow_decreases_by_exact_claimed_amount_on_each_pull() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    let stake_a = 40_000_000_i128;
+    let stake_b = 60_000_000_i128;
+    let predictor_a = Address::generate(&env);
+    let predictor_b = Address::generate(&env);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    fund(&env, &xlm_token, &predictor_a, stake_a);
+    fund(&env, &xlm_token, &predictor_b, stake_b);
+    client.submit_prediction(&predictor_a, &market_id, &symbol_short!("yes"), &stake_a);
+    client.submit_prediction(&predictor_b, &market_id, &symbol_short!("no"), &stake_b);
+
+    client.cancel_market(&admin, &market_id);
+
+    // A claims; escrow drops by stake_a.
+    client.claim_cancel_refund(&predictor_a, &market_id);
+    assert_eq!(token.balance(&client.address), stake_b);
+
+    // B claims; escrow reaches zero.
+    client.claim_cancel_refund(&predictor_b, &market_id);
+    assert_eq!(token.balance(&client.address), 0);
+
+    assert_eq!(token.balance(&predictor_a), stake_a);
+    assert_eq!(token.balance(&predictor_b), stake_b);
+}
+
+// ── AC-5 (extended): no-predictor market ─────────────────────────────────────
+
+/// A market with no participants can be cancelled without error.
+/// No claims are possible since nobody staked.
+#[test]
+fn ac5_cancel_empty_market_is_a_no_op() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+
+    client.cancel_market(&admin, &market_id);
+
+    let market = client.get_market(&market_id);
+    assert!(market.is_cancelled);
+
+    // Escrow is still zero.
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&client.address), 0);
+}
+
+// ── Bonus: resolve-after-cancel and payout paths remain closed ────────────────
+
+/// The oracle cannot resolve a cancelled market, ensuring the payout path
+/// can never be re-opened after a cancellation.
+#[test]
+fn bonus_resolve_after_cancel_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, _xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let params = default_params(&env);
+    let market_id = client.create_market(&creator, &params);
+
+    client.cancel_market(&admin, &market_id);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time + 1);
+    let result = client.try_resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyCancelled))
+    ));
+}
+
+/// `claim_payout` on a cancelled market fails with `MarketNotResolved`, not a
+/// panic — the resolved-payout path is correctly gated.
+#[test]
+fn bonus_claim_payout_on_cancelled_market_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 10_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    client.cancel_market(&admin, &market_id);
+
+    let result = client.try_claim_payout(&predictor, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketNotResolved))
+    ));
+}

--- a/contracts/open-market/tests/market_tests.rs
+++ b/contracts/open-market/tests/market_tests.rs
@@ -936,11 +936,21 @@ fn cancel_market_refunds_all_predictors() {
     StellarAssetClient::new(&env, &xlm_token).mint(&contract_id, &(stake_a + stake_b));
 
     let token_client = TokenClient::new(&env, &xlm_token);
+
+    // Cancel — funds stay in escrow until each participant pulls them.
     client.cancel_market(&admin, &id);
+    assert!(client.get_market(&id).is_cancelled);
+
+    // Funds are still in contract escrow — not pushed.
+    assert_eq!(token_client.balance(&client.address), stake_a + stake_b);
+
+    // Each participant pulls their refund.
+    client.claim_cancel_refund(&predictor_a, &id);
+    client.claim_cancel_refund(&predictor_b, &id);
 
     assert_eq!(token_client.balance(&predictor_a), stake_a);
     assert_eq!(token_client.balance(&predictor_b), stake_b);
-    assert!(client.get_market(&id).is_cancelled);
+    assert_eq!(token_client.balance(&client.address), 0);
 }
 
 #[test]
@@ -1007,16 +1017,19 @@ fn cancel_market_refunds_exact_stake_amounts() {
 
     let token_client = TokenClient::new(&env, &xlm_token);
 
-    // Admin cancels the market
+    // Admin cancels the market (pull pattern — no funds move yet).
     client.cancel_market(&admin, &id);
+    assert!(client.get_market(&id).is_cancelled);
 
-    // Assert each user's balance is restored exactly
+    // Each participant pulls their own refund.
+    client.claim_cancel_refund(&user1, &id);
+    client.claim_cancel_refund(&user2, &id);
+    client.claim_cancel_refund(&user3, &id);
+
+    // Assert each user's balance is restored exactly.
     assert_eq!(token_client.balance(&user1), stake1);
     assert_eq!(token_client.balance(&user2), stake2);
     assert_eq!(token_client.balance(&user3), stake3);
-
-    // Assert market is cancelled
-    assert!(client.get_market(&id).is_cancelled);
 
     // Assert further predictions fail with MarketAlreadyCancelled
     let result = client.try_submit_prediction(&user1, &id, &symbol_short!("yes"), &stake1);
@@ -1026,15 +1039,14 @@ fn cancel_market_refunds_exact_stake_amounts() {
     ));
 }
 
-// ── cancel_market multi-predictor refund flow (#1265) ────────────────────────
+// ── cancel_market multi-predictor refund flow (#1265 / #1341) ────────────────
 //
-// Unlike the storage-injection tests above, these run the full end-to-end
-// flow: predictors are funded, stake real tokens through submit_prediction,
-// and are refunded by cancel_market. Refunds in this contract are push-based —
-// cancel_market transfers every stake back in the same call, so "claiming a
-// refund" is the cancellation itself and the double-claim / non-participant
-// requirements are pinned against every post-cancellation extraction path
-// (second cancel, resolve-after-cancel, claim_payout, batch payouts).
+// These tests run the full end-to-end flow: predictors are funded, stake real
+// tokens through submit_prediction, and retrieve their funds by calling
+// claim_cancel_refund after cancellation. Refunds in this contract are
+// pull-based — cancel_market only marks the market cancelled; each participant
+// calls claim_cancel_refund independently. Double-claim prevention and
+// non-participant exclusion are exercised against every extraction path.
 
 /// Five distinct stakes within default_params' min/max bounds (10M..=100M).
 const FLOW_STAKES: [i128; 5] = [12_000_000, 25_000_000, 40_000_000, 60_000_000, 100_000_000];
@@ -1081,8 +1093,8 @@ fn setup_five_predictor_market(
 }
 
 /// Requirements 1–4 & 7: five predictors with five different stakes across
-/// both outcomes are each made exactly whole by cancellation, and the contract
-/// retains zero tokens from the cancelled market.
+/// both outcomes are each made exactly whole after claiming their refund, and
+/// the contract retains zero tokens once all claims are complete.
 #[test]
 fn cancel_market_five_predictors_restores_exact_pre_stake_balances() {
     let env = Env::default();
@@ -1103,8 +1115,17 @@ fn cancel_market_five_predictors_restores_exact_pre_stake_balances() {
         assert_eq!(token.balance(predictor), balances_before[i] - FLOW_STAKES[i]);
     }
 
+    // Cancel marks the market; funds stay in escrow.
     client.cancel_market(&admin, &id);
     assert!(client.get_market(&id).is_cancelled);
+
+    // Funds are still in escrow — not pushed.
+    assert_eq!(token.balance(&client.address), contract_before + total_staked);
+
+    // Each predictor pulls their own refund.
+    for predictor in predictors.iter() {
+        client.claim_cancel_refund(predictor, &id);
+    }
 
     // Every predictor's balance is restored exactly, regardless of stake size
     // or which outcome they chose.
@@ -1118,10 +1139,9 @@ fn cancel_market_five_predictors_restores_exact_pre_stake_balances() {
 }
 
 /// Requirement 5 & acceptance: a second refund for the same predictor is
-/// impossible. Refunds are pushed by cancel_market, so every path that could
-/// pay a second time is asserted closed: cancelling again, resolving the
-/// cancelled market (which would reopen claim_payout), claiming a payout
-/// directly, and batch-distributing payouts.
+/// impossible via claim_cancel_refund (RefundAlreadyClaimed), and all other
+/// extraction paths (resolve-after-cancel, claim_payout, batch payouts) are
+/// also closed.
 #[test]
 fn cancel_market_second_refund_is_impossible_via_any_path() {
     let env = Env::default();
@@ -1133,6 +1153,20 @@ fn cancel_market_second_refund_is_impossible_via_any_path() {
         setup_five_predictor_market(&env, &client, &xlm_token);
 
     client.cancel_market(&admin, &id);
+
+    // Each predictor claims once successfully.
+    for predictor in predictors.iter() {
+        client.claim_cancel_refund(predictor, &id);
+    }
+
+    // Path 0: a second claim_cancel_refund is rejected with RefundAlreadyClaimed.
+    for predictor in predictors.iter() {
+        let second_claim = client.try_claim_cancel_refund(predictor, &id);
+        assert!(matches!(
+            second_claim,
+            Err(Ok(InsightArenaError::RefundAlreadyClaimed))
+        ));
+    }
 
     // Path 1: cancelling again is rejected.
     let second_cancel = client.try_cancel_market(&admin, &id);
@@ -1167,7 +1201,7 @@ fn cancel_market_second_refund_is_impossible_via_any_path() {
         Err(Ok(InsightArenaError::MarketNotResolved))
     ));
 
-    // After all rejected attempts, balances are exactly the refunded ones and
+    // After all rejected attempts, balances equal the refunded amounts and
     // the contract kept nothing.
     for (i, predictor) in predictors.iter().enumerate() {
         assert_eq!(token.balance(predictor), balances_before[i]);
@@ -1175,8 +1209,8 @@ fn cancel_market_second_refund_is_impossible_via_any_path() {
     assert_eq!(token.balance(&client.address), 0);
 }
 
-/// Requirement 6: an address that never predicted receives nothing from the
-/// cancellation and cannot extract anything afterwards.
+/// Requirement 6: an address that never predicted receives nothing and cannot
+/// call claim_cancel_refund (NotAParticipant).
 #[test]
 fn cancel_market_non_participant_receives_nothing() {
     let env = Env::default();
@@ -1192,14 +1226,20 @@ fn cancel_market_non_participant_receives_nothing() {
 
     client.cancel_market(&admin, &id);
 
-    // The cancellation refunded only the five predictors.
-    assert_eq!(token.balance(&outsider), 0);
-    assert_eq!(token.balance(&client.address), 0);
-
-    // And the outsider has no post-cancellation claim path.
-    let claim = client.try_claim_payout(&outsider, &id);
+    // The outsider has no prediction record — claim is rejected.
+    let claim = client.try_claim_cancel_refund(&outsider, &id);
     assert!(matches!(
         claim,
+        Err(Ok(InsightArenaError::NotAParticipant))
+    ));
+
+    // The outsider received nothing.
+    assert_eq!(token.balance(&outsider), 0);
+
+    // The payout path is also closed.
+    let payout_claim = client.try_claim_payout(&outsider, &id);
+    assert!(matches!(
+        payout_claim,
         Err(Ok(InsightArenaError::MarketNotResolved))
     ));
 }


### PR DESCRIPTION
Fixes #1341

Implements automated, gas-bounded refund on market cancellation using a pull-payment pattern.

### Changes
- Adds market cancellation: admin can cancel a market, transitioning it to a Cancelled state and blocking new predictions (MarketAlreadyCancelled error).
- Adds claim_cancel_refund: each participant individually pulls their own stake back after cancellation — no loop over all participants, so gas cost stays bounded regardless of participant count.
- Double-claim prevention: a second claim attempt returns RefundAlreadyClaimed and transfers nothing extra.
- Only the admin can cancel; only actual participants can claim (NotAParticipant for outsiders); resolved markets can't be cancelled and cancelled markets can't be resolved.

### Tests
12 new tests covering all acceptance criteria, including:
- Cancellation state transition and prediction-blocking
- Single and multi-participant claims with real token balance assertions
- Double-claim rejection
- An escrow-invariant test with deliberately unequal stake amounts confirming sum of all refunds exactly equals total staked, with zero dust left in escrow
- Empty-market cancellation and cross-path checks (resolve-after-cancel, payout-after-cancel)