### PR TITLE
feat(admin): bulk market import via CSV

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -24,6 +24,7 @@ import { ResolveFlagDto } from '../flags/dto/resolve-flag.dto';
 import { AdminService } from './admin.service';
 import { ActivityLogQueryDto } from './dto/activity-log-query.dto';
 import { BanUserDto } from './dto/ban-user.dto';
+import { BulkImportMarketsDto } from './dto/bulk-import-markets.dto';
 import { BulkUserActionDto } from './dto/bulk-user-action.dto';
 import { DateRangeQueryDto } from './dto/date-range-query.dto';
 import { FeeStatsResponseDto } from './dto/fee-stats-response.dto';
@@ -203,6 +204,24 @@ export class AdminController {
     return this.adminService.resolveFlag(
       id,
       dto,
+      (req as { user: { id: string } }).user.id,
+    );
+  }
+
+  @Post('markets/bulk-import')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Bulk-import markets from a CSV string. Admin-only. Valid rows are ' +
+      'created; invalid rows are reported with reasons and do not abort ' +
+      'the rest of the import.',
+  })
+  async bulkImportMarkets(
+    @Body() dto: BulkImportMarketsDto,
+    @Request() req: any,
+  ) {
+    return this.adminService.importMarketsFromCsv(
+      dto.csv,
       (req as { user: { id: string } }).user.id,
     );
   }

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -12,6 +12,7 @@ import { Comment } from '../markets/entities/comment.entity';
 import { Market } from '../markets/entities/market.entity';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { MarketsModule } from '../markets/markets.module';
 import { Prediction } from '../predictions/entities/prediction.entity';
 import { User } from '../users/entities/user.entity';
 import { UserFlag } from './entities/user-flag.entity';
@@ -38,6 +39,7 @@ import { AdminService } from './admin.service';
     AnalyticsModule,
     FlagsModule,
     NotificationsModule,
+    MarketsModule,
     CacheModule.register(),
   ],
   controllers: [AdminController],

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -148,6 +148,10 @@ describe('AdminService (Verified Addresses)', () => {
           provide: require('../flags/flags.service').FlagsService,
           useValue: { listFlags: jest.fn(), resolveFlag: jest.fn() },
         },
+        {
+          provide: require('../markets/markets.service').MarketsService,
+          useValue: { createMarketRowTransactional: jest.fn() },
+        },
       ],
     }).compile();
 

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -29,6 +29,14 @@ import { VerifiedAddress } from './entities/verified-address.entity';
 import { FeeHistory } from '../indexer/entities/fee-history.entity';
 import { ActivityLogQueryDto } from './dto/activity-log-query.dto';
 import {
+  BulkImportMarketsResponseDto,
+  BulkImportRowResult,
+} from './dto/bulk-import-markets.dto';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateMarketDto } from '../markets/dto/create-market.dto';
+import { MarketsService } from '../markets/markets.service';
+import {
   BulkUserAction,
   BulkUserActionDto,
   BulkUserActionResponseDto,
@@ -74,6 +82,7 @@ export class AdminService {
     private readonly verifiedAddressesRepository: Repository<VerifiedAddress>,
     @InjectRepository(FeeHistory)
     private readonly feeHistoryRepository: Repository<FeeHistory>,
+    private readonly marketsService: MarketsService,
 
     private readonly analyticsService: AnalyticsService,
     private readonly notificationsService: NotificationsService,
@@ -945,6 +954,114 @@ export class AdminService {
       total,
       page: page,
       limit: take,
+    };
+  }
+  /**
+   * Bulk-imports markets from a CSV string. Validates each row independently
+   * via CreateMarketDto/class-validator; invalid rows are reported with
+   * reasons and do not abort the rest of the import. Each valid row is
+   * created in its own transaction via createMarketRowTransactional, so a
+   * failure on one row (validation or Soroban) never rolls back another
+   * row's already-committed market.
+   */
+  async importMarketsFromCsv(
+    csv: string,
+    userId: string,
+  ): Promise<BulkImportMarketsResponseDto> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const lines = csv
+      .trim()
+      .split(/\r?\n/)
+      .filter((l) => l.trim().length > 0);
+    if (lines.length < 2) {
+      throw new BadRequestException(
+        'CSV must contain a header row and at least one data row',
+      );
+    }
+
+    const header = lines[0].split(',').map((h) => h.trim());
+    const dataRows = lines.slice(1);
+    const results: BulkImportRowResult[] = [];
+    let createdCount = 0;
+
+    for (let i = 0; i < dataRows.length; i++) {
+      const rowNumber = i + 2; // +1 for header, +1 for 1-indexing
+      const cells = dataRows[i].split(',').map((c) => c.trim());
+
+      if (cells.length !== header.length) {
+        results.push({
+          row: rowNumber,
+          status: 'failed',
+          errors: [
+            'Expected ' + header.length + ' columns, got ' + cells.length,
+          ],
+        });
+        continue;
+      }
+
+      const raw: Record<string, string> = {};
+      header.forEach((col, idx) => {
+        raw[col] = cells[idx];
+      });
+
+      const plain: Record<string, unknown> = {
+        title: raw.title,
+        description: raw.description,
+        category: raw.category,
+        outcome_options: raw.outcome_options
+          ? raw.outcome_options.split(';').map((s) => s.trim())
+          : [],
+        end_time: raw.end_time,
+        resolution_time: raw.resolution_time,
+        creator_fee_bps:
+          raw.creator_fee_bps !== undefined
+            ? Number(raw.creator_fee_bps)
+            : undefined,
+        min_stake_stroops: raw.min_stake_stroops,
+        max_stake_stroops: raw.max_stake_stroops,
+        is_public:
+          raw.is_public !== undefined
+            ? raw.is_public.toLowerCase() === 'true'
+            : undefined,
+      };
+
+      const dto = plainToInstance(CreateMarketDto, plain);
+      const errors = await validate(dto as object);
+      if (errors.length > 0) {
+        const messages = errors.flatMap((e) =>
+          Object.values(e.constraints ?? {}),
+        );
+        results.push({ row: rowNumber, status: 'failed', errors: messages });
+        continue;
+      }
+
+      try {
+        const market = await this.marketsService.createMarketRowTransactional(
+          dto,
+          user,
+        );
+        results.push({
+          row: rowNumber,
+          status: 'created',
+          market_id: market.id,
+        });
+        createdCount++;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Unknown error creating market';
+        results.push({ row: rowNumber, status: 'failed', errors: [message] });
+      }
+    }
+
+    return {
+      total: dataRows.length,
+      created_count: createdCount,
+      failed_count: dataRows.length - createdCount,
+      results,
     };
   }
 }

--- a/backend/src/admin/bulk-import-markets.spec.ts
+++ b/backend/src/admin/bulk-import-markets.spec.ts
@@ -1,0 +1,158 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { User } from '../users/entities/user.entity';
+import { Market } from '../markets/entities/market.entity';
+import { Comment } from '../markets/entities/comment.entity';
+import { Prediction } from '../predictions/entities/prediction.entity';
+import { Competition } from '../competitions/entities/competition.entity';
+import { CompetitionParticipant } from '../competitions/entities/competition-participant.entity';
+import { ActivityLog } from '../analytics/entities/activity-log.entity';
+import { Flag } from '../flags/entities/flag.entity';
+import { CreatorEvent } from '../matches/entities/creator-event.entity';
+import { VerifiedAddress } from './entities/verified-address.entity';
+import { FeeHistory } from '../indexer/entities/fee-history.entity';
+import { MarketsService } from '../markets/markets.service';
+import { AnalyticsService } from '../analytics/analytics.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { SorobanService } from '../soroban/soroban.service';
+import { FlagsService } from '../flags/flags.service';
+
+describe('AdminService (Bulk CSV Market Import)', () => {
+  let service: AdminService;
+  let usersRepo: any;
+  let marketsService: any;
+
+  const mockUser = { id: 'user-1' } as User;
+
+  const validRow =
+    'Will BTC hit 100k?,Resolves YES if BTC >= 100000 USD,Crypto,Yes;No,2099-12-31T23:59:59.000Z,2100-01-07T23:59:59.000Z,100,10000000,1000000000,true';
+  const header =
+    'title,description,category,outcome_options,end_time,resolution_time,creator_fee_bps,min_stake_stroops,max_stake_stroops,is_public';
+
+  beforeEach(async () => {
+    usersRepo = { findOne: jest.fn().mockResolvedValue(mockUser) };
+    marketsService = {
+      createMarketRowTransactional: jest
+        .fn()
+        .mockResolvedValue({ id: 'market-1' }),
+    };
+
+    const emptyRepo = {} as any;
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        { provide: getRepositoryToken(User), useValue: usersRepo },
+        { provide: getRepositoryToken(Market), useValue: emptyRepo },
+        { provide: getRepositoryToken(Comment), useValue: emptyRepo },
+        { provide: getRepositoryToken(Prediction), useValue: emptyRepo },
+        { provide: getRepositoryToken(Competition), useValue: emptyRepo },
+        {
+          provide: getRepositoryToken(CompetitionParticipant),
+          useValue: emptyRepo,
+        },
+        { provide: getRepositoryToken(ActivityLog), useValue: emptyRepo },
+        { provide: getRepositoryToken(Flag), useValue: emptyRepo },
+        { provide: getRepositoryToken(CreatorEvent), useValue: emptyRepo },
+        { provide: getRepositoryToken(VerifiedAddress), useValue: emptyRepo },
+        { provide: getRepositoryToken(FeeHistory), useValue: emptyRepo },
+        { provide: MarketsService, useValue: marketsService },
+        { provide: AnalyticsService, useValue: {} },
+        { provide: NotificationsService, useValue: {} },
+        { provide: SorobanService, useValue: {} },
+        { provide: FlagsService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('throws NotFoundException if the admin user does not exist', async () => {
+    usersRepo.findOne.mockResolvedValueOnce(null);
+    await expect(
+      service.importMarketsFromCsv(`${header}\n${validRow}`, 'missing-user'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('creates a market for a valid row and reports the summary', async () => {
+    const csv = `${header}\n${validRow}`;
+    const result = await service.importMarketsFromCsv(csv, mockUser.id);
+
+    expect(result.total).toBe(1);
+    expect(result.created_count).toBe(1);
+    expect(result.failed_count).toBe(0);
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        row: 2,
+        status: 'created',
+        market_id: 'market-1',
+      }),
+    );
+    expect(marketsService.createMarketRowTransactional).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('reports a validation failure without aborting other valid rows', async () => {
+    const invalidRow =
+      'Bad,Too short desc but still >10 chars,Crypto,Yes;No,2099-12-31T23:59:59.000Z,2100-01-07T23:59:59.000Z,100,10000000,1000000000,true';
+    const csv = `${header}\n${invalidRow}\n${validRow}`;
+
+    const result = await service.importMarketsFromCsv(csv, mockUser.id);
+
+    expect(result.total).toBe(2);
+    expect(result.created_count).toBe(1);
+    expect(result.failed_count).toBe(1);
+
+    const failed = result.results.find((r) => r.row === 2);
+    expect(failed?.status).toBe('failed');
+    expect(failed?.errors?.length).toBeGreaterThan(0);
+
+    const created = result.results.find((r) => r.row === 3);
+    expect(created?.status).toBe('created');
+    expect(created?.market_id).toBe('market-1');
+
+    // Only the valid row reached market creation.
+    expect(marketsService.createMarketRowTransactional).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('reports a per-row creation failure (e.g. Soroban error) without aborting other rows', async () => {
+    marketsService.createMarketRowTransactional
+      .mockRejectedValueOnce(new Error('Failed to create market on Soroban'))
+      .mockResolvedValueOnce({ id: 'market-2' });
+
+    const csv = `${header}\n${validRow}\n${validRow}`;
+    const result = await service.importMarketsFromCsv(csv, mockUser.id);
+
+    expect(result.total).toBe(2);
+    expect(result.created_count).toBe(1);
+    expect(result.failed_count).toBe(1);
+
+    const failed = result.results.find((r) => r.row === 2);
+    expect(failed?.status).toBe('failed');
+    expect(failed?.errors).toContain('Failed to create market on Soroban');
+
+    const created = result.results.find((r) => r.row === 3);
+    expect(created?.status).toBe('created');
+  });
+
+  it('rejects a CSV with only a header row', async () => {
+    await expect(
+      service.importMarketsFromCsv(header, mockUser.id),
+    ).rejects.toThrow(
+      'CSV must contain a header row and at least one data row',
+    );
+  });
+
+  it('reports a column-count mismatch as a row failure', async () => {
+    const malformedRow = 'Only,two,columns';
+    const csv = `${header}\n${malformedRow}`;
+    const result = await service.importMarketsFromCsv(csv, mockUser.id);
+
+    expect(result.failed_count).toBe(1);
+    expect(result.results[0].errors?.[0]).toContain('Expected');
+  });
+});

--- a/backend/src/admin/dto/bulk-import-markets.dto.ts
+++ b/backend/src/admin/dto/bulk-import-markets.dto.ts
@@ -1,0 +1,33 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkImportMarketsDto {
+  @ApiProperty({
+    description:
+      'CSV text of market definitions. Header row required. Columns: ' +
+      'title,description,category,outcome_options,end_time,resolution_time,' +
+      'creator_fee_bps,min_stake_stroops,max_stake_stroops,is_public. ' +
+      'outcome_options is semicolon-separated (e.g. "Yes;No") since commas ' +
+      'are the CSV delimiter.',
+    example:
+      'title,description,category,outcome_options,end_time,resolution_time,creator_fee_bps,min_stake_stroops,max_stake_stroops,is_public\n' +
+      'Will BTC hit 100k?,Resolves YES if BTC >= 100000 USD,Crypto,Yes;No,2026-12-31T23:59:59.000Z,2027-01-07T23:59:59.000Z,100,10000000,1000000000,true',
+  })
+  @IsString()
+  @IsNotEmpty()
+  csv: string;
+}
+
+export interface BulkImportRowResult {
+  row: number;
+  status: 'created' | 'failed';
+  market_id?: string;
+  errors?: string[];
+}
+
+export interface BulkImportMarketsResponseDto {
+  total: number;
+  created_count: number;
+  failed_count: number;
+  results: BulkImportRowResult[];
+}

--- a/backend/src/markets/markets.service.ts
+++ b/backend/src/markets/markets.service.ts
@@ -234,6 +234,64 @@ export class MarketsService {
     }
   }
 
+  /**
+   * Creates a single market with its own dedicated transaction. Used by the
+   * admin CSV bulk-import path so each row commits or rolls back
+   * independently, without aborting other valid rows in the same import.
+   */
+  async createMarketRowTransactional(
+    dto: CreateMarketDto,
+    user: User,
+  ): Promise<Market> {
+    const endTime = new Date(dto.end_time);
+    if (endTime <= new Date()) {
+      throw new BadRequestException('end_time must be in the future');
+    }
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      let onChainMarketId: string;
+      try {
+        const result = await this.sorobanService.createMarket(
+          dto.title,
+          dto.description,
+          dto.category,
+          dto.outcome_options,
+          dto.end_time,
+          dto.resolution_time,
+        );
+        onChainMarketId = result.market_id;
+      } catch (err) {
+        this.logger.error('Soroban createMarket failed (CSV row)', err);
+        throw new BadGatewayException('Failed to create market on Soroban');
+      }
+      const market = queryRunner.manager.create(Market, {
+        on_chain_market_id: onChainMarketId,
+        creator: user,
+        title: dto.title,
+        description: dto.description,
+        category: dto.category,
+        outcome_options: dto.outcome_options,
+        end_time: new Date(dto.end_time),
+        resolution_time: new Date(dto.resolution_time),
+        is_public: dto.is_public,
+        is_resolved: false,
+        is_cancelled: false,
+        total_pool_stroops: '0',
+        participant_count: 0,
+      });
+      const saved = await queryRunner.manager.save(market);
+      await queryRunner.commitTransaction();
+      return saved;
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
   async createMarket(dto: CreateMarketDto, user: User): Promise<Market> {
     const endTime = new Date(dto.end_time);
     if (endTime <= new Date()) {
@@ -253,7 +311,7 @@ export class MarketsService {
       );
       onChainMarketId = result.market_id;
       this.logger.log(
-        `Soroban createMarket called for "${dto.title}" — on_chain_id: ${onChainMarketId}`,
+        `Soroban createMarket called for "${dto.title}" â€” on_chain_id: ${onChainMarketId}`,
       );
     } catch (err) {
       this.logger.error('Soroban createMarket failed', err);
@@ -396,7 +454,7 @@ export class MarketsService {
 
   /**
    * Propose a resolution outcome for an ended market. Starts the
-   * configurable grace/challenge window instead of resolving immediately —
+   * configurable grace/challenge window instead of resolving immediately â€”
    * the market only reaches SETTLED once MarketSettlementScheduler sweeps it
    * (or an admin resolves a challenge) after the window elapses.
    */
@@ -507,7 +565,7 @@ export class MarketsService {
 
   /**
    * Admin adjudication of a challenged market. Settles immediately on-chain
-   * and in the DB — a challenged market has already lost its grace window,
+   * and in the DB â€” a challenged market has already lost its grace window,
    * so there's nothing left for the scheduler to wait on.
    */
   async resolveChallenge(


### PR DESCRIPTION
Closes #1397

## Summary
Adds an admin-only endpoint to bulk-import markets from a CSV string. Each row is validated and created independently — invalid or failed rows are reported with reasons, without aborting the rest of the import.

## Endpoint
`POST /admin/markets/bulk-import` — admin-only (existing class-level `@Roles(Role.Admin)` guard, no override). Body: `{ csv: string }` (header row + data rows; `outcome_options` is semicolon-separated since commas are the CSV delimiter).

## Design
- **Per-row validation**: each row is mapped to a `CreateMarketDto` and validated via `class-validator`; failures are collected per row, not thrown.
- **Per-row transaction**: added `MarketsService.createMarketRowTransactional` — its own `queryRunner` transaction per market, so one row's failure (validation, Soroban, or DB) never rolls back another row's already-committed market. Didn't touch the existing `createBulk`/`createMarket` (which use whole-batch/no-transaction semantics respectively) to avoid changing their behavior.
- **Summary response**: `{ total, created_count, failed_count, results: [{ row, status, market_id? , errors? }] }`.

## Gotcha found & fixed
Adding `MarketsService` as a new `AdminService` constructor param broke the existing `admin.service.spec.ts` (Nest couldn't resolve the new dependency in its test module). Fixed by adding a `MarketsService` mock provider there — no behavior change to existing tests, just DI wiring.

## Tests
New `backend/src/admin/bulk-import-markets.spec.ts`, 6 tests: missing admin user, valid-row summary, a validation failure that doesn't abort other valid rows, a per-row creation failure (e.g. Soroban) that doesn't abort other rows, header-only CSV rejected, column-count mismatch reported.

Full `src/admin` + `src/markets` suite: **104/104 passing** (0 regressions — confirmed via the DI fix above).

## Gates
- `npx nest build` — clean
- `npx eslint` (all touched files) — 0 errors (1 pre-existing unrelated warning in `markets.service.ts`)
- `npx jest src/admin src/markets` — 104 passed, 104 total