### PR TITLE
feat: leaderboard snapshots endpoint, dark mode toggle, wallet reconn…

### DIFF
--- a/backend/src/leaderboard/dto/leaderboard-snapshot-query.dto.ts
+++ b/backend/src/leaderboard/dto/leaderboard-snapshot-query.dto.ts
@@ -1,0 +1,79 @@
+import { IsOptional, IsDateString, IsUUID, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class LeaderboardSnapshotQueryDto {
+  @ApiProperty({
+    description:
+      'Return rankings as of this date (YYYY-MM-DD). The nearest snapshot on or before this date is used.',
+    example: '2026-07-01',
+  })
+  @IsDateString()
+  date: string;
+
+  @ApiPropertyOptional({ description: 'Filter by season ID' })
+  @IsOptional()
+  @IsUUID()
+  season_id?: string;
+
+  @ApiPropertyOptional({ description: 'Page number', default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Items per page (max 100)', default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}
+
+export class SnapshotRankingEntryResponse {
+  @ApiProperty()
+  rank: number;
+
+  @ApiProperty()
+  user_id: string;
+
+  @ApiProperty({ nullable: true })
+  username: string | null;
+
+  @ApiProperty()
+  stellar_address: string;
+
+  @ApiProperty()
+  score: number;
+
+  @ApiProperty()
+  captured_at: Date;
+}
+
+export class PaginatedSnapshotRankingResponse {
+  @ApiProperty({ type: [SnapshotRankingEntryResponse] })
+  data: SnapshotRankingEntryResponse[];
+
+  @ApiProperty({
+    description:
+      'The actual snapshot date used to satisfy the query (nearest on or before the requested date)',
+  })
+  snapshot_date: Date;
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty({
+    description:
+      'Message returned when the requested date is outside the retention window',
+    nullable: true,
+  })
+  message?: string;
+}

--- a/backend/src/leaderboard/leaderboard.controller.spec.ts
+++ b/backend/src/leaderboard/leaderboard.controller.spec.ts
@@ -51,6 +51,7 @@ describe('LeaderboardController', () => {
             getHistory: jest.fn(),
             getHistoryForAddress: jest.fn(),
             getRankHistory: jest.fn(),
+            getSnapshots: jest.fn(),
           },
         },
       ],
@@ -229,6 +230,54 @@ describe('LeaderboardController', () => {
       await expect(
         controller.getRankHistory('INVALID_ADDRESS', {}),
       ).rejects.toThrow();
+    });
+  });
+
+  describe('getSnapshots', () => {
+    it('should return snapshot rankings for a given date', async () => {
+      const mockSnapshotResponse = {
+        data: [
+          {
+            rank: 1,
+            user_id: 'user-uuid-1',
+            username: 'testuser',
+            stellar_address: 'GBRPYHIL2CI3WHZDTOOQFC6EB4RRJC3XNRBF7XN',
+            score: 100,
+            captured_at: new Date('2026-07-01T12:00:00Z'),
+          },
+        ],
+        snapshot_date: new Date('2026-07-01T12:00:00Z'),
+        total: 1,
+        page: 1,
+        limit: 20,
+      };
+      const spy = jest
+        .spyOn(service, 'getSnapshots')
+        .mockResolvedValue(mockSnapshotResponse);
+
+      const result = await controller.getSnapshots({ date: '2026-07-15' });
+
+      expect(spy).toHaveBeenCalledWith({ date: '2026-07-15' });
+      expect(result).toEqual(mockSnapshotResponse);
+    });
+
+    it('should return a message when no snapshots exist', async () => {
+      const mockEmptyResponse = {
+        data: [],
+        snapshot_date: new Date('2026-01-01'),
+        total: 0,
+        page: 1,
+        limit: 20,
+        message: 'No snapshots found on or before 2026-01-01.',
+      };
+      jest
+        .spyOn(service, 'getSnapshots')
+        .mockResolvedValue(mockEmptyResponse);
+
+      const result = await controller.getSnapshots({ date: '2026-01-01' });
+
+      expect(result.data).toEqual([]);
+      expect(result.message).toContain('No snapshots found');
     });
   });
 });

--- a/backend/src/leaderboard/leaderboard.controller.ts
+++ b/backend/src/leaderboard/leaderboard.controller.ts
@@ -23,6 +23,10 @@ import {
   RankHistoryQueryDto,
   RankHistoryResponse,
 } from './dto/rank-history.dto';
+import {
+  LeaderboardSnapshotQueryDto,
+  PaginatedSnapshotRankingResponse,
+} from './dto/leaderboard-snapshot-query.dto';
 import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('Leaderboard')
@@ -89,6 +93,35 @@ export class LeaderboardController {
       );
     }
     return this.leaderboardService.getHistory(query);
+  }
+
+  @Get('snapshots')
+  @Public()
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60)
+  @ApiOperation({
+    summary: 'Get leaderboard ranking as of a specific date',
+    description:
+      'Returns the ranking from the nearest snapshot on or before the requested date. A clear message is returned when the date is outside the retention window.',
+  })
+  @ApiQuery({
+    name: 'date',
+    required: true,
+    type: String,
+    description: 'YYYY-MM-DD date to look up',
+  })
+  @ApiQuery({ name: 'season_id', required: false, type: String })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: 'Historical ranking snapshot',
+    type: PaginatedSnapshotRankingResponse,
+  })
+  async getSnapshots(
+    @Query() query: LeaderboardSnapshotQueryDto,
+  ): Promise<PaginatedSnapshotRankingResponse> {
+    return this.leaderboardService.getSnapshots(query);
   }
 
   @Get(':address/rank-history')

--- a/backend/src/leaderboard/leaderboard.service.spec.ts
+++ b/backend/src/leaderboard/leaderboard.service.spec.ts
@@ -513,4 +513,96 @@ describe('LeaderboardService', () => {
       expect(result.data[1].rank_delta).toBe(3);
     });
   });
+
+  describe('getSnapshots', () => {
+    const mockSnapshotQbForDate = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      getOne: jest.fn(),
+      getManyAndCount: jest.fn(),
+    };
+
+    beforeEach(() => {
+      mockSnapshotRepository.createQueryBuilder.mockReturnValue(
+        mockSnapshotQbForDate,
+      );
+      mockSnapshotQbForDate.leftJoinAndSelect.mockReturnThis();
+      mockSnapshotQbForDate.where.mockReturnThis();
+      mockSnapshotQbForDate.andWhere.mockReturnThis();
+      mockSnapshotQbForDate.orderBy.mockReturnThis();
+      mockSnapshotQbForDate.take.mockReturnThis();
+      mockSnapshotQbForDate.skip.mockReturnThis();
+      mockSnapshotQbForDate.getOne.mockResolvedValue(null);
+      mockSnapshotQbForDate.getManyAndCount.mockResolvedValue([[], 0]);
+    });
+
+    it('should return a message when no snapshots exist before the date', async () => {
+      mockSnapshotQbForDate.getOne.mockResolvedValue(null);
+
+      const result = await service.getSnapshots({ date: '2026-01-01' });
+
+      expect(result.data).toEqual([]);
+      expect(result.message).toContain('No snapshots found');
+      expect(result.total).toBe(0);
+    });
+
+    it('should return rankings from the nearest snapshot', async () => {
+      const snapshotDate = new Date('2026-07-01T12:00:00Z');
+      mockSnapshotQbForDate.getOne.mockResolvedValue({
+        captured_at: snapshotDate,
+      });
+      mockSnapshotQbForDate.getManyAndCount.mockResolvedValue([
+        [
+          {
+            rank: 1,
+            user_id: 'user-uuid-1',
+            user: { username: 'testuser', stellar_address: 'GABC...' },
+            score: 100,
+            captured_at: snapshotDate,
+          },
+        ],
+        1,
+      ]);
+
+      const result = await service.getSnapshots({ date: '2026-07-15' });
+
+      expect(result.snapshot_date).toEqual(snapshotDate);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].rank).toBe(1);
+      expect(result.data[0].username).toBe('testuser');
+    });
+
+    it('should filter by season_id when provided', async () => {
+      const snapshotDate = new Date('2026-07-01T12:00:00Z');
+      mockSnapshotQbForDate.getOne.mockResolvedValue({
+        captured_at: snapshotDate,
+      });
+      mockSnapshotQbForDate.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.getSnapshots({ date: '2026-07-15', season_id: 'season-1' });
+
+      // First query (find nearest snapshot) should filter by season
+      expect(mockSnapshotQbForDate.andWhere).toHaveBeenCalledWith(
+        'snap.season_id = :season_id',
+        { season_id: 'season-1' },
+      );
+    });
+
+    it('should cap limit at 100', async () => {
+      const snapshotDate = new Date('2026-07-01T12:00:00Z');
+      mockSnapshotQbForDate.getOne.mockResolvedValue({
+        captured_at: snapshotDate,
+      });
+      mockSnapshotQbForDate.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.getSnapshots({ date: '2026-07-15', limit: 999 });
+
+      expect(mockSnapshotQbForDate.take).toHaveBeenCalledWith(100);
+    });
+  });
 });

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -38,6 +38,10 @@ import {
   CursorPaginationDto,
   PaginatedCursorResponse,
 } from './dto/cursor-pagination.dto';
+import {
+  LeaderboardSnapshotQueryDto,
+  PaginatedSnapshotRankingResponse,
+} from './dto/leaderboard-snapshot-query.dto';
 import { CACHE_WARMING_KEYS } from '../cache/cache-warming.keys';
 import { SeasonsService } from '../seasons/seasons.service';
 
@@ -688,6 +692,88 @@ export class LeaderboardService {
         `Pruned ${affected} leaderboard snapshot(s) older than ${retentionDays}d`,
       );
     }
+  }
+
+  /**
+   * Return the leaderboard ranking as of the nearest snapshot on or before the
+   * requested date. If the date falls before all stored snapshots the endpoint
+   * returns a clear message instead of an empty list so callers know the
+   * data is outside the retention window.
+   */
+  async getSnapshots(
+    query: LeaderboardSnapshotQueryDto,
+  ): Promise<PaginatedSnapshotRankingResponse> {
+    const page = query.page ?? 1;
+    const limit = Math.min(query.limit ?? 20, 100);
+    const skip = (page - 1) * limit;
+    const requestedDate = new Date(query.date);
+    requestedDate.setHours(23, 59, 59, 999);
+
+    // Find the most recent snapshot at or before the requested date
+    const qb = this.snapshotRepository
+      .createQueryBuilder('snap')
+      .leftJoinAndSelect('snap.user', 'user')
+      .where('snap.captured_at <= :requestedDate', { requestedDate })
+      .orderBy('snap.captured_at', 'DESC')
+      .take(1);
+
+    if (query.season_id) {
+      qb.andWhere('snap.season_id = :season_id', {
+        season_id: query.season_id,
+      });
+    } else {
+      qb.andWhere('snap.season_id IS NULL');
+    }
+
+    const latestSnapshot = await qb.getOne();
+
+    if (!latestSnapshot) {
+      const retentionDays = this.configService.get<number>(
+        'LEADERBOARD_SNAPSHOT_RETENTION_DAYS',
+        30,
+      );
+      return {
+        data: [],
+        snapshot_date: requestedDate,
+        total: 0,
+        page,
+        limit,
+        message: `No snapshots found on or before ${query.date}. Snapshots are retained for ${retentionDays} days.`,
+      };
+    }
+
+    const snapshotDate = latestSnapshot.captured_at;
+
+    // Fetch all rankings from that snapshot
+    const rankQb = this.snapshotRepository
+      .createQueryBuilder('snap')
+      .leftJoinAndSelect('snap.user', 'user')
+      .where('snap.captured_at = :snapshotDate', { snapshotDate })
+      .orderBy('snap.rank', 'ASC');
+
+    if (query.season_id) {
+      rankQb.andWhere('snap.season_id = :season_id', {
+        season_id: query.season_id,
+      });
+    } else {
+      rankQb.andWhere('snap.season_id IS NULL');
+    }
+
+    const [entries, total] = await rankQb
+      .skip(skip)
+      .take(limit)
+      .getManyAndCount();
+
+    const data = entries.map((entry) => ({
+      rank: entry.rank,
+      user_id: entry.user_id,
+      username: entry.user?.username ?? null,
+      stellar_address: entry.user?.stellar_address ?? '',
+      score: entry.score,
+      captured_at: entry.captured_at,
+    }));
+
+    return { data, snapshot_date: snapshotDate, total, page, limit };
   }
 
   /**

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { CreatorEventsProvider } from "@/context/CreatorEventsContext";
 import { ToastProvider } from "@/context/ToastContext";
 import { ConfirmProvider } from "@/context/ConfirmContext";
 import { FavoritesProvider } from "@/context/FavoritesContext";
+import { ThemeProvider } from "@/context/ThemeContext";
 
 import "./globals.css";
 
@@ -87,29 +88,38 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('insightarena.theme.v1');if(!t){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}document.documentElement.classList.toggle('dark',t==='dark')}catch(e){}})()`,
+          }}
+        />
+      </head>
       <body className="font-sans antialiased bg-[#141824] text-white">
-        <WalletProvider>
-          <FavoritesProvider>
-            <CreatorEventsProvider>
-              <ToastProvider>
-                <ConfirmProvider>
-                  <Suspense fallback={null}>
-                    <RouteProgress />
-                  </Suspense>
-                  <PwaManager />
-                  <a href="#main-content" className="skip-link">
-                    Skip to main content
-                  </a>
-                  <div id="main-content" tabIndex={-1}>
-                    <Suspense fallback={<StandardPageLoadingSkeleton />}>
-                      {children}
+        <ThemeProvider>
+          <WalletProvider>
+            <FavoritesProvider>
+              <CreatorEventsProvider>
+                <ToastProvider>
+                  <ConfirmProvider>
+                    <Suspense fallback={null}>
+                      <RouteProgress />
                     </Suspense>
-                  </div>
-                </ConfirmProvider>
-              </ToastProvider>
-            </CreatorEventsProvider>
-          </FavoritesProvider>
-        </WalletProvider>
+                    <PwaManager />
+                    <a href="#main-content" className="skip-link">
+                      Skip to main content
+                    </a>
+                    <div id="main-content" tabIndex={-1}>
+                      <Suspense fallback={<StandardPageLoadingSkeleton />}>
+                        {children}
+                      </Suspense>
+                    </div>
+                  </ConfirmProvider>
+                </ToastProvider>
+              </CreatorEventsProvider>
+            </FavoritesProvider>
+          </WalletProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/portfolio/page.tsx
+++ b/frontend/src/app/portfolio/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ArrowUpDown, ArrowUp, ArrowDown, Filter, Wallet } from "lucide-react";
+
+import Footer from "@/component/Footer";
+import Header from "@/component/Header";
+import PageBackground from "@/component/PageBackground";
+import { useWallet } from "@/context/WalletContext";
+import {
+  usePortfolio,
+  type PositionStatus,
+  type SortField,
+  type SortDirection,
+} from "@/hooks/usePortfolio";
+
+const STATUS_FILTERS: { label: string; value: PositionStatus | "all" }[] = [
+  { label: "All", value: "all" },
+  { label: "Open", value: "open" },
+  { label: "Settled", value: "settled" },
+];
+
+const SORT_OPTIONS: { label: string; field: SortField }[] = [
+  { label: "Stake", field: "stake" },
+  { label: "Current Value", field: "current_value" },
+  { label: "P&L", field: "pnl" },
+];
+
+function formatStroops(stroops: string): string {
+  const num = Number(stroops);
+  if (Number.isNaN(num)) return "0";
+  return (num / 10_000_000).toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatPnl(pnl: string): { text: string; className: string } {
+  const num = Number(pnl);
+  if (Number.isNaN(num) || num === 0)
+    return { text: "0 XLM", className: "text-gray-400" };
+  const formatted = `${num > 0 ? "+" : ""}${(num / 10_000_000).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} XLM`;
+  return {
+    text: formatted,
+    className: num > 0 ? "text-green-400" : "text-red-400",
+  };
+}
+
+const STATUS_BADGE: Record<PositionStatus, string> = {
+  open: "bg-orange-500/10 text-orange-400 border-orange-500/30",
+  settled: "bg-gray-500/10 text-gray-400 border-gray-500/30",
+};
+
+export default function PortfolioPage() {
+  const { address, isAuthenticated } = useWallet();
+  const [statusFilter, setStatusFilter] = useState<PositionStatus | "all">(
+    "all",
+  );
+  const [sortBy, setSortBy] = useState<SortField>("stake");
+  const [sortDir, setSortDir] = useState<SortDirection>("desc");
+  const [page, setPage] = useState(1);
+
+  const effectiveAddress = address ?? "";
+
+  const { positions, total, isLoading, error } = usePortfolio({
+    address: effectiveAddress,
+    status: statusFilter === "all" ? undefined : statusFilter,
+    sortBy,
+    sortDir,
+    page,
+    limit: 20,
+  });
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(total / 20)),
+    [total],
+  );
+
+  const toggleSortDir = () => setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+
+  if (!isAuthenticated) {
+    return (
+      <PageBackground>
+        <Header />
+        <main className="mx-auto max-w-6xl px-6 pt-32 pb-20 text-white">
+          <div className="flex flex-col items-center justify-center rounded-[2rem] border border-white/10 bg-gray-950/60 p-16 text-center">
+            <Wallet className="mb-6 h-12 w-12 text-gray-500" />
+            <h1 className="text-2xl font-bold">Connect Your Wallet</h1>
+            <p className="mt-3 max-w-md text-gray-400">
+              Connect your wallet to view your portfolio and track your
+              positions.
+            </p>
+          </div>
+        </main>
+        <Footer />
+      </PageBackground>
+    );
+  }
+
+  return (
+    <PageBackground>
+      <Header />
+
+      <main className="mx-auto max-w-6xl px-6 pt-32 pb-20 text-white">
+        <section className="rounded-[2rem] border border-white/10 bg-gray-950/60 p-8 shadow-[0_25px_80px_rgba(0,0,0,0.45)] backdrop-blur sm:p-12">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">Portfolio</h1>
+              <p className="mt-2 text-sm text-gray-400">
+                View your open and settled positions with performance tracking.
+              </p>
+            </div>
+          </div>
+
+          {/* Filters */}
+          <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <Filter className="h-4 w-4 text-gray-400" />
+              <div className="flex gap-1 rounded-xl border border-white/10 bg-gray-950/60 p-1">
+                {STATUS_FILTERS.map((f) => (
+                  <button
+                    key={f.value}
+                    type="button"
+                    onClick={() => {
+                      setStatusFilter(f.value);
+                      setPage(1);
+                    }}
+                    className={`rounded-lg px-3 py-1.5 text-sm font-medium transition ${
+                      statusFilter === f.value
+                        ? "bg-orange-500/20 text-orange-400"
+                        : "text-gray-400 hover:text-white"
+                    }`}
+                  >
+                    {f.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as SortField)}
+                className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-2 text-sm text-gray-300 focus:border-orange-500 focus:outline-none"
+              >
+                {SORT_OPTIONS.map((o) => (
+                  <option key={o.field} value={o.field}>
+                    Sort by {o.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={toggleSortDir}
+                aria-label={`Sort ${sortDir === "asc" ? "descending" : "ascending"}`}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 text-gray-400 hover:text-white transition"
+              >
+                <ArrowUpDown className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="mt-6">
+            {isLoading && (
+              <div className="space-y-3">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-20 w-full animate-pulse rounded-2xl border border-white/5 bg-[#0a0f1a]"
+                  />
+                ))}
+              </div>
+            )}
+
+            {!isLoading && error && (
+              <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-8 text-center">
+                <p className="text-red-400">{error}</p>
+              </div>
+            )}
+
+            {!isLoading && !error && positions.length === 0 && (
+              <div className="rounded-2xl border border-white/10 bg-gray-950/60 p-12 text-center">
+                <Wallet className="mx-auto mb-4 h-10 w-10 text-gray-500" />
+                <p className="text-gray-400">No positions found.</p>
+                <p className="mt-1 text-sm text-gray-500">
+                  {statusFilter !== "all"
+                    ? `No ${statusFilter} positions. Try a different filter.`
+                    : "Start predicting to build your portfolio."}
+                </p>
+              </div>
+            )}
+
+            {!isLoading && !error && positions.length > 0 && (
+              <>
+                <div className="overflow-x-auto rounded-2xl border border-white/10">
+                  <table className="min-w-full divide-y divide-white/10 text-left text-sm">
+                    <thead className="bg-gray-950/60 text-xs uppercase tracking-wide text-gray-400">
+                      <tr>
+                        <th scope="col" className="px-5 py-4">
+                          Market
+                        </th>
+                        <th scope="col" className="px-5 py-4">
+                          Outcome
+                        </th>
+                        <th scope="col" className="px-5 py-4 text-right">
+                          Stake
+                        </th>
+                        <th scope="col" className="px-5 py-4 text-right">
+                          Current Value
+                        </th>
+                        <th scope="col" className="px-5 py-4 text-right">
+                          P&L
+                        </th>
+                        <th scope="col" className="px-5 py-4 text-center">
+                          Status
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-white/10 bg-gray-950/40">
+                      {positions.map((pos) => {
+                        const pnl = formatPnl(pos.pnl);
+                        return (
+                          <tr
+                            key={pos.id}
+                            className="hover:bg-white/5 transition-colors"
+                          >
+                            <td className="max-w-[300px] truncate px-5 py-4 font-medium text-white">
+                              {pos.market_title}
+                            </td>
+                            <td className="px-5 py-4 text-gray-300">
+                              {pos.outcome}
+                            </td>
+                            <td className="px-5 py-4 text-right text-gray-300 font-mono">
+                              {formatStroops(pos.stake)} XLM
+                            </td>
+                            <td className="px-5 py-4 text-right text-gray-300 font-mono">
+                              {formatStroops(pos.current_value)} XLM
+                            </td>
+                            <td
+                              className={`px-5 py-4 text-right font-mono font-semibold ${pnl.className}`}
+                            >
+                              {pnl.text}
+                            </td>
+                            <td className="px-5 py-4 text-center">
+                              <span
+                                className={`inline-flex rounded-xl border px-2.5 py-1 text-xs font-semibold ${STATUS_BADGE[pos.status]}`}
+                              >
+                                {pos.status}
+                              </span>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Pagination */}
+                {totalPages > 1 && (
+                  <div className="mt-6 flex items-center justify-center gap-2">
+                    <button
+                      type="button"
+                      disabled={page <= 1}
+                      onClick={() => setPage((p) => p - 1)}
+                      className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-2 text-sm text-gray-300 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed transition"
+                    >
+                      Previous
+                    </button>
+                    <span className="px-3 text-sm text-gray-400">
+                      Page {page} of {totalPages}
+                    </span>
+                    <button
+                      type="button"
+                      disabled={page >= totalPages}
+                      onClick={() => setPage((p) => p + 1)}
+                      className="rounded-lg border border-white/10 bg-gray-950/60 px-3 py-2 text-sm text-gray-300 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed transition"
+                    >
+                      Next
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </PageBackground>
+  );
+}

--- a/frontend/src/component/Header.tsx
+++ b/frontend/src/component/Header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useWallet } from "@/context/WalletContext";
+import { useTheme } from "@/context/ThemeContext";
 import { useConfirm } from "@/hooks/useConfirm";
 import { useToast } from "@/hooks/useToast";
 import { MobileMenu } from "./header/MobileMenu";
@@ -18,6 +19,7 @@ export default function Header() {
   const pathname = usePathname();
   const { address, isAuthenticated, isRestoring, logout, openConnectModal } =
     useWallet();
+  const { theme, toggleTheme } = useTheme();
   const confirm = useConfirm();
   const toast = useToast();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -133,6 +135,22 @@ export default function Header() {
             <NavLinks isActive={isActive} />
             <div className="flex items-center gap-3">
               <WalletBalanceDisplay />
+              <button
+                type="button"
+                onClick={toggleTheme}
+                aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-700 text-gray-300 hover:bg-gray-900 hover:text-white transition-colors"
+              >
+                {theme === "dark" ? (
+                  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+                  </svg>
+                ) : (
+                  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
+                  </svg>
+                )}
+              </button>
               <button
                 ref={menuButtonRef}
                 type="button"

--- a/frontend/src/component/header/MobileMenu.tsx
+++ b/frontend/src/component/header/MobileMenu.tsx
@@ -86,7 +86,7 @@ export function MobileMenu({
             {isRestoring && !isAuthenticated ? (
               <div className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-[#111726] px-4 py-3 text-sm font-semibold text-gray-400">
                 <span className="h-2 w-2 animate-pulse rounded-full bg-gray-500" />
-                Loading...
+                Connecting...
               </div>
             ) : !isAuthenticated ? (
               <button

--- a/frontend/src/component/header/UserWalletControls.tsx
+++ b/frontend/src/component/header/UserWalletControls.tsx
@@ -65,7 +65,7 @@ export function UserWalletControls({
       {isRestoring && !isAuthenticated ? (
         <div className="hidden md:inline-flex items-center gap-2 rounded-lg border border-white/10 bg-[#111726] px-6 py-2 text-sm font-semibold text-gray-400">
           <span className="h-2 w-2 animate-pulse rounded-full bg-gray-500" />
-          Loading...
+          Connecting...
         </div>
       ) : !isAuthenticated ? (
         <button

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "dark",
+  toggleTheme: () => {},
+  setTheme: () => {},
+});
+
+const THEME_STORAGE_KEY = "insightarena.theme.v1";
+
+function getSystemPreference(): Theme {
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function readStoredTheme(): Theme | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(THEME_STORAGE_KEY);
+    if (raw === "light" || raw === "dark") return raw;
+  } catch {
+    // storage unavailable
+  }
+  return null;
+}
+
+function applyThemeToDocument(theme: Theme) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("dark");
+
+  useEffect(() => {
+    const stored = readStoredTheme();
+    const initial = stored ?? getSystemPreference();
+    setThemeState(initial);
+    applyThemeToDocument(initial);
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent) => {
+      if (readStoredTheme() === null) {
+        const next: Theme = e.matches ? "dark" : "light";
+        setThemeState(next);
+        applyThemeToDocument(next);
+      }
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    applyThemeToDocument(next);
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((prev) => {
+      const next: Theme = prev === "dark" ? "light" : "dark";
+      applyThemeToDocument(next);
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, next);
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, toggleTheme, setTheme }),
+    [theme, toggleTheme, setTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { apiClient } from "@/lib/api";
+import { logHookError } from "@/hooks/useHookErrorMessage";
+
+export type PositionStatus = "open" | "settled";
+
+export interface Position {
+  id: string;
+  market_id: string;
+  market_title: string;
+  outcome: string;
+  stake: string;
+  current_value: string;
+  pnl: string;
+  status: PositionStatus;
+  placed_at: string;
+  resolved_at: string | null;
+}
+
+export interface PortfolioResponse {
+  data: Position[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export type SortField = "stake" | "current_value" | "pnl";
+export type SortDirection = "asc" | "desc";
+
+interface UsePortfolioOptions {
+  address: string;
+  status?: PositionStatus;
+  sortBy?: SortField;
+  sortDir?: SortDirection;
+  page?: number;
+  limit?: number;
+}
+
+interface UsePortfolioReturn {
+  positions: Position[];
+  total: number;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function usePortfolio({
+  address,
+  status,
+  sortBy = "stake",
+  sortDir = "desc",
+  page = 1,
+  limit = 20,
+}: UsePortfolioOptions): UsePortfolioReturn {
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPositions = useCallback(async () => {
+    if (!address) return;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams();
+      params.set("page", String(page));
+      params.set("limit", String(limit));
+      params.set("sort_by", sortBy);
+      params.set("sort_dir", sortDir);
+      if (status) params.set("status", status);
+
+      const result = await apiClient.get<PortfolioResponse>(
+        `/api/v1/predictions/portfolio/${encodeURIComponent(address)}?${params.toString()}`,
+      );
+      setPositions(result.data);
+      setTotal(result.total);
+    } catch (err) {
+      setError(
+        logHookError(err, {
+          fallbackMessage: "Failed to load portfolio.",
+          hookName: "usePortfolio",
+          id: address,
+        }),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [address, status, sortBy, sortDir, page, limit]);
+
+  useEffect(() => {
+    fetchPositions();
+  }, [fetchPositions]);
+
+  return { positions, total, isLoading, error, refetch: fetchPositions };
+}


### PR DESCRIPTION
## Summary

Implements four features from AGENTS.md: a historical snapshots leaderboard endpoint, dark mode with persistence, wallet auto-reconnect, and a portfolio/positions dashboard.

---

### #1371 — Leaderboard Historical Snapshots Endpoint

Add `GET /api/v1/leaderboard/snapshots?date=YYYY-MM-DD` that returns rankings from the nearest snapshot on or before the requested date.

- New DTO (`LeaderboardSnapshotQueryDto`) with `date`, `season_id`, `page`, `limit` params
- Service method finds the nearest snapshot, fetches all rankings from that snapshot, or returns a clear message when the date is outside the retention window
- Cached 60s, Swagger-documented, public endpoint
- Tests cover snapshot lookup, empty retention message, season filtering, and limit capping

**Files:** `leaderboard.controller.ts`, `leaderboard.service.ts`, `dto/leaderboard-snapshot-query.dto.ts`, `leaderboard.controller.spec.ts`, `leaderboard.service.spec.ts`

Closes #1371

---

### #1402 — Dark Mode Toggle with Persistence

Add a theme toggle to the header that persists the user's choice across sessions and respects system preference by default.

- `ThemeContext` manages theme state with localStorage persistence (`insightarena.theme.v1`)
- Listens to `prefers-color-scheme` media query for real-time OS theme changes
- Inline `<script>` in `<head>` reads localStorage and applies `.dark` class before React hydration to prevent flash of incorrect theme
- Toggle button in header (sun/moon SVG icons), keyboard-accessible with `aria-label`
- Theme applied via Tailwind v4 `@custom-variant dark (&:is(.dark *))` in `globals.css`

**Files:** `context/ThemeContext.tsx`, `app/layout.tsx`, `component/Header.tsx`

Closes #1402

---

### #1403 — Wallet Auto-Reconnect

Verify and polish the existing wallet auto-reconnect implementation.

- `readStoredSession()` / `writeStoredSession()` / `clearStoredSession()` persist wallet id + address in localStorage
- Silent reconnect on load via `StellarWalletsKit.fetchAddress()`, falls back to disconnected state on failure
- `isRestoring` state shown as "Connecting..." in both desktop and mobile menus
- `logout()` clears stored session to prevent future auto-reconnect

**Files:** `component/header/UserWalletControls.tsx`, `component/header/MobileMenu.tsx`

Closes #1403

---

### #1401 — Portfolio / Positions Dashboard

Add a portfolio page where users can view open and settled positions with performance tracking.

- `usePortfolio` hook fetches `GET /api/v1/predictions/portfolio/:address` with filtering and sorting
- Status filter tabs (All / Open / Settled)
- Sort by Stake, Current Value, or P&L with ascending/descending toggle
- Table displaying market, outcome, stake, current value, P&L (green/red color-coded), and status badge
- Loading skeleton, error state, empty state with contextual messages
- Pagination for large result sets
- Responsive design, wallet connection gate

**Files:** `app/portfolio/page.tsx`, `hooks/usePortfolio.ts`

Closes #1401

---

## Test Plan

- [x] Backend: `npm test` — verify new snapshot endpoint tests pass alongside existing leaderboard tests
- [x] Frontend: `npm run build` — verify no type errors in ThemeContext, portfolio page, usePortfolio hook
- [ ] Manual: Toggle dark mode → reload → theme persists
- [ ] Manual: Disconnect wallet → reload → stays disconnected; connect → reload → auto-reconnects
- [ ] Manual: Visit `/leaderboard/snapshots?date=2026-07-01` → returns rankings or retention message
- [x] Manual: Visit `/portfolio` → shows positions with filtering/sorting working correctly
