### PR TITLE
feat: live odds hook, transaction tracker, onboarding tour, social share

### DIFF
--- a/frontend/src/component/ui/ShareButton.tsx
+++ b/frontend/src/component/ui/ShareButton.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Check, Copy, Share2, Twitter } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface ShareButtonProps {
+  /** Page title used in the share text. */
+  title: string;
+  /** Short description or question for the market. */
+  description: string;
+  /** Canonical URL for this market. Defaults to window.location.href. */
+  url?: string;
+  className?: string;
+}
+
+function buildTwitterUrl(text: string, url: string): string {
+  const params = new URLSearchParams({ text: `${text} ${url}` });
+  return `https://twitter.com/intent/tweet?${params.toString()}`;
+}
+
+/**
+ * Share buttons for a market page.
+ *
+ * Provides: Twitter/X intent link, native Web Share API (mobile), and a
+ * copy-link fallback. Designed to be dropped anywhere on a market detail page.
+ */
+export function ShareButton({ title, description, url, className }: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const resolvedUrl = url ?? (typeof window !== "undefined" ? window.location.href : "");
+  const shareText = `${title} — ${description}`;
+
+  const handleNativeShare = useCallback(async () => {
+    if (!navigator.share) return;
+    try {
+      await navigator.share({ title, text: description, url: resolvedUrl });
+    } catch {
+      // user cancelled or API unavailable — fall through
+    }
+  }, [title, description, resolvedUrl]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(resolvedUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable
+    }
+  }, [resolvedUrl]);
+
+  const hasNativeShare = typeof navigator !== "undefined" && "share" in navigator;
+
+  return (
+    <div className={cn("flex items-center gap-2", className)} role="group" aria-label="Share market">
+      {/* Twitter / X */}
+      <a
+        href={buildTwitterUrl(shareText, resolvedUrl)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="Share on X / Twitter"
+      >
+        <Twitter className="h-3.5 w-3.5" />
+        <span>Share</span>
+      </a>
+
+      {/* Native share (mobile) */}
+      {hasNativeShare && (
+        <button
+          type="button"
+          onClick={handleNativeShare}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Share via native share sheet"
+        >
+          <Share2 className="h-3.5 w-3.5" />
+          <span>More</span>
+        </button>
+      )}
+
+      {/* Copy link */}
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label={copied ? "Link copied" : "Copy link to market"}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-emerald-500" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+        <span>{copied ? "Copied!" : "Copy link"}</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useLiveOdds.ts
+++ b/frontend/src/hooks/useLiveOdds.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { env } from "@/lib/env";
+
+export type ConnectionStatus = "connecting" | "connected" | "disconnected" | "polling";
+
+export interface OddsUpdate {
+  marketId: string;
+  yesOdds: number;
+  noOdds: number;
+  updatedAt: number;
+}
+
+export interface UseLiveOddsResult {
+  odds: OddsUpdate | null;
+  status: ConnectionStatus;
+  lastUpdatedAt: number | null;
+}
+
+const BASE_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 30_000;
+const POLL_INTERVAL_MS = 10_000;
+
+function buildWsUrl(marketId: string): string {
+  const base = env.API_URL.replace(/^http/, "ws");
+  const url = new URL(`/ws/odds/${encodeURIComponent(marketId)}`, base);
+  return url.toString();
+}
+
+async function fetchOddsHttp(marketId: string): Promise<OddsUpdate | null> {
+  try {
+    const res = await fetch(`${env.API_URL}/markets/${encodeURIComponent(marketId)}/odds`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      marketId,
+      yesOdds: data.yes_odds ?? data.yesOdds,
+      noOdds: data.no_odds ?? data.noOdds,
+      updatedAt: data.updated_at ?? Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subscribes to live odds for a market via WebSocket.
+ *
+ * Reconnects with exponential backoff on drop. Falls back to HTTP polling when
+ * the socket is unavailable. Cleans up on unmount.
+ *
+ * @param marketId - The market to subscribe to.
+ */
+export function useLiveOdds(marketId: string | null | undefined): UseLiveOddsResult {
+  const [odds, setOdds] = useState<OddsUpdate | null>(null);
+  const [status, setStatus] = useState<ConnectionStatus>("connecting");
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  const clearTimers = useCallback(() => {
+    if (pollTimerRef.current) { clearTimeout(pollTimerRef.current); pollTimerRef.current = null; }
+    if (reconnectTimerRef.current) { clearTimeout(reconnectTimerRef.current); reconnectTimerRef.current = null; }
+  }, []);
+
+  const closeSocket = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback((id: string) => {
+    if (!mountedRef.current) return;
+    setStatus("polling");
+
+    const poll = async () => {
+      if (!mountedRef.current) return;
+      const result = await fetchOddsHttp(id);
+      if (result && mountedRef.current) {
+        setOdds(result);
+        setLastUpdatedAt(result.updatedAt);
+      }
+      if (mountedRef.current) {
+        pollTimerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    };
+    poll();
+  }, []);
+
+  const connect = useCallback((id: string) => {
+    if (!mountedRef.current) return;
+    closeSocket();
+    clearTimers();
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(buildWsUrl(id));
+    } catch {
+      startPolling(id);
+      return;
+    }
+
+    wsRef.current = ws;
+    setStatus("connecting");
+
+    ws.onopen = () => {
+      if (!mountedRef.current) { ws.close(); return; }
+      attemptRef.current = 0;
+      setStatus("connected");
+    };
+
+    ws.onmessage = (event) => {
+      if (!mountedRef.current) return;
+      try {
+        const data: OddsUpdate = JSON.parse(event.data as string);
+        setOdds(data);
+        setLastUpdatedAt(data.updatedAt ?? Date.now());
+      } catch {
+        // ignore malformed frames
+      }
+    };
+
+    ws.onerror = () => {
+      // onclose fires after onerror — let it handle reconnect
+    };
+
+    ws.onclose = () => {
+      if (!mountedRef.current) return;
+      wsRef.current = null;
+      attemptRef.current += 1;
+      const backoff = Math.min(BASE_BACKOFF_MS * 2 ** (attemptRef.current - 1), MAX_BACKOFF_MS);
+
+      if (attemptRef.current > 5) {
+        // Socket persistently unavailable — switch to polling
+        startPolling(id);
+        return;
+      }
+
+      setStatus("disconnected");
+      reconnectTimerRef.current = setTimeout(() => connect(id), backoff);
+    };
+  }, [closeSocket, clearTimers, startPolling]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    if (!marketId) {
+      setOdds(null);
+      setStatus("disconnected");
+      return;
+    }
+
+    attemptRef.current = 0;
+    connect(marketId);
+
+    return () => {
+      mountedRef.current = false;
+      clearTimers();
+      closeSocket();
+    };
+  }, [marketId, connect, clearTimers, closeSocket]);
+
+  return { odds, status, lastUpdatedAt };
+}

--- a/frontend/src/hooks/useOnboardingTour.ts
+++ b/frontend/src/hooks/useOnboardingTour.ts
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "insightarena.onboarding.v1";
+
+export interface TourStep {
+  id: string;
+  /** CSS selector or element id of the element to highlight. */
+  target: string;
+  title: string;
+  description: string;
+}
+
+export const ONBOARDING_STEPS: TourStep[] = [
+  {
+    id: "connect-wallet",
+    target: "[data-tour='connect-wallet']",
+    title: "Connect your wallet",
+    description:
+      "Start by connecting your Stellar wallet via Freighter. This lets you place predictions and earn rewards.",
+  },
+  {
+    id: "explore-markets",
+    target: "[data-tour='markets-nav']",
+    title: "Explore markets",
+    description:
+      "Browse active prediction markets across sports, crypto, and current events. Each market closes when the event resolves.",
+  },
+  {
+    id: "place-prediction",
+    target: "[data-tour='place-prediction']",
+    title: "Place a prediction",
+    description:
+      "Choose YES or NO, enter an amount, and submit. Your prediction is recorded on-chain — no middleman.",
+  },
+  {
+    id: "track-rewards",
+    target: "[data-tour='rewards-nav']",
+    title: "Track your rewards",
+    description:
+      "Correct predictions earn you rewards. Head to the Rewards page to claim what you've won.",
+  },
+];
+
+interface TourState {
+  completed: boolean;
+  dismissed: boolean;
+}
+
+function readState(): TourState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { completed: false, dismissed: false };
+    return JSON.parse(raw) as TourState;
+  } catch {
+    return { completed: false, dismissed: false };
+  }
+}
+
+function writeState(state: TourState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // storage unavailable — silently ignore
+  }
+}
+
+export interface UseOnboardingTourResult {
+  isActive: boolean;
+  currentStepIndex: number;
+  currentStep: TourStep | null;
+  totalSteps: number;
+  start: () => void;
+  next: () => void;
+  prev: () => void;
+  skip: () => void;
+  complete: () => void;
+  canGoBack: boolean;
+  canGoNext: boolean;
+  isLastStep: boolean;
+}
+
+/**
+ * Manages the new-user onboarding tour.
+ *
+ * Automatically starts for first-time visitors. Persists completion/dismissal
+ * to localStorage so the tour never reappears unless re-launched via `start()`.
+ * Keyboard-accessible: consumers should wire `next` to Enter/ArrowRight and
+ * `prev` to ArrowLeft, and `skip` to Escape.
+ */
+export function useOnboardingTour(): UseOnboardingTourResult {
+  const [isActive, setIsActive] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  // Auto-start for new users after hydration
+  useEffect(() => {
+    const state = readState();
+    if (!state.completed && !state.dismissed) {
+      setIsActive(true);
+    }
+  }, []);
+
+  const start = useCallback(() => {
+    setStepIndex(0);
+    setIsActive(true);
+  }, []);
+
+  const skip = useCallback(() => {
+    setIsActive(false);
+    writeState({ completed: false, dismissed: true });
+  }, []);
+
+  const complete = useCallback(() => {
+    setIsActive(false);
+    writeState({ completed: true, dismissed: false });
+  }, []);
+
+  const next = useCallback(() => {
+    setStepIndex((i) => {
+      const next = i + 1;
+      if (next >= ONBOARDING_STEPS.length) {
+        complete();
+        return i;
+      }
+      return next;
+    });
+  }, [complete]);
+
+  const prev = useCallback(() => {
+    setStepIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const currentStep = isActive ? (ONBOARDING_STEPS[stepIndex] ?? null) : null;
+
+  return {
+    isActive,
+    currentStepIndex: stepIndex,
+    currentStep,
+    totalSteps: ONBOARDING_STEPS.length,
+    start,
+    next,
+    prev,
+    skip,
+    complete,
+    canGoBack: stepIndex > 0,
+    canGoNext: stepIndex < ONBOARDING_STEPS.length - 1,
+    isLastStep: stepIndex === ONBOARDING_STEPS.length - 1,
+  };
+}

--- a/frontend/src/hooks/useTransactionTracker.ts
+++ b/frontend/src/hooks/useTransactionTracker.ts
@@ -1,0 +1,148 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export type TxStatus = "pending" | "confirmed" | "failed";
+
+export interface TrackedTransaction {
+  id: string;
+  hash: string;
+  description: string;
+  status: TxStatus;
+  error?: string;
+  explorerUrl: string;
+  submittedAt: number;
+  resolvedAt?: number;
+}
+
+const STELLAR_EXPERT_BASE = "https://stellar.expert/explorer/testnet/tx";
+const AUTO_DISMISS_MS = 6_000;
+const POLL_INTERVAL_MS = 3_000;
+const MAX_POLLS = 20;
+
+function buildExplorerUrl(hash: string): string {
+  return `${STELLAR_EXPERT_BASE}/${hash}`;
+}
+
+let idCounter = 0;
+function generateId(): string {
+  idCounter += 1;
+  return `tx-${Date.now()}-${idCounter}`;
+}
+
+export interface UseTransactionTrackerResult {
+  transactions: TrackedTransaction[];
+  trackTransaction: (
+    hash: string,
+    description: string,
+    pollFn: (hash: string) => Promise<"pending" | "confirmed" | "failed">,
+  ) => string;
+  dismiss: (id: string) => void;
+  dismissAll: () => void;
+}
+
+/**
+ * Tracks on-chain transactions through pending → confirmed/failed states.
+ *
+ * Polls `pollFn` at a fixed interval until a terminal state is reached or the
+ * poll limit is hit. Confirmed transactions auto-dismiss after a delay.
+ */
+export function useTransactionTracker(): UseTransactionTrackerResult {
+  const [transactions, setTransactions] = useState<TrackedTransaction[]>([]);
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const clearTimer = useCallback((id: string) => {
+    const t = timers.current.get(id);
+    if (t) { clearTimeout(t); timers.current.delete(id); }
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    clearTimer(id);
+    setTransactions((prev) => prev.filter((tx) => tx.id !== id));
+  }, [clearTimer]);
+
+  const dismissAll = useCallback(() => {
+    timers.current.forEach((_, id) => clearTimer(id));
+    setTransactions([]);
+  }, [clearTimer]);
+
+  const scheduleAutoDismiss = useCallback((id: string) => {
+    clearTimer(id);
+    const t = setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
+    timers.current.set(id, t);
+  }, [clearTimer, dismiss]);
+
+  const updateTx = useCallback((id: string, patch: Partial<TrackedTransaction>) => {
+    setTransactions((prev) =>
+      prev.map((tx) => (tx.id === id ? { ...tx, ...patch } : tx)),
+    );
+  }, []);
+
+  const trackTransaction = useCallback(
+    (
+      hash: string,
+      description: string,
+      pollFn: (hash: string) => Promise<TxStatus>,
+    ): string => {
+      const id = generateId();
+      const tx: TrackedTransaction = {
+        id,
+        hash,
+        description,
+        status: "pending",
+        explorerUrl: buildExplorerUrl(hash),
+        submittedAt: Date.now(),
+      };
+
+      setTransactions((prev) => [tx, ...prev]);
+
+      let polls = 0;
+      const poll = async () => {
+        try {
+          const result = await pollFn(hash);
+          polls += 1;
+
+          if (result === "confirmed") {
+            updateTx(id, { status: "confirmed", resolvedAt: Date.now() });
+            scheduleAutoDismiss(id);
+            return;
+          }
+
+          if (result === "failed") {
+            updateTx(id, {
+              status: "failed",
+              error: "Transaction failed on-chain. Check the explorer for details.",
+              resolvedAt: Date.now(),
+            });
+            return;
+          }
+
+          if (polls < MAX_POLLS) {
+            const t = setTimeout(poll, POLL_INTERVAL_MS);
+            timers.current.set(id, t);
+          } else {
+            updateTx(id, {
+              status: "failed",
+              error: "Timed out waiting for confirmation. The transaction may still land — check the explorer.",
+              resolvedAt: Date.now(),
+            });
+          }
+        } catch {
+          updateTx(id, {
+            status: "failed",
+            error: "Could not confirm transaction status. Check the explorer.",
+            resolvedAt: Date.now(),
+          });
+        }
+      };
+
+      const t = setTimeout(poll, POLL_INTERVAL_MS);
+      timers.current.set(id, t);
+
+      return id;
+    },
+    [updateTx, scheduleAutoDismiss],
+  );
+
+  return { transactions, trackTransaction, dismiss, dismissAll };
+}


### PR DESCRIPTION
Closes #1408
Closes #1411
Closes #1414
Closes #1415

## Summary

### #1408 — `useLiveOdds` hook (`frontend/src/hooks/useLiveOdds.ts`)

WebSocket subscription for real-time odds with full lifecycle management:
- Connects to `ws://.../ws/odds/:marketId` derived from `NEXT_PUBLIC_API_URL`
- Reconnects with exponential backoff: 500 ms → 1 s → 2 s → … → 30 s cap
- After 5 failed attempts, switches to HTTP polling (`/markets/:id/odds`) every 10 s
- Exposes `{ odds, status, lastUpdatedAt }` — `status` is `"connecting" | "connected" | "disconnected" | "polling"`
- Full cleanup on unmount (socket + all timers)

### #1411 — `useTransactionTracker` hook (`frontend/src/hooks/useTransactionTracker.ts`)

Tracks submitted on-chain transactions through pending → confirmed/failed:
- Caller supplies a `pollFn(hash) => Promise<"pending" | "confirmed" | "failed">` (wraps their preferred RPC call)
- Polls every 3 s, times out after 20 polls with an actionable error message
- Builds a `stellar.expert` explorer URL per hash
- Confirmed transactions auto-dismiss after 6 s
- Exposes `{ transactions, trackTransaction, dismiss, dismissAll }`

### #1414 — `useOnboardingTour` hook (`frontend/src/hooks/useOnboardingTour.ts`)

Four-step tour for first-time users:
1. Connect wallet
2. Explore markets
3. Place a prediction
4. Track rewards

- Reads/writes `insightarena.onboarding.v1` in localStorage — never re-shows after completion or dismissal
- `start()` re-launches on demand (wire to settings/help)
- Exposes `next / prev / skip / complete` for full keyboard navigation (consumers wire Enter, Arrow, Escape)
- Steps use `data-tour` attribute selectors so the UI can highlight the correct element

### #1415 — `ShareButton` component (`frontend/src/component/ui/ShareButton.tsx`)

Drop-in share bar for any market page:
- **Twitter/X** — intent URL with pre-filled market title + link
- **Native share** (mobile) — Web Share API, rendered only when available
- **Copy link** — writes canonical URL to clipboard, shows "Copied!" for 2 s
- Fully keyboard-accessible (`focus-visible` ring, `aria-label` on every control)

## Test plan

- [ ] `useLiveOdds` — odds update in real time when WS sends a frame; reconnect fires after a forced close; polling activates after 5 failed socket attempts; unmount clears all timers
- [ ] `useTransactionTracker` — transaction appears as pending immediately; transitions to confirmed/failed when `pollFn` returns; explorer URL opens correctly; auto-dismiss fires for confirmed
- [ ] `useOnboardingTour` — tour shows once on first load; does not show again after `skip()` or `complete()`; `start()` re-launches; all four steps cycle correctly
- [ ] `ShareButton` — Twitter link opens with correct pre-filled text; copy button writes URL to clipboard; "Copied!" state resets after 2 s