### PR TITLE
feat(routes): add retryable error boundaries to remaining route groups (Fixes #1422)

### DIFF
--- a/frontend/src/app/(authenticated)/error.tsx
+++ b/frontend/src/app/(authenticated)/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type AuthenticatedErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AuthenticatedErrorPage({
+  error,
+  reset,
+}: AuthenticatedErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Your account"
+      description="This section couldn't finish loading. Retry to restore it without leaving your account."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/(oracle)/error.tsx
+++ b/frontend/src/app/(oracle)/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type OracleErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function OracleErrorPage({
+  error,
+  reset,
+}: OracleErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Oracle"
+      description="The oracle workspace ran into a problem. Retry to reload this section."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/app/admin/error.tsx
+++ b/frontend/src/app/admin/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RouteErrorState } from "@/component/route-error-state";
+
+type AdminErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function AdminErrorPage({
+  error,
+  reset,
+}: AdminErrorPageProps) {
+  return (
+    <RouteErrorState
+      error={error}
+      reset={reset}
+      routeLabel="Admin"
+      description="The admin section couldn't finish loading. Retry to restore this view."
+      fullScreen={false}
+    />
+  );
+}

--- a/frontend/src/component/route-error-state.test.tsx
+++ b/frontend/src/component/route-error-state.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RouteErrorState } from "./route-error-state";
+
+describe("RouteErrorState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the route error and retries only the failed segment", () => {
+    const error = Object.assign(new Error("Could not load"), {
+      digest: "error-reference",
+    });
+    const reset = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <RouteErrorState
+        error={error}
+        reset={reset}
+        routeLabel="Dashboard"
+        description="Please retry."
+        fullScreen={false}
+      />,
+    );
+
+    expect(screen.getByText("Dashboard hit an unexpected problem")).toBeInTheDocument();
+    expect(screen.getByText("Reference: error-reference")).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[Route Error Boundary] Dashboard",
+      expect.objectContaining({
+        message: "Could not load",
+        digest: "error-reference",
+        error,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION

Closes #1422
## Summary
Completes the remaining route coverage for #1422 — adds retryable error boundaries to the authenticated, admin, and oracle route groups, using the existing error-handling pattern already established elsewhere in the app.

## Key changes
- Added retryable error boundaries for the authenticated, admin, and oracle route groups.
- Surrounding layouts and unrelated page state are preserved when a section fails — a failure in one route group doesn't tear down the rest of the shell.
- Reused the existing friendly fallback UI and diagnostic logging rather than introducing a new pattern.
- Added a test covering error logging, error reference display, and retry behavior.

## Key file
`frontend/src/component/route-error-state.test.tsx`

## Validation
- 15 tests passed across 4 test files.
- `git diff --check` passed.
- TypeScript reports four pre-existing missing SVG asset errors referenced by `coursenav.tsx` — these are unrelated to this change and predate it.

## Notes for reviewers
- The four SVG-asset TypeScript errors are pre-existing and not introduced by this PR — flagging so they aren't mistaken for a regression here.