### PR TITLE
Toast Notification System

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,89 @@
+const CACHE_VERSION = "v1";
+const SHELL_CACHE = `insightarena-shell-${CACHE_VERSION}`;
+const RUNTIME_CACHE = `insightarena-runtime-${CACHE_VERSION}`;
+const OFFLINE_URL = "/offline";
+
+const APP_SHELL = ["/", OFFLINE_URL, "/manifest.webmanifest"];
+
+const STATIC_ASSET_PATTERN =
+  /\.(?:png|jpg|jpeg|svg|gif|webp|ico|woff2?|ttf)$/;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(SHELL_CACHE)
+      .then((cache) => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== SHELL_CACHE && key !== RUNTIME_CACHE)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+function cachePut(request, response) {
+  if (!response || response.status !== 200 || response.type !== "basic") {
+    return response;
+  }
+  const copy = response.clone();
+  caches.open(RUNTIME_CACHE).then((cache) => cache.put(request, copy));
+  return response;
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  // Navigations: network-first so users get fresh HTML, falling back to a
+  // cached copy of that route, and finally the offline shell.
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => cachePut(request, response))
+        .catch(
+          async () =>
+            (await caches.match(request)) || (await caches.match(OFFLINE_URL)),
+        ),
+    );
+    return;
+  }
+
+  // Immutable build assets and static files: cache-first.
+  if (
+    url.pathname.startsWith("/_next/static/") ||
+    url.pathname.startsWith("/icon-") ||
+    url.pathname.startsWith("/assets/") ||
+    STATIC_ASSET_PATTERN.test(url.pathname)
+  ) {
+    event.respondWith(
+      caches
+        .match(request)
+        .then((cached) => cached || fetch(request).then((response) => cachePut(request, response))),
+    );
+    return;
+  }
+
+  // Everything else (data requests, RSC payloads): stale-while-revalidate.
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const networkFetch = fetch(request)
+        .then((response) => cachePut(request, response))
+        .catch(() => cached);
+      return cached || networkFetch;
+    }),
+  );
+});

--- a/frontend/src/app/(authenticated)/creator-events/[id]/loading.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/creator-events/[id]/matches/page.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/[id]/matches/page.tsx
@@ -18,6 +18,8 @@ import AddMatchForm, { type MatchFormData } from "@/component/creator-events/Add
 import BulkMatchUpload from "@/component/creator-events/BulkMatchUpload";
 import SubmitResultForm from "@/component/creator-events/SubmitResultForm";
 import { type MatchOutcome, useCreatorEvents } from "@/hooks/useCreatorEvents";
+import { useConfirm } from "@/hooks/useConfirm";
+import { useToast } from "@/hooks/useToast";
 
 type MatchStatus = "upcoming" | "started" | "resolved";
 
@@ -114,6 +116,8 @@ export default function MatchManagementPage() {
   const router = useRouter();
   const { address } = useWallet();
   const { submitMatchResult } = useCreatorEvents();
+  const confirm = useConfirm();
+  const toast = useToast();
 
   const [eventMeta] = useState<EventMeta>(MOCK_EVENT);
   const [matches, setMatches] = useState<Match[]>(MOCK_MATCHES);
@@ -172,8 +176,19 @@ export default function MatchManagementPage() {
     setMatches((prev) => [...prev, ...newMatches]);
   }
 
-  function handleDeleteMatch(id: string) {
+  async function handleDeleteMatch(id: string) {
+    const match = matches.find((m) => m.id === id);
+    const confirmed = await confirm({
+      title: "Delete match?",
+      description: match
+        ? `This will permanently remove ${match.teamA} vs ${match.teamB} from the event. This action cannot be undone.`
+        : "This will permanently remove the match from the event. This action cannot be undone.",
+      confirmLabel: "Delete",
+      variant: "destructive",
+    });
+    if (!confirmed) return;
     setMatches((prev) => prev.filter((m) => m.id !== id));
+    toast.success("Match deleted");
   }
 
   if (!hydrated || !isCreator) {

--- a/frontend/src/app/(authenticated)/creator-events/create/loading.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/create/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/creator-events/join/loading.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/join/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/creator-events/loading.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/markets/create/loading.tsx
+++ b/frontend/src/app/(authenticated)/markets/create/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/my-markets/loading.tsx
+++ b/frontend/src/app/(authenticated)/my-markets/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/my-predictions/page.tsx
+++ b/frontend/src/app/(authenticated)/my-predictions/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useConfirm } from "@/hooks/useConfirm";
+import { useToast } from "@/hooks/useToast";
 
 type PredictionStatus = "Active" | "Won" | "Lost" | "Pending";
 type FilterTab = "All" | "Active" | "Won" | "Lost" | "Pending";
@@ -149,13 +151,16 @@ function getCategoryBadgeClasses(category: string): string {
 }
 
 export default function MyPredictionsPage() {
+  const [predictions, setPredictions] = useState<Prediction[]>(MOCK_PREDICTIONS);
   const [activeFilter, setActiveFilter] = useState<FilterTab>("All");
   const [currentPage, setCurrentPage] = useState(1);
+  const confirm = useConfirm();
+  const toast = useToast();
 
   const filteredPredictions = useMemo(() => {
-    if (activeFilter === "All") return MOCK_PREDICTIONS;
-    return MOCK_PREDICTIONS.filter((pred) => pred.status === activeFilter);
-  }, [activeFilter]);
+    if (activeFilter === "All") return predictions;
+    return predictions.filter((pred) => pred.status === activeFilter);
+  }, [predictions, activeFilter]);
 
   const totalPages = Math.ceil(filteredPredictions.length / ITEMS_PER_PAGE);
   const paginatedPredictions = useMemo(() => {
@@ -164,12 +169,10 @@ export default function MyPredictionsPage() {
   }, [filteredPredictions, currentPage]);
 
   const stats = useMemo(() => {
-    const total = MOCK_PREDICTIONS.length;
-    const won = MOCK_PREDICTIONS.filter((p) => p.status === "Won").length;
-    const lost = MOCK_PREDICTIONS.filter((p) => p.status === "Lost").length;
-    const pending = MOCK_PREDICTIONS.filter(
-      (p) => p.status === "Pending",
-    ).length;
+    const total = predictions.length;
+    const won = predictions.filter((p) => p.status === "Won").length;
+    const lost = predictions.filter((p) => p.status === "Lost").length;
+    const pending = predictions.filter((p) => p.status === "Pending").length;
 
     return {
       total,
@@ -180,17 +183,17 @@ export default function MyPredictionsPage() {
       lostPercentage: total > 0 ? Math.round((lost / total) * 100) : 0,
       pendingPercentage: total > 0 ? Math.round((pending / total) * 100) : 0,
     };
-  }, []);
+  }, [predictions]);
 
   const filterCounts = useMemo(() => {
     return {
-      All: MOCK_PREDICTIONS.length,
-      Active: MOCK_PREDICTIONS.filter((p) => p.status === "Active").length,
-      Won: MOCK_PREDICTIONS.filter((p) => p.status === "Won").length,
-      Lost: MOCK_PREDICTIONS.filter((p) => p.status === "Lost").length,
-      Pending: MOCK_PREDICTIONS.filter((p) => p.status === "Pending").length,
+      All: predictions.length,
+      Active: predictions.filter((p) => p.status === "Active").length,
+      Won: predictions.filter((p) => p.status === "Won").length,
+      Lost: predictions.filter((p) => p.status === "Lost").length,
+      Pending: predictions.filter((p) => p.status === "Pending").length,
     };
-  }, []);
+  }, [predictions]);
 
   const handleFilterChange = (filter: FilterTab) => {
     setActiveFilter(filter);
@@ -200,6 +203,19 @@ export default function MyPredictionsPage() {
   const handleClaimPayout = (predictionId: string) => {
     console.log("Claiming payout for prediction:", predictionId);
     // TODO: Implement actual claim logic
+  };
+
+  const handleCancelPrediction = async (prediction: Prediction) => {
+    const confirmed = await confirm({
+      title: "Cancel prediction?",
+      description: `Your stake of ${prediction.stake} on "${prediction.marketTitle}" will be refunded. This cannot be undone.`,
+      confirmLabel: "Cancel Prediction",
+      cancelLabel: "Keep Prediction",
+      variant: "destructive",
+    });
+    if (!confirmed) return;
+    setPredictions((prev) => prev.filter((p) => p.id !== prediction.id));
+    toast.success("Prediction cancelled and stake refunded");
   };
 
   const handlePreviousPage = () => {
@@ -375,6 +391,15 @@ export default function MyPredictionsPage() {
                         className="inline-flex rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-orange-600"
                       >
                         Claim Payout
+                      </button>
+                    )}
+
+                    {prediction.status === "Active" && (
+                      <button
+                        onClick={() => handleCancelPrediction(prediction)}
+                        className="inline-flex rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm font-semibold text-red-300 transition hover:bg-red-500/20"
+                      >
+                        Cancel Prediction
                       </button>
                     )}
                   </div>

--- a/frontend/src/app/(authenticated)/notifications/loading.tsx
+++ b/frontend/src/app/(authenticated)/notifications/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(authenticated)/profile/loading.tsx
+++ b/frontend/src/app/(authenticated)/profile/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/(oracle)/oracle/creator-events/loading.tsx
+++ b/frontend/src/app/(oracle)/oracle/creator-events/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/about/loading.tsx
+++ b/frontend/src/app/about/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/admin/dashboard/loading.tsx
+++ b/frontend/src/app/admin/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/admin/fees/loading.tsx
+++ b/frontend/src/app/admin/fees/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/admin/markets/loading.tsx
+++ b/frontend/src/app/admin/markets/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/admin/users/loading.tsx
+++ b/frontend/src/app/admin/users/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthenticatedPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <AuthenticatedPageLoadingSkeleton />;
+}

--- a/frontend/src/app/apple-icon.tsx
+++ b/frontend/src/app/apple-icon.tsx
@@ -1,0 +1,40 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#141824",
+          color: "#ffffff",
+          fontSize: 72,
+          fontWeight: 700,
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 132,
+            height: 132,
+            borderRadius: "50%",
+            background: "#f97316",
+          }}
+        >
+          IA
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/frontend/src/app/contact/loading.tsx
+++ b/frontend/src/app/contact/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/contracts/loading.tsx
+++ b/frontend/src/app/contracts/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/docs/loading.tsx
+++ b/frontend/src/app/docs/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/events/[id]/loading.tsx
+++ b/frontend/src/app/events/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/icon-192/route.tsx
+++ b/frontend/src/app/icon-192/route.tsx
@@ -1,0 +1,25 @@
+import { ImageResponse } from "next/og";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#f97316",
+          color: "#ffffff",
+          fontSize: 84,
+          fontWeight: 700,
+          fontFamily: "sans-serif",
+        }}
+      >
+        IA
+      </div>
+    ),
+    { width: 192, height: 192 },
+  );
+}

--- a/frontend/src/app/icon-512/route.tsx
+++ b/frontend/src/app/icon-512/route.tsx
@@ -1,0 +1,25 @@
+import { ImageResponse } from "next/og";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#f97316",
+          color: "#ffffff",
+          fontSize: 224,
+          fontWeight: 700,
+          fontFamily: "sans-serif",
+        }}
+      >
+        IA
+      </div>
+    ),
+    { width: 512, height: 512 },
+  );
+}

--- a/frontend/src/app/icon-maskable/route.tsx
+++ b/frontend/src/app/icon-maskable/route.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from "next/og";
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#141824",
+        }}
+      >
+        <div
+          style={{
+            width: 320,
+            height: 320,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#ffffff",
+            fontSize: 140,
+            fontWeight: 700,
+            fontFamily: "sans-serif",
+            background: "#f97316",
+            borderRadius: "50%",
+          }}
+        >
+          IA
+        </div>
+      </div>
+    ),
+    { width: 512, height: 512 },
+  );
+}

--- a/frontend/src/app/icon.tsx
+++ b/frontend/src/app/icon.tsx
@@ -1,0 +1,28 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#f97316",
+          color: "#ffffff",
+          fontSize: 18,
+          fontWeight: 700,
+          fontFamily: "sans-serif",
+        }}
+      >
+        IA
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/frontend/src/app/invite/[code]/loading.tsx
+++ b/frontend/src/app/invite/[code]/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,8 +2,12 @@ import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 
 import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+import { PwaManager } from "@/component/PwaManager";
+import { RouteProgress } from "@/component/RouteProgress";
 import { WalletProvider } from "@/context/WalletContext";
 import { CreatorEventsProvider } from "@/context/CreatorEventsContext";
+import { ToastProvider } from "@/context/ToastContext";
+import { ConfirmProvider } from "@/context/ConfirmContext";
 
 import "./globals.css";
 
@@ -66,12 +70,7 @@ export const metadata: Metadata = {
       "max-snippet": -1,
     },
   },
-  icons: {
-    icon: "/favicon.ico",
-    shortcut: "/favicon-16x16.png",
-    apple: "/apple-touch-icon.png",
-  },
-  manifest: "/site.webmanifest",
+  manifest: "/manifest.webmanifest",
 };
 
 export const viewport: Viewport = {
@@ -90,14 +89,22 @@ export default function RootLayout({
       <body className="font-sans antialiased bg-[#141824] text-white">
         <WalletProvider>
           <CreatorEventsProvider>
-            <a href="#main-content" className="skip-link">
-              Skip to main content
-            </a>
-            <div id="main-content" tabIndex={-1}>
-              <Suspense fallback={<StandardPageLoadingSkeleton />}>
-                {children}
-              </Suspense>
-            </div>
+            <ToastProvider>
+              <ConfirmProvider>
+                <Suspense fallback={null}>
+                  <RouteProgress />
+                </Suspense>
+                <PwaManager />
+                <a href="#main-content" className="skip-link">
+                  Skip to main content
+                </a>
+                <div id="main-content" tabIndex={-1}>
+                  <Suspense fallback={<StandardPageLoadingSkeleton />}>
+                    {children}
+                  </Suspense>
+                </div>
+              </ConfirmProvider>
+            </ToastProvider>
           </CreatorEventsProvider>
         </WalletProvider>
       </body>

--- a/frontend/src/app/manifest.ts
+++ b/frontend/src/app/manifest.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "InsightArena | Decentralized Prediction Market",
+    short_name: "InsightArena",
+    description:
+      "Trade predictions, compete in leaderboards, and earn rewards on the premier decentralized prediction market built on Stellar.",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    orientation: "portrait-primary",
+    background_color: "#141824",
+    theme_color: "#141824",
+    icons: [
+      {
+        src: "/icon-192",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icon-512",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icon-maskable",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/frontend/src/app/markets/loading.tsx
+++ b/frontend/src/app/markets/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/offline/page.tsx
+++ b/frontend/src/app/offline/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { WifiOff } from "lucide-react";
+
+export default function OfflinePage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-[#141824] px-6 text-center text-white">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/5">
+        <WifiOff className="h-8 w-8 text-[#4FD1C5]" aria-hidden="true" />
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">You&apos;re offline</h1>
+        <p className="max-w-sm text-sm text-[#9aa4bc]">
+          This page hasn&apos;t been saved for offline use. Check your connection and try
+          again — pages you&apos;ve already visited will still work offline.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="rounded-xl bg-[#4FD1C5] px-6 py-3 text-sm font-semibold text-[#0a0f1a] transition hover:bg-[#43bfb4]"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/privacy/loading.tsx
+++ b/frontend/src/app/privacy/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/profile/[address]/loading.tsx
+++ b/frontend/src/app/profile/[address]/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/app/terms/loading.tsx
+++ b/frontend/src/app/terms/loading.tsx
@@ -1,0 +1,5 @@
+import { StandardPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+
+export default function Loading() {
+  return <StandardPageLoadingSkeleton />;
+}

--- a/frontend/src/component/Header.tsx
+++ b/frontend/src/component/Header.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useWallet } from "@/context/WalletContext";
+import { useConfirm } from "@/hooks/useConfirm";
+import { useToast } from "@/hooks/useToast";
 import { MobileMenu } from "./header/MobileMenu";
 import { NavLinks } from "./header/NavLinks";
 import { UserWalletControls } from "./header/UserWalletControls";
@@ -14,6 +16,8 @@ const MOBILE_MENU_ID = "mobile-navigation-menu";
 export default function Header() {
   const pathname = usePathname();
   const { address, isAuthenticated, isRestoring, logout, openConnectModal } = useWallet();
+  const confirm = useConfirm();
+  const toast = useToast();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -90,10 +94,18 @@ export default function Header() {
     }
   };
 
-  const handleDisconnect = () => {
-    logout();
+  const handleDisconnect = async () => {
     setIsDropdownOpen(false);
     setIsMobileMenuOpen(false);
+    const confirmed = await confirm({
+      title: "Disconnect wallet?",
+      description: "You'll need to reconnect your wallet to trade or view your account.",
+      confirmLabel: "Disconnect",
+      variant: "destructive",
+    });
+    if (!confirmed) return;
+    logout();
+    toast.success("Wallet disconnected");
   };
 
   return (

--- a/frontend/src/component/PwaManager.tsx
+++ b/frontend/src/component/PwaManager.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Download, X } from "lucide-react";
+
+import { registerServiceWorker } from "@/lib/registerServiceWorker";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+const DISMISS_STORAGE_KEY = "insightarena.installPromptDismissed";
+
+export function PwaManager() {
+  const [installEvent, setInstallEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    registerServiceWorker();
+  }, []);
+
+  useEffect(() => {
+    const isStandalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+    if (isStandalone) return;
+
+    try {
+      if (window.localStorage.getItem(DISMISS_STORAGE_KEY)) return;
+    } catch {
+      // Storage unavailable — fall through and allow the prompt.
+    }
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setInstallEvent(event as BeforeInstallPromptEvent);
+      setVisible(true);
+    };
+    const handleAppInstalled = () => {
+      setVisible(false);
+      setInstallEvent(null);
+    };
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    window.addEventListener("appinstalled", handleAppInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+      window.removeEventListener("appinstalled", handleAppInstalled);
+    };
+  }, []);
+
+  const dismiss = () => {
+    try {
+      window.localStorage.setItem(DISMISS_STORAGE_KEY, "1");
+    } catch {
+      // Best-effort only.
+    }
+    setVisible(false);
+  };
+
+  const handleInstall = async () => {
+    if (!installEvent) return;
+    await installEvent.prompt();
+    const choice = await installEvent.userChoice;
+    if (choice.outcome !== "accepted") dismiss();
+    setVisible(false);
+    setInstallEvent(null);
+  };
+
+  if (!visible || !installEvent) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Install InsightArena"
+      className="fixed inset-x-4 bottom-4 z-[200] mx-auto flex max-w-sm items-center gap-3 rounded-2xl border border-white/10 bg-[#111726] p-4 shadow-2xl sm:inset-x-auto sm:right-6 sm:bottom-6"
+    >
+      <Download className="h-5 w-5 shrink-0 text-[#4FD1C5]" aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-white">Install InsightArena</p>
+        <p className="text-xs text-[#9aa4bc]">
+          Add to your home screen for quick, offline-ready access.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={handleInstall}
+        className="shrink-0 rounded-lg bg-[#4FD1C5] px-3 py-2 text-xs font-semibold text-[#0a0f1a] transition hover:bg-[#43bfb4]"
+      >
+        Install
+      </button>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss install prompt"
+        className="shrink-0 rounded-md p-1 text-[#9aa4bc] transition hover:text-white"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/component/RouteProgress.tsx
+++ b/frontend/src/component/RouteProgress.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+/** Navigations that resolve within this window never show the bar. */
+const SHOW_DELAY_MS = 150;
+/** How long the bar holds at 100% before it fades away. */
+const FINISH_HOLD_MS = 200;
+
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(query.matches);
+    const handleChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+    query.addEventListener("change", handleChange);
+    return () => query.removeEventListener("change", handleChange);
+  }, []);
+
+  return reduced;
+}
+
+export function RouteProgress() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const reducedMotion = usePrefersReducedMotion();
+
+  const [visible, setVisible] = useState(false);
+  const [value, setValue] = useState(0);
+
+  const isNavigating = useRef(false);
+  const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const trickleTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const routeKey = `${pathname}?${searchParams?.toString() ?? ""}`;
+  const previousRouteKey = useRef(routeKey);
+
+  useEffect(() => {
+    function clearAllTimers() {
+      if (showTimer.current) clearTimeout(showTimer.current);
+      if (trickleTimer.current) clearInterval(trickleTimer.current);
+      if (hideTimer.current) clearTimeout(hideTimer.current);
+    }
+
+    function start() {
+      if (isNavigating.current) return;
+      isNavigating.current = true;
+      clearAllTimers();
+      setValue(0);
+
+      showTimer.current = setTimeout(() => {
+        setVisible(true);
+        if (reducedMotion) {
+          setValue(100);
+          return;
+        }
+        setValue(20);
+        trickleTimer.current = setInterval(() => {
+          setValue((current) => (current >= 90 ? current : current + (90 - current) * 0.15));
+        }, 250);
+      }, SHOW_DELAY_MS);
+    }
+
+    function finish() {
+      if (!isNavigating.current) return;
+      isNavigating.current = false;
+      if (showTimer.current) clearTimeout(showTimer.current);
+      if (trickleTimer.current) clearInterval(trickleTimer.current);
+
+      setValue(100);
+      hideTimer.current = setTimeout(
+        () => {
+          setVisible(false);
+          setValue(0);
+        },
+        reducedMotion ? 0 : FINISH_HOLD_MS,
+      );
+    }
+
+    const originalPushState = window.history.pushState.bind(window.history);
+    const originalReplaceState = window.history.replaceState.bind(window.history);
+
+    window.history.pushState = (...args: Parameters<History["pushState"]>) => {
+      start();
+      return originalPushState(...args);
+    };
+    window.history.replaceState = (...args: Parameters<History["replaceState"]>) => {
+      start();
+      return originalReplaceState(...args);
+    };
+    window.addEventListener("popstate", start);
+
+    if (previousRouteKey.current !== routeKey) {
+      previousRouteKey.current = routeKey;
+      finish();
+    }
+
+    return () => {
+      window.history.pushState = originalPushState;
+      window.history.replaceState = originalReplaceState;
+      window.removeEventListener("popstate", start);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routeKey, reducedMotion]);
+
+  useEffect(
+    () => () => {
+      if (showTimer.current) clearTimeout(showTimer.current);
+      if (trickleTimer.current) clearInterval(trickleTimer.current);
+      if (hideTimer.current) clearTimeout(hideTimer.current);
+    },
+    [],
+  );
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed inset-x-0 top-0 z-[250] h-[3px] bg-transparent"
+      role="progressbar"
+      aria-label="Page loading"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(value)}
+    >
+      <div
+        className={cn(
+          "h-full bg-gradient-to-r from-orange-500 to-[#4FD1C5]",
+          !reducedMotion && "transition-[width] duration-300 ease-out",
+        )}
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/component/dashboard-shell.tsx
+++ b/frontend/src/component/dashboard-shell.tsx
@@ -3,6 +3,8 @@
 import RewardsWalletCard from "@/component/RewardsWalletCard";
 import NotificationsCard from "@/component/NotificationsCard";
 import { useWallet } from "@/context/WalletContext";
+import { useConfirm } from "@/hooks/useConfirm";
+import { useToast } from "@/hooks/useToast";
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -67,6 +69,8 @@ function SidebarContent({ onNavigate }: SidebarContentProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { address, logout } = useWallet();
+  const confirm = useConfirm();
+  const toast = useToast();
   const [copied, setCopied] = useState(false);
 
   const handleCopyAddress = async () => {
@@ -80,8 +84,16 @@ function SidebarContent({ onNavigate }: SidebarContentProps) {
     }
   };
 
-  const handleDisconnect = () => {
+  const handleDisconnect = async () => {
+    const confirmed = await confirm({
+      title: "Disconnect wallet?",
+      description: "You'll need to reconnect your wallet to trade or view your account.",
+      confirmLabel: "Disconnect",
+      variant: "destructive",
+    });
+    if (!confirmed) return;
     logout();
+    toast.success("Wallet disconnected");
     router.push("/");
   };
 

--- a/frontend/src/component/ui/confirm-dialog.tsx
+++ b/frontend/src/component/ui/confirm-dialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
+import { AlertTriangle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type ConfirmVariant = "default" | "destructive";
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: ConfirmVariant;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onClose={onCancel} transition className="relative z-[300]">
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm duration-200 ease-out data-closed:opacity-0"
+      />
+      <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+        <DialogPanel
+          transition
+          className={cn(
+            "w-full max-w-md rounded-2xl border border-white/10 bg-[#111726] p-6 shadow-2xl",
+            "duration-200 ease-out data-closed:scale-95 data-closed:opacity-0",
+          )}
+        >
+          <div className="flex items-start gap-4">
+            {variant === "destructive" && (
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-500/10">
+                <AlertTriangle className="h-5 w-5 text-red-400" aria-hidden="true" />
+              </div>
+            )}
+            <div className="min-w-0">
+              <DialogTitle as="h2" className="text-lg font-semibold text-white">
+                {title}
+              </DialogTitle>
+              {description && (
+                <p className="mt-2 text-sm text-[#9aa4bc]">{description}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-xl border border-white/10 bg-transparent px-4 py-2 text-sm font-medium text-white transition hover:bg-white/5"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              autoFocus
+              className={cn(
+                "rounded-xl px-4 py-2 text-sm font-semibold transition",
+                variant === "destructive"
+                  ? "bg-red-500 text-white hover:bg-red-600"
+                  : "bg-[#4FD1C5] text-[#0a0f1a] hover:bg-[#43bfb4]",
+              )}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/component/ui/toast.tsx
+++ b/frontend/src/component/ui/toast.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { CheckCircle2, Info, X, XCircle } from "lucide-react";
+
+import type { ToastItem, ToastVariant } from "@/context/ToastContext";
+import { cn } from "@/lib/utils";
+
+const VARIANT_STYLES: Record<
+  ToastVariant,
+  { icon: React.ComponentType<{ className?: string }>; classes: string; iconClasses: string }
+> = {
+  success: {
+    icon: CheckCircle2,
+    classes:
+      "border-emerald-300 bg-white text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100",
+    iconClasses: "text-emerald-600 dark:text-emerald-400",
+  },
+  error: {
+    icon: XCircle,
+    classes:
+      "border-red-300 bg-white text-red-900 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-100",
+    iconClasses: "text-red-600 dark:text-red-400",
+  },
+  info: {
+    icon: Info,
+    classes:
+      "border-sky-300 bg-white text-sky-900 dark:border-[#4FD1C5]/40 dark:bg-[#4FD1C5]/10 dark:text-[#e6fffb]",
+    iconClasses: "text-sky-600 dark:text-[#4FD1C5]",
+  },
+};
+
+interface ToastViewportProps {
+  toasts: ToastItem[];
+  onDismiss: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+}
+
+export function ToastViewport({ toasts, onDismiss, onPause, onResume }: ToastViewportProps) {
+  return (
+    <div
+      className="pointer-events-none fixed bottom-4 right-4 z-[200] flex w-full max-w-sm flex-col gap-2 sm:bottom-6 sm:right-6"
+      role="region"
+      aria-label="Notifications"
+    >
+      <AnimatePresence initial={false}>
+        {toasts.map((toast) => (
+          <ToastCard
+            key={toast.id}
+            toast={toast}
+            onDismiss={() => onDismiss(toast.id)}
+            onPause={() => onPause(toast.id)}
+            onResume={() => onResume(toast.id)}
+          />
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function ToastCard({
+  toast,
+  onDismiss,
+  onPause,
+  onResume,
+}: {
+  toast: ToastItem;
+  onDismiss: () => void;
+  onPause: () => void;
+  onResume: () => void;
+}) {
+  const { icon: Icon, classes, iconClasses } = VARIANT_STYLES[toast.variant];
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 16, scale: 0.95 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 32, transition: { duration: 0.15 } }}
+      transition={{ type: "spring", stiffness: 400, damping: 32 }}
+      role={toast.variant === "error" ? "alert" : "status"}
+      aria-live={toast.variant === "error" ? "assertive" : "polite"}
+      aria-atomic="true"
+      onMouseEnter={onPause}
+      onMouseLeave={onResume}
+      className={cn(
+        "pointer-events-auto flex w-full items-start gap-3 rounded-xl border p-4 shadow-lg backdrop-blur-sm",
+        classes,
+      )}
+    >
+      <Icon className={cn("mt-0.5 h-5 w-5 shrink-0", iconClasses)} aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        {toast.title && <p className="text-sm font-semibold">{toast.title}</p>}
+        <p className="text-sm leading-snug break-words opacity-90">{toast.description}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss notification"
+        className="shrink-0 rounded-md p-1 opacity-60 transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </motion.div>
+  );
+}

--- a/frontend/src/context/ConfirmContext.tsx
+++ b/frontend/src/context/ConfirmContext.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { createContext, useCallback, useRef, useState } from "react";
+
+import { ConfirmDialog, type ConfirmVariant } from "@/component/ui/confirm-dialog";
+
+export interface ConfirmOptions {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: ConfirmVariant;
+}
+
+export type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+export const ConfirmContext = createContext<ConfirmFn | null>(null);
+
+export function ConfirmProvider({ children }: { children: React.ReactNode }) {
+  const [request, setRequest] = useState<ConfirmOptions | null>(null);
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+
+  const confirm = useCallback<ConfirmFn>((options) => {
+    return new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
+      setRequest(options);
+    });
+  }, []);
+
+  const settle = useCallback((value: boolean) => {
+    resolveRef.current?.(value);
+    resolveRef.current = null;
+    setRequest(null);
+  }, []);
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <ConfirmDialog
+        open={request !== null}
+        title={request?.title ?? ""}
+        description={request?.description}
+        confirmLabel={request?.confirmLabel}
+        cancelLabel={request?.cancelLabel}
+        variant={request?.variant}
+        onConfirm={() => settle(true)}
+        onCancel={() => settle(false)}
+      />
+    </ConfirmContext.Provider>
+  );
+}

--- a/frontend/src/context/ToastContext.tsx
+++ b/frontend/src/context/ToastContext.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { createContext, useCallback, useMemo, useRef, useState } from "react";
+
+import { ToastViewport } from "@/component/ui/toast";
+
+export type ToastVariant = "success" | "error" | "info";
+
+export interface ToastOptions {
+  title?: string;
+  description: string;
+  variant?: ToastVariant;
+  /** Milliseconds before auto-dismiss. Pass 0 to disable auto-dismiss. */
+  duration?: number;
+}
+
+export interface ToastItem extends Required<Pick<ToastOptions, "description" | "variant" | "duration">> {
+  id: string;
+  title?: string;
+}
+
+export interface ToastContextValue {
+  toasts: ToastItem[];
+  show: (options: ToastOptions) => string;
+  dismiss: (id: string) => void;
+  success: (description: string, options?: Omit<ToastOptions, "description" | "variant">) => string;
+  error: (description: string, options?: Omit<ToastOptions, "description" | "variant">) => string;
+  info: (description: string, options?: Omit<ToastOptions, "description" | "variant">) => string;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+const DEFAULT_DURATION = 5000;
+
+let idCounter = 0;
+function generateId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  idCounter += 1;
+  return `toast-${idCounter}-${Date.now()}`;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const clearTimer = useCallback((id: string) => {
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const dismiss = useCallback(
+    (id: string) => {
+      clearTimer(id);
+      setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    },
+    [clearTimer],
+  );
+
+  const scheduleDismiss = useCallback(
+    (id: string, duration: number) => {
+      clearTimer(id);
+      if (duration <= 0) return;
+      const timer = setTimeout(() => dismiss(id), duration);
+      timers.current.set(id, timer);
+    },
+    [clearTimer, dismiss],
+  );
+
+  const show = useCallback(
+    (options: ToastOptions) => {
+      const id = generateId();
+      const duration = options.duration ?? DEFAULT_DURATION;
+      const toast: ToastItem = {
+        id,
+        title: options.title,
+        description: options.description,
+        variant: options.variant ?? "info",
+        duration,
+      };
+      setToasts((prev) => [...prev, toast]);
+      scheduleDismiss(id, duration);
+      return id;
+    },
+    [scheduleDismiss],
+  );
+
+  const pause = useCallback((id: string) => clearTimer(id), [clearTimer]);
+  const resume = useCallback(
+    (id: string) => {
+      const toast = toasts.find((t) => t.id === id);
+      if (toast) scheduleDismiss(id, toast.duration);
+    },
+    [toasts, scheduleDismiss],
+  );
+
+  const success = useCallback<ToastContextValue["success"]>(
+    (description, options) => show({ ...options, description, variant: "success" }),
+    [show],
+  );
+  const error = useCallback<ToastContextValue["error"]>(
+    (description, options) => show({ ...options, description, variant: "error" }),
+    [show],
+  );
+  const info = useCallback<ToastContextValue["info"]>(
+    (description, options) => show({ ...options, description, variant: "info" }),
+    [show],
+  );
+
+  const value = useMemo<ToastContextValue>(
+    () => ({ toasts, show, dismiss, success, error, info }),
+    [toasts, show, dismiss, success, error, info],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismiss} onPause={pause} onResume={resume} />
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/src/hooks/useConfirm.ts
+++ b/frontend/src/hooks/useConfirm.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useContext } from "react";
+
+import { ConfirmContext } from "@/context/ConfirmContext";
+
+export function useConfirm() {
+  const context = useContext(ConfirmContext);
+  if (!context) {
+    throw new Error("useConfirm must be used within a ConfirmProvider");
+  }
+  return context;
+}

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useContext } from "react";
+
+import { ToastContext } from "@/context/ToastContext";
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}

--- a/frontend/src/lib/registerServiceWorker.ts
+++ b/frontend/src/lib/registerServiceWorker.ts
@@ -1,0 +1,11 @@
+export function registerServiceWorker() {
+  if (typeof window === "undefined") return;
+  if (!("serviceWorker" in navigator)) return;
+  if (process.env.NODE_ENV !== "production") return;
+
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch((error) => {
+      console.error("Service worker registration failed:", error);
+    });
+  });
+}


### PR DESCRIPTION
Toasts — context/ToastContext.tsx + hooks/useToast.ts + component/ui/toast.tsx: stacking, auto-dismiss (pauses on hover), manual dismiss, success/error/info variants with light+dark styling, role="alert"/status + aria-live for screen readers. Wired into layout.tsx.

Confirm dialog — context/ConfirmContext.tsx + hooks/useConfirm.ts + component/ui/confirm-dialog.tsx, built on Headless UI's Dialog (native focus trap, escape, outside-click). Promise-based confirm() API. Applied to: wallet disconnect (Header.tsx, dashboard-shell.tsx), delete match (creator-events/[id]/matches/page.tsx), and a new "Cancel Prediction" action I added to my-predictions/page.tsx (destructive variant on all three).

Route progress — component/RouteProgress.tsx patches history.pushState/replaceState to catch navigation start, completes on pathname/searchParams change, debounces 150ms (no flash on fast/prefetched nav — confirmed in testing), and renders a static non-animated bar under prefers-reduced-motion. Added the 23 missing loading.tsx files across the app following the existing skeleton convention.

PWA — app/manifest.ts (served at /manifest.webmanifest), icon.tsx/apple-icon.tsx plus dedicated /icon-192, /icon-512, /icon-maskable routes rendered via next/og (verified as valid PNGs), public/sw.js (network-first navigations with offline fallback, cache-first static assets, stale-while-revalidate elsewhere), app/offline/page.tsx, lib/registerServiceWorker.ts, and component/PwaManager.tsx for the beforeinstallprompt-driven install banner. Fixed the previously-broken icons/manifest metadata in layout.tsx that pointed at nonexistent files.

Verified with tsc --noEmit, a full next buildluding the new PWA routes), andheadless-browser smoke tests confirming the tith escape-to-cancel), and PWA endpoints allwork with zero console errors.



closes #1429
closes #1433
closes #1428
closes #1434