### PR TITLE
feat(markets): add public read-only markets endpoints (Fixes #1393)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -59,6 +59,11 @@ import { AccountModule } from './account/account.module';
           ttl: config.get<number>('AUTH_THROTTLE_TTL_MS') ?? 60000,
           limit: config.get<number>('AUTH_THROTTLE_LIMIT') ?? 5,
         },
+        {
+          name: 'public',
+          ttl: config.get<number>('PUBLIC_API_THROTTLE_TTL_MS') ?? 60000,
+          limit: config.get<number>('PUBLIC_API_THROTTLE_LIMIT') ?? 60,
+        },
       ],
     }),
     LoggerModule.forRoot({

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -122,6 +122,15 @@ class EnvironmentVariables {
   @IsNumber()
   AUTH_THROTTLE_TTL_MS?: number;
 
+  // Public API key tier rate limiting (#1393)
+  @IsOptional()
+  @IsNumber()
+  PUBLIC_API_THROTTLE_LIMIT?: number;
+
+  @IsOptional()
+  @IsNumber()
+  PUBLIC_API_THROTTLE_TTL_MS?: number;
+
   @IsOptional()
   @IsString()
   MATCH_RESULTS_FEED_URL?: string;

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -40,6 +40,16 @@ async function bootstrap() {
       },
       'api-key',
     )
+    .addApiKey(
+      {
+        type: 'apiKey',
+        name: 'x-api-key',
+        in: 'header',
+        description:
+          'Public API key. Keys must include the public:read scope and use the dedicated public rate-limit tier.',
+      },
+      'public-api-key',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api/v1/docs', app, document);

--- a/backend/src/markets/dto/public-market-response.dto.ts
+++ b/backend/src/markets/dto/public-market-response.dto.ts
@@ -1,0 +1,111 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Market, MarketSettlementState } from '../entities/market.entity';
+
+export class PublicMarketCreatorDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  username: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  avatar_url: string | null;
+}
+
+export class PublicMarketResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty()
+  on_chain_market_id: string;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  description: string;
+
+  @ApiProperty()
+  category: string;
+
+  @ApiProperty({ type: [String] })
+  outcome_options: string[];
+
+  @ApiProperty()
+  end_time: Date;
+
+  @ApiProperty()
+  resolution_time: Date;
+
+  @ApiProperty()
+  is_resolved: boolean;
+
+  @ApiPropertyOptional({ nullable: true })
+  resolved_outcome: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  resolved_at: Date | null;
+
+  @ApiProperty({ enum: MarketSettlementState })
+  settlement_state: MarketSettlementState;
+
+  @ApiProperty()
+  is_featured: boolean;
+
+  @ApiProperty()
+  total_pool_stroops: string;
+
+  @ApiProperty()
+  participant_count: number;
+
+  @ApiProperty()
+  created_at: Date;
+
+  @ApiPropertyOptional({ type: PublicMarketCreatorDto, nullable: true })
+  creator: PublicMarketCreatorDto | null;
+
+  static fromEntity(market: Market): PublicMarketResponseDto {
+    return {
+      id: market.id,
+      on_chain_market_id: market.on_chain_market_id,
+      title: market.title,
+      description: market.description,
+      category: market.category,
+      outcome_options: market.outcome_options,
+      end_time: market.end_time,
+      resolution_time: market.resolution_time,
+      is_resolved: market.is_resolved,
+      resolved_outcome: market.resolved_outcome ?? null,
+      resolved_at: market.resolved_at,
+      settlement_state: market.settlement_state,
+      is_featured: market.is_featured,
+      total_pool_stroops: market.total_pool_stroops,
+      participant_count: market.participant_count,
+      created_at: market.created_at,
+      creator: market.creator
+        ? {
+            id: market.creator.id,
+            username: market.creator.username,
+            avatar_url: market.creator.avatar_url,
+          }
+        : null,
+    };
+  }
+}
+
+export class PaginatedPublicMarketsResponseDto {
+  @ApiProperty({ type: [PublicMarketResponseDto] })
+  data: PublicMarketResponseDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty()
+  totalPages: number;
+}

--- a/backend/src/markets/markets.module.ts
+++ b/backend/src/markets/markets.module.ts
@@ -14,6 +14,9 @@ import { DisputesModule } from '../disputes/disputes.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { CommonModule } from '../common/common.module';
 import { OptionalIdempotencyInterceptor } from '../common/idempotency/optional-idempotency.interceptor';
+import { AuthModule } from '../auth/auth.module';
+import { ApiKeyGuard } from '../common/guards/api-key.guard';
+import { PublicMarketsController } from './public-markets.controller';
 
 @Module({
   imports: [
@@ -29,12 +32,14 @@ import { OptionalIdempotencyInterceptor } from '../common/idempotency/optional-i
     DisputesModule,
     WebhooksModule,
     CommonModule,
+    AuthModule,
   ],
-  controllers: [MarketsController],
+  controllers: [MarketsController, PublicMarketsController],
   providers: [
     MarketsService,
     MarketSettlementScheduler,
     OptionalIdempotencyInterceptor,
+    ApiKeyGuard,
   ],
   exports: [MarketsService, TypeOrmModule],
 })

--- a/backend/src/markets/public-markets.controller.spec.ts
+++ b/backend/src/markets/public-markets.controller.spec.ts
@@ -1,0 +1,99 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ApiKeyService } from '../auth/api-key.service';
+import { Market, MarketSettlementState } from './entities/market.entity';
+import { PublicMarketsController } from './public-markets.controller';
+import { MarketsService } from './markets.service';
+
+describe('PublicMarketsController', () => {
+  let controller: PublicMarketsController;
+
+  const market = {
+    id: '27c91229-34ac-44fd-b343-a96db4108bb3',
+    on_chain_market_id: '42',
+    title: 'Will it rain?',
+    description: 'A public market',
+    category: 'weather',
+    outcome_options: ['yes', 'no'],
+    end_time: new Date('2027-01-01T00:00:00.000Z'),
+    resolution_time: new Date('2027-01-02T00:00:00.000Z'),
+    is_resolved: false,
+    resolved_outcome: null,
+    resolved_at: null,
+    settlement_state: MarketSettlementState.PENDING,
+    is_public: true,
+    is_cancelled: false,
+    is_featured: false,
+    is_paused: false,
+    proposed_outcome: null,
+    resolution_proposed_at: null,
+    grace_period_seconds: 86400,
+    total_pool_stroops: '1000',
+    participant_count: 2,
+    featured_at: null,
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    creator: {
+      id: 'ccb37778-e246-45fd-b6f9-f3376e2e7d71',
+      username: 'creator',
+      avatar_url: null,
+      email: 'private@example.com',
+      stellar_address: 'GPRIVATE',
+      role: 'admin',
+      is_banned: false,
+    },
+  } as Market;
+
+  const marketsService = {
+    findAllFiltered: jest.fn(),
+    findByIdOrOnChainId: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PublicMarketsController],
+      providers: [
+        { provide: MarketsService, useValue: marketsService },
+        { provide: ApiKeyService, useValue: {} },
+      ],
+    }).compile();
+    controller = moduleRef.get(PublicMarketsController);
+  });
+
+  it('forces the public filter and excludes sensitive fields from list results', async () => {
+    marketsService.findAllFiltered.mockResolvedValue({
+      data: [market],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    });
+
+    const result = await controller.list({ is_public: false });
+
+    expect(marketsService.findAllFiltered).toHaveBeenCalledWith({
+      is_public: true,
+    });
+    expect(result.data[0].creator).toEqual({
+      id: market.creator.id,
+      username: market.creator.username,
+      avatar_url: market.creator.avatar_url,
+    });
+    expect(result.data[0]).not.toHaveProperty('proposed_outcome');
+    expect(result.data[0]).not.toHaveProperty('is_paused');
+    expect(result.data[0].creator).not.toHaveProperty('email');
+    expect(result.data[0].creator).not.toHaveProperty('stellar_address');
+    expect(result.data[0].creator).not.toHaveProperty('role');
+  });
+
+  it('does not expose a non-public market by id', async () => {
+    marketsService.findByIdOrOnChainId.mockResolvedValue({
+      ...market,
+      is_public: false,
+    });
+
+    await expect(controller.get(market.id)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+});

--- a/backend/src/markets/public-markets.controller.ts
+++ b/backend/src/markets/public-markets.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { SkipThrottle, Throttle } from '@nestjs/throttler';
+import { Public } from '../common/decorators/public.decorator';
+import { Scopes } from '../common/decorators/scopes.decorator';
+import { ApiKeyGuard } from '../common/guards/api-key.guard';
+import { ListMarketsDto } from './dto/list-markets.dto';
+import {
+  PaginatedPublicMarketsResponseDto,
+  PublicMarketResponseDto,
+} from './dto/public-market-response.dto';
+import { Market } from './entities/market.entity';
+import { MarketsService } from './markets.service';
+
+@ApiTags('Public API')
+@ApiSecurity('public-api-key')
+@Controller('public/markets')
+@Public()
+@UseGuards(ApiKeyGuard)
+@Scopes('public:read')
+@SkipThrottle({ default: true, auth: true })
+@Throttle({ public: {} })
+export class PublicMarketsController {
+  constructor(private readonly marketsService: MarketsService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List public markets',
+    description:
+      'Public API tier endpoint. Requires an X-API-Key with the public:read scope.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated public markets with sensitive fields omitted',
+    type: PaginatedPublicMarketsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Missing or invalid API key' })
+  @ApiResponse({ status: 403, description: 'API key lacks public:read scope' })
+  @ApiResponse({ status: 429, description: 'Public API rate limit exceeded' })
+  async list(
+    @Query() query: ListMarketsDto,
+  ): Promise<PaginatedPublicMarketsResponseDto> {
+    const result = await this.marketsService.findAllFiltered({
+      ...query,
+      is_public: true,
+    });
+
+    return {
+      ...result,
+      data: (result.data as Market[]).map((market) =>
+        PublicMarketResponseDto.fromEntity(market),
+      ),
+    };
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get a public market',
+    description:
+      'Public API tier endpoint. Requires an X-API-Key with the public:read scope.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Public market with sensitive fields omitted',
+    type: PublicMarketResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Missing or invalid API key' })
+  @ApiResponse({ status: 403, description: 'API key lacks public:read scope' })
+  @ApiResponse({ status: 404, description: 'Public market not found' })
+  @ApiResponse({ status: 429, description: 'Public API rate limit exceeded' })
+  async get(@Param('id') id: string): Promise<PublicMarketResponseDto> {
+    const market = await this.marketsService.findByIdOrOnChainId(id);
+    if (!market.is_public) {
+      throw new NotFoundException(`Public market with ID "${id}" not found`);
+    }
+    return PublicMarketResponseDto.fromEntity(market);
+  }
+}

--- a/frontend/src/app/(authenticated)/error.tsx
+++ b/frontend/src/app/(authenticated)/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type AuthenticatedErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AuthenticatedErrorPage({
+  error,
+  reset,
+}: AuthenticatedErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Your account"
+      description="This section couldn't finish loading. Retry to restore it without leaving your account."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(oracle)/error.tsx
+++ b/frontend/src/app/(oracle)/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type OracleErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function OracleErrorPage({
+  error,
+  reset,
+}: OracleErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Oracle"
+      description="The oracle workspace ran into a problem. Retry to reload this section."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/admin/error.tsx
+++ b/frontend/src/app/admin/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type AdminErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AdminErrorPage({
+  error,
+  reset,
+}: AdminErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Admin"
+      description="The admin section couldn't finish loading. Retry to restore this view."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/component/route-error-state.test.tsx
+++ b/frontend/src/component/route-error-state.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RouteErrorState } from "./route-error-state";
+
+describe("RouteErrorState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the route error and retries only the failed segment", () => {
+    const error = Object.assign(new Error("Could not load"), {
+      digest: "error-reference",
+    });
+    const reset = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <RouteErrorState
+        error={error}
+        reset={reset}
+        routeLabel="Dashboard"
+        description="Please retry."
+        fullScreen={false}
+      />,
+    );
+
+    expect(screen.getByText("Dashboard hit an unexpected problem")).toBeInTheDocument();
+    expect(screen.getByText("Reference: error-reference")).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[Route Error Boundary] Dashboard",
+      expect.objectContaining({
+        message: "Could not load",
+        digest: "error-reference",
+        error,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #1393

 — adds API-key-protected, read-only public endpoints for market data, with strict field-level filtering so sensitive/internal data is never exposed.

## Key changes
- New endpoints:
  - `GET /api/v1/public/markets`
  - `GET /api/v1/public/markets/:id`
- Both require the `public:read` API-key scope.
- Dedicated public rate-limit tier, configurable via:
  - `PUBLIC_API_THROTTLE_LIMIT` (default `60`)
  - `PUBLIC_API_THROTTLE_TTL_MS` (default `60000`)
- New public response DTOs that explicitly omit email, Stellar address, role, ban data, and internal market controls — no accidental leakage through shared serializers.
- Per-endpoint Swagger documentation and public API-key authorization annotations.
- Tests covering public-only filtering, private-market exclusion, and sensitive-field removal.

## Files
Main implementation: `backend/src/markets/public-markets.controller.ts`

## Validation
- Focused tests: 2/2 passing
- ESLint: clean
- Production build: successful
- `git diff --check`: clean

## Notes for reviewers
- Please confirm the default throttle values (`60` req / `60000` ms) match expected public API limits elsewhere in the system.
- Would appreciate a second look at the DTO field omissions to confirm nothing sensitive is missing from the exclusion list, given this is a public-facing surface.