### PR TITLE
fix(#1274): retry with exponential backoff for transient email failures

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,3 +24,25 @@ LEADERBOARD_SNAPSHOT_RETENTION_DAYS=30
 
 # Idempotency Key Configuration
 IDEMPOTENCY_KEY_TTL_HOURS=24
+
+# Email / SendGrid Configuration
+SENDGRID_API_KEY=your-sendgrid-api-key-here
+EMAIL_FROM=notifications@insightarena.app
+# Maximum emails sent per minute (sliding-window rate limit)
+EMAIL_RATE_LIMIT_PER_MINUTE=30
+
+# Email retry policy (transient failures only — 5xx/429/network errors)
+# Total number of send attempts before giving up (1 initial + retries).
+# Default: 3 (i.e. initial attempt plus up to 2 retries)
+EMAIL_RETRY_MAX_ATTEMPTS=3
+# Base delay in milliseconds for exponential backoff between retry attempts.
+# Delay formula: EMAIL_RETRY_BASE_DELAY_MS * 4^attemptIndex → 1000 ms, 4000 ms, 16000 ms
+# Default: 1000 (1 second)
+EMAIL_RETRY_BASE_DELAY_MS=1000
+
+# Digest Configuration
+DIGEST_ENABLED=true
+# Hour of the day (0-23, UTC) at which daily digests are sent
+DIGEST_DAILY_HOUR_UTC=8
+# Day of the week (0=Sunday … 6=Saturday) on which weekly digests are sent
+DIGEST_WEEKLY_DAY=1

--- a/backend/src/notifications/email.service.spec.ts
+++ b/backend/src/notifications/email.service.spec.ts
@@ -1,11 +1,300 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { EmailService } from './email.service';
+import {
+  EmailService,
+  QueuedEmail,
+  isNetworkError,
+  isTransientError,
+  computeBackoffDelay,
+} from './email.service';
 import { User } from '../users/entities/user.entity';
 import { UserPreferences } from '../users/entities/user-preferences.entity';
 
-describe('EmailService', () => {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEmail(overrides: Partial<QueuedEmail> = {}): QueuedEmail {
+  return {
+    id: 'test-msg-001',
+    to: 'recipient@example.com',
+    subject: 'Test Subject',
+    html: '<p>Hello</p>',
+    text: 'Hello',
+    queuedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure helpers (no fake timers needed)
+// ---------------------------------------------------------------------------
+
+describe('isNetworkError', () => {
+  it('returns true for a TypeError (fetch network failure)', () => {
+    expect(isNetworkError(new TypeError('fetch failed'))).toBe(true);
+  });
+
+  it('returns true when error cause has ECONNRESET code', () => {
+    const err = new Error('request failed');
+    (err as unknown as { cause: unknown }).cause = { code: 'ECONNRESET' };
+    expect(isNetworkError(err)).toBe(true);
+  });
+
+  it('returns true when error cause has ETIMEDOUT code', () => {
+    const err = new Error('request failed');
+    (err as unknown as { cause: unknown }).cause = { code: 'ETIMEDOUT' };
+    expect(isNetworkError(err)).toBe(true);
+  });
+
+  it('returns true for AbortError (request timeout via AbortController)', () => {
+    const err = new Error('The operation was aborted');
+    err.name = 'AbortError';
+    expect(isNetworkError(err)).toBe(true);
+  });
+
+  it('returns false for a plain application Error', () => {
+    expect(isNetworkError(new Error('something else'))).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isNetworkError('string error')).toBe(false);
+    expect(isNetworkError(null)).toBe(false);
+    expect(isNetworkError(42)).toBe(false);
+  });
+});
+
+describe('isTransientError', () => {
+  it('returns true for network errors', () => {
+    expect(isTransientError(new TypeError('fetch failed'))).toBe(true);
+  });
+
+  it('returns true for HTTP 500', () => {
+    expect(isTransientError(new Error('SendGrid error (500): Internal Server Error'))).toBe(true);
+  });
+
+  it('returns true for HTTP 503', () => {
+    expect(isTransientError(new Error('SendGrid error (503): Service Unavailable'))).toBe(true);
+  });
+
+  it('returns true for HTTP 429 (rate limit)', () => {
+    expect(isTransientError(new Error('SendGrid error (429): Too Many Requests'))).toBe(true);
+  });
+
+  it('returns false for HTTP 400 (bad request — permanent)', () => {
+    expect(isTransientError(new Error('SendGrid error (400): Bad Request'))).toBe(false);
+  });
+
+  it('returns false for HTTP 401 (unauthorised — permanent)', () => {
+    expect(isTransientError(new Error('SendGrid error (401): Unauthorized'))).toBe(false);
+  });
+
+  it('returns false for HTTP 422 (invalid recipient — permanent)', () => {
+    expect(isTransientError(new Error('SendGrid error (422): Unprocessable Entity'))).toBe(false);
+  });
+
+  it('returns false for unrecognised error message shapes', () => {
+    expect(isTransientError(new Error('Something unexpected happened'))).toBe(false);
+  });
+});
+
+describe('computeBackoffDelay', () => {
+  it('returns approximately baseDelay * 4^0 = baseDelay for attempt 0', () => {
+    // Without jitter the exact value equals baseDelay; with ±20% jitter the
+    // result is in [800, 1200] for base=1000.
+    const delay = computeBackoffDelay(1000, 0);
+    expect(delay).toBeGreaterThanOrEqual(800);
+    expect(delay).toBeLessThanOrEqual(1200);
+  });
+
+  it('returns approximately 4000 ms for attempt 1 (base=1000)', () => {
+    const delay = computeBackoffDelay(1000, 1);
+    expect(delay).toBeGreaterThanOrEqual(3200);
+    expect(delay).toBeLessThanOrEqual(4800);
+  });
+
+  it('returns approximately 16000 ms for attempt 2 (base=1000)', () => {
+    const delay = computeBackoffDelay(1000, 2);
+    expect(delay).toBeGreaterThanOrEqual(12800);
+    expect(delay).toBeLessThanOrEqual(19200);
+  });
+
+  it('never returns a negative value', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(computeBackoffDelay(0, 0)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EmailService retry integration tests (fake timers)
+// ---------------------------------------------------------------------------
+
+describe('EmailService — deliverEmailWithRetry', () => {
+  let service: EmailService;
+  let userRepository: jest.Mocked<Pick<import('typeorm').Repository<User>, 'findOne'>>;
+  let preferencesRepository: jest.Mocked<
+    Pick<import('typeorm').Repository<UserPreferences>, 'findOne'>
+  >;
+  let configGetMock: jest.Mock;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+
+    userRepository = { findOne: jest.fn() };
+    preferencesRepository = { findOne: jest.fn() };
+
+    // Default config: 3 attempts, 1000 ms base delay
+    configGetMock = jest.fn((key: string) => {
+      if (key === 'EMAIL_RETRY_MAX_ATTEMPTS') return '3';
+      if (key === 'EMAIL_RETRY_BASE_DELAY_MS') return '1000';
+      if (key === 'SENDGRID_API_KEY') return 'test-api-key';
+      if (key === 'EMAIL_FROM') return 'noreply@test.com';
+      return undefined;
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        {
+          provide: ConfigService,
+          useValue: { get: configGetMock },
+        },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        {
+          provide: getRepositoryToken(UserPreferences),
+          useValue: preferencesRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+    service.onModuleInit();
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: Transient failure on attempt 1, success on attempt 2
+  // -------------------------------------------------------------------------
+
+  it('succeeds on attempt 2 after one transient failure, calling deliverEmail exactly once for the success', async () => {
+    const transientError = new Error('SendGrid error (503): Service Unavailable');
+    let callCount = 0;
+
+    // Spy on the private deliverEmail method
+    const deliverSpy = jest
+      .spyOn(service as unknown as { deliverEmail: (e: QueuedEmail) => Promise<void> }, 'deliverEmail')
+      .mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) throw transientError;
+        // second call succeeds (no-op)
+      });
+
+    const email = makeEmail();
+
+    // Start the retry call but don't await yet — it will pause at the first
+    // setTimeout (the backoff sleep after attempt 1).
+    const retryPromise = service.deliverEmailWithRetry(email);
+
+    // Fast-forward through the backoff delay for attempt 0 (≈ 1000 ms + jitter).
+    // We advance by 2000 ms to comfortably cover the ±20 % jitter range.
+    await jest.advanceTimersByTimeAsync(2000);
+
+    // Now the promise should resolve (attempt 2 succeeded)
+    await expect(retryPromise).resolves.toBeUndefined();
+
+    // deliverEmail was called exactly twice: one failure, one success
+    expect(deliverSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: Permanent failure — zero retries, provider called exactly once
+  // -------------------------------------------------------------------------
+
+  it('throws immediately on permanent failure without any retry', async () => {
+    const permanentError = new Error('SendGrid error (422): invalid recipient address');
+
+    const deliverSpy = jest
+      .spyOn(service as unknown as { deliverEmail: (e: QueuedEmail) => Promise<void> }, 'deliverEmail')
+      .mockRejectedValue(permanentError);
+
+    const email = makeEmail();
+
+    await expect(service.deliverEmailWithRetry(email)).rejects.toThrow(permanentError);
+
+    // Provider was called exactly once — no retries
+    expect(deliverSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: All 3 retries exhausted — final error surfaced, provider called 3×
+  // -------------------------------------------------------------------------
+
+  it('exhausts all 3 attempts on repeated transient failures and throws the final error', async () => {
+    const transientError = new Error('SendGrid error (503): upstream timeout');
+
+    const deliverSpy = jest
+      .spyOn(service as unknown as { deliverEmail: (e: QueuedEmail) => Promise<void> }, 'deliverEmail')
+      .mockRejectedValue(transientError);
+
+    const email = makeEmail({ id: 'exhaust-test' });
+
+    // Catch the rejection up-front so Jest doesn't treat it as unhandled
+    let caughtError: unknown;
+    const retryPromise = service.deliverEmailWithRetry(email).catch((e) => {
+      caughtError = e;
+    });
+
+    // Advance through all backoff delays:
+    //  attempt 0 → delay ≈ 1000 ms (4^0 * 1000)
+    //  attempt 1 → delay ≈ 4000 ms (4^1 * 1000)
+    // Advance by 6000 ms total to cover both gaps with jitter headroom.
+    await jest.advanceTimersByTimeAsync(6000);
+    await retryPromise;
+
+    // Final error surfaced is the transient error from the last attempt
+    expect(caughtError).toBe(transientError);
+
+    // deliverEmail was called exactly 3 times
+    expect(deliverSpy).toHaveBeenCalledTimes(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: Network error is treated as transient and retried
+  // -------------------------------------------------------------------------
+
+  it('retries on network TypeError and succeeds on the second attempt', async () => {
+    const networkError = new TypeError('fetch failed');
+    let callCount = 0;
+
+    const deliverSpy = jest
+      .spyOn(service as unknown as { deliverEmail: (e: QueuedEmail) => Promise<void> }, 'deliverEmail')
+      .mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) throw networkError;
+      });
+
+    const email = makeEmail({ id: 'network-retry-test' });
+    const retryPromise = service.deliverEmailWithRetry(email);
+
+    await jest.advanceTimersByTimeAsync(2000);
+
+    await expect(retryPromise).resolves.toBeUndefined();
+    expect(deliverSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Existing pre-retry tests (regression — must still pass)
+// ---------------------------------------------------------------------------
+
+describe('EmailService — queueing and preferences', () => {
   let service: EmailService;
   let userRepository: jest.Mocked<
     Pick<import('typeorm').Repository<User>, 'findOne'>

--- a/backend/src/notifications/email.service.ts
+++ b/backend/src/notifications/email.service.ts
@@ -28,6 +28,116 @@ export interface QueuedEmail {
 const DEFAULT_RATE_LIMIT = 30;
 const QUEUE_PROCESS_INTERVAL_MS = 2000;
 
+/** Default maximum send attempts (1 initial + 2 retries = 3 total). */
+const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+
+/**
+ * Default base delay in milliseconds for exponential backoff.
+ * Delay formula: baseDelay * 4^attempt  →  1 s, 4 s, 16 s for attempts 0, 1, 2.
+ */
+const DEFAULT_RETRY_BASE_DELAY_MS = 1000;
+
+/**
+ * Jitter factor: each computed delay is randomised by ±20 % to avoid
+ * thundering-herd retries when multiple emails fail simultaneously.
+ */
+const JITTER_FACTOR = 0.2;
+
+// ---------------------------------------------------------------------------
+// Error-classification helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the error originates from a network-layer failure
+ * (connection refused, DNS lookup failure, TCP reset, request abort/timeout).
+ * These are always transient — the send can be retried.
+ *
+ * With Node's built-in `fetch` (>= 18), network errors surface as a
+ * `TypeError` whose `.cause` may carry a `NodeJS.ErrnoException`.
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  // Fetch/network-level TypeErrors are transient (e.g. "fetch failed",
+  // "terminated", "network socket disconnected").
+  if (error instanceof TypeError) return true;
+
+  // Errors with a cause that has a transient errno code.
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause && typeof cause === 'object') {
+    const code = (cause as { code?: unknown }).code;
+    if (
+      typeof code === 'string' &&
+      ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND',
+       'EPIPE', 'EHOSTUNREACH', 'EAI_AGAIN'].includes(code)
+    ) {
+      return true;
+    }
+  }
+
+  // Abort / timeout signals (AbortError name set by fetch AbortController).
+  if (error.name === 'AbortError') return true;
+
+  return false;
+}
+
+/**
+ * Returns true when the HTTP response status code is transient.
+ * 5xx responses from SendGrid (server errors, rate-limit 429 treated as
+ * transient) should be retried.  4xx responses (invalid recipient 550-style
+ * errors reflected as HTTP 4xx) are permanent and must not be retried.
+ *
+ * SendGrid wraps errors as: `"SendGrid error (STATUS): body"`
+ */
+export function isTransientHttpStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+/**
+ * Classifies a thrown error as transient (eligible for retry) or permanent.
+ *
+ * Transient:
+ *  - Network-level failures (TypeError, errno codes, AbortError)
+ *  - HTTP 5xx and HTTP 429 (rate-limit / server unavailable)
+ *
+ * Permanent:
+ *  - HTTP 4xx (except 429): invalid address, auth failure, bad request, etc.
+ *  - Any other non-network, non-HTTP error (unexpected shape)
+ */
+export function isTransientError(error: unknown): boolean {
+  if (isNetworkError(error)) return true;
+
+  if (error instanceof Error) {
+    // Parse the status code embedded by deliverEmail: "SendGrid error (STATUS): ..."
+    const match = /SendGrid error \((\d{3})\)/.exec(error.message);
+    if (match) {
+      const status = parseInt(match[1], 10);
+      return isTransientHttpStatus(status);
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Backoff delay helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the delay before attempt `attemptIndex` (0-based).
+ *
+ * Formula: baseDelayMs * 4^attemptIndex  →  1 s, 4 s, 16 s
+ * Jitter:  ±JITTER_FACTOR of the computed delay (uniform distribution)
+ */
+export function computeBackoffDelay(
+  baseDelayMs: number,
+  attemptIndex: number,
+): number {
+  const exponential = baseDelayMs * Math.pow(4, attemptIndex);
+  const jitter = exponential * JITTER_FACTOR * (Math.random() * 2 - 1);
+  return Math.max(0, Math.round(exponential + jitter));
+}
+
 @Injectable()
 export class EmailService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(EmailService.name);
@@ -171,7 +281,7 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
         return;
       }
 
-      await this.deliverEmail(email);
+      await this.deliverEmailWithRetry(email);
       this.sentTimestamps.push(Date.now());
     } catch (error) {
       this.logger.error(
@@ -191,6 +301,67 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
     const recent = this.sentTimestamps.filter((t) => t >= cutoff);
     this.sentTimestamps.splice(0, this.sentTimestamps.length, ...recent);
     return recent.length < limit;
+  }
+
+  /**
+   * Wraps `deliverEmail` with an exponential-backoff retry policy.
+   *
+   * - Max attempts: EMAIL_RETRY_MAX_ATTEMPTS (default 3)
+   * - Delay formula: EMAIL_RETRY_BASE_DELAY_MS * 4^attemptIndex  →  1 s, 4 s, 16 s
+   * - Jitter: ±20 % of the computed delay
+   * - Only transient errors (network failures, HTTP 5xx/429) are retried.
+   * - Permanent errors (HTTP 4xx) throw immediately without retry.
+   */
+  async deliverEmailWithRetry(email: QueuedEmail): Promise<void> {
+    const maxAttempts = Number(
+      this.configService.get<string>('EMAIL_RETRY_MAX_ATTEMPTS') ??
+        DEFAULT_RETRY_MAX_ATTEMPTS,
+    );
+    const baseDelayMs = Number(
+      this.configService.get<string>('EMAIL_RETRY_BASE_DELAY_MS') ??
+        DEFAULT_RETRY_BASE_DELAY_MS,
+    );
+
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        await this.deliverEmail(email);
+        return; // success
+      } catch (error) {
+        lastError = error;
+
+        if (!isTransientError(error)) {
+          // Permanent failure — do not retry
+          this.logger.error(
+            `Permanent email failure for message ${email.id} (attempt ${attempt + 1}/${maxAttempts}): ` +
+              `${error instanceof Error ? error.message : String(error)}`,
+          );
+          throw error;
+        }
+
+        const attemptsRemaining = maxAttempts - attempt - 1;
+
+        if (attemptsRemaining === 0) {
+          break; // exhausted — log final error below
+        }
+
+        const delayMs = computeBackoffDelay(baseDelayMs, attempt);
+        this.logger.warn(
+          `Transient email failure for message ${email.id} — attempt ${attempt + 1}/${maxAttempts}, ` +
+            `retrying in ${delayMs} ms: ${error instanceof Error ? error.message : String(error)}`,
+        );
+
+        await this.sleep(delayMs);
+      }
+    }
+
+    // All attempts exhausted
+    this.logger.error(
+      `Email delivery failed after ${maxAttempts} attempt(s) for message ${email.id} — ` +
+        `final error: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+    );
+    throw lastError;
   }
 
   private async deliverEmail(email: QueuedEmail): Promise<void> {
@@ -229,5 +400,10 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
     this.logger.log(
       `[DEV] Email queued for ${email.to}: ${email.subject}\n${email.text}`,
     );
+  }
+
+  /** Thin wrapper around `setTimeout` so tests can mock it via fake timers. */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }


### PR DESCRIPTION
Fixes #1274

Adds a retry-with-exponential-backoff policy for transient email send failures.

### Changes
- deliverEmailWithRetry wraps the existing provider send call: up to 3 attempts (configurable), with exponential backoff of baseDelay * 4^attempt — producing ~1s, 4s, 16s delays, plus ±20% jitter to avoid thundering-herd retries.
- Error classification via isTransientError: network-layer failures (connection reset, timeout, DNS failure, abort) and HTTP 5xx/429 are treated as transient and retried; HTTP 4xx (e.g. invalid recipient) fails immediately with zero retries.
- Per-attempt retry logging includes message id and attempt number; a distinct error log fires on final exhaustion.
- New env vars EMAIL_RETRY_MAX_ATTEMPTS (default 3) and EMAIL_RETRY_BASE_DELAY_MS (default 1000ms), documented in backend/.env.example.

### Tests
- Pure unit tests for isNetworkError, isTransientError, and computeBackoffDelay covering realistic transient/permanent error shapes.
- Integration tests using Jest fake timers (no real waiting) covering: recovery after one transient failure, immediate failure with zero retries on permanent errors, full exhaustion after 3 transient failures, and network-error retry handling — each asserting exact call counts on the provider.
- All existing EmailService tests preserved and passing.