### PR TITLE
[Contract] Escrow emergency pause with guardian role

### DIFF
--- a/contracts/open-market/src/config.rs
+++ b/contracts/open-market/src/config.rs
@@ -135,9 +135,14 @@ pub struct Config {
     /// Address of the XLM Stellar Asset Contract used for escrow transfers.
     pub xlm_token: Address,
     /// When `true`, all non-admin entry points must revert with `Paused`.
+    /// Set via [`set_paused`]: only `guardian` may set this to `true`
+    /// (pause); only `admin` may set it back to `false` (unpause).
     pub is_paused: bool,
     /// Address authorized to veto a queued governance proposal during its
-    /// timelock window. Defaults to `admin` at initialization.
+    /// timelock window, and to engage the emergency pause (see
+    /// [`set_paused`]). Distinct from `admin` so a single compromised role
+    /// cannot both halt *and* resume the contract. Defaults to `admin` at
+    /// initialization.
     pub guardian: Address,
     /// Delay (seconds) a passed governance proposal must wait in the queue
     /// before `execute_proposal` will apply it. This value — and `guardian`
@@ -359,24 +364,49 @@ pub fn update_protocol_fee_from_governance(
     Ok(())
 }
 
-/// Pause or resume the contract. Caller must be the stored admin.
+/// Engage or lift the emergency pause, enforcing strict separation of duties:
 ///
-/// When `paused` is `true`, all non-admin entry points should call
-/// [`ensure_not_paused`] and revert with [`InsightArenaError::Paused`].
+/// - Pausing (`paused == true`) may only be authorized by the stored
+///   **guardian**. The guardian is a distinct, lower-trust role intended to
+///   react quickly to a discovered exploit without needing full admin
+///   authority.
+/// - Unpausing (`paused == false`) may only be authorized by the stored
+///   **admin**. This ensures a single compromised or malicious guardian can
+///   halt the contract but can never be the one to resume it — resuming
+///   operation after an incident requires the higher-trust admin role.
+///
+/// While `paused` is `true`, all fund-moving and other sensitive entry points
+/// call [`ensure_not_paused`] (or, for the escrow primitives, check it
+/// directly) and revert with [`InsightArenaError::Paused`].
 ///
 /// `reason_code` is an opaque, caller-defined code (e.g. 1 = incident,
 /// 2 = scheduled maintenance, 0 = resume/no reason) recorded on the emitted
 /// event for off-chain auditing. It is not validated or persisted.
+///
+/// # Errors
+/// - `Unauthorized` is not returned directly here; instead `require_auth`
+///   panics (reverting the transaction) when the wrong role signs the call,
+///   consistent with every other role-gated setter in this module.
 pub fn set_paused(env: &Env, paused: bool, reason_code: u32) -> Result<(), InsightArenaError> {
     let mut config = load_config(env)?;
 
-    config.admin.require_auth();
+    // Separation of duties: the guardian engages the pause, only the admin
+    // may lift it. Branching on `paused` (rather than exposing two entry
+    // points) keeps the public ABI unchanged while still requiring the
+    // correct, distinct role for each direction.
+    let actor = if paused {
+        config.guardian.require_auth();
+        config.guardian.clone()
+    } else {
+        config.admin.require_auth();
+        config.admin.clone()
+    };
 
     config.is_paused = paused;
     env.storage().persistent().set(&DataKey::Config, &config);
     bump_config(env);
 
-    emit_paused_toggled(env, &config.admin, paused, reason_code);
+    emit_paused_toggled(env, &actor, paused, reason_code);
 
     Ok(())
 }

--- a/contracts/open-market/src/errors.rs
+++ b/contracts/open-market/src/errors.rs
@@ -14,7 +14,17 @@ pub enum InsightArenaError {
     // ── Authorization ─────────────────────────────────────────────────────────
     /// The caller does not have the required role for this operation
     /// (e.g. a non-creator attempting to resolve a market, or a non-admin
-    /// calling an admin-only function).
+    /// calling an admin-only function). Also covers the guardian/admin
+    /// separation of duties enforced by `config::set_paused` — pausing
+    /// requires the guardian and unpausing requires the admin, and each
+    /// role attempting the other's half reverts via `require_auth`
+    /// (surfacing as an authorization failure rather than this error code,
+    /// consistent with every other role-gated setter in `config.rs`).
+    ///
+    /// NOTE: `#[contracterror]` enums are hard-capped at 50 XDR cases
+    /// (`ScSpecUdtErrorEnumV0::cases<50>`) and this enum is already at that
+    /// limit (see `ZeroShareTransfer = 112` below) — reuse this variant
+    /// rather than adding a new one for role-check failures.
     Unauthorized = 3,
     /// A cryptographic signature supplied with the call could not be verified
     /// against the expected public key or message payload.

--- a/contracts/open-market/src/escrow.rs
+++ b/contracts/open-market/src/escrow.rs
@@ -43,12 +43,16 @@ fn bump_treasury(env: &Env) {
 /// until the market is resolved (payout) or cancelled (refund).
 ///
 /// # Errors
+/// - `Paused` when the contract's emergency pause is engaged (checked here
+///   directly so this fund-moving primitive is self-defending regardless of
+///   whether the caller already checked, defense in depth).
 /// - `InvalidInput` when `amount <= 0`.
 /// - Propagates any error returned by [`config::get_config`].
 ///
 /// Token transfer panics are handled by the Soroban runtime and surface as
 /// contract failures.
 pub fn lock_stake(env: &Env, from: &Address, amount: i128) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
     acquire_escrow_lock(env)?;
 
     if amount <= 0 {
@@ -75,6 +79,8 @@ pub fn lock_stake(env: &Env, from: &Address, amount: i128) -> Result<(), Insight
 /// where the token holder pre-approves the contract separately.
 ///
 /// # Errors
+/// - `Paused` when the contract's emergency pause is engaged (checked here
+///   directly, defense in depth).
 /// - `InvalidInput` when `amount <= 0`.
 /// - `InsufficientFunds` when the allowance is insufficient.
 /// - Propagates any error returned by [`config::get_config`].
@@ -83,6 +89,7 @@ pub fn lock_stake_via_allowance(
     from: &Address,
     amount: i128,
 ) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
     acquire_escrow_lock(env)?;
 
     if amount <= 0 {
@@ -116,10 +123,13 @@ pub fn lock_stake_via_allowance(
 /// payout distribution.
 ///
 /// # Errors
+/// - `Paused` when the contract's emergency pause is engaged (checked here
+///   directly, defense in depth).
 /// - `InvalidInput` when `amount <= 0`.
 /// - `EscrowEmpty` when the contract balance cannot cover the refund.
 /// - Propagates any error returned by [`config::get_config`].
 pub fn refund(env: &Env, to: &Address, amount: i128) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
     acquire_escrow_lock(env)?;
 
     if amount <= 0 {
@@ -146,7 +156,12 @@ pub fn refund(env: &Env, to: &Address, amount: i128) -> Result<(), InsightArenaE
 ///
 /// This is semantically distinct from `refund` (used for market cancellation),
 /// but uses the same escrow transfer path from contract balance to recipient.
+///
+/// # Errors
+/// - `Paused` when the contract's emergency pause is engaged (checked here
+///   directly, defense in depth).
 pub fn release_payout(env: &Env, to: &Address, amount: i128) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(env)?;
     acquire_escrow_lock(env)?;
 
     if amount <= 0 {
@@ -321,11 +336,15 @@ pub fn transfer_fee(
 /// tracked treasury balance.
 ///
 /// # Errors
+/// - `Paused` when the contract's emergency pause is engaged (checked here
+///   directly, defense in depth).
 /// - `InvalidInput` when `amount <= 0`.
 /// - `Unauthorized` when caller is not the admin.
 /// - `InsufficientFunds` when `amount` exceeds the tracked treasury balance.
 /// - `EscrowEmpty` if the contract token balance cannot cover the withdrawal.
 pub fn withdraw_treasury(env: Env, caller: Address, amount: i128) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(&env)?;
+
     if amount <= 0 {
         return Err(InsightArenaError::InvalidInput);
     }

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -81,7 +81,10 @@ impl InsightArenaContract {
         config::update_protocol_fee(&env, new_fee_bps)
     }
 
-    /// Pause or resume the contract. Caller must be the stored admin.
+    /// Pause or resume the contract. Only the stored **guardian** may pause
+    /// (`paused = true`); only the stored **admin** may unpause
+    /// (`paused = false`) — a deliberate separation of duties so no single
+    /// role can both trigger and clear an emergency halt.
     /// `reason_code` is recorded on the emitted event for auditing.
     pub fn set_paused(env: Env, paused: bool, reason_code: u32) -> Result<(), InsightArenaError> {
         config::set_paused(&env, paused, reason_code)

--- a/contracts/open-market/tests/circuit_breaker_tests.rs
+++ b/contracts/open-market/tests/circuit_breaker_tests.rs
@@ -11,9 +11,20 @@
 //! read-only views keep working while paused.
 
 use insightarena_contract::market::CreateMarketParams;
-use insightarena_contract::{InsightArenaContract, InsightArenaContractClient};
+use insightarena_contract::{
+    InsightArenaContract, InsightArenaContractClient, InsightArenaError,
+};
 use soroban_sdk::testutils::{Address as _, Events, MockAuth, MockAuthInvoke};
 use soroban_sdk::{symbol_short, vec, Address, Env, IntoVal, String, Symbol, TryIntoVal};
+
+/// Assert the contract is currently paused without calling `get_config`
+/// directly — `get_config` itself reverts with `Paused` while paused (see
+/// `ensure_not_paused_err_when_paused` in config_tests.rs), so callers must
+/// go through `try_get_config` to observe the paused state from outside.
+fn assert_is_paused(client: &InsightArenaContractClient<'_>) {
+    let result = client.try_get_config();
+    assert!(matches!(result, Err(Ok(InsightArenaError::Paused))));
+}
 
 fn register_token(env: &Env) -> Address {
     let token_admin = Address::generate(env);
@@ -111,11 +122,13 @@ fn resume_event_carries_false_and_its_own_reason() {
 }
 
 #[test]
-fn only_admin_can_toggle_pause() {
+fn toggle_pause_requires_authentication() {
     let env = Env::default();
     // `initialize` itself does not require auth, so we can deploy without
     // ever engaging `mock_all_auths` — leaving `set_paused`'s internal
-    // `config.admin.require_auth()` as the only thing gating this call.
+    // `config.guardian.require_auth()` (for pausing) as the only thing
+    // gating this call. With no mocked auth at all, it must revert
+    // regardless of which role is checked.
     let id = env.register(InsightArenaContract, ());
     let client = InsightArenaContractClient::new(&env, &id);
     let admin = Address::generate(&env);
@@ -128,7 +141,13 @@ fn only_admin_can_toggle_pause() {
 }
 
 #[test]
-fn former_admin_cannot_toggle_pause_after_transfer() {
+fn former_admin_cannot_unpause_after_transfer() {
+    // Pausing is guardian-gated, not admin-gated (see #1334), and
+    // `transfer_admin` never moves the guardian role — so the *former* admin
+    // (who is still the guardian, since guardian defaults to admin at
+    // `initialize`) can still pause after the transfer. What must be
+    // rejected is the former admin trying to *unpause*, since unpausing is
+    // admin-only and admin has moved to `new_admin`.
     let env = Env::default();
     let (client, admin, _oracle) = deploy(&env);
     let new_admin = Address::generate(&env);
@@ -144,9 +163,8 @@ fn former_admin_cannot_toggle_pause_after_transfer() {
     }]);
     client.transfer_admin(&new_admin);
 
-    // The old admin still signs the call, but `config.admin` is now
-    // `new_admin` — set_paused's internal `config.admin.require_auth()` must
-    // reject an authorization from an address that is no longer the admin.
+    // The former admin is still the guardian, so it can still engage the
+    // pause.
     env.mock_auths(&[MockAuth {
         address: &admin,
         invoke: &MockAuthInvoke {
@@ -156,7 +174,23 @@ fn former_admin_cannot_toggle_pause_after_transfer() {
             sub_invokes: &[],
         },
     }]);
-    let result = client.try_set_paused(&true, &1u32);
+    client.set_paused(&true, &1u32);
+    assert_is_paused(&client);
+
+    // The old admin signs the unpause call, but `config.admin` is now
+    // `new_admin` — set_paused's internal `config.admin.require_auth()` for
+    // the unpause direction must reject an authorization from an address
+    // that is no longer the admin, even though it still holds guardian.
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_paused",
+            args: (false, 0u32).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = client.try_set_paused(&false, &0u32);
     assert!(result.is_err());
 }
 
@@ -180,4 +214,154 @@ fn reads_remain_available_while_paused() {
     assert_eq!(client.get_treasury_balance(), 0);
     let _ = client.get_platform_stats();
     let _ = client.list_categories();
+}
+
+// ── Guardian pause / admin unpause role separation (#1334) ───────────────────
+//
+// Note: the tests above (`set_paused_emits_event_with_actor_and_reason`,
+// `resume_event_carries_false_and_its_own_reason`,
+// `toggle_pause_requires_authentication`) still pass unmodified because
+// `initialize` defaults `guardian` to `admin`, so those two addresses are
+// identical in `deploy()` — the tests below make the roles genuinely
+// distinct to prove the separation of duties actually holds.
+
+#[test]
+fn admin_cannot_pause_once_guardian_differs() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle) = deploy(&env);
+    let guardian = Address::generate(&env);
+    client.set_guardian(&admin, &guardian);
+
+    // Admin is no longer the guardian, so admin's signature must not be
+    // sufficient to pause.
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_paused",
+            args: (true, 1u32).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = client.try_set_paused(&true, &1u32);
+    assert!(result.is_err());
+    assert!(!client.get_config().is_paused);
+}
+
+#[test]
+fn guardian_can_pause_once_distinct_from_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle) = deploy(&env);
+    let guardian = Address::generate(&env);
+    client.set_guardian(&admin, &guardian);
+
+    env.mock_auths(&[MockAuth {
+        address: &guardian,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_paused",
+            args: (true, 1u32).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_paused(&true, &1u32);
+    assert_is_paused(&client);
+}
+
+#[test]
+fn guardian_cannot_unpause_once_distinct_from_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle) = deploy(&env);
+    let guardian = Address::generate(&env);
+    client.set_guardian(&admin, &guardian);
+    client.set_paused(&true, &1u32);
+
+    // Guardian paused it, but guardian must not be able to lift the pause —
+    // only admin may unpause.
+    env.mock_auths(&[MockAuth {
+        address: &guardian,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_paused",
+            args: (false, 0u32).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = client.try_set_paused(&false, &0u32);
+    assert!(result.is_err());
+    assert_is_paused(&client);
+}
+
+#[test]
+fn admin_can_unpause_once_distinct_from_guardian() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle) = deploy(&env);
+    let guardian = Address::generate(&env);
+    client.set_guardian(&admin, &guardian);
+    client.set_paused(&true, &1u32);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "set_paused",
+            args: (false, 0u32).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_paused(&false, &0u32);
+    assert!(!client.get_config().is_paused);
+}
+
+/// Find the `(cfg, paused)` event emitted by the most recent contract
+/// invocation and decode its `(actor, paused, reason_code)` payload.
+///
+/// The test env's `events().all()` only reflects the *last* top-level
+/// invocation (each new contract call starts a fresh event buffer), so this
+/// must be called immediately after each `set_paused` call rather than once
+/// at the end of a multi-call test.
+fn find_paused_event(env: &Env, contract_id: &Address) -> Option<(Address, bool, u32)> {
+    let events = env.events().all();
+    for event in events.iter() {
+        if &event.0 == contract_id && event.1.len() == 2 {
+            let topic0: Result<Symbol, _> = event.1.get(0).unwrap().try_into_val(env);
+            let topic1: Result<Symbol, _> = event.1.get(1).unwrap().try_into_val(env);
+            if let (Ok(t0), Ok(t1)) = (topic0, topic1) {
+                if t0 == Symbol::new(env, "cfg") && t1 == Symbol::new(env, "paused") {
+                    let data: Result<(Address, bool, u32), _> = event.2.try_into_val(env);
+                    if let Ok(decoded) = data {
+                        return Some(decoded);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn pause_event_actor_is_guardian_and_unpause_event_actor_is_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle) = deploy(&env);
+    let guardian = Address::generate(&env);
+    client.set_guardian(&admin, &guardian);
+
+    client.set_paused(&true, &3u32);
+    let (pause_actor, pause_flag, pause_reason) =
+        find_paused_event(&env, &client.address).expect("expected a pause event");
+    assert_eq!(pause_actor, guardian, "pause event actor must be the guardian");
+    assert!(pause_flag);
+    assert_eq!(pause_reason, 3u32);
+
+    client.set_paused(&false, &0u32);
+    let (unpause_actor, unpause_flag, unpause_reason) =
+        find_paused_event(&env, &client.address).expect("expected an unpause event");
+    assert_eq!(unpause_actor, admin, "unpause event actor must be the admin");
+    assert!(!unpause_flag);
+    assert_eq!(unpause_reason, 0u32);
 }

--- a/contracts/open-market/tests/escrow_tests.rs
+++ b/contracts/open-market/tests/escrow_tests.rs
@@ -975,3 +975,149 @@ fn test_concurrent_escrow_operations() {
     let final_contract_balance = env.as_contract(&client.address, || get_contract_balance(&env));
     assert_eq!(final_contract_balance, 0);
 }
+
+// ── Emergency pause (#1334): escrow primitives revert while paused ───────────
+//
+// Each fund-moving escrow primitive checks `config::ensure_not_paused`
+// directly (defense in depth), independent of whatever pause guard its
+// upstream caller (market.rs/prediction.rs/liquidity.rs) already applied.
+
+#[test]
+fn test_lock_stake_reverts_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let xlm_token = register_token(&env);
+    let client = deploy(&env, &xlm_token);
+    let predictor = Address::generate(&env);
+    fund(&env, &xlm_token, &predictor, 10_000_000);
+
+    client.set_paused(&true, &1u32);
+
+    let result = env.as_contract(&client.address, || {
+        lock_stake(&env, &predictor, 10_000_000_i128)
+    });
+    assert_eq!(result, Err(InsightArenaError::Paused));
+
+    // Balance must be untouched.
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&predictor), 10_000_000);
+    assert_eq!(token.balance(&client.address), 0);
+}
+
+#[test]
+fn test_lock_stake_via_allowance_reverts_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let xlm_token = register_token(&env);
+    let client = deploy(&env, &xlm_token);
+    let predictor = Address::generate(&env);
+    fund(&env, &xlm_token, &predictor, 10_000_000);
+
+    client.set_paused(&true, &1u32);
+
+    let result = env.as_contract(&client.address, || {
+        lock_stake_via_allowance(&env, &predictor, 10_000_000_i128)
+    });
+    assert_eq!(result, Err(InsightArenaError::Paused));
+}
+
+#[test]
+fn test_refund_reverts_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let xlm_token = register_token(&env);
+    let client = deploy(&env, &xlm_token);
+    let recipient = Address::generate(&env);
+    let amount = 20_000_000_i128;
+
+    fund(&env, &xlm_token, &client.address, amount);
+
+    client.set_paused(&true, &1u32);
+
+    let result = env.as_contract(&client.address, || refund(&env, &recipient, amount));
+    assert_eq!(result, Err(InsightArenaError::Paused));
+
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&client.address), amount);
+    assert_eq!(token.balance(&recipient), 0);
+}
+
+#[test]
+fn test_release_payout_reverts_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let xlm_token = register_token(&env);
+    let client = deploy(&env, &xlm_token);
+    let recipient = Address::generate(&env);
+    let payout = 20_000_000_i128;
+
+    fund(&env, &xlm_token, &client.address, payout);
+
+    client.set_paused(&true, &1u32);
+
+    let result = env.as_contract(&client.address, || release_payout(&env, &recipient, payout));
+    assert_eq!(result, Err(InsightArenaError::Paused));
+
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&client.address), payout);
+    assert_eq!(token.balance(&recipient), 0);
+}
+
+#[test]
+fn test_withdraw_treasury_reverts_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let xlm_token = register_token(&env);
+    let client = deploy(&env, &xlm_token);
+
+    let cfg = env.as_contract(&client.address, || config::get_config(&env).unwrap());
+    let admin = cfg.admin.clone();
+    let fee_amount = 3_000_000_i128;
+
+    fund(&env, &xlm_token, &client.address, fee_amount);
+    env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Treasury, &fee_amount);
+    });
+
+    client.set_paused(&true, &1u32);
+
+    let result = env.as_contract(&client.address, || {
+        withdraw_treasury(env.clone(), admin.clone(), fee_amount)
+    });
+    assert_eq!(result, Err(InsightArenaError::Paused));
+
+    // Treasury balance and token balance must be untouched.
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&client.address), fee_amount);
+    let remaining = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get::<_, i128>(&DataKey::Treasury)
+            .unwrap_or(0)
+    });
+    assert_eq!(remaining, fee_amount);
+}
+
+#[test]
+fn test_escrow_operations_resume_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let xlm_token = register_token(&env);
+    let client = deploy(&env, &xlm_token);
+    let predictor = Address::generate(&env);
+    let amount = 10_000_000_i128;
+    fund(&env, &xlm_token, &predictor, amount);
+
+    client.set_paused(&true, &1u32);
+    let paused_result = env.as_contract(&client.address, || lock_stake(&env, &predictor, amount));
+    assert_eq!(paused_result, Err(InsightArenaError::Paused));
+
+    client.set_paused(&false, &0u32);
+    let resumed_result = env.as_contract(&client.address, || lock_stake(&env, &predictor, amount));
+    assert_eq!(resumed_result, Ok(()));
+
+    let token = TokenClient::new(&env, &xlm_token);
+    assert_eq!(token.balance(&client.address), amount);
+}


### PR DESCRIPTION
## Summary

Implements guardian-gated emergency pause with strict separation of duties, per #1334.

The contract already had `Config::guardian` and `Config::is_paused`, plus an admin-only `set_paused` and a `config::ensure_not_paused` guard used across ~30 entry points. The gap: **the admin alone could both pause and unpause**, so a single compromised/malicious admin key defeats the whole point of having a separate guardian role, and there was no direct pause check inside the escrow module's own fund-moving primitives (they relied entirely on upstream callers remembering to check).

This PR closes both gaps:

- **`config.rs`** — `set_paused` now branches its `require_auth()` on the requested direction instead of always checking `admin`:
  - `paused == true` (pause) → requires `config.guardian.require_auth()`
  - `paused == false` (unpause) → requires `config.admin.require_auth()`

  Kept as a single entry point (rather than splitting into `guardian_pause`/`admin_unpause`) so the public contract ABI in `lib.rs` is unchanged — smallest possible diff for the same guarantee. The emitted `(cfg, paused)` event now carries whichever role actually authorized the call (guardian on pause, admin on unpause), reusing the existing `emit_paused_toggled` helper.

- **`escrow.rs`** — `lock_stake`, `lock_stake_via_allowance`, `refund`, `release_payout`, and `withdraw_treasury` now call `config::ensure_not_paused` directly as their first statement (matching the existing convention used everywhere else in market.rs/liquidity.rs/prediction.rs), so these fund-moving primitives are self-defending regardless of whether the caller already checked pause state.

- **`errors.rs`** — no new error variant added. The `#[contracterror]` enum is hard-capped at 50 XDR cases and this crate is already at that limit (`ZeroShareTransfer = 112` is case #50). Role-check failures reuse the existing `Unauthorized` (3) — consistent with every other admin-only setter in `config.rs` — and the doc comment now documents that reuse plus the cap.

## Before / after

| | Before | After |
|---|---|---|
| Who can pause (`paused=true`) | admin | **guardian only** |
| Who can unpause (`paused=false`) | admin | admin only (unchanged) |
| Escrow primitives check pause themselves | no (relied on caller) | yes, defense in depth |

Because `initialize` defaults `guardian` to `admin`, this is backward compatible for any deployment that hasn't yet diverged the two roles — pausing still "just works" for a single-key setup. The behavior change only becomes observable once `set_guardian` has assigned a distinct guardian address.

One existing test, `former_admin_cannot_toggle_pause_after_transfer` in `circuit_breaker_tests.rs`, encoded the old assumption that pausing was admin-gated. Since `transfer_admin` never moves the guardian role, the former admin (still the guardian) can in fact still pause after being replaced as admin — what it can no longer do is *unpause*. Renamed to `former_admin_cannot_unpause_after_transfer` and rewritten to assert that.

## Testing

- `cargo build` — clean (one pre-existing unrelated warning in `prediction.rs`).
- `cargo test` — full suite green, 629 tests across all test binaries, 0 failures.
- New/updated coverage:
  - `circuit_breaker_tests.rs`: `admin_cannot_pause_once_guardian_differs`, `guardian_can_pause_once_distinct_from_admin`, `guardian_cannot_unpause_once_distinct_from_admin`, `admin_can_unpause_once_distinct_from_guardian`, `pause_event_actor_is_guardian_and_unpause_event_actor_is_admin`, plus the rewritten `former_admin_cannot_unpause_after_transfer`.
  - `escrow_tests.rs`: pause-revert cases for all five escrow primitives (`test_lock_stake_reverts_while_paused`, `test_lock_stake_via_allowance_reverts_while_paused`, `test_refund_reverts_while_paused`, `test_release_payout_reverts_while_paused`, `test_withdraw_treasury_reverts_while_paused`) plus `test_escrow_operations_resume_after_unpause`.

Closes #1334
