### PR TITLE
 TWAP Outcome-Price Oracle

### DIFF
--- a/contracts/open-market/src/errors.rs
+++ b/contracts/open-market/src/errors.rs
@@ -169,4 +169,18 @@ pub enum InsightArenaError {
     // ── Batch Operations ──────────────────────────────────────────────────────
     /// The number of items in a batch operation exceeds the maximum allowed size.
     BatchSizeExceeded = 107,
+
+    // ── TWAP Price Oracle ─────────────────────────────────────────────────────
+    /// `get_twap` was called with a zero-second window, which cannot produce a
+    /// meaningful average.
+    TwapEmptyWindow = 108,
+    /// Not enough retained price history to cover the requested window: either
+    /// this outcome has never had a price-changing operation, or the window's
+    /// start predates the oldest observation still held in the ring buffer
+    /// (older samples were evicted by wraparound). Raised instead of silently
+    /// truncating the window or dividing by an under-covered interval.
+    TwapInsufficientHistory = 109,
+    /// The elapsed time between the window's start and now collapsed to zero
+    /// seconds, which would require dividing the price integral by zero.
+    TwapDivideByZero = 110,
 }

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -30,8 +30,8 @@ pub use crate::storage_types::{
     ConditionalChain, ConditionalMarket, CreatorLeaderboardEntry, CreatorStats, DataKey,
     DependencyStatus, Dispute, Event, EventMatch, EventPrediction, FeeTier, FeeTierConfig,
     InviteCode, LPPosition, LeaderboardEntry, LeaderboardSnapshot, LiquidityPool, Market,
-    MarketFeeInfo, MarketStats, PlatformStats, Prediction, Season, SwapRecord, UserProfile,
-    VolatilityState, Winner,
+    MarketFeeInfo, MarketStats, PlatformStats, Prediction, PriceAccumulator, PriceObservation,
+    Season, SwapRecord, UserProfile, VolatilityState, Winner,
 };
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
@@ -772,6 +772,18 @@ impl InsightArenaContract {
         market_id: u64,
     ) -> Result<i128, InsightArenaError> {
         liquidity::collect_lp_fees(&env, provider, market_id)
+    }
+
+    /// Compute the time-weighted average price of `outcome` over the trailing
+    /// `window` seconds. See `liquidity::TWAP_RING_BUFFER_CAPACITY` for the
+    /// maximum window the ring buffer can currently honor.
+    pub fn get_twap(
+        env: Env,
+        market_id: u64,
+        outcome: Symbol,
+        window: u64,
+    ) -> Result<i128, InsightArenaError> {
+        liquidity::get_twap(&env, market_id, outcome, window)
     }
 
     // ── Dynamic Swap Fee ──────────────────────────────────────────────────────

--- a/contracts/open-market/src/liquidity.rs
+++ b/contracts/open-market/src/liquidity.rs
@@ -5,8 +5,8 @@ use crate::errors::InsightArenaError;
 use crate::escrow;
 use crate::market;
 use crate::storage_types::{
-    DataKey, FeeTier, FeeTierConfig, LPPosition, LiquidityPool, MarketFeeInfo, SwapRecord,
-    VolatilityState,
+    DataKey, FeeTier, FeeTierConfig, LPPosition, LiquidityPool, MarketFeeInfo, PriceAccumulator,
+    PriceObservation, SwapRecord, VolatilityState,
 };
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -21,6 +21,22 @@ pub const DEFAULT_FEE_BPS: u32 = 30;
 /// the rolling volatility EMA. Higher values make the measure more reactive
 /// to recent swaps; lower values smooth it out over a longer window.
 pub const VOLATILITY_ALPHA_BPS: u32 = 2000;
+
+/// Fixed number of [`PriceObservation`] slots retained per (market, outcome) pair
+/// in the TWAP ring buffer. Bounds per-outcome storage growth: once this many
+/// price-changing operations have occurred, the oldest observation is
+/// overwritten by the newest.
+///
+/// **Max supported window:** `get_twap` can only average over the span still
+/// covered by the buffer, i.e. from the oldest surviving observation's
+/// timestamp to now. If an outcome has traded fewer than
+/// `TWAP_RING_BUFFER_CAPACITY` times since the pool was created, its entire
+/// history is available and any window back to pool creation is honored. Once
+/// more than `TWAP_RING_BUFFER_CAPACITY` price-changing swaps have occurred,
+/// only the most recent ones remain, so a window reaching further back than
+/// the oldest retained sample returns `TwapInsufficientHistory` rather than a
+/// silently truncated (and therefore misleading) average.
+pub const TWAP_RING_BUFFER_CAPACITY: u32 = 64;
 
 // ── AMM Math Functions ────────────────────────────────────────────────────────
 
@@ -260,6 +276,150 @@ pub fn get_market_fee_info(env: &Env, market_id: u64) -> Result<MarketFeeInfo, I
     })
 }
 
+// ── TWAP Price Oracle ─────────────────────────────────────────────────────────
+//
+// Accumulators are stored inline on `LiquidityPool::price_accumulators` (keyed
+// by outcome) rather than under a dedicated `DataKey` variant: `DataKey` is a
+// `#[contracttype]` union, and the underlying XDR spec caps a union at 50
+// cases — a limit this contract's `DataKey` already sits at. Piggybacking on
+// the pool, which every price-changing operation already loads and saves,
+// avoids the cap and gives each swap a single atomic read/write instead of two.
+
+/// Record a new price sample for `outcome` on `pool`, updating its cumulative
+/// price integral and pushing an observation into its ring buffer. Must be
+/// called on every operation that changes an outcome's reserve, with the
+/// pool's ledger timestamp; the caller is responsible for persisting `pool`
+/// afterwards (e.g. via `save_pool`).
+///
+/// The price active since the *previous* observation (`acc.last_price`) is
+/// integrated over the elapsed time since it was recorded before the new
+/// sample is stored — so a price that spikes and reverts within a single
+/// ledger timestamp contributes zero to the accumulator, making the resulting
+/// TWAP expensive to move with an intra-block manipulation.
+fn record_price_observation(
+    env: &Env,
+    pool: &mut LiquidityPool,
+    outcome: Symbol,
+    price: i128,
+) -> Result<(), InsightArenaError> {
+    let mut acc = pool
+        .price_accumulators
+        .get(outcome.clone())
+        .unwrap_or_else(|| PriceAccumulator::empty(env, pool.market_id, outcome.clone()));
+
+    let now = env.ledger().timestamp();
+
+    if acc.total_count > 0 {
+        let elapsed = now.saturating_sub(acc.last_timestamp);
+        let contribution = acc
+            .last_price
+            .checked_mul(elapsed as i128)
+            .ok_or(InsightArenaError::Overflow)?;
+        acc.cumulative = acc
+            .cumulative
+            .checked_add(contribution)
+            .ok_or(InsightArenaError::Overflow)?;
+    }
+
+    let observation = PriceObservation {
+        timestamp: now,
+        price,
+        price_cumulative: acc.cumulative,
+    };
+
+    if acc.observations.len() < TWAP_RING_BUFFER_CAPACITY {
+        acc.observations.push_back(observation);
+    } else {
+        acc.observations.set(acc.next_index, observation);
+    }
+    acc.next_index = (acc.next_index + 1) % TWAP_RING_BUFFER_CAPACITY;
+
+    acc.last_price = price;
+    acc.last_timestamp = now;
+    acc.total_count = acc.total_count.saturating_add(1);
+
+    pool.price_accumulators.set(outcome, acc);
+    Ok(())
+}
+
+/// Compute the time-weighted average price of `outcome` over the trailing
+/// `window` seconds (i.e. `[now - window, now]`).
+///
+/// Uses the standard cumulative-price-accumulator technique: the price
+/// integral is reconstructed at the window's start by locating the latest
+/// retained observation at or before that timestamp and extrapolating with
+/// its price for the remainder, then compared against the integral extrapolated
+/// to now. See `TWAP_RING_BUFFER_CAPACITY` for the max window the ring buffer
+/// can currently honor.
+pub fn get_twap(
+    env: &Env,
+    market_id: u64,
+    outcome: Symbol,
+    window: u64,
+) -> Result<i128, InsightArenaError> {
+    if window == 0 {
+        return Err(InsightArenaError::TwapEmptyWindow);
+    }
+
+    let pool = get_pool(env, market_id)?;
+    if pool.outcome_reserves.get(outcome.clone()).is_none() {
+        return Err(InsightArenaError::InvalidOutcome);
+    }
+
+    let acc = pool
+        .price_accumulators
+        .get(outcome)
+        .ok_or(InsightArenaError::TwapInsufficientHistory)?;
+    if acc.total_count == 0 {
+        return Err(InsightArenaError::TwapInsufficientHistory);
+    }
+
+    let now = env.ledger().timestamp();
+    let window_start = now.saturating_sub(window);
+
+    // Latest retained observation at or before `window_start`.
+    let mut before: Option<PriceObservation> = None;
+    for obs in acc.observations.iter() {
+        if obs.timestamp <= window_start {
+            let take = match &before {
+                Some(b) => obs.timestamp > b.timestamp,
+                None => true,
+            };
+            if take {
+                before = Some(obs);
+            }
+        }
+    }
+    let before = before.ok_or(InsightArenaError::TwapInsufficientHistory)?;
+
+    let cumulative_start = before
+        .price
+        .checked_mul((window_start - before.timestamp) as i128)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_add(before.price_cumulative)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    let cumulative_now = acc
+        .last_price
+        .checked_mul((now - acc.last_timestamp) as i128)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_add(acc.cumulative)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    let elapsed = now.saturating_sub(window_start);
+    if elapsed == 0 {
+        return Err(InsightArenaError::TwapDivideByZero);
+    }
+
+    let twap = cumulative_now
+        .checked_sub(cumulative_start)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(elapsed as i128)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    Ok(twap)
+}
+
 // ── Helper Functions ──────────────────────────────────────────────────────────
 
 fn bump_pool(env: &Env, market_id: u64) {
@@ -406,7 +566,9 @@ pub fn add_liquidity(
         .persistent()
         .get::<_, LiquidityPool>(&DataKey::LiquidityPool(market_id));
 
-    let (lp_tokens, new_pool) = if let Some(mut pool) = pool {
+    let is_new_pool = pool.is_none();
+
+    let (lp_tokens, mut new_pool) = if let Some(mut pool) = pool {
         let lp_tokens = calculate_lp_tokens(amount, pool.total_liquidity, pool.lp_token_supply)?;
         pool.total_liquidity = pool
             .total_liquidity
@@ -423,6 +585,7 @@ pub fn add_liquidity(
             reserves.set(outcome, amount / mkt.outcome_options.len() as i128);
         }
         let pool = LiquidityPool::new(
+            env,
             market_id,
             reserves,
             DEFAULT_FEE_BPS,
@@ -433,6 +596,14 @@ pub fn add_liquidity(
         pool.total_liquidity = amount;
         (amount, pool)
     };
+
+    if is_new_pool {
+        for outcome in mkt.outcome_options.iter() {
+            if let Some(reserve) = new_pool.outcome_reserves.get(outcome.clone()) {
+                record_price_observation(env, &mut new_pool, outcome, reserve)?;
+            }
+        }
+    }
 
     save_pool(env, &new_pool);
     add_provider_to_list(env, market_id, &provider);
@@ -579,6 +750,9 @@ pub fn swap_outcome(
         .set(from_outcome.clone(), new_from_reserve);
     pool.outcome_reserves.set(to_outcome.clone(), new_to_reserve);
     pool.fee_bps = effective_fee_bps;
+
+    record_price_observation(env, &mut pool, from_outcome.clone(), new_from_reserve)?;
+    record_price_observation(env, &mut pool, to_outcome.clone(), new_to_reserve)?;
 
     save_pool(env, &pool);
 

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Map, String, Symbol, Vec};
+use soroban_sdk::{contracttype, Address, Env, Map, String, Symbol, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -330,10 +330,15 @@ pub struct LiquidityPool {
     pub lp_token_supply: i128,
     pub fee_bps: u32,
     pub created_at: u64,
+    /// Per-outcome TWAP price accumulators. Kept on the pool itself (rather than
+    /// a separate storage key) so a single `save_pool` persists both the reserve
+    /// update and its price observation atomically. See [`PriceAccumulator`].
+    pub price_accumulators: Map<Symbol, PriceAccumulator>,
 }
 
 impl LiquidityPool {
     pub fn new(
+        env: &Env,
         market_id: u64,
         initial_reserves: Map<Symbol, i128>,
         fee_bps: u32,
@@ -348,6 +353,7 @@ impl LiquidityPool {
             lp_token_supply: 0,
             fee_bps,
             created_at,
+            price_accumulators: Map::new(env),
         }
     }
 }
@@ -506,6 +512,70 @@ pub struct MarketFeeInfo {
     pub tier: FeeTier,
     pub effective_fee_bps: u32,
     pub volatility_ema_bps: u32,
+}
+
+// ── TWAP Price Oracle Types ───────────────────────────────────────────────────
+
+/// A single recorded price sample for one outcome, kept in the [`PriceAccumulator`]
+/// ring buffer.
+///
+/// `price_cumulative` is the value of the running price integral (sum of
+/// `price * elapsed_seconds` over the outcome's whole history) *as of*
+/// `timestamp`, i.e. immediately before `price` itself takes effect. This lets
+/// `get_twap` reconstruct the integral at any timestamp `t >= observations[0].timestamp`
+/// by locating the latest observation at or before `t` and extrapolating with
+/// its `price` for the remaining `t - timestamp` seconds.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceObservation {
+    /// Ledger timestamp this observation was recorded at.
+    pub timestamp: u64,
+    /// Instantaneous outcome price (pool reserve) that became active at `timestamp`.
+    pub price: i128,
+    /// Cumulative price integral as of `timestamp`, not yet including `price` itself.
+    pub price_cumulative: i128,
+}
+
+/// Per-(market, outcome) TWAP state: a cumulative price accumulator plus a
+/// fixed-capacity ring buffer of historical observations used to answer
+/// windowed `get_twap` queries. Updated on every operation that changes the
+/// outcome's reserve (pool creation, swaps).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceAccumulator {
+    pub market_id: u64,
+    pub outcome: Symbol,
+    /// Fixed-capacity ring buffer of the most recent observations. Once full,
+    /// new observations overwrite the oldest slot (see `next_index`).
+    pub observations: Vec<PriceObservation>,
+    /// Index in `observations` that the next write will occupy (wraps modulo capacity).
+    pub next_index: u32,
+    /// Total number of observations ever recorded for this outcome (monotonic;
+    /// may exceed `observations.len()` once the buffer has wrapped).
+    pub total_count: u64,
+    /// The price active since `last_timestamp`, used to extrapolate the
+    /// cumulative integral forward to "now" without a storage write.
+    pub last_price: i128,
+    /// Ledger timestamp of the most recent observation.
+    pub last_timestamp: u64,
+    /// Cumulative price integral as of `last_timestamp` (mirrors the most
+    /// recent observation's `price_cumulative`).
+    pub cumulative: i128,
+}
+
+impl PriceAccumulator {
+    pub fn empty(env: &Env, market_id: u64, outcome: Symbol) -> Self {
+        Self {
+            market_id,
+            outcome,
+            observations: Vec::new(env),
+            next_index: 0,
+            total_count: 0,
+            last_price: 0,
+            last_timestamp: 0,
+            cumulative: 0,
+        }
+    }
 }
 
 #[contracttype]

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -2163,3 +2163,298 @@ fn test_swap_history_records_effective_fee_paid() {
     let expected_fee = swap_amount * fee_bps as i128 / 10_000;
     assert_eq!(record.fee_paid, expected_fee);
 }
+
+// ── TWAP Price Oracle Tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_twap_multi_swap_matches_hand_computed_average() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let t0 = env.ledger().timestamp();
+    let p0 = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+
+    let swap_amount = 20_000_i128;
+    sa.mint(&trader, &(swap_amount * 3));
+    token.approve(&trader, &client.address, &(swap_amount * 3), &9999);
+
+    // Three swaps, each 100 seconds apart, all moving "yes" reserve upward.
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+    let p1 = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+    let p2 = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let now = env.ledger().timestamp();
+    assert_eq!(now, t0 + 300);
+
+    // The window exactly spans pool creation to now, so the hand-computed
+    // average only needs the prices active during each 100s interval: p0 for
+    // [t0, t0+100), p1 for [t0+100, t0+200), p2 for [t0+200, t0+300). The final
+    // swap (which set the price now current at t0+300) contributes zero
+    // duration and is correctly excluded.
+    let window: u64 = 300;
+    let expected = (p0 * 100 + p1 * 100 + p2 * 100) / window as i128;
+
+    let twap = client.get_twap(&market_id, &symbol_short!("yes"), &window);
+    assert_eq!(twap, expected);
+}
+
+#[test]
+fn test_twap_resists_single_block_price_spike() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let liquidity = 10_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let t0 = env.ledger().timestamp();
+
+    // Let a long baseline period elapse with the price sitting at its initial level.
+    env.ledger().with_mut(|l| l.timestamp += 10_000);
+    let price_before_spike = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+
+    // A single huge swap spikes the "yes" reserve (and therefore the spot price).
+    let spike_amount = 20_000_000_i128;
+    sa.mint(&trader, &spike_amount);
+    token.approve(&trader, &client.address, &spike_amount, &9999);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &spike_amount,
+        &0_i128,
+    );
+
+    // Advance a single second so the spike itself contributes a (tiny) sliver
+    // of duration to the accumulator, then read both spot and TWAP.
+    env.ledger().with_mut(|l| l.timestamp += 1);
+    let spot_after_spike = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+
+    let now = env.ledger().timestamp();
+    let window = now - t0;
+    let twap = client.get_twap(&market_id, &symbol_short!("yes"), &window);
+
+    assert!(spot_after_spike > price_before_spike * 2, "spike should be dramatic");
+
+    let spot_move = (spot_after_spike - price_before_spike).abs();
+    let twap_move = (twap - price_before_spike).abs();
+
+    // The spike lasted a single second out of a 10,001 second window, so it
+    // can move the TWAP by at most ~1/10000th as much as it moved the spot price.
+    assert!(
+        twap_move * 100 < spot_move,
+        "twap_move={twap_move} should be far smaller than spot_move={spot_move}"
+    );
+}
+
+#[test]
+fn test_twap_empty_window_returns_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+    let liquidity = 100_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let result = client.try_get_twap(&market_id, &symbol_short!("yes"), &0_u64);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TwapEmptyWindow))
+    ));
+}
+
+#[test]
+fn test_twap_window_predating_history_returns_typed_error() {
+    let env = Env::default();
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+    let liquidity = 100_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    // Pool was created at t=500; a window of 10,000s reaches back before
+    // genesis (t=0), which predates the oldest retained observation.
+    let result = client.try_get_twap(&market_id, &symbol_short!("yes"), &10_000_u64);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TwapInsufficientHistory))
+    ));
+}
+
+#[test]
+fn test_twap_zero_elapsed_returns_typed_error() {
+    let env = Env::default();
+    env.ledger().with_mut(|l| l.timestamp = 0);
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+    let liquidity = 100_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    assert_eq!(env.ledger().timestamp(), 0);
+
+    // At t=0 with any positive window, `window_start` saturates to 0 too, so
+    // `now - window_start` collapses to zero elapsed seconds.
+    let result = client.try_get_twap(&market_id, &symbol_short!("yes"), &1_u64);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TwapDivideByZero))
+    ));
+}
+
+#[test]
+fn test_twap_unknown_outcome_returns_invalid_outcome() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+    let liquidity = 100_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let result = client.try_get_twap(&market_id, &symbol_short!("maybe"), &100_u64);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidOutcome))));
+}
+
+#[test]
+fn test_twap_ring_buffer_wraparound() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let liquidity = 100_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let t0 = env.ledger().timestamp();
+
+    // Trade well past the ring buffer's capacity so it wraps at least once.
+    let num_swaps: u32 = TWAP_RING_BUFFER_CAPACITY + 20;
+    let swap_amount = 1_000_i128;
+    sa.mint(&trader, &(swap_amount * num_swaps as i128));
+    token.approve(&trader, &client.address, &(swap_amount * num_swaps as i128), &9999);
+
+    for _ in 0..num_swaps {
+        env.ledger().with_mut(|l| l.timestamp += 50);
+        client.swap_outcome(
+            &trader,
+            &market_id,
+            &symbol_short!("yes"),
+            &symbol_short!("no"),
+            &swap_amount,
+            &0_i128,
+        );
+    }
+
+    let now = env.ledger().timestamp();
+    assert_eq!(now, t0 + (num_swaps as u64) * 50);
+
+    // A window reaching all the way back to pool creation now exceeds what the
+    // wrapped ring buffer retains (its oldest entries were overwritten), so it
+    // must be rejected with a typed error rather than a silently truncated
+    // (misleading) average or a panic.
+    let full_window = now - t0;
+    let result = client.try_get_twap(&market_id, &symbol_short!("yes"), &full_window);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TwapInsufficientHistory))
+    ));
+
+    // A window covering only the most recently retained observations still
+    // succeeds without panicking, even though far more than
+    // `TWAP_RING_BUFFER_CAPACITY` price-changing operations occurred over the
+    // pool's full lifetime.
+    let recent_window: u64 = (TWAP_RING_BUFFER_CAPACITY as u64 / 2) * 50;
+    let twap = client.get_twap(&market_id, &symbol_short!("yes"), &recent_window);
+    assert!(twap > 0);
+}


### PR DESCRIPTION

Adds a manipulation-resistant TWAP (time-weighted average price) oracle for AMM outcome prices, alongside the existing spot-price getter, which is trivially moved with a single-transaction trade.

- Maintains a cumulative price accumulator per `(market, outcome)`, updated on every price-changing operation (pool creation, swaps) with the ledger timestamp.
- Adds `get_twap(market_id, outcome, window)`, computing the average price over the trailing `window` seconds using the standard cumulative-price-accumulator technique (Uniswap V2-style).
- Bounds storage growth with a fixed-capacity (64-slot) ring buffer of observations per outcome; oldest samples are overwritten once full.
- Guards divide-by-zero, empty-window, and stale/insufficient-history cases with dedicated typed errors instead of panicking.

## Design notes

- **Where the accumulator lives:** `PriceAccumulator` is stored inline on `LiquidityPool.price_accumulators` (keyed by outcome) rather than under a new `DataKey` variant. `DataKey` is a `#[contracttype]` union, and its XDR spec caps a union at 50 cases — this contract's `DataKey` was already at exactly 50, so adding a variant panics the build (`LengthExceedsMax`). Piggybacking on the pool, which every price-changing operation already loads and saves, also means each swap does one atomic read/write instead of two.
- **Manipulation resistance:** the price active since the previous observation is integrated over the elapsed time *before* the new sample is recorded, so a price that spikes and reverts within a single ledger timestamp contributes zero duration to the accumulator — an attacker who moves the AMM price and reverses it in the same block cannot move the TWAP at all.
- **Max supported window:** bounded by `TWAP_RING_BUFFER_CAPACITY` (64 observations per outcome). If an outcome has traded fewer than 64 times since pool creation, the full history back to genesis is queryable. Once more than 64 price-changing swaps have occurred, only the most recent ones are retained; a window reaching further back than the oldest surviving observation returns `TwapInsufficientHistory` rather than silently truncating (and thus misrepresenting) the average.

## New errors (`InsightArenaError`)

| Error | When |
|---|---|
| `TwapEmptyWindow` | `window == 0` |
| `TwapInsufficientHistory` | No price history yet, or the window's start predates the oldest retained observation (evicted by ring-buffer wraparound or before pool creation) |
| `TwapDivideByZero` | The window's start and `now` collapse to zero elapsed seconds |

## Files changed

- `contracts/open-market/src/storage_types.rs` — `PriceObservation`, `PriceAccumulator` types; `price_accumulators` field on `LiquidityPool`.
- `contracts/open-market/src/liquidity.rs` — `TWAP_RING_BUFFER_CAPACITY`, `record_price_observation`, `get_twap`; hooked into `add_liquidity` (seeds accumulators on pool creation) and `swap_outcome` (records both legs of every swap).
- `contracts/open-market/src/errors.rs` — three new typed TWAP errors.
- `contracts/open-market/src/lib.rs` — `get_twap` contract entry point; new types exported.
- `contracts/open-market/tests/liquidity_tests.rs` — 7 new tests.

## Test plan

- [x] `test_twap_multi_swap_matches_hand_computed_average` — TWAP across 3 time-spaced swaps equals a manually computed time-weighted average.
- [x] `test_twap_resists_single_block_price_spike` — a single huge swap moves spot price 5x+ but the TWAP moves less than 1% as much.
- [x] `test_twap_empty_window_returns_typed_error` — `window = 0` returns `TwapEmptyWindow`, not a panic.
- [x] `test_twap_window_predating_history_returns_typed_error` — window reaching before pool genesis returns `TwapInsufficientHistory`.
- [x] `test_twap_zero_elapsed_returns_typed_error` — zero-elapsed edge case returns `TwapDivideByZero`.
- [x] `test_twap_unknown_outcome_returns_invalid_outcome` — querying a non-existent outcome symbol errors cleanly.
- [x] `test_twap_ring_buffer_wraparound` — 84 swaps against a 64-slot buffer: full-history window correctly rejected as insufficient, recent window still resolves without panicking.
- [x] `cargo test` (workspace) — 590/590 passing, no regressions.
- [x] `cargo clippy --all-targets` — no new warnings.
- [x] `cargo build --target wasm32-unknown-unknown --release` — contract still builds and its spec is valid under the XDR union-size limit.



closes #1309