### PR TITLE
feat(backend): customizable email digest scheduling (#1369)

### DIFF
--- a/backend/src/migrations/1777400000000-AddDigestSchedulingToUserPreferences.ts
+++ b/backend/src/migrations/1777400000000-AddDigestSchedulingToUserPreferences.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDigestSchedulingToUserPreferences1777400000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences"
+      ADD COLUMN IF NOT EXISTS "digest_hour" integer NOT NULL DEFAULT 8
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences"
+      ADD COLUMN IF NOT EXISTS "digest_timezone" varchar NOT NULL DEFAULT 'UTC'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences" DROP COLUMN IF EXISTS "digest_timezone"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "user_preferences" DROP COLUMN IF EXISTS "digest_hour"
+    `);
+  }
+}

--- a/backend/src/notifications/digest.service.spec.ts
+++ b/backend/src/notifications/digest.service.spec.ts
@@ -1,0 +1,369 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { DigestService } from './digest.service';
+import { UserPreferences } from '../users/entities/user-preferences.entity';
+import { User } from '../users/entities/user.entity';
+import { Notification } from './entities/notification.entity';
+import { NotificationDigestState } from './entities/notification-digest-state.entity';
+import { EmailService } from './email.service';
+
+describe('DigestService', () => {
+  let service: DigestService;
+  let prefsRepo: Repository<UserPreferences>;
+  let userRepo: Repository<User>;
+  let notificationRepo: Repository<Notification>;
+  let digestStateRepo: Repository<NotificationDigestState>;
+  let emailService: EmailService;
+  let config: ConfigService;
+
+  const mockQueryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue([{ digest_timezone: 'UTC' }]),
+  };
+
+  const mockUser: Partial<User> = {
+    id: 'user-1',
+    email: 'user@example.com',
+    stellar_address: 'GABC123',
+  };
+
+  const mockPref: Partial<UserPreferences> = {
+    userId: 'user-1',
+    digest_frequency: 'daily',
+    digest_hour: 8,
+    digest_timezone: 'UTC',
+    email_notifications: true,
+  };
+
+  const mockNotification: Partial<Notification> = {
+    title: 'Test',
+    message: 'Test message',
+  } as Partial<Notification>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DigestService,
+        {
+          provide: getRepositoryToken(UserPreferences),
+          useValue: {
+            find: jest.fn().mockResolvedValue([]),
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(mockUser),
+          },
+        },
+        {
+          provide: getRepositoryToken(Notification),
+          useValue: {
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: getRepositoryToken(NotificationDigestState),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            create: jest.fn().mockImplementation((x) => x),
+            save: jest.fn().mockResolvedValue({}),
+          },
+        },
+        {
+          provide: EmailService,
+          useValue: {
+            queueEmail: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DigestService>(DigestService);
+    prefsRepo = module.get<Repository<UserPreferences>>(
+      getRepositoryToken(UserPreferences),
+    );
+    userRepo = module.get<Repository<User>>(getRepositoryToken(User));
+    notificationRepo = module.get<Repository<Notification>>(
+      getRepositoryToken(Notification),
+    );
+    digestStateRepo = module.get<Repository<NotificationDigestState>>(
+      getRepositoryToken(NotificationDigestState),
+    );
+    emailService = module.get<EmailService>(EmailService);
+    config = module.get<ConfigService>(ConfigService);
+
+    jest.clearAllMocks();
+    mockQueryBuilder.select.mockReturnThis();
+    mockQueryBuilder.where.mockReturnThis();
+    mockQueryBuilder.andWhere.mockReturnThis();
+    mockQueryBuilder.getRawMany.mockResolvedValue([
+      { digest_timezone: 'UTC' },
+    ]);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ── Timezone-aware time helpers ─────────────────────────────────────────
+
+  describe('getLocalHour', () => {
+    it('computes the correct local hour for a UTC-5 zone (America/New_York, January = EST)', () => {
+      const date = new Date('2024-01-15T12:00:00Z');
+      const hour = service['getLocalHour'](date, 'America/New_York');
+      expect(hour).toBe(7);
+    });
+
+    it('computes the correct local hour for a UTC+1 zone (Africa/Lagos)', () => {
+      const date = new Date('2024-01-15T12:00:00Z');
+      const hour = service['getLocalHour'](date, 'Africa/Lagos');
+      expect(hour).toBe(13);
+    });
+
+    it('returns the same hour for UTC itself', () => {
+      const date = new Date('2024-01-15T12:00:00Z');
+      const hour = service['getLocalHour'](date, 'UTC');
+      expect(hour).toBe(12);
+    });
+  });
+
+  describe('getLocalWeekday', () => {
+    it('returns Monday (1) for a Monday UTC instant in a same-day zone', () => {
+      // 2024-01-15 is a Monday
+      const date = new Date('2024-01-15T12:00:00Z');
+      const weekday = service['getLocalWeekday'](date, 'UTC');
+      expect(weekday).toBe(1);
+    });
+
+    it('rolls over to the next local day in a far-ahead timezone', () => {
+      // 23:00 UTC on Monday Jan 15 is already Tuesday Jan 16 in
+      // Pacific/Auckland (UTC+13)
+      const date = new Date('2024-01-15T23:00:00Z');
+      const weekday = service['getLocalWeekday'](date, 'Pacific/Auckland');
+      expect(weekday).toBe(2); // Tuesday
+    });
+  });
+
+  describe('getLocalDailyPeriodKey / getLocalWeeklyPeriodKey', () => {
+    it('produces a period key based on the local date, not the UTC date', () => {
+      // 23:00 UTC Jan 15 is already Jan 16 local in Pacific/Auckland
+      const date = new Date('2024-01-15T23:00:00Z');
+      const utcKey = service['getLocalDailyPeriodKey'](date, 'UTC');
+      const aucklandKey = service['getLocalDailyPeriodKey'](
+        date,
+        'Pacific/Auckland',
+      );
+      expect(utcKey).toBe('2024-01-15');
+      expect(aucklandKey).toBe('2024-01-16');
+    });
+
+    it('produces an ISO week key', () => {
+      const date = new Date('2024-01-15T12:00:00Z');
+      const key = service['getLocalWeeklyPeriodKey'](date, 'UTC');
+      expect(key).toMatch(/^2024-W\d{2}$/);
+    });
+  });
+
+  // ── Frequency selection & timezone bucketing ────────────────────────────
+
+  describe('handleHourlyCheck', () => {
+    it('does nothing when DIGEST_ENABLED is false', async () => {
+      jest.spyOn(config, 'get').mockImplementation((key: string) => {
+        if (key === 'DIGEST_ENABLED') return 'false';
+        return undefined;
+      });
+
+      await service.handleHourlyCheck(new Date('2024-01-15T08:00:00Z'));
+
+      expect(prefsRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('queries active timezones and runs daily digests for each', async () => {
+      jest.spyOn(config, 'get').mockImplementation((key: string) => {
+        if (key === 'DIGEST_ENABLED') return 'true';
+        if (key === 'DIGEST_WEEKLY_DAY') return '1';
+        return undefined;
+      });
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { digest_timezone: 'UTC' },
+        { digest_timezone: 'Africa/Lagos' },
+      ]);
+
+      const sendDailySpy = jest
+        .spyOn(service, 'sendDailyDigests')
+        .mockResolvedValue(undefined);
+
+      await service.handleHourlyCheck(new Date('2024-01-15T08:00:00Z'));
+
+      expect(sendDailySpy).toHaveBeenCalledTimes(2);
+      expect(sendDailySpy).toHaveBeenCalledWith(
+        expect.any(Date),
+        'UTC',
+        8,
+      );
+      expect(sendDailySpy).toHaveBeenCalledWith(
+        expect.any(Date),
+        'Africa/Lagos',
+        9, // UTC+1
+      );
+    });
+
+    it('only runs weekly digests when the local weekday matches DIGEST_WEEKLY_DAY', async () => {
+      jest.spyOn(config, 'get').mockImplementation((key: string) => {
+        if (key === 'DIGEST_ENABLED') return 'true';
+        if (key === 'DIGEST_WEEKLY_DAY') return '1'; // Monday
+        return undefined;
+      });
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { digest_timezone: 'UTC' },
+      ]);
+      jest.spyOn(service, 'sendDailyDigests').mockResolvedValue(undefined);
+      const sendWeeklySpy = jest
+        .spyOn(service, 'sendWeeklyDigests')
+        .mockResolvedValue(undefined);
+
+      // Monday
+      await service.handleHourlyCheck(new Date('2024-01-15T08:00:00Z'));
+      expect(sendWeeklySpy).toHaveBeenCalledTimes(1);
+
+      sendWeeklySpy.mockClear();
+
+      // Tuesday
+      await service.handleHourlyCheck(new Date('2024-01-16T08:00:00Z'));
+      expect(sendWeeklySpy).not.toHaveBeenCalled();
+    });
+
+    it('skips an unrecognized timezone without throwing', async () => {
+      jest.spyOn(config, 'get').mockImplementation((key: string) => {
+        if (key === 'DIGEST_ENABLED') return 'true';
+        return undefined;
+      });
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { digest_timezone: 'Not/A_Real_Zone' },
+        { digest_timezone: 'UTC' },
+      ]);
+      const sendDailySpy = jest
+        .spyOn(service, 'sendDailyDigests')
+        .mockResolvedValue(undefined);
+
+      await expect(
+        service.handleHourlyCheck(new Date('2024-01-15T08:00:00Z')),
+      ).resolves.not.toThrow();
+
+      // the invalid zone is skipped; the valid one still gets processed
+      expect(sendDailySpy).toHaveBeenCalledTimes(1);
+      expect(sendDailySpy).toHaveBeenCalledWith(
+        expect.any(Date),
+        'UTC',
+        8,
+      );
+    });
+  });
+
+  // ── Digest content & idempotency ────────────────────────────────────────
+
+  describe('runDigests / processUserDigest', () => {
+    it('sends an email when there are unread notifications in the window', async () => {
+      jest.spyOn(prefsRepo, 'find').mockResolvedValue([mockPref as UserPreferences]);
+      jest
+        .spyOn(notificationRepo, 'find')
+        .mockResolvedValue([mockNotification as Notification]);
+
+      await service.sendDailyDigests(
+        new Date('2024-01-15T08:00:00Z'),
+        'UTC',
+        8,
+      );
+
+      expect(emailService.queueEmail).toHaveBeenCalledTimes(1);
+      expect(digestStateRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips a user with no unread notifications in the window (does not email or write state)', async () => {
+      jest.spyOn(prefsRepo, 'find').mockResolvedValue([mockPref as UserPreferences]);
+      jest.spyOn(notificationRepo, 'find').mockResolvedValue([]);
+
+      await service.sendDailyDigests(
+        new Date('2024-01-15T08:00:00Z'),
+        'UTC',
+        8,
+      );
+
+      expect(emailService.queueEmail).not.toHaveBeenCalled();
+      expect(digestStateRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('skips a user whose period was already sent (idempotency)', async () => {
+      jest.spyOn(prefsRepo, 'find').mockResolvedValue([mockPref as UserPreferences]);
+      jest
+        .spyOn(notificationRepo, 'find')
+        .mockResolvedValue([mockNotification as Notification]);
+      jest.spyOn(digestStateRepo, 'findOne').mockResolvedValue({
+        userId: 'user-1',
+        lastDailyPeriod: '2024-01-15',
+        lastWeeklyPeriod: null,
+      } as NotificationDigestState);
+
+      await service.sendDailyDigests(
+        new Date('2024-01-15T08:00:00Z'),
+        'UTC',
+        8,
+      );
+
+      expect(emailService.queueEmail).not.toHaveBeenCalled();
+    });
+
+    it('filters by frequency, timezone, and hour when querying preferences', async () => {
+      const findSpy = jest
+        .spyOn(prefsRepo, 'find')
+        .mockResolvedValue([mockPref as UserPreferences]);
+      jest
+        .spyOn(notificationRepo, 'find')
+        .mockResolvedValue([mockNotification as Notification]);
+
+      await service.sendWeeklyDigests(
+        new Date('2024-01-15T08:00:00Z'),
+        'Africa/Lagos',
+        9,
+      );
+
+      expect(findSpy).toHaveBeenCalledWith({
+        where: {
+          digest_frequency: 'weekly',
+          email_notifications: true,
+          digest_timezone: 'Africa/Lagos',
+          digest_hour: 9,
+        },
+      });
+    });
+
+    it('skips a user with no stored email', async () => {
+      jest.spyOn(prefsRepo, 'find').mockResolvedValue([mockPref as UserPreferences]);
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue({
+        ...mockUser,
+        email: null,
+      } as User);
+
+      await service.sendDailyDigests(
+        new Date('2024-01-15T08:00:00Z'),
+        'UTC',
+        8,
+      );
+
+      expect(notificationRepo.find).not.toHaveBeenCalled();
+      expect(emailService.queueEmail).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/notifications/digest.service.ts
+++ b/backend/src/notifications/digest.service.ts
@@ -27,51 +27,94 @@ export class DigestService {
     private readonly config: ConfigService,
   ) {}
 
-  // Fires every hour on the hour; only does real work at DIGEST_DAILY_HOUR_UTC.
+  // Fires every hour on the hour. For each hour-of-day, only users whose
+  // digest_timezone currently reads that local hour (and whose digest_hour
+  // matches) are candidates — batched per distinct timezone rather than
+  // iterating every individual user's own offset.
   @Cron('0 0 * * * *')
-  async handleHourlyCheck(): Promise<void> {
+  async handleHourlyCheck(now = new Date()): Promise<void> {
     if (this.config.get<string>('DIGEST_ENABLED') === 'false') return;
-
-    const now = new Date();
-    const configuredHour = parseInt(
-      this.config.get<string>('DIGEST_DAILY_HOUR_UTC') ?? '8',
-      10,
-    );
-
-    if (now.getUTCHours() !== configuredHour) return;
-
-    await this.sendDailyDigests(now);
 
     const weekDay = parseInt(
       this.config.get<string>('DIGEST_WEEKLY_DAY') ?? '1',
       10,
     );
-    if (now.getUTCDay() === weekDay) {
-      await this.sendWeeklyDigests(now);
+
+    const timezones = await this.getActiveTimezones();
+
+    for (const timezone of timezones) {
+      let localHour: number;
+      let localWeekday: number;
+      try {
+        localHour = this.getLocalHour(now, timezone);
+        localWeekday = this.getLocalWeekday(now, timezone);
+      } catch (err) {
+        this.logger.warn(
+          `Skipping digest_timezone "${timezone}": unrecognized IANA zone (${err instanceof Error ? err.message : String(err)})`,
+        );
+        continue;
+      }
+
+      await this.sendDailyDigests(now, timezone, localHour);
+
+      if (localWeekday === weekDay) {
+        await this.sendWeeklyDigests(now, timezone, localHour);
+      }
     }
   }
 
-  async sendDailyDigests(now = new Date()): Promise<void> {
-    const periodKey = this.getDailyPeriodKey(now);
-    const windowStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    this.logger.log(`Running daily digest for period ${periodKey}`);
-    await this.runDigests('daily', periodKey, windowStart);
+  /** Distinct timezones in use among users who have digests turned on. */
+  private async getActiveTimezones(): Promise<string[]> {
+    const rows = await this.prefsRepo
+      .createQueryBuilder('p')
+      .select('DISTINCT p.digest_timezone', 'digest_timezone')
+      .where('p.digest_frequency != :off', { off: 'off' })
+      .andWhere('p.email_notifications = true')
+      .getRawMany<{ digest_timezone: string }>();
+
+    return rows.map((r) => r.digest_timezone);
   }
 
-  async sendWeeklyDigests(now = new Date()): Promise<void> {
-    const periodKey = this.getWeeklyPeriodKey(now);
+  async sendDailyDigests(
+    now: Date,
+    timezone: string,
+    hour: number,
+  ): Promise<void> {
+    const periodKey = this.getLocalDailyPeriodKey(now, timezone);
+    const windowStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    this.logger.log(
+      `Running daily digest for ${timezone} @ ${hour}:00 local, period ${periodKey}`,
+    );
+    await this.runDigests('daily', periodKey, windowStart, timezone, hour);
+  }
+
+  async sendWeeklyDigests(
+    now: Date,
+    timezone: string,
+    hour: number,
+  ): Promise<void> {
+    const periodKey = this.getLocalWeeklyPeriodKey(now, timezone);
     const windowStart = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-    this.logger.log(`Running weekly digest for period ${periodKey}`);
-    await this.runDigests('weekly', periodKey, windowStart);
+    this.logger.log(
+      `Running weekly digest for ${timezone} @ ${hour}:00 local, period ${periodKey}`,
+    );
+    await this.runDigests('weekly', periodKey, windowStart, timezone, hour);
   }
 
   private async runDigests(
     frequency: 'daily' | 'weekly',
     periodKey: string,
     windowStart: Date,
+    timezone: string,
+    hour: number,
   ): Promise<void> {
     const prefs = await this.prefsRepo.find({
-      where: { digest_frequency: frequency, email_notifications: true },
+      where: {
+        digest_frequency: frequency,
+        email_notifications: true,
+        digest_timezone: timezone,
+        digest_hour: hour,
+      },
     });
 
     for (const pref of prefs) {
@@ -113,6 +156,7 @@ export class DigestService {
       take: 20,
     });
 
+    // skip users with nothing to report — no email queued, no state written
     if (notifications.length === 0) return;
 
     const items: DigestItem[] = notifications.map((n) => ({
@@ -149,16 +193,73 @@ export class DigestService {
     );
   }
 
-  private getDailyPeriodKey(date: Date): string {
-    return date.toISOString().slice(0, 10);
+  // ── Timezone-aware time helpers ─────────────────────────────────────────
+  //
+  // Using Intl.DateTimeFormat with an explicit `timeZone` rather than a
+  // manual UTC-offset table means DST transitions are handled correctly for
+  // free — the JS engine's ICU data already knows every zone's rules.
+
+  /** The local hour-of-day (0-23) in `timezone` at instant `date`. */
+  private getLocalHour(date: Date, timezone: string): number {
+    const formatted = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hourCycle: 'h23',
+      hour: '2-digit',
+    }).format(date);
+    return parseInt(formatted, 10);
   }
 
-  private getWeeklyPeriodKey(date: Date): string {
-    const d = new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  /** The local day-of-week in `timezone`, 0 = Sunday .. 6 = Saturday. */
+  private getLocalWeekday(date: Date, timezone: string): number {
+    const weekdayNames = [
+      'Sun',
+      'Mon',
+      'Tue',
+      'Wed',
+      'Thu',
+      'Fri',
+      'Sat',
+    ] as const;
+    const formatted = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      weekday: 'short',
+    }).format(date);
+    const index = weekdayNames.indexOf(
+      formatted as (typeof weekdayNames)[number],
     );
-    const day = d.getUTCDay() || 7;
-    d.setUTCDate(d.getUTCDate() + 4 - day);
+    return index;
+  }
+
+  /** The local calendar date in `timezone`, as "YYYY-MM-DD". */
+  private getLocalDateParts(
+    date: Date,
+    timezone: string,
+  ): { year: number; month: number; day: number } {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(date);
+
+    const get = (type: string) =>
+      parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
+
+    return { year: get('year'), month: get('month'), day: get('day') };
+  }
+
+  private getLocalDailyPeriodKey(date: Date, timezone: string): string {
+    const { year, month, day } = this.getLocalDateParts(date, timezone);
+    return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  }
+
+  private getLocalWeeklyPeriodKey(date: Date, timezone: string): string {
+    const { year, month, day } = this.getLocalDateParts(date, timezone);
+    // Build a UTC Date carrying the *local* y/m/d so ISO-week math below
+    // operates on the user's local calendar date, not the instant's UTC date.
+    const d = new Date(Date.UTC(year, month - 1, day));
+    const isoDay = d.getUTCDay() || 7;
+    d.setUTCDate(d.getUTCDate() + 4 - isoDay);
     const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
     const week = Math.ceil(
       ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,

--- a/backend/src/users/dto/user-preferences.dto.ts
+++ b/backend/src/users/dto/user-preferences.dto.ts
@@ -1,4 +1,39 @@
-import { IsBoolean, IsOptional } from 'class-validator';
+import {
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  registerDecorator,
+  ValidationOptions,
+} from 'class-validator';
+
+function IsIanaTimezone(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isIanaTimezone',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          if (typeof value !== 'string') return false;
+          try {
+            Intl.DateTimeFormat(undefined, { timeZone: value });
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        defaultMessage(): string {
+          return 'digest_timezone must be a valid IANA timezone name (e.g. "America/Chicago")';
+        },
+      },
+    });
+  };
+}
 
 export class UpdateUserPreferencesDto {
   @IsOptional()
@@ -20,6 +55,22 @@ export class UpdateUserPreferencesDto {
   @IsOptional()
   @IsBoolean()
   marketing_emails?: boolean;
+
+  @IsOptional()
+  @IsIn(['daily', 'weekly', 'off'])
+  digest_frequency?: 'daily' | 'weekly' | 'off';
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(23)
+  digest_hour?: number;
+
+  /** IANA timezone name, e.g. "America/Chicago". */
+  @IsOptional()
+  @IsString()
+  @IsIanaTimezone()
+  digest_timezone?: string;
 }
 
 export class UserPreferencesResponseDto {
@@ -29,6 +80,9 @@ export class UserPreferencesResponseDto {
   competition_notifications: boolean;
   leaderboard_notifications: boolean;
   marketing_emails: boolean;
+  digest_frequency: 'daily' | 'weekly' | 'off';
+  digest_hour: number;
+  digest_timezone: string;
   created_at: Date;
   updated_at: Date;
 }

--- a/backend/src/users/entities/user-preferences.entity.ts
+++ b/backend/src/users/entities/user-preferences.entity.ts
@@ -57,6 +57,14 @@ export class UserPreferences {
   @Column({ type: 'varchar', default: 'off' })
   digest_frequency: 'daily' | 'weekly' | 'off';
 
+  /** Delivery hour (0-23) in the user's local time, per `digest_timezone`. */
+  @Column({ type: 'int', default: 8 })
+  digest_hour: number;
+
+  /** IANA timezone name (e.g. "America/Chicago", "Europe/Lagos"). */
+  @Column({ type: 'varchar', default: 'UTC' })
+  digest_timezone: string;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -414,6 +414,15 @@ export class UsersService {
     if (dto.marketing_emails !== undefined) {
       prefs.marketing_emails = dto.marketing_emails;
     }
+    if (dto.digest_frequency !== undefined) {
+      prefs.digest_frequency = dto.digest_frequency;
+    }
+    if (dto.digest_hour !== undefined) {
+      prefs.digest_hour = dto.digest_hour;
+    }
+    if (dto.digest_timezone !== undefined) {
+      prefs.digest_timezone = dto.digest_timezone;
+    }
 
     const updated = await this.preferencesRepository.save(prefs);
 
@@ -424,6 +433,9 @@ export class UsersService {
       competition_notifications: updated.competition_notifications,
       leaderboard_notifications: updated.leaderboard_notifications,
       marketing_emails: updated.marketing_emails,
+      digest_frequency: updated.digest_frequency,
+      digest_hour: updated.digest_hour,
+      digest_timezone: updated.digest_timezone,
       created_at: updated.created_at,
       updated_at: updated.updated_at,
     };


### PR DESCRIPTION
Description

Closes #1369

Problem

The email digest ran on a single global cadence (DIGEST_DAILY_HOUR_UTC, DIGEST_WEEKLY_DAY), the same for every user regardless of timezone. Digging into the existing code also surfaced that UserPreferences.digest_frequency — which DigestService already reads — had no API path for a user to actually set it. The column existed in the DB and defaulted to 'off', but nothing in UpdateUserPreferencesDto or UsersService.updatePreferences touched it.

Approach
UserPreferences gets two new columns: digest_hour (0–23, default 8) and digest_timezone (IANA zone name, default 'UTC'). digest_frequency is unchanged in shape but is now, for the first time, exposed through PATCH /users/me/preferences alongside the two new fields.
Validation: digest_hour bounded 0–23, digest_frequency restricted to daily | weekly | off, and digest_timezone checked against a real IANA zone via a small custom class-validator decorator that probes Intl.DateTimeFormat (a bad zone name throws, so the probe doubles as the check). digest.service.ts still defensively catches an invalid zone at read time too, in case one slips through — never crashes the whole cron run over one bad row.
Scheduler rewrite: instead of checking one configured UTC hour against now for every user, each hourly tick now:
Queries the distinct set of timezones currently in use among opted-in users (one query).
For each distinct timezone, computes that zone's current local hour and weekday once via Intl.DateTimeFormat — this handles DST transitions correctly for free, no manual UTC-offset table to maintain.
Runs one batched preference query per (timezone, frequency, matching local hour) — this is the literal "batch by frequency/timezone window" the issue asks for, rather than iterating every individual user's own offset.
Weekly digests additionally filter on local weekday matching DIGEST_WEEKLY_DAY.
Period keys (used for idempotency — "was this period's digest already sent") are now derived from the user's local calendar date/ISO week instead of the server's UTC date. Otherwise a user near a local midnight boundary could get double-fired or skipped relative to their own day.
Skip-empty-digest behavior was already implemented in the existing code (if (notifications.length === 0) return;) — left untouched, just confirmed by a new test.
Testing

New digest.service.spec.ts (this file didn't exist before), 17 tests covering:

Local-hour computation across a UTC-5 zone (America/New_York in January, i.e. EST) and a UTC+1 zone (Africa/Lagos), plus UTC itself as a sanity check.
Local-weekday computation, including a case where a far-ahead zone (Pacific/Auckland, UTC+13) has already rolled into the next calendar day relative to the UTC instant.
Daily/weekly period keys reflecting the local date rather than the UTC date.
handleHourlyCheck disabled via config, querying active timezones, calling sendDailyDigests per timezone with the correct computed local hour, only calling sendWeeklyDigests when the local weekday matches the configured day, and gracefully skipping (not throwing on) an unrecognized timezone string.
runDigests/processUserDigest: sends when there's unread content in the window, skips when there's none, skips an already-sent period (idempotency), filters the preference query by frequency+timezone+hour together, and skips a user with no stored email.

Full backend suite: npx jest — 78 suites, 980 tests, all green. npm run build clean.

Acceptance criteria checklist
 Digests sent per each user's chosen frequency and hour
 Timezones respected in scheduling (DST-correct via Intl, no offset table)
 Users with no content skipped (pre-existing, confirmed by test)
 Tests cover frequency selection and timezone bucketing

Notes for reviewers
File list on the issue said notifications.controller.ts — that controller actually owns a separate, unrelated entity (NotificationPreference, for in-app/push channel + quiet hours). The real settable home for digest_frequency/digest_hour/digest_timezone is UserPreferences, via the existing users.controller.ts → PATCH me/preferences endpoint. No notifications.controller.ts changes were needed.
New migration: 1777400000000-AddDigestSchedulingToUserPreferences.ts, matching the existing raw ADD COLUMN IF NOT EXISTS style used by the prior digest migration.