### PR TITLE
 Add `transfer_prediction`: secondary-transfer primitive for open positions

### DIFF
--- a/contracts/open-market/src/errors.rs
+++ b/contracts/open-market/src/errors.rs
@@ -183,4 +183,15 @@ pub enum InsightArenaError {
     /// The elapsed time between the window's start and now collapsed to zero
     /// seconds, which would require dividing the price integral by zero.
     TwapDivideByZero = 110,
+
+    // ── Prediction Transfer ───────────────────────────────────────────────────
+    // NOTE: `#[contracterror]` enums are hard-capped at 50 XDR cases
+    // (`ScSpecUdtErrorEnumV0::cases<50>`) — this enum is now at the limit.
+    // Reuse an existing variant rather than adding a new one.
+    /// `transfer_prediction` was called with `from == to`.
+    /// A position cannot be transferred to itself.
+    SelfTransfer = 111,
+    /// `transfer_prediction` was called with `shares <= 0`.
+    /// A transfer must move a strictly positive amount.
+    ZeroShareTransfer = 112,
 }

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -319,6 +319,18 @@ impl InsightArenaContract {
         prediction::submit_predictions_batch(&env, predictor, requests)
     }
 
+    /// Transfer part or all of a prediction position from `from` to `to` while
+    /// the market is still open. Pure accounting move — no token transfer.
+    pub fn transfer_prediction(
+        env: Env,
+        market_id: u64,
+        from: Address,
+        to: Address,
+        shares: i128,
+    ) -> Result<(), InsightArenaError> {
+        prediction::transfer_prediction(&env, market_id, from, to, shares)
+    }
+
     /// Return the stored [`Prediction`] for a given `(market_id, predictor)` pair.
     pub fn get_prediction(
         env: Env,

--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -37,6 +37,113 @@ fn bump_user(env: &Env, address: &Address) {
     config::extend_user_ttl(env, address);
 }
 
+// ── PredictorList / UserMarkets index helpers (used by transfer_prediction) ───
+
+fn add_predictor_to_list(env: &Env, market_id: u64, predictor: &Address) {
+    let list_key = DataKey::PredictorList(market_id);
+    let mut predictors: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&list_key)
+        .unwrap_or_else(|| Vec::new(env));
+    predictors.push_back(predictor.clone());
+    env.storage().persistent().set(&list_key, &predictors);
+    bump_predictor_list(env, market_id);
+}
+
+fn remove_predictor_from_list(env: &Env, market_id: u64, predictor: &Address) {
+    let list_key = DataKey::PredictorList(market_id);
+    let mut predictors: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&list_key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    let mut index: u32 = 0;
+    while index < predictors.len() {
+        if predictors.get(index) == Some(predictor.clone()) {
+            predictors.remove(index);
+            break;
+        }
+        index += 1;
+    }
+
+    env.storage().persistent().set(&list_key, &predictors);
+    bump_predictor_list(env, market_id);
+}
+
+fn add_user_market(env: &Env, user: &Address, market_id: u64) {
+    let key = DataKey::UserMarkets(user.clone());
+    let mut markets: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    if !markets.contains(market_id) {
+        markets.push_back(market_id);
+        env.storage().persistent().set(&key, &markets);
+    }
+    bump_user_markets(env, user);
+}
+
+fn remove_user_market(env: &Env, user: &Address, market_id: u64) {
+    let key = DataKey::UserMarkets(user.clone());
+    let mut markets: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    let mut index: u32 = 0;
+    while index < markets.len() {
+        if markets.get(index) == Some(market_id) {
+            markets.remove(index);
+            break;
+        }
+        index += 1;
+    }
+
+    env.storage().persistent().set(&key, &markets);
+    bump_user_markets(env, user);
+}
+
+fn decrease_user_stake(env: &Env, user: &Address, amount: i128) -> Result<(), InsightArenaError> {
+    let user_key = DataKey::User(user.clone());
+    let mut profile: UserProfile = env
+        .storage()
+        .persistent()
+        .get(&user_key)
+        .unwrap_or_else(|| UserProfile::new(user.clone(), env.ledger().timestamp()));
+
+    profile.total_staked = profile
+        .total_staked
+        .checked_sub(amount)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    env.storage().persistent().set(&user_key, &profile);
+    bump_user(env, user);
+    Ok(())
+}
+
+fn increase_user_stake(env: &Env, user: &Address, amount: i128) -> Result<(), InsightArenaError> {
+    let user_key = DataKey::User(user.clone());
+    let mut profile: UserProfile = env
+        .storage()
+        .persistent()
+        .get(&user_key)
+        .unwrap_or_else(|| UserProfile::new(user.clone(), env.ledger().timestamp()));
+
+    profile.total_staked = profile
+        .total_staked
+        .checked_add(amount)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    env.storage().persistent().set(&user_key, &profile);
+    bump_user(env, user);
+    season::track_user_profile(env, user);
+    Ok(())
+}
+
 // ── Event emission ────────────────────────────────────────────────────────────
 
 fn emit_prediction_submitted(
@@ -69,6 +176,19 @@ fn emit_payout_claimed(
             protocol_fee,
             creator_fee,
         ),
+    );
+}
+
+fn emit_prediction_transferred(
+    env: &Env,
+    market_id: u64,
+    from: &Address,
+    to: &Address,
+    shares: i128,
+) {
+    env.events().publish(
+        (symbol_short!("pred"), symbol_short!("transfr")),
+        (market_id, from.clone(), to.clone(), shares),
     );
 }
 
@@ -375,6 +495,176 @@ fn do_submit_prediction(
 
     // ── Emit PredictionSubmitted event ────────────────────────────────────────
     emit_prediction_submitted(env, market_id, &predictor, &chosen_outcome, stake_amount);
+
+    Ok(())
+}
+
+/// Transfer part or all of a prediction position from `from` to `to` while the
+/// market is still open — a secondary-transfer primitive letting a predictor
+/// exit or offload risk before resolution.
+///
+/// This is a pure accounting move: the staked XLM never leaves contract
+/// escrow, so no token transfer occurs. Only the `Prediction` record(s) and
+/// the `PredictorList`/`UserMarkets` indexes change ownership.
+///
+/// Validation order:
+/// 1. Platform not paused
+/// 2. `from` authorisation via `require_auth()`
+/// 3. `from != to` (else `SelfTransfer`)
+/// 4. `shares > 0` (else `ZeroShareTransfer`)
+/// 5. Market exists (else `MarketNotFound`)
+/// 6. Market has not been resolved (else `MarketAlreadyResolved`), cancelled
+///    (else `MarketAlreadyCancelled`), or passed `end_time` — i.e. entered its
+///    resolution window (else `MarketExpired`)
+/// 7. `from` holds a prediction on this market (else `PredictionNotFound`)
+/// 8. `shares <= from`'s current `stake_amount` (else `InvalidInput`)
+/// 9. If `to` already holds a prediction on this market, its `chosen_outcome`
+///    must match `from`'s, or the two positions could not be merged into one
+///    consistent record (else `AlreadyPredicted`)
+///
+/// On success:
+/// - `from`'s position shrinks by `shares`. If that leaves zero, the
+///   `Prediction` record is deleted and `from` is dropped from
+///   `PredictorList(market_id)` and `UserMarkets(from)`.
+/// - `to` gains `shares`, merged into an existing same-outcome position or
+///   written as a new `Prediction` record (adding `to` to `PredictorList` and
+///   `UserMarkets` in the latter case).
+/// - `market.participant_count` is adjusted for any net change in unique
+///   holders; `market.total_pool` is left untouched, since no stake enters or
+///   leaves escrow — only its owner changes.
+/// - Both parties' `UserProfile.total_staked` move by exactly `shares` in
+///   opposite directions, so the sum staked across all users is conserved.
+/// - A `PredictionTransferred` event is emitted.
+pub fn transfer_prediction(
+    env: &Env,
+    market_id: u64,
+    from: Address,
+    to: Address,
+    shares: i128,
+) -> Result<(), InsightArenaError> {
+    // ── Guard 1: platform not paused ─────────────────────────────────────────
+    config::ensure_not_paused(env)?;
+
+    // ── Guard 2: sender authorisation ────────────────────────────────────────
+    from.require_auth();
+
+    // ── Guard 3: no self-transfer ─────────────────────────────────────────────
+    if from == to {
+        return Err(InsightArenaError::SelfTransfer);
+    }
+
+    // ── Guard 4: shares must be strictly positive ─────────────────────────────
+    if shares <= 0 {
+        return Err(InsightArenaError::ZeroShareTransfer);
+    }
+
+    // ── Guard 5: market must exist ────────────────────────────────────────────
+    let mut market: Market = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Market(market_id))
+        .ok_or(InsightArenaError::MarketNotFound)?;
+
+    // ── Guard 6: market must still be open (not resolved/cancelled/expired) ───
+    if market.is_resolved {
+        return Err(InsightArenaError::MarketAlreadyResolved);
+    }
+    if market.is_cancelled {
+        return Err(InsightArenaError::MarketAlreadyCancelled);
+    }
+    let now = env.ledger().timestamp();
+    if now >= market.end_time {
+        return Err(InsightArenaError::MarketExpired);
+    }
+
+    // ── Guard 7: sender must hold a position on this market ──────────────────
+    let from_key = DataKey::Prediction(market_id, from.clone());
+    let mut from_prediction: Prediction = env
+        .storage()
+        .persistent()
+        .get(&from_key)
+        .ok_or(InsightArenaError::PredictionNotFound)?;
+
+    // ── Guard 8: cannot transfer more than the sender holds ───────────────────
+    if shares > from_prediction.stake_amount {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    // ── Guard 9: recipient's existing position (if any) must be compatible ────
+    let to_key = DataKey::Prediction(market_id, to.clone());
+    let existing_to: Option<Prediction> = env.storage().persistent().get(&to_key);
+    if let Some(existing) = &existing_to {
+        if existing.chosen_outcome != from_prediction.chosen_outcome {
+            return Err(InsightArenaError::AlreadyPredicted);
+        }
+    }
+    let to_is_new_participant = existing_to.is_none();
+
+    let remaining = from_prediction
+        .stake_amount
+        .checked_sub(shares)
+        .ok_or(InsightArenaError::Overflow)?;
+    let from_fully_exited = remaining == 0;
+
+    // ── Shrink or delete the sender's position ────────────────────────────────
+    if from_fully_exited {
+        env.storage().persistent().remove(&from_key);
+        remove_predictor_from_list(env, market_id, &from);
+        remove_user_market(env, &from, market_id);
+    } else {
+        from_prediction.stake_amount = remaining;
+        env.storage().persistent().set(&from_key, &from_prediction);
+        bump_prediction(env, market_id, &from);
+    }
+
+    // ── Grow or create the recipient's position ───────────────────────────────
+    match existing_to {
+        Some(mut to_prediction) => {
+            to_prediction.stake_amount = to_prediction
+                .stake_amount
+                .checked_add(shares)
+                .ok_or(InsightArenaError::Overflow)?;
+            env.storage().persistent().set(&to_key, &to_prediction);
+            bump_prediction(env, market_id, &to);
+        }
+        None => {
+            let to_prediction = Prediction::new(
+                market_id,
+                to.clone(),
+                from_prediction.chosen_outcome.clone(),
+                shares,
+                now,
+            );
+            env.storage().persistent().set(&to_key, &to_prediction);
+            bump_prediction(env, market_id, &to);
+            add_predictor_to_list(env, market_id, &to);
+            add_user_market(env, &to, market_id);
+        }
+    }
+
+    // ── Adjust market.participant_count; total_pool is unchanged ─────────────
+    if to_is_new_participant {
+        market.participant_count = market
+            .participant_count
+            .checked_add(1)
+            .ok_or(InsightArenaError::Overflow)?;
+    }
+    if from_fully_exited {
+        market.participant_count = market
+            .participant_count
+            .checked_sub(1)
+            .ok_or(InsightArenaError::Overflow)?;
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::Market(market_id), &market);
+    bump_market(env, market_id);
+
+    // ── Move the staked amount between the two UserProfiles ──────────────────
+    decrease_user_stake(env, &from, shares)?;
+    increase_user_stake(env, &to, shares)?;
+
+    emit_prediction_transferred(env, market_id, &from, &to, shares);
 
     Ok(())
 }

--- a/contracts/open-market/tests/transfer_prediction_tests.rs
+++ b/contracts/open-market/tests/transfer_prediction_tests.rs
@@ -1,0 +1,422 @@
+//! Tests for `transfer_prediction`: the secondary-transfer primitive that lets
+//! a predictor move part or all of an open position to another address before
+//! a market enters its resolution window.
+//!
+//! Acceptance criteria covered:
+//! 1. Full transfer leaves `from` with zero position and `to` with exact
+//!    shares; totals (market.total_pool, sum of stakes) are conserved.
+//! 2. Partial transfer produces two consistent positions summing to the
+//!    original stake.
+//! 3. Post-resolution, self-transfers, and zero-share transfers return the
+//!    correct typed errors.
+//! 4. `PredictorList`/`UserMarkets` indexes (via `list_market_predictions`,
+//!    `has_predicted`, `list_user_markets`) reflect the new ownership.
+
+use insightarena_contract::market::CreateMarketParams;
+use insightarena_contract::{InsightArenaContract, InsightArenaContractClient, InsightArenaError};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+fn register_token(env: &Env) -> Address {
+    let token_admin = Address::generate(env);
+    env.register_stellar_asset_contract_v2(token_admin)
+        .address()
+}
+
+/// Deploy and initialise the contract; return client + xlm_token address + admin + oracle.
+fn deploy(env: &Env) -> (InsightArenaContractClient<'_>, Address, Address, Address) {
+    let id = env.register(InsightArenaContract, ());
+    let client = InsightArenaContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+    let xlm_token = register_token(env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle, &200_u32, &xlm_token);
+    (client, xlm_token, admin, oracle)
+}
+
+fn default_params(env: &Env) -> CreateMarketParams {
+    let now = env.ledger().timestamp();
+    CreateMarketParams {
+        title: String::from_str(env, "Will it rain?"),
+        description: String::from_str(env, "Daily weather market"),
+        category: Symbol::new(env, "Sports"),
+        outcomes: vec![env, symbol_short!("yes"), symbol_short!("no")],
+        end_time: now + 1000,
+        resolution_time: now + 2000,
+        dispute_window: 86_400,
+        creator_fee_bps: 100,
+        min_stake: 10_000_000,
+        max_stake: 100_000_000,
+        is_public: true,
+    }
+}
+
+fn fund(env: &Env, xlm_token: &Address, recipient: &Address, amount: i128) {
+    StellarAssetClient::new(env, xlm_token).mint(recipient, &amount);
+}
+
+// ── Full transfer ────────────────────────────────────────────────────────
+
+#[test]
+fn full_transfer_zeroes_sender_and_credits_recipient_exactly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    let market_before = client.get_market(&market_id);
+
+    client.transfer_prediction(&market_id, &from, &to, &stake);
+
+    // `from` has no position left.
+    assert!(!client.has_predicted(&market_id, &from));
+    // `to` holds exactly the transferred amount.
+    assert!(client.has_predicted(&market_id, &to));
+    let to_prediction = client.get_prediction(&market_id, &to);
+    assert_eq!(to_prediction.stake_amount, stake);
+    assert_eq!(to_prediction.chosen_outcome, symbol_short!("yes"));
+
+    // Total pool is conserved — a transfer never mints or burns stake.
+    let market_after = client.get_market(&market_id);
+    assert_eq!(market_after.total_pool, market_before.total_pool);
+    assert_eq!(market_after.participant_count, market_before.participant_count);
+}
+
+#[test]
+fn full_transfer_removes_from_predictor_indexes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    client.transfer_prediction(&market_id, &from, &to, &stake);
+
+    // PredictorList reflects the new owner only.
+    let predictions = client.list_market_predictions(&market_id);
+    assert_eq!(predictions.len(), 1);
+    assert_eq!(predictions.get(0).unwrap().predictor, to);
+
+    // UserMarkets reverse index moves with the position.
+    let from_markets = client.list_user_markets(&from);
+    assert!(!from_markets.contains(market_id));
+    let to_markets = client.list_user_markets(&to);
+    assert!(to_markets.contains(market_id));
+}
+
+// ── Partial transfer ─────────────────────────────────────────────────────
+
+#[test]
+fn partial_transfer_produces_two_positions_summing_to_original() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+    let shares = 8_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    client.transfer_prediction(&market_id, &from, &to, &shares);
+
+    let from_prediction = client.get_prediction(&market_id, &from);
+    let to_prediction = client.get_prediction(&market_id, &to);
+
+    assert_eq!(from_prediction.stake_amount, stake - shares);
+    assert_eq!(to_prediction.stake_amount, shares);
+    assert_eq!(
+        from_prediction.stake_amount + to_prediction.stake_amount,
+        stake
+    );
+
+    // Both remain distinct predictor-list entries.
+    let predictions = client.list_market_predictions(&market_id);
+    assert_eq!(predictions.len(), 2);
+
+    let market = client.get_market(&market_id);
+    assert_eq!(market.total_pool, stake);
+    assert_eq!(market.participant_count, 2);
+}
+
+#[test]
+fn partial_transfer_merges_into_existing_same_outcome_position() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let from_stake = 20_000_000_i128;
+    let to_stake = 15_000_000_i128;
+    let shares = 5_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, from_stake);
+    fund(&env, &xlm_token, &to, to_stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &from_stake);
+    client.submit_prediction(&to, &market_id, &symbol_short!("yes"), &to_stake);
+
+    let market_before = client.get_market(&market_id);
+
+    client.transfer_prediction(&market_id, &from, &to, &shares);
+
+    let from_prediction = client.get_prediction(&market_id, &from);
+    let to_prediction = client.get_prediction(&market_id, &to);
+    assert_eq!(from_prediction.stake_amount, from_stake - shares);
+    assert_eq!(to_prediction.stake_amount, to_stake + shares);
+
+    // No new participant was created — count and pool stay put.
+    let market_after = client.get_market(&market_id);
+    assert_eq!(market_after.participant_count, market_before.participant_count);
+    assert_eq!(market_after.total_pool, market_before.total_pool);
+}
+
+#[test]
+fn transfer_to_recipient_with_conflicting_outcome_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    fund(&env, &xlm_token, &to, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+    client.submit_prediction(&to, &market_id, &symbol_short!("no"), &stake);
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &5_000_000_i128);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::AlreadyPredicted))
+    ));
+}
+
+// ── Typed error cases ────────────────────────────────────────────────────
+
+#[test]
+fn transfer_after_resolution_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, oracle) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let params = default_params(&env);
+    let market_id = client.create_market(&Address::generate(&env), &params);
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.resolution_time);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &stake);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyResolved))
+    ));
+}
+
+#[test]
+fn transfer_after_end_time_rejected_even_if_unresolved() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let params = default_params(&env);
+    let market_id = client.create_market(&Address::generate(&env), &params);
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    // Market has closed for new predictions but the oracle has not resolved
+    // it yet — it has still entered its resolution window.
+    env.ledger()
+        .with_mut(|li| li.timestamp = params.end_time);
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &stake);
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketExpired))));
+}
+
+#[test]
+fn transfer_on_cancelled_market_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, admin, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    client.cancel_market(&admin, &market_id);
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &stake);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketAlreadyCancelled))
+    ));
+}
+
+#[test]
+fn self_transfer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let predictor = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    let result =
+        client.try_transfer_prediction(&market_id, &predictor, &predictor, &stake);
+    assert!(matches!(result, Err(Ok(InsightArenaError::SelfTransfer))));
+}
+
+#[test]
+fn zero_share_transfer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &0_i128);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::ZeroShareTransfer))
+    ));
+}
+
+#[test]
+fn negative_share_transfer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &(-1_i128));
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::ZeroShareTransfer))
+    ));
+}
+
+#[test]
+fn transfer_exceeding_position_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &from, stake);
+    client.submit_prediction(&from, &market_id, &symbol_short!("yes"), &stake);
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &(stake + 1));
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn transfer_with_no_existing_position_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+
+    let result = client.try_transfer_prediction(&market_id, &from, &to, &1_000_000_i128);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::PredictionNotFound))
+    ));
+}
+
+#[test]
+fn transfer_on_nonexistent_market_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _xlm_token, _, _) = deploy(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    let result = client.try_transfer_prediction(&999_u64, &from, &to, &1_000_000_i128);
+    assert!(matches!(result, Err(Ok(InsightArenaError::MarketNotFound))));
+}
+
+// ── has_predicted / list_market_predictions consistency ─────────────────
+
+#[test]
+fn indexes_stay_accurate_across_a_chain_of_transfers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, xlm_token, _, _) = deploy(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    let stake = 30_000_000_i128;
+
+    let market_id = client.create_market(&Address::generate(&env), &default_params(&env));
+    fund(&env, &xlm_token, &alice, stake);
+    client.submit_prediction(&alice, &market_id, &symbol_short!("yes"), &stake);
+
+    // Alice -> Bob (partial), then Bob -> Carol (full, everything Bob holds).
+    client.transfer_prediction(&market_id, &alice, &bob, &10_000_000_i128);
+    let bob_stake = client.get_prediction(&market_id, &bob).stake_amount;
+    client.transfer_prediction(&market_id, &bob, &carol, &bob_stake);
+
+    assert!(client.has_predicted(&market_id, &alice));
+    assert!(!client.has_predicted(&market_id, &bob));
+    assert!(client.has_predicted(&market_id, &carol));
+
+    let predictions = client.list_market_predictions(&market_id);
+    assert_eq!(predictions.len(), 2);
+
+    let total: i128 = predictions.iter().map(|p| p.stake_amount).sum();
+    assert_eq!(total, stake);
+
+    let market = client.get_market(&market_id);
+    assert_eq!(market.total_pool, stake);
+    assert_eq!(market.participant_count, 2);
+}


### PR DESCRIPTION

## Summary

Predictors are currently locked into a position until a market resolves —
there's no way to exit or offload risk early. This adds
`transfer_prediction(market_id, from, to, shares)` to the `open-market`
contract, letting a predictor move part or all of an open position to another
address while the market is still accepting predictions.

- **Pure accounting move.** The staked XLM never leaves contract escrow, so
  no token transfer occurs — only the `Prediction` record(s) and the
  `PredictorList`/`UserMarkets` indexes change ownership. `market.total_pool`
  is left untouched by construction, since nothing enters or leaves escrow.
- **Full or partial transfers.** A full transfer (`shares == from`'s entire
  stake) deletes `from`'s position and drops them from the predictor indexes.
  A partial transfer shrinks `from`'s stake and either merges into an
  existing same-outcome position for `to` or creates a new one.
- **Closed to resolution/settlement.** Once a market is resolved, cancelled,
  or has passed `end_time` (the same cutoff `submit_prediction` uses),
  transfers are rejected — mirrors the existing "market is still open" gate
  used elsewhere in the contract.
- **Guards against corruption, not just misuse.** Self-transfers and
  non-positive `shares` are rejected with dedicated typed errors. Transferring
  more than `from` holds, and transferring into a recipient who already holds
  a *different*-outcome position on the same market (which can't be merged
  into one consistent record), are also rejected.

## Changes

- `contracts/open-market/src/prediction.rs` — `transfer_prediction` plus
  index helpers (`add`/`remove_predictor_from_list`,
  `add`/`remove_user_market`) and stake-accounting helpers
  (`increase`/`decrease_user_stake`) reused by the transfer path.
- `contracts/open-market/src/errors.rs` — added `SelfTransfer` and
  `ZeroShareTransfer`.
  - Note: `#[contracterror]` enums are hard-capped at 50 XDR cases
    (`ScSpecUdtErrorEnumV0::cases<50>`); this enum was already at 48, so the
    "transfer exceeds sender's balance" case reuses the existing
    `InvalidInput` rather than adding a third variant.
- `contracts/open-market/src/lib.rs` — exposed `transfer_prediction` as a
  contract entry point.
- `contracts/open-market/tests/transfer_prediction_tests.rs` (new) — 15
  integration tests.

## Test plan

- [x] `cargo build` — compiles clean (also caught the 50-variant
      `#[contracterror]` cap before it could land as a build-breaking panic).
- [x] `cargo test` — full suite green (516 tests, 0 failures), including the
      15 new tests:
  - Full transfer zeroes `from` and credits `to` exactly; `total_pool` and
    `participant_count` conserved.
  - Full transfer removes `from` from `PredictorList`/`UserMarkets`.
  - Partial transfer produces two positions summing to the original stake.
  - Partial transfer merges into an existing same-outcome position without
    creating a phantom participant.
  - Transfer to a recipient with a conflicting outcome is rejected
    (`AlreadyPredicted`).
  - Transfer after resolution (`MarketAlreadyResolved`), after `end_time`
    but before resolution (`MarketExpired`), and on a cancelled market
    (`MarketAlreadyCancelled`).
  - Self-transfer (`SelfTransfer`), zero/negative shares
    (`ZeroShareTransfer`), shares exceeding the sender's position
    (`InvalidInput`).
  - Transfer with no existing position (`PredictionNotFound`) / nonexistent
    market (`MarketNotFound`).
  - Multi-hop transfer chain (A → B partial, B → C full): `has_predicted`,
    `list_market_predictions`, and `list_user_markets` all stay accurate,
    and stake sums are conserved end to end.
- [x] `cargo clippy --all-targets` — clean on every file touched (only
      pre-existing warnings in unrelated test files).



closes #1310