### PR TITLE
[Contract] Impermanent loss accounting for LPs

### DIFF
--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -916,6 +916,21 @@ impl InsightArenaContract {
         liquidity::get_lp_position_public(&env, provider, market_id)
     }
 
+    /// Return the current impermanent loss (bps, always `<= 0`) for an open LP
+    /// position, computed live against the pool's current reserves relative to
+    /// the position's immutable entry-price snapshot. See
+    /// `liquidity::calculate_impermanent_loss_bps` for the formula and
+    /// `liquidity::get_position_il` for how it differs from the
+    /// `LPPosition::cumulative_il_bps` field (which only reflects the last
+    /// withdrawal).
+    pub fn get_position_il(
+        env: Env,
+        provider: Address,
+        market_id: u64,
+    ) -> Result<i128, InsightArenaError> {
+        liquidity::get_position_il(&env, provider, market_id)
+    }
+
     /// Get all active LP positions for a market.
     pub fn get_all_lp_providers(env: Env, market_id: u64) -> Vec<crate::storage_types::LPPosition> {
         liquidity::get_all_lp_providers(&env, market_id)

--- a/contracts/open-market/src/liquidity.rs
+++ b/contracts/open-market/src/liquidity.rs
@@ -38,6 +38,12 @@ pub const VOLATILITY_ALPHA_BPS: u32 = 2000;
 /// silently truncated (and therefore misleading) average.
 pub const TWAP_RING_BUFFER_CAPACITY: u32 = 64;
 
+/// Fixed-point scale used when computing the entry-vs-current reserve ratio for
+/// impermanent-loss accounting. `1e8` is chosen because it is a perfect square
+/// (`(1e4)^2`), which keeps the integer-sqrt step in
+/// [`calculate_impermanent_loss_bps`] exact for clean reference ratios.
+const IL_RATIO_SCALE: u128 = 100_000_000;
+
 // ── AMM Math Functions ────────────────────────────────────────────────────────
 
 /// Calculate output amount for a swap using constant product formula.
@@ -420,6 +426,140 @@ pub fn get_twap(
     Ok(twap)
 }
 
+// ── Impermanent Loss Accounting ───────────────────────────────────────────────
+//
+// Scope: this contract's AMM pool is generalized to N outcomes
+// (`LiquidityPool::outcome_reserves`), but the standard impermanent-loss
+// formula is derived for a 2-asset constant-product pool. Rather than
+// inventing a non-standard N-asset generalization, IL here is tracked against
+// a single *designated pair*: the market's first two `outcome_options`, in
+// declaration order (see `il_pair_reserves`). This covers the common 2-outcome
+// prediction market exactly; for markets with more than 2 outcomes, the
+// reported IL reflects only the price movement between those two designated
+// outcomes, not the full multi-asset position. Markets with a single outcome
+// degrade to a trivial (a, a) pair, for which the ratio is always 1 and IL is
+// always zero.
+
+/// Integer square root (floor) of a `u128`, via Newton's method. Soroban
+/// contracts cannot use floating point, so this backs the fixed-point
+/// impermanent-loss formula below.
+fn isqrt_u128(n: u128) -> u128 {
+    if n == 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = x.div_ceil(2);
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+/// Resolve the reserve pair this pool tracks for impermanent-loss purposes:
+/// the reserves of `mkt.outcome_options[0]` and `mkt.outcome_options[1]`. If
+/// the market has fewer than 2 outcomes, both entries mirror
+/// `outcome_options[0]`'s reserve (ratio 1, i.e. IL is always zero).
+fn il_pair_reserves(pool: &LiquidityPool, mkt: &Market) -> (i128, i128) {
+    let outcome_a = match mkt.outcome_options.get(0) {
+        Some(o) => o,
+        None => return (0, 0),
+    };
+    let reserve_a = pool.outcome_reserves.get(outcome_a).unwrap_or(0);
+
+    let reserve_b = match mkt.outcome_options.get(1) {
+        Some(outcome_b) => pool.outcome_reserves.get(outcome_b).unwrap_or(reserve_a),
+        None => reserve_a,
+    };
+
+    (reserve_a, reserve_b)
+}
+
+/// Compute the impermanent loss, in basis points (always `<= 0`), of an LP
+/// position that entered a pool at reserve ratio `entry_a : entry_b` and is
+/// now observed at `current_a : current_b`.
+///
+/// Uses the standard constant-product-AMM impermanent-loss formula, expressed
+/// in terms of the *ratio of ratios* `k = (current_a/current_b) / (entry_a/entry_b)`:
+///
+/// ```text
+/// IL = 2*sqrt(k) / (1 + k) - 1        (always <= 0; 0 exactly when k == 1)
+/// ```
+///
+/// e.g. `k == 1` (no price change) gives `IL == 0`; `k == 4` (the tracked
+/// pair's relative price quadruples) gives `IL == 2*sqrt(4)/(1+4) - 1 == -0.2`,
+/// i.e. -2000 bps.
+///
+/// Substituting `N = current_a*entry_b`, `D = entry_a*current_b` (so `k = N/D`)
+/// lets the whole computation stay in fixed-point integer arithmetic — Soroban
+/// contracts have no floating point:
+///
+/// ```text
+/// IL = 2*sqrt(N*D) / (N + D) - 1
+/// ```
+///
+/// This is evaluated here by scaling the entry/current ratios by
+/// [`IL_RATIO_SCALE`] (a perfect square) before taking an integer square root,
+/// which keeps the result exact for clean reference ratios such as the ones
+/// above.
+pub fn calculate_impermanent_loss_bps(
+    entry_a: i128,
+    entry_b: i128,
+    current_a: i128,
+    current_b: i128,
+) -> Result<i128, InsightArenaError> {
+    if entry_a <= 0 || entry_b <= 0 || current_a <= 0 || current_b <= 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    let scale = IL_RATIO_SCALE as i128;
+
+    // r0 = (entry_a / entry_b) * SCALE, r1 = (current_a / current_b) * SCALE
+    let r0 = entry_a
+        .checked_mul(scale)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(entry_b)
+        .ok_or(InsightArenaError::Overflow)?;
+    let r1 = current_a
+        .checked_mul(scale)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(current_b)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    if r0 <= 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    // k_scaled represents k * SCALE, where k = r1/r0 (current ratio over entry ratio).
+    let k_scaled = r1
+        .checked_mul(scale)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(r0)
+        .ok_or(InsightArenaError::Overflow)? as u128;
+
+    // s ~= sqrt(k) * sqrt(SCALE)
+    let s = isqrt_u128(k_scaled);
+
+    let numerator = 2u128
+        .checked_mul(s)
+        .and_then(|v| v.checked_mul(IL_RATIO_SCALE))
+        .ok_or(InsightArenaError::Overflow)?;
+    let denominator = IL_RATIO_SCALE
+        .checked_add(k_scaled)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    // term_bps == (2*sqrt(k)/(1+k)) * 10_000, already in basis points.
+    let term_bps = numerator
+        .checked_div(denominator)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    let il_bps = (term_bps as i128) - 10_000;
+
+    // By AM-GM, 2*sqrt(k)/(1+k) <= 1 always (equality only at k == 1), so
+    // `il_bps` is mathematically <= 0. `.min(0)` is just a rounding-noise belt.
+    Ok(il_bps.min(0))
+}
+
 // ── Helper Functions ──────────────────────────────────────────────────────────
 
 fn bump_pool(env: &Env, market_id: u64) {
@@ -686,13 +826,38 @@ pub fn add_liquidity(
     save_pool(env, &new_pool);
     add_provider_to_list(env, market_id, &provider);
 
-    let position = LPPosition::new(
+    // The IL entry snapshot must never change once a position exists, even if
+    // the same provider deposits again later (a "top-up"). Carry the original
+    // snapshot (and the last-recorded cumulative IL) forward in that case;
+    // only a brand-new position gets a fresh snapshot of the pool's current
+    // designated-pair reserves.
+    let existing_position: Option<LPPosition> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LPPosition(market_id, provider.clone()));
+
+    let (entry_reserve_a, entry_reserve_b, cumulative_il_bps) = match &existing_position {
+        Some(existing) => (
+            existing.entry_reserve_a,
+            existing.entry_reserve_b,
+            existing.cumulative_il_bps,
+        ),
+        None => {
+            let (a, b) = il_pair_reserves(&new_pool, &mkt);
+            (a, b, 0)
+        }
+    };
+
+    let mut position = LPPosition::new(
         provider.clone(),
         market_id,
         lp_tokens,
         amount,
         env.ledger().timestamp(),
+        entry_reserve_a,
+        entry_reserve_b,
     );
+    position.cumulative_il_bps = cumulative_il_bps;
     save_lp_position(env, &position);
 
     Ok(lp_tokens)
@@ -712,6 +877,7 @@ pub fn remove_liquidity(
         return Err(InsightArenaError::InvalidInput);
     }
 
+    let mkt = market::get_market(env, market_id)?;
     let mut pool = get_pool(env, market_id)?;
     let mut position = get_lp_position(env, &provider, market_id)?;
 
@@ -721,6 +887,18 @@ pub fn remove_liquidity(
 
     let withdrawal_amount =
         calculate_liquidity_value(lp_tokens, pool.lp_token_supply, pool.total_liquidity)?;
+
+    // Compute impermanent loss relative to the position's immutable entry
+    // snapshot, using the pool's reserves as they stand *before* this
+    // withdrawal mutates them (i.e. the price the provider is exiting at), and
+    // persist it as the position's cumulative IL for reporting.
+    let (current_a, current_b) = il_pair_reserves(&pool, &mkt);
+    position.cumulative_il_bps = calculate_impermanent_loss_bps(
+        position.entry_reserve_a,
+        position.entry_reserve_b,
+        current_a,
+        current_b,
+    )?;
 
     pool.lp_token_supply = pool
         .lp_token_supply
@@ -926,6 +1104,33 @@ pub fn get_lp_position_public(
     market_id: u64,
 ) -> Result<LPPosition, InsightArenaError> {
     get_lp_position(env, &provider, market_id)
+}
+
+/// Return the current impermanent loss (basis points, always `<= 0`) for an
+/// open LP position, computed live against the pool's *current* reserves.
+///
+/// Unlike `LPPosition::cumulative_il_bps` (only refreshed as of the position's
+/// last withdrawal), this always reflects "now" — it recomputes
+/// `calculate_impermanent_loss_bps` from the position's immutable entry
+/// snapshot and the pool's live reserves on every call, without mutating any
+/// stored state.
+pub fn get_position_il(
+    env: &Env,
+    provider: Address,
+    market_id: u64,
+) -> Result<i128, InsightArenaError> {
+    let mkt = market::get_market(env, market_id)?;
+    let pool = get_pool(env, market_id)?;
+    let position = get_lp_position(env, &provider, market_id)?;
+
+    let (current_a, current_b) = il_pair_reserves(&pool, &mkt);
+
+    calculate_impermanent_loss_bps(
+        position.entry_reserve_a,
+        position.entry_reserve_b,
+        current_a,
+        current_b,
+    )
 }
 
 pub fn get_all_lp_providers(env: &Env, market_id: u64) -> Vec<LPPosition> {

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -408,15 +408,37 @@ pub struct LPPosition {
     pub initial_deposit: i128,
     pub fees_earned: i128,
     pub created_at: u64,
+    /// Reserve of the pool's first IL-tracked outcome (`Market::outcome_options[0]`)
+    /// at the moment this position was opened. An immutable entry-price snapshot:
+    /// set once in `LPPosition::new` / `liquidity::add_liquidity` and never
+    /// mutated afterward, even when the same provider tops up their position with
+    /// additional deposits. Used as the impermanent-loss baseline — see
+    /// `liquidity::calculate_impermanent_loss_bps`.
+    pub entry_reserve_a: i128,
+    /// Reserve of the pool's second IL-tracked outcome (`Market::outcome_options[1]`)
+    /// at the moment this position was opened. Immutable; see `entry_reserve_a`.
+    /// For single-outcome markets this mirrors `entry_reserve_a`, which yields a
+    /// price ratio of 1 (i.e. impermanent loss is always zero in that case).
+    pub entry_reserve_b: i128,
+    /// Impermanent loss, in basis points (always `<= 0`), computed relative to
+    /// `entry_reserve_a` / `entry_reserve_b` the last time this position was
+    /// withdrawn from via `liquidity::remove_liquidity`. Zero until the first
+    /// withdrawal. For the always-current figure, use `liquidity::get_position_il`,
+    /// which recomputes live against the pool's current reserves instead of
+    /// relying on this cached, withdrawal-time value.
+    pub cumulative_il_bps: i128,
 }
 
 impl LPPosition {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         provider: Address,
         market_id: u64,
         lp_tokens: i128,
         initial_deposit: i128,
         created_at: u64,
+        entry_reserve_a: i128,
+        entry_reserve_b: i128,
     ) -> Self {
         Self {
             provider,
@@ -425,6 +447,9 @@ impl LPPosition {
             initial_deposit,
             fees_earned: 0,
             created_at,
+            entry_reserve_a,
+            entry_reserve_b,
+            cumulative_il_bps: 0,
         }
     }
 }

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -2784,3 +2784,351 @@ fn test_swap_output_invariant_k_never_decreases_with_fees() {
 
     assert!(k_after >= k_before);
 }
+
+// ── Impermanent Loss Accounting Tests (Issue #1335) ──────────────────────────
+//
+// `calculate_impermanent_loss_bps` implements the standard 2-asset
+// constant-product IL formula `IL = 2*sqrt(k)/(1+k) - 1`, where `k` is the
+// ratio of (current reserve-ratio) over (entry reserve-ratio) for the pool's
+// designated IL-tracked pair (`Market::outcome_options[0]` / `[1]`). Because
+// the formula only depends on the *magnitude* of the ratio change, it is
+// symmetric under `k -> 1/k`: a price move that doubles outcome A's reserve
+// relative to B produces the same IL magnitude as one that halves it. This is
+// expected DeFi behavior (IL is a loss relative to holding regardless of
+// which side moved) and is exercised explicitly below, not a bug.
+
+#[test]
+fn test_il_no_price_change_is_zero() {
+    // k == 1 (entry ratio == current ratio) must give exactly 0 bps.
+    assert_eq!(calculate_impermanent_loss_bps(1000, 1000, 1000, 1000), Ok(0));
+    assert_eq!(
+        calculate_impermanent_loss_bps(500_000, 500_000, 2_000_000, 2_000_000),
+        Ok(0)
+    );
+    // Same *ratio*, different absolute reserves (pool grew, ratio held at 1:1).
+    assert_eq!(
+        calculate_impermanent_loss_bps(100_000, 100_000, 300_000, 300_000),
+        Ok(0)
+    );
+}
+
+#[test]
+fn test_il_price_ratio_quadruples_is_twenty_percent() {
+    // k == 4: IL = 2*sqrt(4)/(1+4) - 1 = 2*2/5 - 1 = 0.8 - 1 = -0.20, i.e. -2000 bps.
+    let il = calculate_impermanent_loss_bps(100_000, 100_000, 400_000, 100_000).unwrap();
+    assert_eq!(il, -2000);
+}
+
+#[test]
+fn test_il_symmetric_for_inverse_price_ratio() {
+    // k == 1/4 is the mirror image of k == 4 (same magnitude of relative price
+    // change, opposite direction) and must produce the same IL.
+    let il_k4 = calculate_impermanent_loss_bps(100_000, 100_000, 400_000, 100_000).unwrap();
+    let il_k_quarter = calculate_impermanent_loss_bps(100_000, 100_000, 100_000, 400_000).unwrap();
+    assert_eq!(il_k4, il_k_quarter);
+    assert_eq!(il_k_quarter, -2000);
+}
+
+#[test]
+fn test_il_moderate_price_move_k_2() {
+    // k == 2: IL = 2*sqrt(2)/3 - 1 ≈ -0.05719, i.e. ≈ -571.9 bps.
+    let il = calculate_impermanent_loss_bps(100_000, 100_000, 200_000, 100_000).unwrap();
+    let expected_float_bps = (2.0 * 2.0_f64.sqrt() / 3.0 - 1.0) * 10_000.0;
+    assert!(il < 0);
+    assert!((il as f64 - expected_float_bps).abs() <= 2.0);
+}
+
+#[test]
+fn test_il_never_positive() {
+    // By AM-GM, 2*sqrt(k)/(1+k) <= 1 for any k > 0, so IL must never be positive
+    // regardless of how extreme the price move is.
+    for (entry_a, entry_b, current_a, current_b) in [
+        (1_i128, 1_i128, 1_000_000_i128, 1_i128),
+        (1_i128, 1_000_000_i128, 1_i128, 1_i128),
+        (100_000_i128, 100_000_i128, 100_001_i128, 99_999_i128),
+    ] {
+        let il = calculate_impermanent_loss_bps(entry_a, entry_b, current_a, current_b).unwrap();
+        assert!(il <= 0);
+    }
+}
+
+#[test]
+fn test_il_rejects_non_positive_inputs() {
+    assert_eq!(
+        calculate_impermanent_loss_bps(0, 1000, 1000, 1000),
+        Err(InsightArenaError::InvalidInput)
+    );
+    assert_eq!(
+        calculate_impermanent_loss_bps(1000, 0, 1000, 1000),
+        Err(InsightArenaError::InvalidInput)
+    );
+    assert_eq!(
+        calculate_impermanent_loss_bps(1000, 1000, 0, 1000),
+        Err(InsightArenaError::InvalidInput)
+    );
+    assert_eq!(
+        calculate_impermanent_loss_bps(1000, 1000, 1000, 0),
+        Err(InsightArenaError::InvalidInput)
+    );
+    assert_eq!(
+        calculate_impermanent_loss_bps(-1000, 1000, 1000, 1000),
+        Err(InsightArenaError::InvalidInput)
+    );
+}
+
+#[test]
+fn test_get_position_il_zero_immediately_after_deposit() {
+    // No price movement has occurred yet, so the live IL for a freshly opened
+    // position must be exactly zero.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 200_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    assert_eq!(client.get_position_il(&provider, &market_id), 0);
+
+    // The stored per-withdrawal cumulative figure also starts at zero.
+    let position = client.get_lp_position(&provider, &market_id);
+    assert_eq!(position.cumulative_il_bps, 0);
+}
+
+#[test]
+fn test_get_position_il_favorable_price_move() {
+    // Swapping YES for NO increases the YES reserve relative to NO, pushing
+    // the tracked pair's ratio above the 1:1 entry ratio (k > 1).
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let position = client.get_lp_position(&provider, &market_id);
+    let (entry_a, entry_b) = (position.entry_reserve_a, position.entry_reserve_b);
+    assert_eq!(entry_a, entry_b); // 2-outcome pool: equal 1:1 entry split.
+
+    let swap_amount = 300_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let current_a = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+    let current_b = client.get_outcome_price(&market_id, &symbol_short!("no"));
+    assert!(current_a > entry_a);
+    assert!(current_b < entry_b);
+
+    let expected_il =
+        calculate_impermanent_loss_bps(entry_a, entry_b, current_a, current_b).unwrap();
+    assert!(expected_il < 0);
+
+    let live_il = client.get_position_il(&provider, &market_id);
+    assert_eq!(live_il, expected_il);
+}
+
+#[test]
+fn test_get_position_il_adverse_price_move() {
+    // Swapping NO for YES is the mirror-image trade: it decreases the YES
+    // reserve relative to NO, pushing the ratio below the 1:1 entry ratio
+    // (k < 1). IL is still <= 0 (never a gain), consistent with the formula's
+    // symmetry under k -> 1/k.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let position = client.get_lp_position(&provider, &market_id);
+    let (entry_a, entry_b) = (position.entry_reserve_a, position.entry_reserve_b);
+
+    let swap_amount = 300_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("no"),
+        &symbol_short!("yes"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    let current_a = client.get_outcome_price(&market_id, &symbol_short!("yes"));
+    let current_b = client.get_outcome_price(&market_id, &symbol_short!("no"));
+    assert!(current_a < entry_a);
+    assert!(current_b > entry_b);
+
+    let expected_il =
+        calculate_impermanent_loss_bps(entry_a, entry_b, current_a, current_b).unwrap();
+    assert!(expected_il < 0);
+
+    let live_il = client.get_position_il(&provider, &market_id);
+    assert_eq!(live_il, expected_il);
+}
+
+#[test]
+fn test_entry_snapshot_immutable_across_topup() {
+    // The entry snapshot must never change once a position exists, even when
+    // the same provider deposits again after the pool's price has moved.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let first_deposit = 500_000_i128;
+    sa.mint(&provider, &first_deposit);
+    token.approve(&provider, &client.address, &first_deposit, &9999);
+    client.add_liquidity(&provider, &market_id, &first_deposit);
+
+    let position_before = client.get_lp_position(&provider, &market_id);
+    let (entry_a_before, entry_b_before) =
+        (position_before.entry_reserve_a, position_before.entry_reserve_b);
+
+    // Move the pool's price before the top-up.
+    let swap_amount = 200_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    // Top-up deposit by the same provider.
+    let second_deposit = 100_000_i128;
+    sa.mint(&provider, &second_deposit);
+    token.approve(&provider, &client.address, &second_deposit, &9999);
+    client.add_liquidity(&provider, &market_id, &second_deposit);
+
+    let position_after = client.get_lp_position(&provider, &market_id);
+    assert_eq!(position_after.entry_reserve_a, entry_a_before);
+    assert_eq!(position_after.entry_reserve_b, entry_b_before);
+}
+
+#[test]
+fn test_cumulative_il_untouched_by_swaps_updated_on_withdrawal() {
+    // `cumulative_il_bps` must only change when the position is withdrawn
+    // from — not merely because the pool's price moved via a swap.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    let lp_tokens = client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 300_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    // Price has moved, so the live IL is non-zero, but nothing has been
+    // withdrawn yet, so the stored cumulative figure is still zero.
+    let live_il_before_withdrawal = client.get_position_il(&provider, &market_id);
+    assert!(live_il_before_withdrawal < 0);
+    let position_before_withdrawal = client.get_lp_position(&provider, &market_id);
+    assert_eq!(position_before_withdrawal.cumulative_il_bps, 0);
+
+    // Withdraw part of the position; this must snapshot the current IL into
+    // `cumulative_il_bps`. `remove_liquidity` does not touch outcome_reserves,
+    // so the live figure right after should be unchanged from right before.
+    client.remove_liquidity(&provider, &market_id, &(lp_tokens / 2));
+
+    let position_after_withdrawal = client.get_lp_position(&provider, &market_id);
+    assert_eq!(
+        position_after_withdrawal.cumulative_il_bps,
+        live_il_before_withdrawal
+    );
+
+    let live_il_after_withdrawal = client.get_position_il(&provider, &market_id);
+    assert_eq!(live_il_after_withdrawal, live_il_before_withdrawal);
+}
+
+#[test]
+fn test_cumulative_il_zero_on_withdrawal_without_price_change() {
+    // Withdrawing without any prior swap must record zero IL.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let creator = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&creator, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 200_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    let lp_tokens = client.add_liquidity(&provider, &market_id, &liquidity);
+
+    client.remove_liquidity(&provider, &market_id, &(lp_tokens / 2));
+
+    let position = client.get_lp_position(&provider, &market_id);
+    assert_eq!(position.cumulative_il_bps, 0);
+}


### PR DESCRIPTION
## Summary

Liquidity providers previously had no on-chain record of impermanent loss (IL), making it impossible to compute fair compensation or show accurate LP performance. This PR adds IL accounting to the `open-market` liquidity pool contract:

- **Entry snapshot**: `LPPosition` now stores `entry_reserve_a` / `entry_reserve_b` — the pool's designated IL-tracked pair (`Market::outcome_options[0]` / `[1]`) at the moment the position is opened. Set once in `add_liquidity` and never mutated afterward, including across top-up deposits by the same provider (previously, a top-up rebuilt `LPPosition` from scratch on every call, which would have silently reset the snapshot).
- **IL computation**: `liquidity::calculate_impermanent_loss_bps(entry_a, entry_b, current_a, current_b)` implements the standard constant-product-AMM formula `IL = 2*sqrt(k)/(1+k) - 1`, where `k` is the ratio of the current reserve ratio over the entry reserve ratio. Computed entirely with fixed-point integer arithmetic and an integer square root (Newton's method) — no floating point, per Soroban constraints.
- **Cumulative storage**: `LPPosition.cumulative_il_bps` is (re)computed and persisted every time `remove_liquidity` is called, using the pool's reserves as they stood immediately before that withdrawal.
- **Read function**: a new `get_position_il(provider, market_id)` contract entry point (backed by `liquidity::get_position_il`) returns the position's IL live, computed against the pool's *current* reserves — unlike `cumulative_il_bps`, which only reflects the value as of the last withdrawal.

### Scope / generalization decision for >2-outcome pools
The contract's AMM pool (`LiquidityPool::outcome_reserves`) is generalized to N outcomes, but the textbook IL formula is derived for a 2-asset pool. Rather than inventing a non-standard N-asset formula, IL here is tracked against a single designated pair — the market's first two `outcome_options`, in declaration order. This covers the common 2-outcome prediction market exactly (verified end-to-end in tests). For markets with >2 outcomes, the reported IL reflects only the price movement between those two designated outcomes. Single-outcome markets degrade to a trivial 1:1 ratio (IL always 0). This is documented at the top of the new "Impermanent Loss Accounting" section in `liquidity.rs`.

### No new error variants
The issue suggested adding error codes for e.g. "position not found," but `errors.rs`'s `InsightArenaError` enum is already at the hard 50-case cap imposed by the Soroban XDR spec for `#[contracterror]` (confirmed: exactly 50 variants currently declared, and the file already has a comment noting a prior variant was removed to make room for the same reason). New code therefore reuses the existing `PredictionNotFound` variant for a missing LP position, matching the convention `get_lp_position` already used before this PR.

## Before / after

**Before:** `LPPosition` had no notion of entry price; there was no way to compute or query IL for a position, on-chain or off-chain.

**After:** every LP position carries an immutable entry snapshot, its cumulative IL is recorded on each withdrawal, and `get_position_il` can be queried at any time for a live, accurate IL figure.

## How this was tested

Added 12 tests to `contracts/open-market/tests/liquidity_tests.rs`:

- Pure formula tests against `calculate_impermanent_loss_bps`: no price change (`k=1` -> 0 bps), price ratio quadruples (`k=4` -> exactly -2000 bps, matching `2*sqrt(4)/(1+4)-1 = -0.20`), symmetry under `k -> 1/k`, a non-perfect-square case (`k=2` -> approx -571.9 bps, checked against the floating-point reference within 2 bps), IL is never positive across several extreme ratios, and rejection of non-positive inputs.
- Contract-level integration tests via `InsightArenaContractClient`: IL is exactly 0 immediately after opening a position; a favorable-direction swap (YES appreciates vs. NO) and an adverse-direction swap (NO appreciates vs. YES) both produce a live IL that exactly matches an independent call to `calculate_impermanent_loss_bps` using the actual on-chain reserves; the entry snapshot is provably unchanged after a top-up deposit made post-price-move; `cumulative_il_bps` stays 0 across swaps and only updates on `remove_liquidity`, at which point it matches the live figure; and `cumulative_il_bps` is exactly 0 when withdrawing without any prior price movement.

Ran from `contracts/open-market/`:
- `cargo build` — clean.
- `cargo test` — all 610 tests across the crate pass (141 in `liquidity_tests.rs`, including the 12 new ones), 0 failures.
- `cargo clippy --all-targets` — no new warnings introduced by this change (pre-existing warnings in unrelated test files untouched).

Closes #1335