### PR TITLE
[Contract] Protocol treasury fee split

### DIFF
--- a/contracts/open-market/src/config.rs
+++ b/contracts/open-market/src/config.rs
@@ -179,6 +179,26 @@ pub struct Config {
     /// `liquidity::add_liquidity`. Admin-configurable via
     /// `set_max_liquidity_per_outcome`. Defaults to `0` at initialization.
     pub max_liquidity_per_outcome: i128,
+    /// Address that receives the protocol's share of every collected swap
+    /// fee (see `treasury_split_bps`), tracked via the internal treasury
+    /// balance (`escrow::get_treasury_balance` / `escrow::withdraw_treasury`).
+    /// Admin-configurable via `set_treasury_split`. Defaults to `admin` at
+    /// initialization.
+    pub treasury_address: Address,
+    /// Share (bps, 0-10000) of the protocol's fee cut — i.e. the portion of
+    /// every collected swap fee already earmarked for the protocol via
+    /// `FeeTierConfig::protocol_share_bps` (see `liquidity::swap_outcome`) —
+    /// that is routed to `treasury_address` rather than redistributed to
+    /// liquidity providers. Paired with `lp_split_bps`; the two must always
+    /// sum to exactly `10_000`, enforced by `set_treasury_split`. Defaults to
+    /// `10_000` (100%) at initialization, which preserves the pre-existing
+    /// behaviour where the entire protocol fee share accrues to the
+    /// treasury.
+    pub treasury_split_bps: u32,
+    /// Complement of `treasury_split_bps`: share (bps) of the protocol's fee
+    /// cut redirected to liquidity providers instead of the treasury.
+    /// Defaults to `0` at initialization. See `treasury_split_bps`.
+    pub lp_split_bps: u32,
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────
@@ -200,6 +220,18 @@ fn load_config(env: &Env) -> Result<Config, InsightArenaError> {
 
 fn validate_protocol_fee(fee_bps: u32) -> Result<(), InsightArenaError> {
     if fee_bps > 10_000 {
+        return Err(InsightArenaError::InvalidFee);
+    }
+
+    Ok(())
+}
+
+/// Validate that a protocol-treasury-vs-LP fee split sums to exactly
+/// `10_000` bps. Reusing `InvalidFee` here matches the convention already
+/// used by `validate_protocol_fee` and `set_insurance_pool_share_bps` for
+/// bps-range validation.
+fn validate_treasury_split(treasury_split_bps: u32, lp_split_bps: u32) -> Result<(), InsightArenaError> {
+    if treasury_split_bps.checked_add(lp_split_bps) != Some(10_000) {
         return Err(InsightArenaError::InvalidFee);
     }
 
@@ -274,6 +306,7 @@ pub fn initialize(
 
     validate_protocol_fee(fee_bps)?;
 
+    let admin_for_treasury = admin.clone();
     let config = Config {
         guardian: admin.clone(),
         admin,
@@ -291,6 +324,9 @@ pub fn initialize(
         insurance_pool_balance: 0,
         insurance_pool_payouts_total: 0,
         max_liquidity_per_outcome: 0, // unlimited until admin configures a cap
+        treasury_address: admin_for_treasury,
+        treasury_split_bps: 10_000, // 100% to treasury, preserving prior behaviour
+        lp_split_bps: 0,
     };
 
     env.storage().persistent().set(&DataKey::Config, &config);
@@ -726,6 +762,81 @@ fn emit_max_liquidity_per_outcome_updated(env: &Env, old_cap: i128, new_cap: i12
     env.events().publish(
         (symbol_short!("cfg"), symbol_short!("liq_cap")),
         (old_cap, new_cap),
+    );
+}
+
+/// Update the protocol treasury address and the split (bps) of the
+/// protocol's fee cut between the treasury and liquidity providers. Caller
+/// must be the stored admin.
+///
+/// The actual per-swap split is applied in `liquidity::swap_outcome`, which
+/// further divides the fee share already earmarked for the protocol (via
+/// `FeeTierConfig::protocol_share_bps`) between `treasury_address`
+/// (`treasury_split_bps`) and liquidity providers (`lp_split_bps`), emitting
+/// a `(fee, split)` event on every swap that collects a non-zero fee.
+///
+/// # Errors
+/// - `Unauthorized` if `admin` is not the stored admin.
+/// - `InvalidFee` if `treasury_split_bps + lp_split_bps != 10_000`.
+pub fn set_treasury_split(
+    env: &Env,
+    admin: Address,
+    new_treasury_address: Address,
+    treasury_split_bps: u32,
+    lp_split_bps: u32,
+) -> Result<(), InsightArenaError> {
+    let mut config = load_config(env)?;
+
+    admin.require_auth();
+    if admin != config.admin {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    validate_treasury_split(treasury_split_bps, lp_split_bps)?;
+
+    let old_treasury_address = config.treasury_address.clone();
+    let old_treasury_split_bps = config.treasury_split_bps;
+    let old_lp_split_bps = config.lp_split_bps;
+
+    config.treasury_address = new_treasury_address.clone();
+    config.treasury_split_bps = treasury_split_bps;
+    config.lp_split_bps = lp_split_bps;
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    emit_treasury_split_updated(
+        env,
+        &old_treasury_address,
+        &new_treasury_address,
+        old_treasury_split_bps,
+        old_lp_split_bps,
+        treasury_split_bps,
+        lp_split_bps,
+    );
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_treasury_split_updated(
+    env: &Env,
+    old_treasury_address: &Address,
+    new_treasury_address: &Address,
+    old_treasury_split_bps: u32,
+    old_lp_split_bps: u32,
+    new_treasury_split_bps: u32,
+    new_lp_split_bps: u32,
+) {
+    env.events().publish(
+        (symbol_short!("cfg"), symbol_short!("trs_upd")),
+        (
+            old_treasury_address.clone(),
+            new_treasury_address.clone(),
+            old_treasury_split_bps,
+            old_lp_split_bps,
+            new_treasury_split_bps,
+            new_lp_split_bps,
+        ),
     );
 }
 

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -581,6 +581,28 @@ impl InsightArenaContract {
         escrow::transfer_fee(&env, &admin, &to, amount)
     }
 
+    /// Update the protocol treasury address and the split (bps) of the
+    /// protocol's fee cut between the treasury and liquidity providers.
+    /// Caller must be the current admin. Reverts with `InvalidFee` if
+    /// `treasury_split_bps + lp_split_bps != 10_000`. See
+    /// `liquidity::swap_outcome` for where the split is applied and its
+    /// `(fee, split)` event emitted.
+    pub fn set_treasury_split(
+        env: Env,
+        admin: Address,
+        treasury_address: Address,
+        treasury_split_bps: u32,
+        lp_split_bps: u32,
+    ) -> Result<(), InsightArenaError> {
+        config::set_treasury_split(
+            &env,
+            admin,
+            treasury_address,
+            treasury_split_bps,
+            lp_split_bps,
+        )
+    }
+
     // ── Slashed-funds insurance pool ─────────────────────────────────────────
 
     /// Update the share (bps) of every slashed bond routed into the

--- a/contracts/open-market/src/liquidity.rs
+++ b/contracts/open-market/src/liquidity.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Map, Symbol, Vec};
+use soroban_sdk::{symbol_short, Address, Env, Map, Symbol, Vec};
 
 use crate::config::{self, PERSISTENT_BUMP, PERSISTENT_THRESHOLD};
 use crate::errors::InsightArenaError;
@@ -842,10 +842,39 @@ pub fn swap_outcome(
         new_to_reserve,
     )?;
 
-    distribute_fees_to_lps(env, market_id, lp_fee_share)?;
-    if protocol_fee_share > 0 {
-        escrow::add_to_treasury_balance(env, protocol_fee_share);
+    // Further split the protocol's fee cut between the configured treasury
+    // address and liquidity providers, per `Config::treasury_split_bps` /
+    // `Config::lp_split_bps` (validated at configuration time — see
+    // `config::set_treasury_split` — to sum to exactly 10_000 bps). By
+    // default `treasury_split_bps == 10_000`, so the entire protocol fee
+    // share keeps flowing to the treasury exactly as it did before this
+    // split was introduced.
+    let cfg = config::get_config(env)?;
+    let treasury_amount = protocol_fee_share
+        .checked_mul(cfg.treasury_split_bps as i128)
+        .ok_or(InsightArenaError::Overflow)?
+        .checked_div(10_000)
+        .ok_or(InsightArenaError::Overflow)?;
+    let lp_amount_from_protocol = protocol_fee_share
+        .checked_sub(treasury_amount)
+        .ok_or(InsightArenaError::Overflow)?;
+    let total_lp_share = lp_fee_share
+        .checked_add(lp_amount_from_protocol)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    distribute_fees_to_lps(env, market_id, total_lp_share)?;
+    if treasury_amount > 0 {
+        escrow::add_to_treasury_balance(env, treasury_amount);
     }
+
+    emit_treasury_fee_split(
+        env,
+        market_id,
+        &cfg.treasury_address,
+        fee_amount,
+        treasury_amount,
+        total_lp_share,
+    );
 
     let record = SwapRecord::new(
         trader,
@@ -871,6 +900,31 @@ pub fn swap_outcome(
     update_pool_volume(env, market_id, amount_in);
 
     Ok(amount_out)
+}
+
+/// Emit an event recording exactly how a swap's collected fee was split
+/// between the protocol treasury and liquidity providers. Published on every
+/// swap that reaches the fee-collection step, including zero-fee swaps (in
+/// which case both shares are `0`), so off-chain consumers can reconstruct a
+/// complete, gap-free accounting trail per market.
+fn emit_treasury_fee_split(
+    env: &Env,
+    market_id: u64,
+    treasury_address: &Address,
+    fee_amount: i128,
+    treasury_amount: i128,
+    lp_amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("fee"), symbol_short!("split")),
+        (
+            market_id,
+            treasury_address.clone(),
+            fee_amount,
+            treasury_amount,
+            lp_amount,
+        ),
+    );
 }
 
 fn distribute_fees_to_lps(

--- a/contracts/open-market/tests/config_tests.rs
+++ b/contracts/open-market/tests/config_tests.rs
@@ -244,3 +244,109 @@ fn set_stake_bounds_rejects_non_positive() {
     let result = client.try_set_stake_bounds(&admin, &10_i128, &0_i128);
     assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
 }
+
+// ── Protocol Treasury Fee Split (#1336) ───────────────────────────────────────
+
+#[test]
+fn treasury_split_defaults_on_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.initialize(&admin, &oracle, &200_u32, &register_token(&env));
+
+    let cfg = client.get_config();
+    // Defaults preserve the pre-existing behaviour: the whole protocol fee
+    // share keeps flowing to the treasury (now the admin address) and none
+    // is redirected to liquidity providers, until an admin opts in.
+    assert_eq!(cfg.treasury_address, admin);
+    assert_eq!(cfg.treasury_split_bps, 10_000);
+    assert_eq!(cfg.lp_split_bps, 0);
+}
+
+#[test]
+fn set_treasury_split_updates_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.initialize(&admin, &oracle, &200_u32, &register_token(&env));
+
+    let new_treasury = Address::generate(&env);
+    client.set_treasury_split(&admin, &new_treasury, &7_000_u32, &3_000_u32);
+
+    let cfg = client.get_config();
+    assert_eq!(cfg.treasury_address, new_treasury);
+    assert_eq!(cfg.treasury_split_bps, 7_000);
+    assert_eq!(cfg.lp_split_bps, 3_000);
+}
+
+#[test]
+fn set_treasury_split_accepts_uneven_ratio_that_still_sums_to_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.initialize(&admin, &oracle, &200_u32, &register_token(&env));
+
+    let new_treasury = Address::generate(&env);
+    // 33.33% / 66.67% — an uneven split that only sums to exactly 10_000
+    // because the two bps values are complementary, not because either is a
+    // "round" number.
+    client.set_treasury_split(&admin, &new_treasury, &3_333_u32, &6_667_u32);
+
+    let cfg = client.get_config();
+    assert_eq!(cfg.treasury_split_bps, 3_333);
+    assert_eq!(cfg.lp_split_bps, 6_667);
+}
+
+#[test]
+fn set_treasury_split_rejects_bps_summing_below_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.initialize(&admin, &oracle, &200_u32, &register_token(&env));
+
+    let new_treasury = Address::generate(&env);
+    let result = client.try_set_treasury_split(&admin, &new_treasury, &4_000_u32, &4_000_u32);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidFee))));
+
+    // Config is untouched on rejection.
+    let cfg = client.get_config();
+    assert_eq!(cfg.treasury_split_bps, 10_000);
+    assert_eq!(cfg.lp_split_bps, 0);
+}
+
+#[test]
+fn set_treasury_split_rejects_bps_summing_above_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.initialize(&admin, &oracle, &200_u32, &register_token(&env));
+
+    let new_treasury = Address::generate(&env);
+    let result = client.try_set_treasury_split(&admin, &new_treasury, &6_000_u32, &6_000_u32);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidFee))));
+}
+
+#[test]
+fn set_treasury_split_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    client.initialize(&admin, &oracle, &200_u32, &register_token(&env));
+
+    let not_admin = Address::generate(&env);
+    let new_treasury = Address::generate(&env);
+    let result = client.try_set_treasury_split(&not_admin, &new_treasury, &5_000_u32, &5_000_u32);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -14,9 +14,9 @@ use insightarena_contract::{
     CreateMarketParams, FeeTier, FeeTierConfig, InsightArenaContract, InsightArenaContractClient,
     InsightArenaError,
 };
-use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::testutils::{Address as _, Events, Ledger as _};
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
-use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol};
+use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol, TryIntoVal};
 
 // ── Test Helpers ─────────────────────────────────────────────────────────────
 
@@ -2125,6 +2125,256 @@ fn test_dynamic_fee_split_between_lp_and_protocol_treasury_is_conserved() {
     let expected_protocol_share = expected_total_fee * cfg.protocol_share_bps as i128 / 10_000;
     assert_eq!(protocol_share, expected_protocol_share);
     assert_eq!(lp_share, expected_total_fee - expected_protocol_share);
+}
+
+// ── Protocol Treasury Fee Split (#1336) ───────────────────────────────────────
+
+/// Fetches the `(fee, split)` event payload most recently published by the
+/// contract, decoded as `(market_id, treasury_address, fee_amount,
+/// treasury_amount, lp_amount)`. Panics if no such event was found.
+///
+/// Must be called immediately after the swap whose event is under test —
+/// before any further contract calls — because the test host's `Events::all`
+/// only retains events from the most recent top-level invocation.
+fn last_treasury_split_event(
+    env: &Env,
+    contract_id: &Address,
+) -> (u64, Address, i128, i128, i128) {
+    let events = env.events().all();
+    for event in events.iter().rev() {
+        if &event.0 != contract_id || event.1.len() != 2 {
+            continue;
+        }
+        let topic0: Result<Symbol, _> = event.1.get(0).unwrap().try_into_val(env);
+        let topic1: Result<Symbol, _> = event.1.get(1).unwrap().try_into_val(env);
+        if let (Ok(t0), Ok(t1)) = (topic0, topic1) {
+            if t0 == Symbol::new(env, "fee") && t1 == Symbol::new(env, "split") {
+                let data: (u64, Address, i128, i128, i128) =
+                    event.2.try_into_val(env).expect("decode fee/split event");
+                return data;
+            }
+        }
+    }
+    panic!("expected a fee/split event");
+}
+
+#[test]
+fn test_treasury_split_default_preserves_prior_swap_behavior() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    // Default config: 100% of the protocol's fee cut still goes to the
+    // treasury and 0% is redirected to LPs, exactly matching behaviour
+    // before this feature existed.
+    let cfg = client.get_config();
+    assert_eq!(cfg.treasury_split_bps, 10_000);
+    assert_eq!(cfg.lp_split_bps, 0);
+
+    let fee_bps = client.get_market_fee_info(&market_id).effective_fee_bps;
+    let swap_amount = 1_000_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    let treasury_before = client.get_treasury_balance();
+    let lp_fees_before = client.get_lp_position(&provider, &market_id).fees_earned;
+
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    // Must read the event right after the swap, before any further calls.
+    let (event_market_id, event_treasury, event_fee, event_treasury_amt, event_lp_amt) =
+        last_treasury_split_event(&env, &client.address);
+
+    let treasury_after = client.get_treasury_balance();
+    let lp_fees_after = client.get_lp_position(&provider, &market_id).fees_earned;
+
+    let tier_cfg = FeeTierConfig::default_config();
+    let expected_total_fee = swap_amount * fee_bps as i128 / 10_000;
+    let expected_protocol_share = expected_total_fee * tier_cfg.protocol_share_bps as i128 / 10_000;
+    let expected_lp_share = expected_total_fee - expected_protocol_share;
+
+    assert_eq!(treasury_after - treasury_before, expected_protocol_share);
+    assert_eq!(lp_fees_after - lp_fees_before, expected_lp_share);
+
+    assert_eq!(event_market_id, market_id);
+    assert_eq!(event_treasury, cfg.treasury_address);
+    assert_eq!(event_fee, expected_total_fee);
+    assert_eq!(event_treasury_amt, expected_protocol_share);
+    assert_eq!(event_lp_amt, expected_lp_share);
+    assert_eq!(event_treasury_amt + event_lp_amt, event_fee);
+}
+
+/// Runs a single swap under a custom `(treasury_split_bps, lp_split_bps)`
+/// configuration and returns `(protocol_fee_share, treasury_delta, lp_delta,
+/// event)` so callers can assert exact split amounts — including rounding
+/// remainders — and the accompanying event, across several ratios.
+#[allow(clippy::too_many_arguments)]
+fn swap_with_treasury_split(
+    env: &Env,
+    client: &InsightArenaContractClient<'_>,
+    admin: &Address,
+    treasury_split_bps: u32,
+    lp_split_bps: u32,
+    market_id: u64,
+    provider: &Address,
+    trader: &Address,
+    swap_amount: i128,
+) -> (i128, i128, i128, (u64, Address, i128, i128, i128)) {
+    let new_treasury = Address::generate(env);
+    client.set_treasury_split(admin, &new_treasury, &treasury_split_bps, &lp_split_bps);
+
+    let fee_bps = client.get_market_fee_info(&market_id).effective_fee_bps;
+    let tier_cfg = FeeTierConfig::default_config();
+    let expected_total_fee = swap_amount * fee_bps as i128 / 10_000;
+    let protocol_fee_share = expected_total_fee * tier_cfg.protocol_share_bps as i128 / 10_000;
+
+    let treasury_before = client.get_treasury_balance();
+    let lp_fees_before = client.get_lp_position(provider, &market_id).fees_earned;
+
+    client.swap_outcome(
+        trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    // Must read the event right after the swap, before any further calls.
+    let event = last_treasury_split_event(env, &client.address);
+
+    let treasury_after = client.get_treasury_balance();
+    let lp_fees_after = client.get_lp_position(provider, &market_id).fees_earned;
+
+    (
+        protocol_fee_share,
+        treasury_after - treasury_before,
+        lp_fees_after - lp_fees_before,
+        event,
+    )
+}
+
+#[test]
+fn test_treasury_split_custom_ratio_conserves_protocol_share_with_rounding() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 1_000_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    let tier_cfg_before = FeeTierConfig::default_config();
+    let fee_bps = client.get_market_fee_info(&market_id).effective_fee_bps;
+    let expected_total_fee = swap_amount * fee_bps as i128 / 10_000;
+    let protocol_fee_share =
+        expected_total_fee * tier_cfg_before.protocol_share_bps as i128 / 10_000;
+    let original_lp_share = expected_total_fee - protocol_fee_share;
+
+    // 3333 / 6667 does not divide `protocol_fee_share` evenly, so this also
+    // exercises the rounding behaviour: the treasury amount is rounded down
+    // and the LP amount absorbs the remainder, with no stroop lost.
+    let (returned_protocol_share, treasury_delta, lp_delta, event) = swap_with_treasury_split(
+        &env,
+        &client,
+        &admin,
+        3_333,
+        6_667,
+        market_id,
+        &provider,
+        &trader,
+        swap_amount,
+    );
+
+    assert_eq!(returned_protocol_share, protocol_fee_share);
+    let expected_treasury_amount = protocol_fee_share * 3_333 / 10_000;
+    let expected_lp_amount_from_protocol = protocol_fee_share - expected_treasury_amount;
+
+    assert_eq!(treasury_delta, expected_treasury_amount);
+    assert_eq!(lp_delta, original_lp_share + expected_lp_amount_from_protocol);
+    // Conservation: every stroop of the protocol's fee cut is accounted for.
+    assert_eq!(
+        treasury_delta + (lp_delta - original_lp_share),
+        protocol_fee_share
+    );
+
+    let cfg = client.get_config();
+    let (_, event_treasury, event_fee, event_treasury_amt, event_lp_amt) = event;
+    assert_eq!(event_treasury, cfg.treasury_address);
+    assert_eq!(event_fee, expected_total_fee);
+    assert_eq!(event_treasury_amt, expected_treasury_amount);
+    assert_eq!(event_lp_amt, original_lp_share + expected_lp_amount_from_protocol);
+}
+
+#[test]
+fn test_treasury_split_all_to_lp_sends_nothing_to_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let market_id = client.create_market(&admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 1_000_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    let (protocol_fee_share, treasury_delta, _lp_delta, event) = swap_with_treasury_split(
+        &env,
+        &client,
+        &admin,
+        0,
+        10_000,
+        market_id,
+        &provider,
+        &trader,
+        swap_amount,
+    );
+
+    assert!(protocol_fee_share > 0);
+    assert_eq!(treasury_delta, 0);
+    let (_, _, event_fee, event_treasury_amt, event_lp_amt) = event;
+    assert_eq!(event_treasury_amt, 0);
+    // With treasury_split_bps == 0, the entire collected fee (both the LPs'
+    // original share and the redirected protocol share) ends up with LPs.
+    assert_eq!(event_lp_amt, event_fee);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a configurable protocol treasury fee split to the open-market contract, per #1336.

- **Config** (`contracts/open-market/src/config.rs`): three new fields — `treasury_address: Address`, `treasury_split_bps: u32`, `lp_split_bps: u32` — plus a new admin-only `set_treasury_split(admin, treasury_address, treasury_split_bps, lp_split_bps)` entrypoint (also exposed in `lib.rs`). The setter validates `treasury_split_bps + lp_split_bps == 10_000` exactly, reverting otherwise, and emits a `(cfg, trs_upd)` event recording the old/new address and bps values.
- **Liquidity** (`contracts/open-market/src/liquidity.rs`): `swap_outcome` now further splits the already-computed protocol fee cut (`FeeTierConfig::protocol_share_bps`, unchanged) between the configured treasury address and liquidity providers, per the new Config-level split, and emits a `(fee, split)` event on every fee collection recording `(market_id, treasury_address, fee_amount, treasury_amount, lp_amount)`.

### Before / after behavior

- **Before**: the protocol's entire fee cut flowed silently into a single internal treasury balance (`DataKey::Treasury`), withdrawable by the admin to any address chosen at withdrawal time. No config-level treasury address existed, no validated split, and no event was emitted at fee-collection time.
- **After**: `Config` now has a first-class `treasury_address` and an explicit, validated split. By default (`treasury_split_bps = 10_000`, `lp_split_bps = 0`, `treasury_address = admin`), behavior is **unchanged** — 100% of the protocol fee cut still accrues to the treasury balance, exactly as before. Once an admin calls `set_treasury_split`, a configurable share of that fee cut is instead redistributed to liquidity providers, and every swap that collects a fee emits an accurate split event.

### Design notes

- `errors.rs` was intentionally left untouched: `InsightArenaError` is already at its documented 50-variant hard cap for `#[contracterror]` (see the existing comment above `SelfTransfer`/`ZeroShareTransfer`), so the new bps-sum validation reuses `InsightArenaError::InvalidFee`, consistent with how this file already reuses `InvalidFee` for other bps-range checks (`validate_protocol_fee`, `set_insurance_pool_share_bps`, `validate_fee_tier_config`).
- `storage_types.rs` was intentionally left untouched: no new `DataKey` variant was needed (the split lives on the existing `Config` singleton), and the existing `FeeTierConfig::protocol_share_bps` field/behavior is preserved unmodified for backward compatibility — the new split operates on top of it rather than replacing it.

## Test plan

- [x] `cargo test` from `contracts/open-market/` — full suite passes, 0 failures across all test binaries (liquidity_tests: 132 passed, config_tests included in that count; every other existing test file also still passes unmodified).
- [x] `cargo build` — compiles cleanly (one pre-existing, unrelated warning in `prediction.rs`).
- [x] New tests added:
  - `tests/config_tests.rs`: default split values on `initialize`, `set_treasury_split` updates config, accepts an uneven ratio that sums to 10000 (3333/6667), rejects sums below/above 10000, rejects unauthorized callers.
  - `tests/liquidity_tests.rs`: default split preserves prior swap behavior exactly (regression guard), a custom uneven ratio (3333/6667) with exact rounding/conservation checks, full redirection to LPs (0/10000), and event-payload assertions for each.

Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)