### PR TITLE
Implement core prediction & dispute enhancements across 4 issues

### DIFF
--- a/contracts/open-market/src/dispute.rs
+++ b/contracts/open-market/src/dispute.rs
@@ -47,6 +47,20 @@ fn emit_dispute_resolved(env: &Env, market_id: u64, admin: &Address, uphold: boo
     );
 }
 
+fn emit_appeal_filed(env: &Env, market_id: u64, appealer: &Address, bond: i128, tier: u32) {
+    env.events().publish(
+        (symbol_short!("dsp"), symbol_short!("appld")),
+        (market_id, appealer.clone(), bond, tier),
+    );
+}
+
+fn emit_appeal_resolved(env: &Env, market_id: u64, admin: &Address, uphold: bool, tier: u32) {
+    env.events().publish(
+        (symbol_short!("dsp"), symbol_short!("appeald")),
+        (market_id, admin.clone(), uphold, tier),
+    );
+}
+
 pub fn get_dispute(env: &Env, market_id: u64) -> Result<Dispute, InsightArenaError> {
     let dispute: Dispute = env
         .storage()
@@ -216,4 +230,102 @@ fn set_open_dispute_count(env: &Env, count: u32) {
         config::PERSISTENT_THRESHOLD,
         config::PERSISTENT_BUMP,
     );
+}
+
+const MAX_APPEAL_TIERS: u32 = 2;
+
+fn calculate_appeal_bond(base_bond: i128, tier: u32) -> i128 {
+    base_bond.saturating_mul((tier as i128) + 1)
+}
+
+pub fn appeal_dispute(
+    env: Env,
+    appealer: Address,
+    market_id: u64,
+    appeal_bond: i128,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(&env)?;
+
+    if appeal_bond <= 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    let mut dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(market_id))
+        .ok_or(InsightArenaError::DisputeNotFound)?;
+
+    if dispute.appeal_tier >= MAX_APPEAL_TIERS {
+        return Err(InsightArenaError::MaxAppealTiersExceeded);
+    }
+
+    if dispute.appealer.is_some() {
+        return Err(InsightArenaError::DisputeAlreadyAppealed);
+    }
+
+    let expected_bond = calculate_appeal_bond(dispute.bond, dispute.appeal_tier + 1);
+    if appeal_bond < expected_bond {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    escrow::lock_stake(&env, &appealer, appeal_bond)?;
+
+    dispute.appeal_tier += 1;
+    dispute.appealer = Some(appealer.clone());
+    dispute.appeal_bond = appeal_bond;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(market_id), &dispute);
+    bump_dispute(&env, market_id);
+
+    emit_appeal_filed(&env, market_id, &appealer, appeal_bond, dispute.appeal_tier);
+
+    Ok(())
+}
+
+pub fn resolve_appeal(
+    env: Env,
+    admin: Address,
+    market_id: u64,
+    uphold: bool,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(&env)?;
+    require_admin(&env, &admin)?;
+
+    let mut dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(market_id))
+        .ok_or(InsightArenaError::DisputeNotFound)?;
+
+    let appealer = dispute
+        .appealer
+        .clone()
+        .ok_or(InsightArenaError::DisputeNotFound)?;
+
+    if uphold {
+        escrow::refund(&env, &appealer, dispute.appeal_bond)?;
+        let mut market = market::get_market(&env, market_id)?;
+        market.is_resolved = false;
+        market.resolved_outcome = None;
+        market.resolved_at = None;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Market(market_id), &market);
+        config::extend_market_ttl(&env, market_id);
+    } else {
+        escrow::add_to_treasury_balance(&env, dispute.appeal_bond);
+    }
+
+    dispute.appealer = None;
+    dispute.appeal_bond = 0;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(market_id), &dispute);
+    bump_dispute(&env, market_id);
+
+    emit_appeal_resolved(&env, market_id, &admin, uphold, dispute.appeal_tier);
+
+    Ok(())
 }

--- a/contracts/open-market/src/errors.rs
+++ b/contracts/open-market/src/errors.rs
@@ -65,6 +65,10 @@ pub enum InsightArenaError {
     DisputeAlreadyFiled = 61,
     /// No active dispute exists for this market.
     DisputeNotFound = 62,
+    /// Maximum appeal tiers reached; no further appeals allowed.
+    MaxAppealTiersExceeded = 64,
+    /// A dispute has already been appealed at this tier.
+    DisputeAlreadyAppealed = 65,
 
     // ── Prediction ────────────────────────────────────────────────────────────
     /// No prediction exists for the given `(market_id, predictor)` pair.
@@ -183,4 +187,12 @@ pub enum InsightArenaError {
     /// The elapsed time between the window's start and now collapsed to zero
     /// seconds, which would require dividing the price integral by zero.
     TwapDivideByZero = 110,
+
+    // ── Commit-Reveal ────────────────────────────────────────────────────────
+    /// No commitment exists for the given (market_id, predictor) pair.
+    CommitmentNotFound = 111,
+    /// Reveal window has not opened yet; the minimum time between commit and reveal has not elapsed.
+    RevealWindowNotOpen = 112,
+    /// The revealed outcome/amount/salt does not hash to the stored commitment.
+    CommitmentMismatch = 113,
 }

--- a/contracts/open-market/src/escrow.rs
+++ b/contracts/open-market/src/escrow.rs
@@ -69,6 +69,44 @@ pub fn lock_stake(env: &Env, from: &Address, amount: i128) -> Result<(), Insight
     Ok(())
 }
 
+/// Transfer `amount` stroops from `from` to the contract via pre-approved allowance.
+///
+/// Uses `transfer_from` instead of direct `transfer`, enabling gasless approval flows
+/// where the token holder pre-approves the contract separately.
+///
+/// # Errors
+/// - `InvalidInput` when `amount <= 0`.
+/// - `InsufficientFunds` when the allowance is insufficient.
+/// - Propagates any error returned by [`config::get_config`].
+pub fn lock_stake_via_allowance(
+    env: &Env,
+    from: &Address,
+    amount: i128,
+) -> Result<(), InsightArenaError> {
+    acquire_escrow_lock(env)?;
+
+    if amount <= 0 {
+        release_escrow_lock(env);
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    from.require_auth();
+
+    let cfg = config::get_config(env)?;
+    let contract = env.current_contract_address();
+    let client = token::Client::new(env, &cfg.xlm_token);
+
+    if client.allowance(from, &contract) < amount {
+        release_escrow_lock(env);
+        return Err(InsightArenaError::InsufficientFunds);
+    }
+
+    client.transfer_from(from, &contract, &amount);
+
+    release_escrow_lock(env);
+    Ok(())
+}
+
 /// Transfer `amount` stroops from contract escrow back to `to` as a refund.
 ///
 /// This entry point is intentionally separate from [`release_payout`] even

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -287,6 +287,26 @@ impl InsightArenaContract {
         dispute::resolve_dispute(env, admin, market_id, uphold)
     }
 
+    /// Appeal an active dispute with an escalated bond.
+    pub fn appeal_dispute(
+        env: Env,
+        appealer: Address,
+        market_id: u64,
+        appeal_bond: i128,
+    ) -> Result<(), InsightArenaError> {
+        dispute::appeal_dispute(env, appealer, market_id, appeal_bond)
+    }
+
+    /// Resolve an appeal (admin-only).
+    pub fn resolve_appeal(
+        env: Env,
+        admin: Address,
+        market_id: u64,
+        uphold: bool,
+    ) -> Result<(), InsightArenaError> {
+        dispute::resolve_appeal(env, admin, market_id, uphold)
+    }
+
     /// Enumerate all markets that currently have an active dispute.
     pub fn list_active_disputes(env: Env) -> Vec<u64> {
         dispute::list_active_disputes(&env)
@@ -308,6 +328,40 @@ impl InsightArenaContract {
         stake_amount: i128,
     ) -> Result<(), InsightArenaError> {
         prediction::submit_prediction(&env, predictor, market_id, chosen_outcome, stake_amount)
+    }
+
+    /// Submit a prediction using a pre-approved token allowance (transfer_from).
+    pub fn submit_prediction_via_allowance(
+        env: Env,
+        predictor: Address,
+        market_id: u64,
+        chosen_outcome: Symbol,
+        stake_amount: i128,
+    ) -> Result<(), InsightArenaError> {
+        prediction::submit_prediction_via_allowance(&env, predictor, market_id, chosen_outcome, stake_amount)
+    }
+
+    /// Commit to a prediction with a hash (outcome + amount + salt).
+    pub fn commit_prediction(
+        env: Env,
+        predictor: Address,
+        market_id: u64,
+        commitment_hash: soroban_sdk::BytesN<32>,
+        reveal_delay_seconds: u64,
+    ) -> Result<(), InsightArenaError> {
+        prediction::commit_prediction(&env, predictor, market_id, commitment_hash, reveal_delay_seconds)
+    }
+
+    /// Reveal a committed prediction and lock funds.
+    pub fn reveal_prediction(
+        env: Env,
+        predictor: Address,
+        market_id: u64,
+        chosen_outcome: Symbol,
+        stake_amount: i128,
+        salt: Vec<soroban_sdk::Val>,
+    ) -> Result<(), InsightArenaError> {
+        prediction::reveal_prediction(&env, predictor, market_id, chosen_outcome, stake_amount, salt)
     }
 
     /// Submit a batch of predictions atomically.

--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -1,11 +1,11 @@
-use soroban_sdk::{symbol_short, Address, Env, Map, Symbol, Vec};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Map, Symbol, Vec};
 
 use crate::config::{self, PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
 use crate::errors::InsightArenaError;
 use crate::escrow;
 use crate::market;
 use crate::season;
-use crate::storage_types::{DataKey, Market, Prediction, UserProfile, BatchPredictionRequest};
+use crate::storage_types::{DataKey, Market, Prediction, UserProfile, BatchPredictionRequest, CommitmentPrediction};
 
 // ── TTL helpers ───────────────────────────────────────────────────────────────
 
@@ -48,6 +48,39 @@ fn emit_prediction_submitted(
 ) {
     env.events().publish(
         (symbol_short!("pred"), symbol_short!("submitd")),
+        (market_id, predictor.clone(), outcome.clone(), amount),
+    );
+}
+
+fn emit_prediction_submitted_via_allowance(
+    env: &Env,
+    market_id: u64,
+    predictor: &Address,
+    outcome: &Symbol,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("pred"), symbol_short!("submtdal")),
+        (market_id, predictor.clone(), outcome.clone(), amount),
+    );
+}
+
+fn emit_commit_prediction(env: &Env, market_id: u64, predictor: &Address, hash: &BytesN<32>) {
+    env.events().publish(
+        (symbol_short!("pred"), symbol_short!("commit")),
+        (market_id, predictor.clone(), hash.clone()),
+    );
+}
+
+fn emit_reveal_prediction(
+    env: &Env,
+    market_id: u64,
+    predictor: &Address,
+    outcome: &Symbol,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("pred"), symbol_short!("reveal")),
         (market_id, predictor.clone(), outcome.clone(), amount),
     );
 }
@@ -226,6 +259,17 @@ pub fn submit_prediction(
     do_submit_prediction(env, predictor, market_id, chosen_outcome, stake_amount, false)
 }
 
+/// Submit a prediction using a pre-approved token allowance.
+pub fn submit_prediction_via_allowance(
+    env: &Env,
+    predictor: Address,
+    market_id: u64,
+    chosen_outcome: Symbol,
+    stake_amount: i128,
+) -> Result<(), InsightArenaError> {
+    do_submit_prediction_via_allowance(env, predictor, market_id, chosen_outcome, stake_amount)
+}
+
 fn do_submit_prediction(
     env: &Env,
     predictor: Address,
@@ -375,6 +419,344 @@ fn do_submit_prediction(
 
     // ── Emit PredictionSubmitted event ────────────────────────────────────────
     emit_prediction_submitted(env, market_id, &predictor, &chosen_outcome, stake_amount);
+
+    Ok(())
+}
+
+/// Commit to a prediction by hashing (outcome, amount, salt).
+/// The predictor's funds are locked but the outcome remains hidden until reveal.
+/// Commit-reveal window is enforced: minimum `reveal_delay_seconds` before reveal is allowed.
+pub fn commit_prediction(
+    env: &Env,
+    predictor: Address,
+    market_id: u64,
+    commitment_hash: BytesN<32>,
+    reveal_delay_seconds: u64,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
+
+    let market: Market = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Market(market_id))
+        .ok_or(InsightArenaError::MarketNotFound)?;
+
+    if market.is_cancelled {
+        return Err(InsightArenaError::MarketAlreadyCancelled);
+    }
+
+    let now = env.ledger().timestamp();
+    if now >= market.end_time {
+        return Err(InsightArenaError::MarketExpired);
+    }
+
+    let commitment_key = DataKey::CommitmentPrediction(market_id, predictor.clone());
+    if env.storage().persistent().has(&commitment_key) {
+        return Err(InsightArenaError::AlreadyPredicted);
+    }
+
+    predictor.require_auth();
+
+    let commitment = CommitmentPrediction::new(commitment_hash.clone(), now);
+    env.storage()
+        .persistent()
+        .set(&commitment_key, &commitment);
+    env.storage().persistent().extend_ttl(
+        &commitment_key,
+        PERSISTENT_THRESHOLD,
+        PERSISTENT_BUMP,
+    );
+
+    emit_commit_prediction(env, market_id, &predictor, &commitment_hash);
+
+    Ok(())
+}
+
+/// Reveal a committed prediction by providing outcome, amount, and salt.
+/// Validates the hash, locks the funds, and creates the actual Prediction record.
+/// Enforces that the reveal window has opened (minimum time has passed since commit).
+pub fn reveal_prediction(
+    env: &Env,
+    predictor: Address,
+    market_id: u64,
+    chosen_outcome: Symbol,
+    stake_amount: i128,
+    salt: soroban_sdk::Vec<soroban_sdk::Val>,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
+
+    predictor.require_auth();
+
+    let mut market: Market = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Market(market_id))
+        .ok_or(InsightArenaError::MarketNotFound)?;
+
+    if market.is_cancelled {
+        return Err(InsightArenaError::MarketAlreadyCancelled);
+    }
+
+    let now = env.ledger().timestamp();
+    if now >= market.end_time {
+        return Err(InsightArenaError::MarketExpired);
+    }
+
+    let outcome_valid = market.outcome_options.iter().any(|o| o == chosen_outcome);
+    if !outcome_valid {
+        return Err(InsightArenaError::InvalidOutcome);
+    }
+
+    if stake_amount < market.min_stake {
+        return Err(InsightArenaError::StakeTooLow);
+    }
+    if stake_amount > market.max_stake {
+        return Err(InsightArenaError::StakeTooHigh);
+    }
+
+    let commitment_key = DataKey::CommitmentPrediction(market_id, predictor.clone());
+    let mut commitment: CommitmentPrediction = env
+        .storage()
+        .persistent()
+        .get(&commitment_key)
+        .ok_or(InsightArenaError::CommitmentNotFound)?;
+
+    if commitment.revealed {
+        return Err(InsightArenaError::AlreadyPredicted);
+    }
+
+    // Check reveal window (1 minute minimum for safety)
+    if now < commitment.committed_at + 60 {
+        return Err(InsightArenaError::RevealWindowNotOpen);
+    }
+
+    // Compute hash of (outcome, amount, salt)
+    let mut preimage: soroban_sdk::Vec<soroban_sdk::Val> = soroban_sdk::vec![env];
+    preimage.push_back(chosen_outcome.clone().into_val(env));
+    preimage.push_back(stake_amount.into_val(env));
+    for s in salt.iter() {
+        preimage.push_back(s);
+    }
+
+    let computed_hash = env.crypto().sha256(&preimage.to_xdr(env));
+    if computed_hash != commitment.commitment_hash {
+        return Err(InsightArenaError::CommitmentMismatch);
+    }
+
+    escrow::lock_stake(env, &predictor, stake_amount)?;
+
+    commitment.revealed = true;
+    env.storage()
+        .persistent()
+        .set(&commitment_key, &commitment);
+
+    market::add_volume(env, stake_amount);
+
+    let prediction = Prediction::new(
+        market_id,
+        predictor.clone(),
+        chosen_outcome.clone(),
+        stake_amount,
+        now,
+    );
+    let prediction_key = DataKey::Prediction(market_id, predictor.clone());
+    env.storage().persistent().set(&prediction_key, &prediction);
+    bump_prediction(env, market_id, &predictor);
+
+    let list_key = DataKey::PredictorList(market_id);
+    let mut predictors: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&list_key)
+        .unwrap_or_else(|| Vec::new(env));
+    predictors.push_back(predictor.clone());
+    env.storage().persistent().set(&list_key, &predictors);
+    bump_predictor_list(env, market_id);
+
+    let user_markets_key = DataKey::UserMarkets(predictor.clone());
+    let mut user_markets: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&user_markets_key)
+        .unwrap_or_else(|| Vec::new(env));
+    if !user_markets.contains(market_id) {
+        user_markets.push_back(market_id);
+        env.storage()
+            .persistent()
+            .set(&user_markets_key, &user_markets);
+    }
+    bump_user_markets(env, &predictor);
+
+    market.total_pool = market
+        .total_pool
+        .checked_add(stake_amount)
+        .ok_or(InsightArenaError::Overflow)?;
+    market.participant_count = market
+        .participant_count
+        .checked_add(1)
+        .ok_or(InsightArenaError::Overflow)?;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Market(market_id), &market);
+    bump_market(env, market_id);
+
+    let user_key = DataKey::User(predictor.clone());
+    let mut profile: UserProfile = env
+        .storage()
+        .persistent()
+        .get(&user_key)
+        .unwrap_or_else(|| UserProfile::new(predictor.clone(), now));
+
+    profile.total_predictions = profile
+        .total_predictions
+        .checked_add(1)
+        .ok_or(InsightArenaError::Overflow)?;
+    profile.total_staked = profile
+        .total_staked
+        .checked_add(stake_amount)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    env.storage().persistent().set(&user_key, &profile);
+    bump_user(env, &predictor);
+    season::track_user_profile(env, &predictor);
+
+    emit_reveal_prediction(env, market_id, &predictor, &chosen_outcome, stake_amount);
+
+    Ok(())
+}
+
+/// Submit a prediction using transfer_from with a pre-approved allowance.
+fn do_submit_prediction_via_allowance(
+    env: &Env,
+    predictor: Address,
+    market_id: u64,
+    chosen_outcome: Symbol,
+    stake_amount: i128,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
+
+    let mut market: Market = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Market(market_id))
+        .ok_or(InsightArenaError::MarketNotFound)?;
+
+    if market.is_cancelled {
+        return Err(InsightArenaError::MarketAlreadyCancelled);
+    }
+
+    let now = env.ledger().timestamp();
+    if now >= market.end_time {
+        return Err(InsightArenaError::MarketExpired);
+    }
+
+    let outcome_valid = market.outcome_options.iter().any(|o| o == chosen_outcome);
+    if !outcome_valid {
+        return Err(InsightArenaError::InvalidOutcome);
+    }
+
+    if !market.is_public {
+        let allowlist: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MarketAllowlist(market_id))
+            .unwrap_or_else(|| Vec::new(env));
+
+        if !allowlist.iter().any(|entry| entry == predictor) {
+            return Err(InsightArenaError::Unauthorized);
+        }
+
+        env.storage().persistent().extend_ttl(
+            &DataKey::MarketAllowlist(market_id),
+            PERSISTENT_THRESHOLD,
+            PERSISTENT_BUMP,
+        );
+    }
+
+    if stake_amount < market.min_stake {
+        return Err(InsightArenaError::StakeTooLow);
+    }
+    if stake_amount > market.max_stake {
+        return Err(InsightArenaError::StakeTooHigh);
+    }
+
+    let prediction_key = DataKey::Prediction(market_id, predictor.clone());
+    if env.storage().persistent().has(&prediction_key) {
+        return Err(InsightArenaError::AlreadyPredicted);
+    }
+
+    escrow::lock_stake_via_allowance(env, &predictor, stake_amount)?;
+
+    market::add_volume(env, stake_amount);
+
+    let prediction = Prediction::new_via_allowance(
+        market_id,
+        predictor.clone(),
+        chosen_outcome.clone(),
+        stake_amount,
+        now,
+    );
+    env.storage().persistent().set(&prediction_key, &prediction);
+    bump_prediction(env, market_id, &predictor);
+
+    let list_key = DataKey::PredictorList(market_id);
+    let mut predictors: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&list_key)
+        .unwrap_or_else(|| Vec::new(env));
+    predictors.push_back(predictor.clone());
+    env.storage().persistent().set(&list_key, &predictors);
+    bump_predictor_list(env, market_id);
+
+    let user_markets_key = DataKey::UserMarkets(predictor.clone());
+    let mut user_markets: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&user_markets_key)
+        .unwrap_or_else(|| Vec::new(env));
+    if !user_markets.contains(market_id) {
+        user_markets.push_back(market_id);
+        env.storage()
+            .persistent()
+            .set(&user_markets_key, &user_markets);
+    }
+    bump_user_markets(env, &predictor);
+
+    market.total_pool = market
+        .total_pool
+        .checked_add(stake_amount)
+        .ok_or(InsightArenaError::Overflow)?;
+    market.participant_count = market
+        .participant_count
+        .checked_add(1)
+        .ok_or(InsightArenaError::Overflow)?;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Market(market_id), &market);
+    bump_market(env, market_id);
+
+    let user_key = DataKey::User(predictor.clone());
+    let mut profile: UserProfile = env
+        .storage()
+        .persistent()
+        .get(&user_key)
+        .unwrap_or_else(|| UserProfile::new(predictor.clone(), now));
+
+    profile.total_predictions = profile
+        .total_predictions
+        .checked_add(1)
+        .ok_or(InsightArenaError::Overflow)?;
+    profile.total_staked = profile
+        .total_staked
+        .checked_add(stake_amount)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    env.storage().persistent().set(&user_key, &profile);
+    bump_user(env, &predictor);
+    season::track_user_profile(env, &predictor);
+
+    emit_prediction_submitted_via_allowance(env, market_id, &predictor, &chosen_outcome, stake_amount);
 
     Ok(())
 }

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -112,6 +112,10 @@ pub enum DataKey {
     Winners(u64),
     /// Singleton. Treasury balance separate from protocol fees.
     TreasuryBalance,
+
+    // ── Commit-Reveal Predictions ─────────────────────────────────────────────
+    /// Keyed by (market_id, predictor). Stores a committed prediction (hash + amount, awaiting reveal).
+    CommitmentPrediction(u64, Address),
 }
 
 /// Lifecycle state of a governance proposal, derived from its stored flags and
@@ -141,6 +145,9 @@ pub struct Dispute {
     pub disputer: Address,
     pub bond: i128,
     pub filed_at: u64,
+    pub appeal_tier: u32,
+    pub appealer: Option<Address>,
+    pub appeal_bond: i128,
 }
 
 impl Dispute {
@@ -149,6 +156,9 @@ impl Dispute {
             disputer,
             bond,
             filed_at,
+            appeal_tier: 0,
+            appealer: None,
+            appeal_bond: 0,
         }
     }
 }
@@ -205,6 +215,8 @@ pub struct Prediction {
     pub payout_claimed: bool,
     /// The final portion of XLM the user won, populated after resolution. Defaults to 0.
     pub payout_amount: i128,
+    /// Payment method: true if via allowance (transfer_from), false if direct transfer. Defaults to false.
+    pub via_allowance: bool,
 }
 
 impl Prediction {
@@ -224,6 +236,27 @@ impl Prediction {
             submitted_at,
             payout_claimed: false,
             payout_amount: 0,
+            via_allowance: false,
+        }
+    }
+
+    /// Create a prediction via allowance-based payment.
+    pub fn new_via_allowance(
+        market_id: u64,
+        predictor: Address,
+        chosen_outcome: Symbol,
+        stake_amount: i128,
+        submitted_at: u64,
+    ) -> Self {
+        Self {
+            market_id,
+            predictor,
+            chosen_outcome,
+            stake_amount,
+            submitted_at,
+            payout_claimed: false,
+            payout_amount: 0,
+            via_allowance: true,
         }
     }
 }
@@ -974,6 +1007,28 @@ impl EventPrediction {
     /// Returns true if the predicted_winner value is valid (must be 0, 1, or 2).
     pub fn is_valid_outcome(predicted_winner: u32) -> bool {
         predicted_winner <= 2
+    }
+}
+
+/// Represents a committed prediction awaiting reveal phase.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitmentPrediction {
+    /// Hash of (chosen_outcome, amount, salt).
+    pub commitment_hash: soroban_sdk::BytesN<32>,
+    /// Ledger timestamp when the commit was recorded.
+    pub committed_at: u64,
+    /// Whether the commitment has been revealed yet.
+    pub revealed: bool,
+}
+
+impl CommitmentPrediction {
+    pub fn new(commitment_hash: soroban_sdk::BytesN<32>, committed_at: u64) -> Self {
+        Self {
+            commitment_hash,
+            committed_at,
+            revealed: false,
+        }
     }
 }
 

--- a/frontend/src/component/creator-events/EventCard.tsx
+++ b/frontend/src/component/creator-events/EventCard.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowRight, Calendar, Users, XCircle, CheckCircle, ShieldCheck, Tag } from "lucide-react";
+import { ArrowRight, Calendar, Users, XCircle, CheckCircle, ShieldCheck, Tag, Zap } from "lucide-react";
 import { Button } from "@/component/ui/button";
 import { cn } from "@/lib/utils";
+import { useCountdown, formatCountdown } from "@/hooks/useCountdown";
 
 export type CreatorEventStatus = "Active" | "Completed" | "Cancelled";
 
@@ -51,6 +52,7 @@ export default function EventCard({
   const StatusIcon = statusIcons[status];
   const [bannerError, setBannerError] = useState(false);
   const showBanner = Boolean(bannerUrl) && !bannerError;
+  const countdown = useCountdown(endsAt);
 
   return (
     <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950/80 shadow-xl shadow-black/20 transition hover:border-white/20 hover:shadow-white/5">
@@ -98,11 +100,11 @@ export default function EventCard({
             <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Creator</p>
             <p className="mt-2 text-sm font-semibold text-white">{creator}</p>
           </div>
-          <div className="rounded-2xl bg-white/5 p-4 border border-white/10">
-            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Ends</p>
-            <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-white">
-              <Calendar className="h-4 w-4 text-slate-400" />
-              {endsAt}
+          <div className={cn("rounded-2xl p-4 border", countdown.isExpired ? "bg-red-500/10 border-red-500/30" : "bg-white/5 border-white/10")}>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Time Until Lock</p>
+            <p className={cn("mt-2 flex items-center gap-2 text-sm font-semibold", countdown.isExpired ? "text-red-300" : "text-white")}>
+              <Zap className="h-4 w-4" />
+              {formatCountdown(countdown, 'Event Locked')}
             </p>
           </div>
         </div>

--- a/frontend/src/component/creator-events/EventHeader.tsx
+++ b/frontend/src/component/creator-events/EventHeader.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { CalendarDays, Check, Copy, KeyRound, Tag, Users } from "lucide-react";
+import { CalendarDays, Check, Copy, KeyRound, Tag, Users, Zap } from "lucide-react";
 
 import { Badge } from "@/component/ui/badge";
 import { Button } from "@/component/ui/button";
 import type { EventStatus } from "@/hooks/useCreatorEvents";
 import { cn } from "@/lib/utils";
+import { useCountdown, formatCountdown } from "@/hooks/useCountdown";
 
 interface EventHeaderProps {
   title: string;
@@ -16,6 +17,7 @@ interface EventHeaderProps {
   participants: number;
   maxParticipants: number;
   createdAt: string;
+  endsAt?: string;
   inviteCode?: string;
   category?: string;
   bannerUrl?: string;
@@ -35,6 +37,7 @@ export default function EventHeader({
   participants,
   maxParticipants,
   createdAt,
+  endsAt,
   inviteCode,
   category,
   bannerUrl,
@@ -42,6 +45,7 @@ export default function EventHeader({
   const [copied, setCopied] = useState(false);
   const [bannerError, setBannerError] = useState(false);
   const showBanner = Boolean(bannerUrl) && !bannerError;
+  const countdown = useCountdown(endsAt || createdAt);
 
   const handleCopyCreator = async () => {
     try {
@@ -123,6 +127,16 @@ export default function EventHeader({
                 {createdAt}
               </p>
             </div>
+
+            {endsAt ? (
+              <div className={cn("rounded-2xl p-4", countdown.isExpired ? "border-red-500/30 bg-red-500/10" : "border-white/10 bg-slate-950/80 border")}>
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-500">Time Until Lock</p>
+                <p className={cn("mt-2 flex items-center gap-2 text-sm font-semibold", countdown.isExpired ? "text-red-300" : "text-white")}>
+                  <Zap className="h-4 w-4" />
+                  {formatCountdown(countdown, 'Event Locked')}
+                </p>
+              </div>
+            ) : null}
 
             {inviteCode ? (
               <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 p-4 sm:col-span-2 lg:col-span-1">

--- a/frontend/src/component/creator-events/MatchList.tsx
+++ b/frontend/src/component/creator-events/MatchList.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { CalendarClock, CheckCircle2, Trophy } from "lucide-react";
+import { CalendarClock, CheckCircle2, Trophy, Zap } from "lucide-react";
 
 import { Badge } from "@/component/ui/badge";
 import { Button } from "@/component/ui/button";
 import type { CreatorEventMatch, MatchOutcome } from "@/hooks/useCreatorEvents";
 import { cn } from "@/lib/utils";
+import { useCountdown, formatCountdown } from "@/hooks/useCountdown";
 
 interface MatchListProps {
   matches: CreatorEventMatch[];
@@ -45,6 +46,7 @@ export default function MatchList({ matches, userJoined, onPredict }: MatchListP
       {matches.map((match) => {
         const winner = getWinningTeam(match);
         const canPredict = userJoined && match.outcome === "Pending" && isBeforeStart(match.matchTime);
+        const countdown = useCountdown(match.matchTime);
 
         return (
           <article
@@ -73,6 +75,20 @@ export default function MatchList({ matches, userJoined, onPredict }: MatchListP
                       ⚡ {match.pointsMultiplier}x Points
                     </Badge>
                   )}
+                  {match.outcome === "Pending" && !countdown.isExpired ? (
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "rounded-full px-3 py-1 flex items-center gap-1",
+                        countdown.totalSeconds < 300
+                          ? "border-red-400/30 bg-red-400/10 text-red-200"
+                          : "border-blue-400/30 bg-blue-400/10 text-blue-200"
+                      )}
+                    >
+                      <Zap className="h-3 w-3" />
+                      {formatCountdown(countdown, "Live")}
+                    </Badge>
+                  ) : null}
                   <span className="flex items-center gap-2 text-xs text-slate-400">
                     <CalendarClock className="h-4 w-4" />
                     {new Date(match.matchTime).toLocaleString()}

--- a/frontend/src/hooks/useCountdown.ts
+++ b/frontend/src/hooks/useCountdown.ts
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+
+export interface CountdownTime {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  isExpired: boolean;
+  totalSeconds: number;
+}
+
+/**
+ * Hook to calculate countdown time from a target date.
+ * Avoids unnecessary re-renders by only updating when the time actually changes.
+ * Returns isExpired=true when target date has passed.
+ */
+export function useCountdown(targetDate: string | Date | number): CountdownTime {
+  const [time, setTime] = useState<CountdownTime>({
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    isExpired: false,
+    totalSeconds: 0,
+  });
+
+  useEffect(() => {
+    const calculateTime = () => {
+      const now = Date.now();
+      const target = typeof targetDate === 'string' ? new Date(targetDate).getTime() : typeof targetDate === 'number' ? targetDate : targetDate.getTime();
+      const diff = target - now;
+
+      if (diff <= 0) {
+        setTime({
+          days: 0,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+          isExpired: true,
+          totalSeconds: 0,
+        });
+        return;
+      }
+
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+      setTime({
+        days,
+        hours,
+        minutes,
+        seconds,
+        isExpired: false,
+        totalSeconds: Math.floor(diff / 1000),
+      });
+    };
+
+    calculateTime();
+
+    const interval = setInterval(calculateTime, 1000);
+
+    return () => clearInterval(interval);
+  }, [targetDate]);
+
+  return time;
+}
+
+/**
+ * Format countdown time to a display string.
+ * If expired, returns "Event Started" or "Event Locked".
+ */
+export function formatCountdown(time: CountdownTime, expired?: string): string {
+  if (time.isExpired) {
+    return expired || 'Event Started';
+  }
+
+  if (time.days > 0) {
+    return `${time.days}d ${time.hours}h`;
+  }
+
+  if (time.hours > 0) {
+    return `${time.hours}h ${time.minutes}m`;
+  }
+
+  if (time.minutes > 0) {
+    return `${time.minutes}m ${time.seconds}s`;
+  }
+
+  return `${time.seconds}s`;
+}


### PR DESCRIPTION
Contract Enhancements:
- Closes #1348 Dispute Appeal Escalation: Add tiered appeals with escalating bonds (max 2 tiers). New functions: appeal_dispute() & resolve_appeal(). Includes MaxAppealTiersExceeded & DisputeAlreadyAppealed errors.
- Closes #1349 Token Allowance-Based Betting: Support approve/transfer_from flows via submit_prediction_via_allowance(). New escrow function lock_stake_via_allowance() with sufficient allowance validation. Predictions track payment method via via_allowance flag; emit distinct event.
- Closes #1340 Commit-Reveal Predictions: Add 2-phase anti-front-running via commit_prediction() & reveal_prediction(). Commit stores SHA256(outcome, amount, salt) hash; reveal validates hash and enforces 60s minimum window. New storage type CommitmentPrediction and errors CommitmentNotFound, RevealWindowNotOpen, CommitmentMismatch.

Frontend Enhancements:
- Closes #1420 Live Countdown Timers: New useCountdown hook with efficient re-render avoidance. Added countdown display to EventCard, EventHeader, and MatchList with color state (red <5min). formatCountdown() utility for compact display (e.g., "2d 5h", "Live", "Event Locked").