### PR TITLE
feat: prediction fraud signals, dispute SLA timers, referral tracking…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,3 +52,32 @@ DIGEST_ENABLED=true
 DIGEST_DAILY_HOUR_UTC=8
 # Day of the week (0=Sunday … 6=Saturday) on which weekly digests are sent
 DIGEST_WEEKLY_DAY=1
+
+# Prediction Fraud Signal Thresholds (advisory only - no auto-enforcement)
+# Minimum number of a user's predictions required before the timing
+# clustering signal is evaluated.
+FRAUD_TIMING_MIN_SAMPLE=5
+# Consecutive predictions submitted within this many seconds of each other
+# count as "clustered".
+FRAUD_TIMING_CLUSTER_WINDOW_SECONDS=30
+# Fraction (0-1) of a user's submission gaps that must be clustered to raise
+# a timing clustering flag.
+FRAUD_TIMING_CLUSTER_MIN_RATIO=0.6
+# Minimum number of distinct markets a user must have predicted on before
+# the counterparty concentration signal is evaluated.
+FRAUD_COUNTERPARTY_MIN_MARKETS=5
+# Herfindahl-Hirschman Index threshold (0-1) over counterparty market
+# co-participation share; higher means more concentrated on a small clique.
+FRAUD_COUNTERPARTY_HHI_THRESHOLD=0.5
+
+# Dispute SLA Configuration
+DISPUTE_SLA_ENABLED=true
+# Hours a pending dispute has for its initial review before it escalates.
+DISPUTE_SLA_INITIAL_REVIEW_HOURS=48
+# Additional hours granted once a dispute escalates past initial review.
+DISPUTE_SLA_ESCALATION_HOURS=24
+# How many hours before a stage deadline to send an "approaching" notice.
+DISPUTE_SLA_APPROACHING_WINDOW_HOURS=6
+# Minimum hours between repeat "still breached" notifications once a
+# dispute is in its terminal escalated stage.
+DISPUTE_SLA_REESCALATION_INTERVAL_HOURS=24

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -21,6 +21,7 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { ListFlagsQueryDto } from '../flags/dto/list-flags-query.dto';
 import { ResolveFlagDto } from '../flags/dto/resolve-flag.dto';
+import { ListFraudFlagsQueryDto } from '../predictions/dto/list-fraud-flags-query.dto';
 import { AdminService } from './admin.service';
 import { ActivityLogQueryDto } from './dto/activity-log-query.dto';
 import { BanUserDto } from './dto/ban-user.dto';
@@ -192,6 +193,20 @@ export class AdminController {
   @Roles(Role.Admin, Role.Moderator)
   async listFlags(@Query() query: ListFlagsQueryDto) {
     return this.adminService.listFlags(query);
+  }
+
+  @Get('predictions/fraud-flags')
+  @Roles(Role.Admin, Role.Moderator)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'List advisory prediction fraud signal flags (timing clustering, ' +
+      'counterparty concentration). Advisory only - no automatic ' +
+      'enforcement is taken from these flags.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated list of fraud flags' })
+  async listFraudFlags(@Query() query: ListFraudFlagsQueryDto) {
+    return this.adminService.listFraudFlags(query);
   }
 
   @Patch('flags/:id/resolve')

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -14,6 +14,7 @@ import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { MarketsModule } from '../markets/markets.module';
 import { Prediction } from '../predictions/entities/prediction.entity';
+import { PredictionsModule } from '../predictions/predictions.module';
 import { User } from '../users/entities/user.entity';
 import { UserFlag } from './entities/user-flag.entity';
 import { VerifiedAddress } from './entities/verified-address.entity';
@@ -40,6 +41,7 @@ import { AdminService } from './admin.service';
     FlagsModule,
     NotificationsModule,
     MarketsModule,
+    PredictionsModule,
     CacheModule.register(),
   ],
   controllers: [AdminController],

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -152,6 +152,11 @@ describe('AdminService (Verified Addresses)', () => {
           provide: require('../markets/markets.service').MarketsService,
           useValue: { createMarketRowTransactional: jest.fn() },
         },
+        {
+          provide: require('../predictions/predictions.service')
+            .PredictionsService,
+          useValue: { listFraudFlags: jest.fn() },
+        },
       ],
     }).compile();
 

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -21,6 +21,8 @@ import { Market } from '../markets/entities/market.entity';
 import { NotificationType } from '../notifications/entities/notification.entity';
 import { NotificationsService } from '../notifications/notifications.service';
 import { Prediction } from '../predictions/entities/prediction.entity';
+import { ListFraudFlagsQueryDto } from '../predictions/dto/list-fraud-flags-query.dto';
+import { PredictionsService } from '../predictions/predictions.service';
 import { SorobanService } from '../soroban/soroban.service';
 import { User } from '../users/entities/user.entity';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
@@ -88,6 +90,7 @@ export class AdminService {
     private readonly notificationsService: NotificationsService,
     private readonly sorobanService: SorobanService,
     private readonly flagsService: FlagsService,
+    private readonly predictionsService: PredictionsService,
   ) {}
 
   async getStats(): Promise<StatsResponseDto> {
@@ -492,6 +495,15 @@ export class AdminService {
 
   async listFlags(query: ListFlagsQueryDto) {
     return this.flagsService.listFlags(query);
+  }
+
+  /**
+   * Advisory prediction-fraud signal flags (timing clustering, counterparty
+   * concentration). Informational only - resolving/dismissing a flag here
+   * does not itself ban or restrict the flagged user.
+   */
+  async listFraudFlags(query: ListFraudFlagsQueryDto) {
+    return this.predictionsService.listFraudFlags(query);
   }
 
   async resolveFlag(

--- a/backend/src/admin/bulk-import-markets.spec.ts
+++ b/backend/src/admin/bulk-import-markets.spec.ts
@@ -18,6 +18,7 @@ import { AnalyticsService } from '../analytics/analytics.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { SorobanService } from '../soroban/soroban.service';
 import { FlagsService } from '../flags/flags.service';
+import { PredictionsService } from '../predictions/predictions.service';
 
 describe('AdminService (Bulk CSV Market Import)', () => {
   let service: AdminService;
@@ -62,6 +63,7 @@ describe('AdminService (Bulk CSV Market Import)', () => {
         { provide: NotificationsService, useValue: {} },
         { provide: SorobanService, useValue: {} },
         { provide: FlagsService, useValue: {} },
+        { provide: PredictionsService, useValue: {} },
       ],
     }).compile();
 

--- a/backend/src/disputes/admin-disputes.controller.ts
+++ b/backend/src/disputes/admin-disputes.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Post,
+  Patch,
   Body,
   Param,
   UseGuards,
@@ -16,6 +17,7 @@ import {
 } from '@nestjs/swagger';
 import { DisputesService } from './disputes.service';
 import { ResolveDisputeDto } from './dto/resolve-dispute.dto';
+import { AssignArbiterDto } from './dto/assign-arbiter.dto';
 import { Dispute } from './entities/dispute.entity';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
@@ -59,5 +61,41 @@ export class AdminDisputesController {
     @CurrentUser() adminUser: User,
   ): Promise<Dispute> {
     return this.disputesService.resolve(id, resolveDisputeDto, adminUser);
+  }
+
+  @Patch(':id/assign-arbiter')
+  @HttpCode(HttpStatus.OK)
+  @Roles(Role.Admin)
+  @ApiOperation({
+    summary:
+      'Assign an admin/moderator as the arbiter for a pending dispute ' +
+      '(Admin only). Determines who is notified as the SLA deadline ' +
+      'approaches or is breached.',
+  })
+  @ApiParam({ name: 'id', description: 'Dispute ID' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Arbiter assigned successfully',
+    type: Dispute,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Dispute or arbiter user not found',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description:
+      'Dispute is not pending, or the target user is not an admin/moderator',
+  })
+  async assignArbiter(
+    @Param('id') id: string,
+    @Body() assignArbiterDto: AssignArbiterDto,
+    @CurrentUser() adminUser: User,
+  ): Promise<Dispute> {
+    return this.disputesService.assignArbiter(
+      id,
+      assignArbiterDto.arbiter_id,
+      adminUser.id,
+    );
   }
 }

--- a/backend/src/disputes/disputes.module.ts
+++ b/backend/src/disputes/disputes.module.ts
@@ -8,11 +8,13 @@ import { AdminDisputesController } from './admin-disputes.controller';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
 import { SorobanModule } from '../soroban/soroban.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Dispute, DisputeEvidence, Market, User]),
     SorobanModule,
+    NotificationsModule,
   ],
   controllers: [DisputesController, AdminDisputesController],
   providers: [DisputesService],

--- a/backend/src/disputes/disputes.service.spec.ts
+++ b/backend/src/disputes/disputes.service.spec.ts
@@ -694,7 +694,13 @@ describe('DisputesService', () => {
     });
 
     it('throws NotFoundException when the arbiter user does not exist', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue(mockDispute);
+      // Cloned rather than reusing the shared mockDispute: earlier describe
+      // blocks (e.g. 'resolve') mutate mockDispute.status in place via the
+      // service, so relying on the shared reference here is order-dependent.
+      jest.spyOn(service, 'findOne').mockResolvedValue({
+        ...mockDispute,
+        status: DisputeStatus.PENDING,
+      });
       jest.spyOn(usersRepository, 'findOne').mockResolvedValue(null);
 
       await expect(
@@ -703,7 +709,10 @@ describe('DisputesService', () => {
     });
 
     it('throws BadRequestException when the target user is not admin/moderator', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue(mockDispute);
+      jest.spyOn(service, 'findOne').mockResolvedValue({
+        ...mockDispute,
+        status: DisputeStatus.PENDING,
+      });
       jest.spyOn(usersRepository, 'findOne').mockResolvedValue({
         ...mockUser,
         role: 'user',

--- a/backend/src/disputes/disputes.service.spec.ts
+++ b/backend/src/disputes/disputes.service.spec.ts
@@ -12,11 +12,13 @@ import {
   Dispute,
   DisputeStatus,
   DisputeResolution,
+  DisputeSlaStage,
 } from './entities/dispute.entity';
 import { DisputeEvidence } from './entities/dispute-evidence.entity';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
 import { SorobanService } from '../soroban/soroban.service';
+import { NotificationGeneratorService } from '../notifications/notification-generator.service';
 import { Repository } from 'typeorm';
 import { CreateDisputeDto } from './dto/create-dispute.dto';
 import { ResolveDisputeDto } from './dto/resolve-dispute.dto';
@@ -27,7 +29,10 @@ describe('DisputesService', () => {
   let disputesRepository: Repository<Dispute>;
   let marketsRepository: Repository<Market>;
   let evidenceRepository: Repository<DisputeEvidence>;
+  let usersRepository: Repository<User>;
   let sorobanService: SorobanService;
+  let notificationGenerator: jest.Mocked<NotificationGeneratorService>;
+  let mockConfigGet: jest.Mock;
 
   const mockUser: User = {
     id: 'user-123',
@@ -67,6 +72,8 @@ describe('DisputesService', () => {
   } as Dispute;
 
   beforeEach(async () => {
+    mockConfigGet = jest.fn().mockReturnValue(undefined);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DisputesService,
@@ -96,6 +103,13 @@ describe('DisputesService', () => {
           },
         },
         {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn(),
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
           provide: SorobanService,
           useValue: {
             raiseDispute: jest.fn(),
@@ -105,7 +119,14 @@ describe('DisputesService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockReturnValue(undefined),
+            get: mockConfigGet,
+          },
+        },
+        {
+          provide: NotificationGeneratorService,
+          useValue: {
+            notifyDisputeSlaApproaching: jest.fn().mockResolvedValue(undefined),
+            notifyDisputeSlaBreached: jest.fn().mockResolvedValue(undefined),
           },
         },
       ],
@@ -121,7 +142,9 @@ describe('DisputesService', () => {
     evidenceRepository = module.get<Repository<DisputeEvidence>>(
       getRepositoryToken(DisputeEvidence),
     );
+    usersRepository = module.get<Repository<User>>(getRepositoryToken(User));
     sorobanService = module.get<SorobanService>(SorobanService);
+    notificationGenerator = module.get(NotificationGeneratorService);
   });
 
   it('should be defined', () => {
@@ -151,12 +174,16 @@ describe('DisputesService', () => {
       expect(marketsRepository.findOne).toHaveBeenCalledWith({
         where: { id: 'market-123' },
       });
-      expect(disputesRepository.create).toHaveBeenCalledWith({
-        marketId: 'market-123',
-        disputantId: 'user-123',
-        reason: 'Test dispute reason',
-        status: DisputeStatus.PENDING,
-      });
+      expect(disputesRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketId: 'market-123',
+          disputantId: 'user-123',
+          reason: 'Test dispute reason',
+          status: DisputeStatus.PENDING,
+          slaStage: DisputeSlaStage.INITIAL_REVIEW,
+          slaDeadline: expect.any(Date),
+        }),
+      );
       expect(sorobanService.raiseDispute).toHaveBeenCalledWith(
         'chain-market-123',
         'Test dispute reason',
@@ -621,6 +648,213 @@ describe('DisputesService', () => {
       await expect(
         service.listEvidence('dispute-123', outsider),
       ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('assignArbiter', () => {
+    const mockAdmin: User = {
+      id: 'admin-1',
+      role: 'admin',
+      stellar_address: 'GADMIN',
+    } as User;
+
+    it('assigns an admin as the arbiter for a pending dispute', async () => {
+      const pendingDispute = { ...mockDispute, status: DisputeStatus.PENDING };
+      jest
+        .spyOn(service, 'findOne')
+        .mockResolvedValueOnce(pendingDispute)
+        .mockResolvedValueOnce({
+          ...pendingDispute,
+          assignedArbiterId: 'admin-1',
+        });
+      jest.spyOn(usersRepository, 'findOne').mockResolvedValue(mockAdmin);
+      jest.spyOn(disputesRepository, 'save').mockResolvedValue(pendingDispute);
+
+      const result = await service.assignArbiter(
+        'dispute-123',
+        'admin-1',
+        'requesting-admin',
+      );
+
+      expect(disputesRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ assignedArbiterId: 'admin-1' }),
+      );
+      expect(result.assignedArbiterId).toBe('admin-1');
+    });
+
+    it('throws BadRequestException when the dispute is not pending', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue({
+        ...mockDispute,
+        status: DisputeStatus.RESOLVED,
+      });
+
+      await expect(
+        service.assignArbiter('dispute-123', 'admin-1', 'requesting-admin'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when the arbiter user does not exist', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockDispute);
+      jest.spyOn(usersRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.assignArbiter('dispute-123', 'missing-user', 'requesting-admin'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when the target user is not admin/moderator', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockDispute);
+      jest.spyOn(usersRepository, 'findOne').mockResolvedValue({
+        ...mockUser,
+        role: 'user',
+      });
+
+      await expect(
+        service.assignArbiter('dispute-123', 'user-123', 'requesting-admin'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('runSlaCheck', () => {
+    const makePendingDispute = (overrides: Partial<Dispute> = {}): Dispute =>
+      ({
+        id: 'dispute-sla-1',
+        marketId: 'market-123',
+        status: DisputeStatus.PENDING,
+        slaStage: DisputeSlaStage.INITIAL_REVIEW,
+        slaDeadline: new Date(Date.now() + 48 * 60 * 60 * 1000),
+        slaBreachedAt: null,
+        slaApproachingNotifiedAt: null,
+        slaBreachedNotifiedAt: null,
+        assignedArbiter: null,
+        market: { title: 'Test Market' } as any,
+        ...overrides,
+      }) as Dispute;
+
+    it('does nothing when DISPUTE_SLA_ENABLED is false', async () => {
+      mockConfigGet.mockReturnValue('false');
+      const findSpy = jest.spyOn(disputesRepository, 'find');
+
+      const result = await service.runSlaCheck();
+
+      expect(result).toEqual({ approaching: 0, breached: 0, escalated: 0 });
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    it('notifies once when a dispute enters its approaching window', async () => {
+      mockConfigGet.mockReturnValue(undefined);
+      const dispute = makePendingDispute({
+        slaDeadline: new Date(Date.now() + 2 * 60 * 60 * 1000), // 2h away, default window is 6h
+      });
+      jest.spyOn(disputesRepository, 'find').mockResolvedValue([dispute]);
+      jest.spyOn(disputesRepository, 'save').mockResolvedValue(dispute);
+
+      const result = await service.runSlaCheck();
+
+      expect(result.approaching).toBe(1);
+      expect(dispute.slaApproachingNotifiedAt).toBeInstanceOf(Date);
+      expect(
+        notificationGenerator.notifyDisputeSlaApproaching,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ disputeId: 'dispute-sla-1' }),
+      );
+    });
+
+    it('does not re-notify approaching once already notified', async () => {
+      mockConfigGet.mockReturnValue(undefined);
+      const dispute = makePendingDispute({
+        slaDeadline: new Date(Date.now() + 2 * 60 * 60 * 1000),
+        slaApproachingNotifiedAt: new Date(),
+      });
+      jest.spyOn(disputesRepository, 'find').mockResolvedValue([dispute]);
+
+      const result = await service.runSlaCheck();
+
+      expect(result.approaching).toBe(0);
+      expect(
+        notificationGenerator.notifyDisputeSlaApproaching,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('escalates and notifies on first SLA breach', async () => {
+      mockConfigGet.mockReturnValue(undefined);
+      const dispute = makePendingDispute({
+        slaDeadline: new Date(Date.now() - 60 * 1000), // just passed
+      });
+      jest.spyOn(disputesRepository, 'find').mockResolvedValue([dispute]);
+      jest.spyOn(disputesRepository, 'save').mockResolvedValue(dispute);
+
+      const result = await service.runSlaCheck();
+
+      expect(result.breached).toBe(1);
+      expect(result.escalated).toBe(1);
+      expect(dispute.slaStage).toBe(DisputeSlaStage.ESCALATED);
+      expect(dispute.slaBreachedAt).toBeInstanceOf(Date);
+      expect(dispute.slaDeadline.getTime()).toBeGreaterThan(Date.now());
+      expect(
+        notificationGenerator.notifyDisputeSlaBreached,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          disputeId: 'dispute-sla-1',
+          escalated: true,
+        }),
+      );
+    });
+
+    it('does not re-escalate an already-escalated dispute still within the re-notification window', async () => {
+      mockConfigGet.mockReturnValue(undefined);
+      const dispute = makePendingDispute({
+        slaStage: DisputeSlaStage.ESCALATED,
+        slaDeadline: new Date(Date.now() - 60 * 1000),
+        slaBreachedAt: new Date(Date.now() - 60 * 1000),
+        slaBreachedNotifiedAt: new Date(), // just notified
+      });
+      jest.spyOn(disputesRepository, 'find').mockResolvedValue([dispute]);
+
+      const result = await service.runSlaCheck();
+
+      expect(result.breached).toBe(0);
+      expect(result.escalated).toBe(0);
+      expect(
+        notificationGenerator.notifyDisputeSlaBreached,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('re-notifies a still-breached escalated dispute past the re-escalation interval', async () => {
+      mockConfigGet.mockReturnValue(undefined);
+      const dispute = makePendingDispute({
+        slaStage: DisputeSlaStage.ESCALATED,
+        slaDeadline: new Date(Date.now() - 60 * 60 * 1000),
+        slaBreachedAt: new Date(Date.now() - 48 * 60 * 60 * 1000),
+        slaBreachedNotifiedAt: new Date(Date.now() - 25 * 60 * 60 * 1000), // >24h ago
+      });
+      jest.spyOn(disputesRepository, 'find').mockResolvedValue([dispute]);
+      jest.spyOn(disputesRepository, 'save').mockResolvedValue(dispute);
+
+      const result = await service.runSlaCheck();
+
+      expect(result.breached).toBe(1);
+      expect(result.escalated).toBe(0);
+      // Stage does not change again - it's already at the terminal stage.
+      expect(dispute.slaStage).toBe(DisputeSlaStage.ESCALATED);
+      expect(
+        notificationGenerator.notifyDisputeSlaBreached,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ escalated: false }),
+      );
+    });
+
+    it('never changes dispute status - SLA tracking is advisory only', async () => {
+      mockConfigGet.mockReturnValue(undefined);
+      const dispute = makePendingDispute({
+        slaDeadline: new Date(Date.now() - 60 * 1000),
+      });
+      jest.spyOn(disputesRepository, 'find').mockResolvedValue([dispute]);
+      jest.spyOn(disputesRepository, 'save').mockResolvedValue(dispute);
+
+      await service.runSlaCheck();
+
+      expect(dispute.status).toBe(DisputeStatus.PENDING);
     });
   });
 });

--- a/backend/src/disputes/disputes.service.ts
+++ b/backend/src/disputes/disputes.service.ts
@@ -469,7 +469,7 @@ export class DisputesService {
       throw new NotFoundException('Arbiter user not found');
     }
 
-    if (arbiter.role !== Role.Admin && arbiter.role !== Role.Moderator) {
+    if (arbiter.role !== 'admin' && arbiter.role !== 'moderator') {
       throw new BadRequestException(
         'Arbiter must have the admin or moderator role',
       );

--- a/backend/src/disputes/disputes.service.ts
+++ b/backend/src/disputes/disputes.service.ts
@@ -9,10 +9,12 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
 import {
   Dispute,
   DisputeStatus,
   DisputeResolution,
+  DisputeSlaStage,
 } from './entities/dispute.entity';
 import { DisputeEvidence } from './entities/dispute-evidence.entity';
 import { CreateDisputeDto } from './dto/create-dispute.dto';
@@ -20,7 +22,9 @@ import { ResolveDisputeDto } from './dto/resolve-dispute.dto';
 import { AttachEvidenceDto } from './dto/attach-evidence.dto';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
+import { Role } from '../common/enums/role.enum';
 import { SorobanService } from '../soroban/soroban.service';
+import { NotificationGeneratorService } from '../notifications/notification-generator.service';
 
 const DEFAULT_EVIDENCE_MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 const DEFAULT_EVIDENCE_ALLOWED_MIME_TYPES = [
@@ -30,6 +34,11 @@ const DEFAULT_EVIDENCE_ALLOWED_MIME_TYPES = [
   'image/webp',
   'application/pdf',
 ];
+
+const DEFAULT_SLA_INITIAL_REVIEW_HOURS = 48;
+const DEFAULT_SLA_ESCALATION_HOURS = 24;
+const DEFAULT_SLA_APPROACHING_WINDOW_HOURS = 6;
+const DEFAULT_SLA_REESCALATION_INTERVAL_HOURS = 24;
 
 @Injectable()
 export class DisputesService {
@@ -47,8 +56,11 @@ export class DisputesService {
     private readonly marketsRepository: Repository<Market>,
     @InjectRepository(DisputeEvidence)
     private readonly evidenceRepository: Repository<DisputeEvidence>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
     private readonly sorobanService: SorobanService,
     private readonly configService: ConfigService,
+    private readonly notificationGenerator: NotificationGeneratorService,
   ) {
     const configuredMaxSize = this.configService.get<number>(
       'DISPUTE_EVIDENCE_MAX_SIZE_BYTES',
@@ -106,12 +118,23 @@ export class DisputesService {
       throw new ConflictException('Dispute already raised for this market');
     }
 
-    // Create dispute
+    // Create dispute with its initial-review SLA clock running
+    const slaDeadline = new Date();
+    slaDeadline.setHours(
+      slaDeadline.getHours() +
+        this.getSlaHoursConfig(
+          'DISPUTE_SLA_INITIAL_REVIEW_HOURS',
+          DEFAULT_SLA_INITIAL_REVIEW_HOURS,
+        ),
+    );
+
     const dispute = this.disputesRepository.create({
       marketId,
       disputantId: user.id,
       reason,
       status: DisputeStatus.PENDING,
+      slaStage: DisputeSlaStage.INITIAL_REVIEW,
+      slaDeadline,
     });
 
     const savedDispute = await this.disputesRepository.save(dispute);
@@ -417,6 +440,226 @@ export class DisputesService {
         'Only dispute participants can access evidence for this dispute',
       );
     }
+  }
+
+  /**
+   * Assign an admin/moderator as the arbiter responsible for a pending
+   * dispute. Assigning an arbiter does not itself change the SLA clock -
+   * it only changes who gets notified as the deadline approaches or is
+   * breached.
+   */
+  async assignArbiter(
+    disputeId: string,
+    arbiterId: string,
+    adminId: string,
+  ): Promise<Dispute> {
+    const dispute = await this.findOne(disputeId);
+
+    if (dispute.status !== DisputeStatus.PENDING) {
+      throw new BadRequestException(
+        'Arbiters can only be assigned to pending disputes',
+      );
+    }
+
+    const arbiter = await this.usersRepository.findOne({
+      where: { id: arbiterId },
+    });
+
+    if (!arbiter) {
+      throw new NotFoundException('Arbiter user not found');
+    }
+
+    if (arbiter.role !== Role.Admin && arbiter.role !== Role.Moderator) {
+      throw new BadRequestException(
+        'Arbiter must have the admin or moderator role',
+      );
+    }
+
+    dispute.assignedArbiterId = arbiter.id;
+    await this.disputesRepository.save(dispute);
+
+    this.logger.log(
+      `Admin ${adminId} assigned arbiter ${arbiter.id} to dispute ${disputeId}`,
+    );
+
+    return this.findOne(disputeId);
+  }
+
+  /**
+   * Scheduled SLA sweep: runs hourly. For every pending dispute, checks
+   * whether its current SLA stage deadline has passed (escalating and
+   * notifying on first breach, and periodically re-notifying afterwards)
+   * or is approaching (notifying once per stage). This never resolves,
+   * bans, or otherwise auto-enforces anything - it only tracks time and
+   * sends advisory notifications, per policy.
+   */
+  @Cron('0 0 * * * *')
+  async runSlaCheck(): Promise<{
+    approaching: number;
+    breached: number;
+    escalated: number;
+  }> {
+    if (this.configService.get<string>('DISPUTE_SLA_ENABLED') === 'false') {
+      return { approaching: 0, breached: 0, escalated: 0 };
+    }
+
+    const pendingDisputes = await this.disputesRepository.find({
+      where: { status: DisputeStatus.PENDING },
+      relations: ['market', 'disputant', 'assignedArbiter'],
+    });
+
+    let approaching = 0;
+    let breached = 0;
+    let escalated = 0;
+    const now = new Date();
+
+    for (const dispute of pendingDisputes) {
+      try {
+        const outcome = await this.evaluateDisputeSla(dispute, now);
+        if (outcome === 'approaching') approaching++;
+        if (outcome === 'breached') breached++;
+        if (outcome === 'escalated') {
+          breached++;
+          escalated++;
+        }
+      } catch (error) {
+        this.logger.error(
+          `SLA evaluation failed for dispute ${dispute.id}`,
+          error,
+        );
+      }
+    }
+
+    if (approaching || breached) {
+      this.logger.log(
+        `Dispute SLA sweep: ${approaching} approaching, ${breached} breached (${escalated} newly escalated)`,
+      );
+    }
+
+    return { approaching, breached, escalated };
+  }
+
+  private async evaluateDisputeSla(
+    dispute: Dispute,
+    now: Date,
+  ): Promise<'none' | 'approaching' | 'breached' | 'escalated'> {
+    const approachingWindowHours = this.getSlaHoursConfig(
+      'DISPUTE_SLA_APPROACHING_WINDOW_HOURS',
+      DEFAULT_SLA_APPROACHING_WINDOW_HOURS,
+    );
+    const reescalationIntervalHours = this.getSlaHoursConfig(
+      'DISPUTE_SLA_REESCALATION_INTERVAL_HOURS',
+      DEFAULT_SLA_REESCALATION_INTERVAL_HOURS,
+    );
+
+    if (now < dispute.slaDeadline) {
+      const hoursUntilDeadline =
+        (dispute.slaDeadline.getTime() - now.getTime()) / (60 * 60 * 1000);
+
+      if (
+        hoursUntilDeadline <= approachingWindowHours &&
+        !dispute.slaApproachingNotifiedAt
+      ) {
+        dispute.slaApproachingNotifiedAt = now;
+        await this.disputesRepository.save(dispute);
+        await this.notifySlaRecipients(dispute, 'approaching', false);
+        return 'approaching';
+      }
+
+      return 'none';
+    }
+
+    // Deadline has passed.
+    if (!dispute.slaBreachedAt) {
+      dispute.slaBreachedAt = now;
+      let escalatedNow = false;
+
+      if (dispute.slaStage === DisputeSlaStage.INITIAL_REVIEW) {
+        dispute.slaStage = DisputeSlaStage.ESCALATED;
+        const escalationHours = this.getSlaHoursConfig(
+          'DISPUTE_SLA_ESCALATION_HOURS',
+          DEFAULT_SLA_ESCALATION_HOURS,
+        );
+        const newDeadline = new Date(now);
+        newDeadline.setHours(newDeadline.getHours() + escalationHours);
+        dispute.slaDeadline = newDeadline;
+        dispute.slaApproachingNotifiedAt = null;
+        escalatedNow = true;
+      }
+
+      dispute.slaBreachedNotifiedAt = now;
+      await this.disputesRepository.save(dispute);
+      await this.notifySlaRecipients(dispute, 'breached', escalatedNow);
+      return escalatedNow ? 'escalated' : 'breached';
+    }
+
+    // Already breached previously (already at the terminal ESCALATED
+    // stage) - re-notify periodically so it doesn't silently go stale.
+    const hoursSinceLastNotified = dispute.slaBreachedNotifiedAt
+      ? (now.getTime() - dispute.slaBreachedNotifiedAt.getTime()) /
+        (60 * 60 * 1000)
+      : Infinity;
+
+    if (hoursSinceLastNotified >= reescalationIntervalHours) {
+      dispute.slaBreachedNotifiedAt = now;
+      await this.disputesRepository.save(dispute);
+      await this.notifySlaRecipients(dispute, 'breached', false);
+      return 'breached';
+    }
+
+    return 'none';
+  }
+
+  private async notifySlaRecipients(
+    dispute: Dispute,
+    kind: 'approaching' | 'breached',
+    escalated: boolean,
+  ): Promise<void> {
+    const recipientAddresses = await this.getSlaRecipientAddresses(dispute);
+    const input = {
+      disputeId: dispute.id,
+      marketId: dispute.marketId,
+      marketTitle: dispute.market?.title ?? dispute.marketId,
+      slaDeadline: dispute.slaDeadline,
+      recipientAddresses,
+    };
+
+    if (kind === 'approaching') {
+      await this.notificationGenerator.notifyDisputeSlaApproaching(input);
+    } else {
+      await this.notificationGenerator.notifyDisputeSlaBreached({
+        ...input,
+        escalated,
+      });
+    }
+  }
+
+  /**
+   * Recipients for SLA notifications: the assigned arbiter (if any) plus
+   * every admin, deduplicated by address.
+   */
+  private async getSlaRecipientAddresses(dispute: Dispute): Promise<string[]> {
+    const admins = await this.usersRepository.find({
+      where: { role: Role.Admin },
+    });
+
+    const addresses = new Set<string>();
+    if (dispute.assignedArbiter?.stellar_address) {
+      addresses.add(dispute.assignedArbiter.stellar_address);
+    }
+    for (const admin of admins) {
+      if (admin.stellar_address) {
+        addresses.add(admin.stellar_address);
+      }
+    }
+
+    return Array.from(addresses);
+  }
+
+  private getSlaHoursConfig(key: string, fallback: number): number {
+    const raw = this.configService.get<string>(key);
+    const parsed = raw !== undefined ? parseFloat(raw) : NaN;
+    return Number.isFinite(parsed) ? parsed : fallback;
   }
 
   /**

--- a/backend/src/disputes/dto/assign-arbiter.dto.ts
+++ b/backend/src/disputes/dto/assign-arbiter.dto.ts
@@ -1,0 +1,12 @@
+import { IsUUID, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AssignArbiterDto {
+  @ApiProperty({
+    description: 'ID of the admin/moderator user to assign as arbiter',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  arbiter_id: string;
+}

--- a/backend/src/disputes/entities/dispute.entity.ts
+++ b/backend/src/disputes/entities/dispute.entity.ts
@@ -20,6 +20,17 @@ export enum DisputeResolution {
   OVERTURNED = 'overturned',
 }
 
+/**
+ * Tracks which SLA clock is currently running for a pending dispute.
+ * INITIAL_REVIEW is the first window after creation; a breach of that
+ * window escalates the dispute into ESCALATED, which carries its own
+ * (shorter) deadline. RESOLVED disputes stop tracking SLA entirely.
+ */
+export enum DisputeSlaStage {
+  INITIAL_REVIEW = 'initial_review',
+  ESCALATED = 'escalated',
+}
+
 @Entity('disputes')
 @Index(['marketId'])
 @Index(['disputantId'])
@@ -81,6 +92,39 @@ export class Dispute {
   })
   onChainResolutionTx: string | null;
 
+  @Column({
+    name: 'sla_stage',
+    type: 'enum',
+    enum: DisputeSlaStage,
+    default: DisputeSlaStage.INITIAL_REVIEW,
+  })
+  @Index()
+  slaStage: DisputeSlaStage;
+
+  @Column({ name: 'sla_deadline', type: 'timestamptz' })
+  slaDeadline: Date;
+
+  @Column({ name: 'sla_breached_at', type: 'timestamptz', nullable: true })
+  slaBreachedAt: Date | null;
+
+  @Column({
+    name: 'sla_approaching_notified_at',
+    type: 'timestamptz',
+    nullable: true,
+  })
+  slaApproachingNotifiedAt: Date | null;
+
+  @Column({
+    name: 'sla_breached_notified_at',
+    type: 'timestamptz',
+    nullable: true,
+  })
+  slaBreachedNotifiedAt: Date | null;
+
+  @Column({ name: 'assigned_arbiter_id', nullable: true })
+  @Index()
+  assignedArbiterId: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
@@ -96,4 +140,8 @@ export class Dispute {
   @ManyToOne(() => User, { eager: true, nullable: true })
   @JoinColumn({ name: 'resolved_by_id', referencedColumnName: 'id' })
   resolvedBy: User | null;
+
+  @ManyToOne(() => User, { eager: true, nullable: true })
+  @JoinColumn({ name: 'assigned_arbiter_id', referencedColumnName: 'id' })
+  assignedArbiter: User | null;
 }

--- a/backend/src/migrations/1777500000000-CreatePredictionFraudFlags.ts
+++ b/backend/src/migrations/1777500000000-CreatePredictionFraudFlags.ts
@@ -1,0 +1,121 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreatePredictionFraudFlags1777500000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'prediction_fraud_flags',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'signal_type',
+            type: 'varchar',
+            length: '50',
+            isNullable: false,
+          },
+          {
+            name: 'score',
+            type: 'double precision',
+            isNullable: false,
+          },
+          {
+            name: 'threshold',
+            type: 'double precision',
+            isNullable: false,
+          },
+          {
+            name: 'details',
+            type: 'jsonb',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'varchar',
+            length: '20',
+            default: "'open'",
+            isNullable: false,
+          },
+          {
+            name: 'reviewed_by',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'reviewed_at',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'prediction_fraud_flags',
+      new TableIndex({
+        name: 'IDX_prediction_fraud_flags_user_id',
+        columnNames: ['user_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'prediction_fraud_flags',
+      new TableIndex({
+        name: 'IDX_prediction_fraud_flags_signal_type',
+        columnNames: ['signal_type'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'prediction_fraud_flags',
+      new TableIndex({
+        name: 'IDX_prediction_fraud_flags_status',
+        columnNames: ['status'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'prediction_fraud_flags',
+      new TableForeignKey({
+        name: 'FK_prediction_fraud_flags_user',
+        columnNames: ['user_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey(
+      'prediction_fraud_flags',
+      'FK_prediction_fraud_flags_user',
+    );
+    await queryRunner.dropTable('prediction_fraud_flags');
+  }
+}

--- a/backend/src/migrations/1777600000000-AddDisputeSlaFields.ts
+++ b/backend/src/migrations/1777600000000-AddDisputeSlaFields.ts
@@ -1,0 +1,107 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class AddDisputeSlaFields1777600000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('disputes', [
+      new TableColumn({
+        name: 'sla_stage',
+        type: 'varchar',
+        length: '20',
+        default: "'initial_review'",
+        isNullable: false,
+      }),
+      new TableColumn({
+        name: 'sla_deadline',
+        type: 'timestamptz',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'sla_breached_at',
+        type: 'timestamptz',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'sla_approaching_notified_at',
+        type: 'timestamptz',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'sla_breached_notified_at',
+        type: 'timestamptz',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'assigned_arbiter_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    ]);
+
+    // Backfill existing pending disputes with a deadline so the SLA sweep
+    // has something to compare against, then make the column mandatory for
+    // new rows going forward via the entity/application layer.
+    await queryRunner.query(
+      `UPDATE "disputes" SET "sla_deadline" = "created_at" + INTERVAL '48 hours' WHERE "sla_deadline" IS NULL`,
+    );
+
+    await queryRunner.changeColumn(
+      'disputes',
+      'sla_deadline',
+      new TableColumn({
+        name: 'sla_deadline',
+        type: 'timestamptz',
+        isNullable: false,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'disputes',
+      new TableIndex({
+        name: 'IDX_disputes_sla_stage',
+        columnNames: ['sla_stage'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'disputes',
+      new TableIndex({
+        name: 'IDX_disputes_assigned_arbiter_id',
+        columnNames: ['assigned_arbiter_id'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'disputes',
+      new TableForeignKey({
+        name: 'FK_disputes_assigned_arbiter_id',
+        columnNames: ['assigned_arbiter_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey(
+      'disputes',
+      'FK_disputes_assigned_arbiter_id',
+    );
+    await queryRunner.dropIndex('disputes', 'IDX_disputes_assigned_arbiter_id');
+    await queryRunner.dropIndex('disputes', 'IDX_disputes_sla_stage');
+    await queryRunner.dropColumns('disputes', [
+      'assigned_arbiter_id',
+      'sla_breached_notified_at',
+      'sla_approaching_notified_at',
+      'sla_breached_at',
+      'sla_deadline',
+      'sla_stage',
+    ]);
+  }
+}

--- a/backend/src/migrations/1777700000000-CreateUserReferrals.ts
+++ b/backend/src/migrations/1777700000000-CreateUserReferrals.ts
@@ -1,0 +1,106 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateUserReferrals1777700000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_referrals',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'referrer_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'referred_id',
+            type: 'uuid',
+            isNullable: false,
+            isUnique: true,
+          },
+          {
+            name: 'status',
+            type: 'varchar',
+            length: '20',
+            default: "'pending'",
+            isNullable: false,
+          },
+          {
+            name: 'qualified_at',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'user_referrals',
+      new TableIndex({
+        name: 'IDX_user_referrals_referrer_id',
+        columnNames: ['referrer_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'user_referrals',
+      new TableIndex({
+        name: 'IDX_user_referrals_status',
+        columnNames: ['status'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'user_referrals',
+      new TableForeignKey({
+        name: 'FK_user_referrals_referrer',
+        columnNames: ['referrer_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'user_referrals',
+      new TableForeignKey({
+        name: 'FK_user_referrals_referred',
+        columnNames: ['referred_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey(
+      'user_referrals',
+      'FK_user_referrals_referred',
+    );
+    await queryRunner.dropForeignKey(
+      'user_referrals',
+      'FK_user_referrals_referrer',
+    );
+    await queryRunner.dropTable('user_referrals');
+  }
+}

--- a/backend/src/notifications/entities/notification.entity.ts
+++ b/backend/src/notifications/entities/notification.entity.ts
@@ -14,6 +14,8 @@ export enum NotificationType {
   MatchResolved = 'match_resolved',
   WinnerVerified = 'winner_verified',
   EventCancelled = 'event_cancelled',
+  DisputeSlaApproaching = 'dispute_sla_approaching',
+  DisputeSlaBreached = 'dispute_sla_breached',
 }
 
 @Entity('notifications')

--- a/backend/src/notifications/notification-generator.service.ts
+++ b/backend/src/notifications/notification-generator.service.ts
@@ -18,6 +18,14 @@ export interface NotificationBatch {
   }>;
 }
 
+export interface DisputeSlaNotificationInput {
+  disputeId: string;
+  marketId: string;
+  marketTitle: string;
+  slaDeadline: Date;
+  recipientAddresses: string[];
+}
+
 @Injectable()
 export class NotificationGeneratorService implements OnModuleDestroy {
   private readonly logger = new Logger(NotificationGeneratorService.name);
@@ -298,6 +306,62 @@ export class NotificationGeneratorService implements OnModuleDestroy {
       title: 'Event Cancelled',
       message: `The event "${event.title}" has been cancelled.`,
       data: { event_id: eventId, event_title: event.title },
+    }));
+
+    await this.queueBatchNotifications(notifications);
+  }
+
+  /**
+   * Advisory reminder that a pending dispute's current SLA stage is close
+   * to its deadline. Sent to the assigned arbiter (if any) and admins.
+   */
+  async notifyDisputeSlaApproaching(
+    input: DisputeSlaNotificationInput,
+  ): Promise<void> {
+    if (input.recipientAddresses.length === 0) return;
+
+    const notifications = input.recipientAddresses.map((address) => ({
+      userAddress: address,
+      type: NotificationType.DisputeSlaApproaching,
+      title: 'Dispute SLA Approaching',
+      message: `Dispute for market "${input.marketTitle}" must be reviewed before ${input.slaDeadline.toISOString()}.`,
+      data: {
+        dispute_id: input.disputeId,
+        market_id: input.marketId,
+        sla_deadline: input.slaDeadline.toISOString(),
+      },
+    }));
+
+    await this.queueBatchNotifications(notifications);
+  }
+
+  /**
+   * Sent when a pending dispute's SLA deadline has passed. `escalated`
+   * indicates the dispute was moved into the next SLA stage as a result.
+   */
+  async notifyDisputeSlaBreached(
+    input: DisputeSlaNotificationInput & { escalated: boolean },
+  ): Promise<void> {
+    if (input.recipientAddresses.length === 0) return;
+
+    const title = input.escalated
+      ? 'Dispute SLA Breached — Escalated'
+      : 'Dispute SLA Breached';
+    const message = `Dispute for market "${input.marketTitle}" missed its SLA deadline (${input.slaDeadline.toISOString()})${
+      input.escalated ? ' and has been escalated' : ''
+    }.`;
+
+    const notifications = input.recipientAddresses.map((address) => ({
+      userAddress: address,
+      type: NotificationType.DisputeSlaBreached,
+      title,
+      message,
+      data: {
+        dispute_id: input.disputeId,
+        market_id: input.marketId,
+        sla_deadline: input.slaDeadline.toISOString(),
+        escalated: input.escalated,
+      },
     }));
 
     await this.queueBatchNotifications(notifications);

--- a/backend/src/predictions/dto/list-fraud-flags-query.dto.ts
+++ b/backend/src/predictions/dto/list-fraud-flags-query.dto.ts
@@ -1,0 +1,33 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+import {
+  FraudFlagStatus,
+  FraudSignalType,
+} from '../entities/prediction-fraud-flag.entity';
+
+export class ListFraudFlagsQueryDto {
+  @IsOptional()
+  @IsEnum(FraudFlagStatus)
+  status?: FraudFlagStatus;
+
+  @IsOptional()
+  @IsEnum(FraudSignalType)
+  signal_type?: FraudSignalType;
+
+  @IsOptional()
+  @IsUUID()
+  user_id?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/backend/src/predictions/entities/prediction-fraud-flag.entity.ts
+++ b/backend/src/predictions/entities/prediction-fraud-flag.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum FraudSignalType {
+  TIMING_CLUSTERING = 'timing_clustering',
+  COUNTERPARTY_CONCENTRATION = 'counterparty_concentration',
+}
+
+export enum FraudFlagStatus {
+  OPEN = 'open',
+  REVIEWED = 'reviewed',
+  DISMISSED = 'dismissed',
+}
+
+/**
+ * Advisory-only record of a suspicious prediction pattern. Created when a
+ * computed signal (see PredictionsService.evaluateFraudSignalsForUser)
+ * exceeds its configured threshold. Never drives automatic enforcement -
+ * admins review and resolve flags manually.
+ */
+@Entity('prediction_fraud_flags')
+@Index(['user_id'])
+@Index(['signal_type'])
+@Index(['status'])
+export class PredictionFraudFlag {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  user_id: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ type: 'enum', enum: FraudSignalType })
+  signal_type: FraudSignalType;
+
+  @Column({ type: 'float' })
+  score: number;
+
+  @Column({ type: 'float' })
+  threshold: number;
+
+  @Column({ type: 'jsonb' })
+  details: Record<string, unknown>;
+
+  @Column({
+    type: 'enum',
+    enum: FraudFlagStatus,
+    default: FraudFlagStatus.OPEN,
+  })
+  status: FraudFlagStatus;
+
+  @Column({ type: 'uuid', nullable: true })
+  reviewed_by: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  reviewed_at: Date | null;
+
+  @CreateDateColumn()
+  created_at: Date;
+}

--- a/backend/src/predictions/predictions.module.ts
+++ b/backend/src/predictions/predictions.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Prediction } from './entities/prediction.entity';
+import { PredictionFraudFlag } from './entities/prediction-fraud-flag.entity';
 import { PredictionsService } from './predictions.service';
 import { PredictionsController } from './predictions.controller';
 import { SlippageCheckerService } from './services/slippage-checker.service';
@@ -13,7 +14,7 @@ import { Market } from '../markets/entities/market.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Prediction, User, Market]),
+    TypeOrmModule.forFeature([Prediction, User, Market, PredictionFraudFlag]),
     UsersModule,
     MarketsModule,
     SorobanModule,

--- a/backend/src/predictions/predictions.service.spec.ts
+++ b/backend/src/predictions/predictions.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import {
   BadRequestException,
   ConflictException,
@@ -10,15 +11,29 @@ import {
 import { Repository, ObjectLiteral } from 'typeorm';
 import { PredictionsService } from './predictions.service';
 import { Prediction } from './entities/prediction.entity';
+import {
+  FraudFlagStatus,
+  FraudSignalType,
+  PredictionFraudFlag,
+} from './entities/prediction-fraud-flag.entity';
 import { Market } from '../markets/entities/market.entity';
 import { PredictionStatus } from './dto/list-my-predictions.dto';
 import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
 import { SorobanService } from '../soroban/soroban.service';
 import { SlippageCheckerService } from './services/slippage-checker.service';
 import { SlippageExceededException } from './exceptions/slippage-exceeded.exception';
 
 type MockRepo<T extends ObjectLiteral> = jest.Mocked<
-  Pick<Repository<T>, 'findOne' | 'create' | 'save' | 'findAndCount' | 'find'>
+  Pick<
+    Repository<T>,
+    | 'findOne'
+    | 'create'
+    | 'save'
+    | 'findAndCount'
+    | 'find'
+    | 'createQueryBuilder'
+  >
 >;
 
 const makeUser = (overrides: Partial<User> = {}): User =>
@@ -64,6 +79,8 @@ describe('PredictionsService', () => {
   let service: PredictionsService;
   let mockPredictionsRepo: MockRepo<Prediction>;
   let mockMarketsRepo: MockRepo<Market>;
+  let mockFraudFlagsRepo: MockRepo<PredictionFraudFlag>;
+  let mockConfigService: jest.Mocked<ConfigService>;
   let mockSoroban: jest.Mocked<SorobanService>;
   let mockSlippageChecker: jest.Mocked<SlippageCheckerService>;
   let submitPrediction: jest.SpyInstance;
@@ -86,13 +103,22 @@ describe('PredictionsService', () => {
       execute: jest.fn().mockResolvedValue(undefined),
     };
 
+    const fraudQbMock = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+
     mockPredictionsRepo = {
       findOne: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
       findAndCount: jest.fn(),
-      find: jest.fn(),
-    };
+      find: jest.fn().mockResolvedValue([]),
+      createQueryBuilder: jest.fn().mockReturnValue(fraudQbMock),
+    } as unknown as MockRepo<Prediction>;
 
     mockMarketsRepo = {
       findOne: jest.fn(),
@@ -131,6 +157,26 @@ describe('PredictionsService', () => {
       }),
     };
 
+    mockFraudFlagsRepo = {
+      findOne: jest.fn(),
+      create: jest.fn((data: Partial<PredictionFraudFlag>) => data),
+      save: jest.fn((entity: Partial<PredictionFraudFlag>) =>
+        Promise.resolve({ id: 'flag-uuid-1', ...entity }),
+      ),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      }),
+    } as unknown as MockRepo<PredictionFraudFlag>;
+
+    mockConfigService = {
+      get: jest.fn().mockReturnValue(undefined),
+    } as unknown as jest.Mocked<ConfigService>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PredictionsService,
@@ -140,9 +186,20 @@ describe('PredictionsService', () => {
         },
         { provide: getRepositoryToken(Market), useValue: mockMarketsRepo },
         { provide: getRepositoryToken(User), useValue: {} },
+        {
+          provide: getRepositoryToken(PredictionFraudFlag),
+          useValue: mockFraudFlagsRepo,
+        },
         { provide: SorobanService, useValue: mockSoroban },
         { provide: SlippageCheckerService, useValue: mockSlippageChecker },
+        {
+          provide: UsersService,
+          useValue: {
+            recordQualifyingAction: jest.fn().mockResolvedValue(undefined),
+          },
+        },
         { provide: getDataSourceToken(), useValue: mockDataSource },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
 
@@ -1140,6 +1197,245 @@ describe('PredictionsService', () => {
 
       expect(result.total).toBe(25);
       expect(result.data).toHaveLength(5);
+    });
+  });
+
+  describe('evaluateFraudSignalsForUser', () => {
+    const makePrediction = (submittedAt: Date) =>
+      ({ submitted_at: submittedAt }) as Prediction;
+
+    beforeEach(() => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        const values: Record<string, string> = {
+          FRAUD_TIMING_MIN_SAMPLE: '3',
+          FRAUD_TIMING_CLUSTER_WINDOW_SECONDS: '30',
+          FRAUD_TIMING_CLUSTER_MIN_RATIO: '0.6',
+          FRAUD_COUNTERPARTY_MIN_MARKETS: '3',
+          FRAUD_COUNTERPARTY_HHI_THRESHOLD: '0.5',
+        };
+        return values[key];
+      });
+    });
+
+    describe('timing clustering signal', () => {
+      it('flags a user whose predictions cluster tightly in time', async () => {
+        const base = Date.now();
+        mockPredictionsRepo.find.mockResolvedValue([
+          makePrediction(new Date(base)),
+          makePrediction(new Date(base + 5_000)),
+          makePrediction(new Date(base + 10_000)),
+          makePrediction(new Date(base + 15_000)),
+        ]);
+
+        await service.evaluateFraudSignalsForUser('user-1');
+
+        expect(mockFraudFlagsRepo.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            user_id: 'user-1',
+            signal_type: FraudSignalType.TIMING_CLUSTERING,
+            status: FraudFlagStatus.OPEN,
+          }),
+        );
+      });
+
+      it('does not flag a user with widely-spaced predictions', async () => {
+        const base = Date.now();
+        mockPredictionsRepo.find.mockResolvedValue([
+          makePrediction(new Date(base)),
+          makePrediction(new Date(base + 6 * 60 * 60 * 1000)),
+          makePrediction(new Date(base + 12 * 60 * 60 * 1000)),
+          makePrediction(new Date(base + 18 * 60 * 60 * 1000)),
+        ]);
+
+        await service.evaluateFraudSignalsForUser('user-1');
+
+        expect(mockFraudFlagsRepo.save).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal_type: FraudSignalType.TIMING_CLUSTERING,
+          }),
+        );
+      });
+
+      it('does not evaluate below the minimum sample size', async () => {
+        const base = Date.now();
+        mockPredictionsRepo.find.mockResolvedValue([
+          makePrediction(new Date(base)),
+          makePrediction(new Date(base + 1_000)),
+        ]);
+
+        await service.evaluateFraudSignalsForUser('user-1');
+
+        expect(mockFraudFlagsRepo.save).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal_type: FraudSignalType.TIMING_CLUSTERING,
+          }),
+        );
+      });
+
+      it('refreshes an existing open flag instead of duplicating it', async () => {
+        const base = Date.now();
+        mockPredictionsRepo.find.mockResolvedValue([
+          makePrediction(new Date(base)),
+          makePrediction(new Date(base + 5_000)),
+          makePrediction(new Date(base + 10_000)),
+        ]);
+        const existingFlag = {
+          id: 'existing-flag',
+          user_id: 'user-1',
+          signal_type: FraudSignalType.TIMING_CLUSTERING,
+          status: FraudFlagStatus.OPEN,
+          score: 0,
+          threshold: 0.6,
+          details: {},
+        } as PredictionFraudFlag;
+        mockFraudFlagsRepo.findOne.mockResolvedValue(existingFlag);
+
+        await service.evaluateFraudSignalsForUser('user-1');
+
+        expect(mockFraudFlagsRepo.create).not.toHaveBeenCalled();
+        expect(mockFraudFlagsRepo.save).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'existing-flag' }),
+        );
+      });
+    });
+
+    describe('counterparty concentration signal', () => {
+      it('flags a user concentrated on a small clique of counterparties', async () => {
+        mockPredictionsRepo.find.mockResolvedValue([]); // no timing signal
+
+        const qb = mockPredictionsRepo.createQueryBuilder(
+          'prediction',
+        ) as unknown as {
+          getRawMany: jest.Mock;
+        };
+
+        // First call: distinct markets the user participated in.
+        // Second call: co-participants across those markets.
+        qb.getRawMany
+          .mockResolvedValueOnce([
+            { marketId: 'm1' },
+            { marketId: 'm2' },
+            { marketId: 'm3' },
+          ])
+          .mockResolvedValueOnce([
+            { counterpartyId: 'clique-user', marketId: 'm1' },
+            { counterpartyId: 'clique-user', marketId: 'm2' },
+            { counterpartyId: 'clique-user', marketId: 'm3' },
+          ]);
+
+        await service.evaluateFraudSignalsForUser('user-1');
+
+        expect(mockFraudFlagsRepo.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            user_id: 'user-1',
+            signal_type: FraudSignalType.COUNTERPARTY_CONCENTRATION,
+            status: FraudFlagStatus.OPEN,
+          }),
+        );
+      });
+
+      it('does not flag a user with diverse counterparties', async () => {
+        mockPredictionsRepo.find.mockResolvedValue([]);
+
+        const qb = mockPredictionsRepo.createQueryBuilder(
+          'prediction',
+        ) as unknown as {
+          getRawMany: jest.Mock;
+        };
+
+        qb.getRawMany
+          .mockResolvedValueOnce([
+            { marketId: 'm1' },
+            { marketId: 'm2' },
+            { marketId: 'm3' },
+          ])
+          .mockResolvedValueOnce([
+            { counterpartyId: 'a', marketId: 'm1' },
+            { counterpartyId: 'b', marketId: 'm2' },
+            { counterpartyId: 'c', marketId: 'm3' },
+          ]);
+
+        await service.evaluateFraudSignalsForUser('user-1');
+
+        expect(mockFraudFlagsRepo.save).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal_type: FraudSignalType.COUNTERPARTY_CONCENTRATION,
+          }),
+        );
+      });
+
+      it('does not evaluate below the minimum market sample size', async () => {
+        mockPredictionsRepo.find.mockResolvedValue([]);
+
+        const qb = mockPredictionsRepo.createQueryBuilder(
+          'prediction',
+        ) as unknown as {
+          getRawMany: jest.Mock;
+        };
+
+        qb.getRawMany.mockResolvedValueOnce([{ marketId: 'm1' }]);
+
+        await service.evaluateFraudSignalsForUser('user-1');
+
+        expect(mockFraudFlagsRepo.save).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal_type: FraudSignalType.COUNTERPARTY_CONCENTRATION,
+          }),
+        );
+      });
+    });
+
+    it('returns the created flags without throwing or banning the user', async () => {
+      const base = Date.now();
+      mockPredictionsRepo.find.mockResolvedValue([
+        makePrediction(new Date(base)),
+        makePrediction(new Date(base + 1_000)),
+        makePrediction(new Date(base + 2_000)),
+      ]);
+
+      const result = await service.evaluateFraudSignalsForUser('user-1');
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(
+        result.every((flag) => flag.status === FraudFlagStatus.OPEN),
+      ).toBe(true);
+    });
+  });
+
+  describe('listFraudFlags', () => {
+    it('returns a paginated list scoped by status, signal type, and user', async () => {
+      const flags = [{ id: 'flag-1' } as PredictionFraudFlag];
+      const qb = mockFraudFlagsRepo.createQueryBuilder('flag') as unknown as {
+        andWhere: jest.Mock;
+        getManyAndCount: jest.Mock;
+      };
+      qb.getManyAndCount.mockResolvedValue([flags, 1]);
+
+      const result = await service.listFraudFlags({
+        status: FraudFlagStatus.OPEN,
+        signal_type: FraudSignalType.TIMING_CLUSTERING,
+        user_id: 'user-1',
+        page: 1,
+        limit: 20,
+      });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('flag.status = :status', {
+        status: FraudFlagStatus.OPEN,
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'flag.signal_type = :signalType',
+        { signalType: FraudSignalType.TIMING_CLUSTERING },
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith('flag.user_id = :userId', {
+        userId: 'user-1',
+      });
+      expect(result).toEqual({
+        data: flags,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
     });
   });
 });

--- a/backend/src/predictions/predictions.service.ts
+++ b/backend/src/predictions/predictions.service.ts
@@ -7,8 +7,15 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { Repository, DataSource } from 'typeorm';
 import { Prediction } from './entities/prediction.entity';
+import {
+  FraudFlagStatus,
+  FraudSignalType,
+  PredictionFraudFlag,
+} from './entities/prediction-fraud-flag.entity';
+import { ListFraudFlagsQueryDto } from './dto/list-fraud-flags-query.dto';
 import { SubmitPredictionDto } from './dto/submit-prediction.dto';
 import { SubmitPredictionResponseDto } from './dto/submit-prediction-response.dto';
 import { UpdatePredictionNoteDto } from './dto/update-prediction-note.dto';
@@ -24,6 +31,7 @@ import {
   PaginatedMyPredictionsResponse,
 } from './dto/list-my-predictions.dto';
 import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
 import { Market } from '../markets/entities/market.entity';
 import { SorobanService } from '../soroban/soroban.service';
 import { SlippageCheckerService } from './services/slippage-checker.service';
@@ -49,9 +57,13 @@ export class PredictionsService {
     private readonly marketsRepository: Repository<Market>,
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
+    @InjectRepository(PredictionFraudFlag)
+    private readonly fraudFlagsRepository: Repository<PredictionFraudFlag>,
     private readonly sorobanService: SorobanService,
     private readonly slippageCheckerService: SlippageCheckerService,
     private readonly dataSource: DataSource,
+    private readonly configService: ConfigService,
+    private readonly usersService: UsersService,
   ) { }
 
   /**
@@ -177,6 +189,25 @@ export class PredictionsService {
         `Prediction ${saved.id} saved for user ${user.id} on market ${market.id}`,
       );
       return saved;
+    });
+
+    // Fraud signals are advisory-only and must never block or roll back a
+    // legitimate prediction submission, so evaluation failures are swallowed.
+    this.evaluateFraudSignalsForUser(user.id).catch((err) => {
+      this.logger.error(
+        `Fraud signal evaluation failed for user ${user.id}`,
+        err,
+      );
+    });
+
+    // A submitted prediction is this user's qualifying action for referral
+    // purposes; no-ops if they weren't referred. Non-blocking for the same
+    // reason as fraud signal evaluation above.
+    this.usersService.recordQualifyingAction(user.id).catch((err) => {
+      this.logger.error(
+        `Referral qualifying-action tracking failed for user ${user.id}`,
+        err,
+      );
     });
 
     return {
@@ -494,4 +525,286 @@ export class PredictionsService {
 
     return { data, total, page, limit };
   }
+
+  /**
+   * Compute fraud signals for a user and persist advisory flags for any
+   * signal that exceeds its configured threshold. This never bans, mutes,
+   * or otherwise restricts the user - it only records data for admin review.
+   */
+  async evaluateFraudSignalsForUser(
+    userId: string,
+  ): Promise<PredictionFraudFlag[]> {
+    const created: PredictionFraudFlag[] = [];
+
+    const timingResult = await this.computeTimingClusteringSignal(userId);
+    if (timingResult) {
+      created.push(
+        await this.upsertFraudFlag(
+          userId,
+          FraudSignalType.TIMING_CLUSTERING,
+          timingResult,
+        ),
+      );
+    }
+
+    const concentrationResult =
+      await this.computeCounterpartyConcentrationSignal(userId);
+    if (concentrationResult) {
+      created.push(
+        await this.upsertFraudFlag(
+          userId,
+          FraudSignalType.COUNTERPARTY_CONCENTRATION,
+          concentrationResult,
+        ),
+      );
+    }
+
+    return created;
+  }
+
+  /**
+   * Timing clustering signal: measures how tightly a user's prediction
+   * submissions bunch together in time. A high ratio of very short gaps
+   * between consecutive predictions is characteristic of scripted/bot-driven
+   * wash-trading rather than organic, independently-timed decisions.
+   */
+  private async computeTimingClusteringSignal(
+    userId: string,
+  ): Promise<FraudSignalResult | null> {
+    const minSample = this.getIntConfig('FRAUD_TIMING_MIN_SAMPLE', 5);
+    const windowSeconds = this.getIntConfig(
+      'FRAUD_TIMING_CLUSTER_WINDOW_SECONDS',
+      30,
+    );
+    const minRatio = this.getFloatConfig(
+      'FRAUD_TIMING_CLUSTER_MIN_RATIO',
+      0.6,
+    );
+
+    const predictions = await this.predictionsRepository.find({
+      where: { user: { id: userId } },
+      order: { submitted_at: 'ASC' },
+    });
+
+    if (predictions.length < minSample) {
+      return null;
+    }
+
+    const totalGaps = predictions.length - 1;
+    let clusteredGaps = 0;
+    for (let i = 1; i < predictions.length; i++) {
+      const gapSeconds =
+        (predictions[i].submitted_at.getTime() -
+          predictions[i - 1].submitted_at.getTime()) /
+        1000;
+      if (gapSeconds <= windowSeconds) {
+        clusteredGaps++;
+      }
+    }
+
+    const ratio = totalGaps > 0 ? clusteredGaps / totalGaps : 0;
+    if (ratio < minRatio) {
+      return null;
+    }
+
+    return {
+      score: ratio,
+      threshold: minRatio,
+      details: {
+        sample_size: predictions.length,
+        clustered_gaps: clusteredGaps,
+        total_gaps: totalGaps,
+        window_seconds: windowSeconds,
+      },
+    };
+  }
+
+  /**
+   * Counterparty concentration signal: measures how concentrated a user's
+   * market co-participation is across other users, using a
+   * Herfindahl-Hirschman Index (HHI) over the share of the user's markets
+   * each counterparty also participated in. A high HHI means the user
+   * repeatedly shows up alongside the same small clique of accounts, which
+   * is a hallmark of collusion rings or self-dealing across linked wallets.
+   */
+  private async computeCounterpartyConcentrationSignal(
+    userId: string,
+  ): Promise<FraudSignalResult | null> {
+    const minMarkets = this.getIntConfig(
+      'FRAUD_COUNTERPARTY_MIN_MARKETS',
+      5,
+    );
+    const hhiThreshold = this.getFloatConfig(
+      'FRAUD_COUNTERPARTY_HHI_THRESHOLD',
+      0.5,
+    );
+
+    const userMarketRows: Array<{ marketId: string }> =
+      await this.predictionsRepository
+        .createQueryBuilder('prediction')
+        .select('DISTINCT prediction.marketId', 'marketId')
+        .where('prediction.userId = :userId', { userId })
+        .getRawMany();
+
+    const marketIds = userMarketRows.map((row) => row.marketId);
+    if (marketIds.length < minMarkets) {
+      return null;
+    }
+
+    const counterpartyRows: Array<{
+      counterpartyId: string;
+      marketId: string;
+    }> = await this.predictionsRepository
+      .createQueryBuilder('prediction')
+      .select('prediction.userId', 'counterpartyId')
+      .addSelect('prediction.marketId', 'marketId')
+      .where('prediction.marketId IN (:...marketIds)', { marketIds })
+      .andWhere('prediction.userId != :userId', { userId })
+      .getRawMany();
+
+    const marketsByCounterparty = new Map<string, Set<string>>();
+    for (const row of counterpartyRows) {
+      const set = marketsByCounterparty.get(row.counterpartyId) ?? new Set();
+      set.add(row.marketId);
+      marketsByCounterparty.set(row.counterpartyId, set);
+    }
+
+    if (marketsByCounterparty.size === 0) {
+      return null;
+    }
+
+    const totalMarkets = marketIds.length;
+    let hhi = 0;
+    let topCounterpartyId: string | null = null;
+    let topShare = 0;
+    for (const [counterpartyId, sharedMarkets] of marketsByCounterparty) {
+      const share = sharedMarkets.size / totalMarkets;
+      hhi += share * share;
+      if (share > topShare) {
+        topShare = share;
+        topCounterpartyId = counterpartyId;
+      }
+    }
+
+    if (hhi < hhiThreshold) {
+      return null;
+    }
+
+    return {
+      score: hhi,
+      threshold: hhiThreshold,
+      details: {
+        total_markets: totalMarkets,
+        distinct_counterparties: marketsByCounterparty.size,
+        top_counterparty_id: topCounterpartyId,
+        top_counterparty_share: topShare,
+      },
+    };
+  }
+
+  /**
+   * Creates a new advisory flag, or refreshes the existing open flag for the
+   * same user/signal so repeated evaluations don't spam duplicate rows.
+   */
+  private async upsertFraudFlag(
+    userId: string,
+    signalType: FraudSignalType,
+    result: FraudSignalResult,
+  ): Promise<PredictionFraudFlag> {
+    const existing = await this.fraudFlagsRepository.findOne({
+      where: {
+        user_id: userId,
+        signal_type: signalType,
+        status: FraudFlagStatus.OPEN,
+      },
+    });
+
+    if (existing) {
+      existing.score = result.score;
+      existing.threshold = result.threshold;
+      existing.details = result.details;
+      return this.fraudFlagsRepository.save(existing);
+    }
+
+    const flag = this.fraudFlagsRepository.create({
+      user_id: userId,
+      signal_type: signalType,
+      score: result.score,
+      threshold: result.threshold,
+      details: result.details,
+      status: FraudFlagStatus.OPEN,
+    });
+
+    const saved = await this.fraudFlagsRepository.save(flag);
+
+    this.logger.warn(
+      `Fraud signal "${signalType}" flagged for user ${userId} (score=${result.score.toFixed(3)}, threshold=${result.threshold})`,
+    );
+
+    return saved;
+  }
+
+  private getIntConfig(key: string, fallback: number): number {
+    const raw = this.configService.get<string>(key);
+    const parsed = raw !== undefined ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  private getFloatConfig(key: string, fallback: number): number {
+    const raw = this.configService.get<string>(key);
+    const parsed = raw !== undefined ? parseFloat(raw) : NaN;
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  /**
+   * Paginated, admin-facing listing of advisory fraud flags. Flags are
+   * informational only; no enforcement action is taken based on this data
+   * alone.
+   */
+  async listFraudFlags(query: ListFraudFlagsQueryDto): Promise<{
+    data: PredictionFraudFlag[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }> {
+    const page = query.page ?? 1;
+    const limit = Math.min(query.limit ?? 20, 100);
+    const skip = (page - 1) * limit;
+
+    const qb = this.fraudFlagsRepository
+      .createQueryBuilder('flag')
+      .leftJoinAndSelect('flag.user', 'user')
+      .orderBy('flag.created_at', 'DESC');
+
+    if (query.status) {
+      qb.andWhere('flag.status = :status', { status: query.status });
+    }
+    if (query.signal_type) {
+      qb.andWhere('flag.signal_type = :signalType', {
+        signalType: query.signal_type,
+      });
+    }
+    if (query.user_id) {
+      qb.andWhere('flag.user_id = :userId', { userId: query.user_id });
+    }
+
+    qb.skip(skip).take(limit);
+
+    const [data, total] = await qb.getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+}
+
+interface FraudSignalResult {
+  score: number;
+  threshold: number;
+  details: Record<string, unknown>;
 }

--- a/backend/src/users/dto/referral.dto.ts
+++ b/backend/src/users/dto/referral.dto.ts
@@ -1,0 +1,37 @@
+import { IsUUID, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ReferralStatus } from '../entities/user-referral.entity';
+
+export class ClaimReferralDto {
+  @ApiProperty({
+    description: 'User ID of the account that referred the current user',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsUUID()
+  @IsNotEmpty()
+  referrer_id: string;
+}
+
+export class ClaimReferralResponseDto {
+  success: boolean;
+  message: string;
+}
+
+export class ReferralItemDto {
+  id: string;
+  referred_id: string;
+  referred_username: string | null;
+  referred_stellar_address: string;
+  status: ReferralStatus;
+  created_at: Date;
+  qualified_at: Date | null;
+}
+
+export class MyReferralsResponseDto {
+  /** Share this user's ID as their referral code. */
+  referral_code: string;
+  total: number;
+  pending: number;
+  qualified: number;
+  referrals: ReferralItemDto[];
+}

--- a/backend/src/users/entities/user-referral.entity.ts
+++ b/backend/src/users/entities/user-referral.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { User } from './user.entity';
+
+export enum ReferralStatus {
+  PENDING = 'pending',
+  QUALIFIED = 'qualified',
+}
+
+/**
+ * A referrer -> referred relationship. `referred_id` is unique so a user
+ * can only ever be attributed to a single referrer (no duplicate/competing
+ * attribution). Status starts PENDING and moves to QUALIFIED once the
+ * referred user completes a qualifying action (see
+ * UsersService.recordQualifyingAction).
+ */
+@Entity('user_referrals')
+@Unique('UQ_user_referrals_referred', ['referred_id'])
+@Index(['referrer_id'])
+@Index(['status'])
+export class UserReferral {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  referrer_id: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'referrer_id' })
+  referrer: User;
+
+  @Column({ type: 'uuid' })
+  referred_id: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'referred_id' })
+  referred: User;
+
+  @Column({
+    type: 'enum',
+    enum: ReferralStatus,
+    default: ReferralStatus.PENDING,
+  })
+  status: ReferralStatus;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  qualified_at: Date | null;
+
+  @CreateDateColumn()
+  created_at: Date;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -46,6 +46,11 @@ import {
   PaginatedUserMarketsResponse,
 } from './dto/list-user-markets.dto';
 import { UserStatsResponseDto } from './dto/user-stats.dto';
+import {
+  ClaimReferralDto,
+  ClaimReferralResponseDto,
+  MyReferralsResponseDto,
+} from './dto/referral.dto';
 
 @Controller('users')
 export class UsersController {
@@ -91,6 +96,53 @@ export class UsersController {
     @Query() query: ListUserBookmarksDto,
   ): Promise<PaginatedUserBookmarksResponse> {
     return this.usersService.findUserBookmarks(user.id, query);
+  }
+
+  @Get('me/referrals')
+  @ApiOperation({
+    summary: "Get the current user's referral code, counts, and statuses",
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Referral counts and statuses retrieved successfully',
+    type: MyReferralsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyReferrals(
+    @CurrentUser() user: User,
+  ): Promise<MyReferralsResponseDto> {
+    return this.usersService.getMyReferrals(user.id);
+  }
+
+  @Post('me/referrals/claim')
+  @UsePipes(
+    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: false }),
+  )
+  @ApiOperation({
+    summary: 'Record that the current user was referred by another user',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Referral recorded successfully',
+    type: ClaimReferralResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Self-referral is not allowed',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Referrer not found',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'A referral has already been recorded for this account',
+  })
+  async claimReferral(
+    @CurrentUser() user: User,
+    @Body() dto: ClaimReferralDto,
+  ): Promise<ClaimReferralResponseDto> {
+    return this.usersService.claimReferral(user.id, dto.referrer_id);
   }
 
   @Patch('me')

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { UserPreferences } from './entities/user-preferences.entity';
 import { UserFollow } from './entities/user-follow.entity';
+import { UserReferral } from './entities/user-referral.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { Prediction } from '../predictions/entities/prediction.entity';
@@ -17,6 +18,7 @@ import { UserBookmark } from '../markets/entities/user-bookmark.entity';
       User,
       UserPreferences,
       UserFollow,
+      UserReferral,
       Prediction,
       CompetitionParticipant,
       Market,

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -23,6 +23,10 @@ import {
   UserMarketsSortOrder,
 } from './dto/list-user-markets.dto';
 import { UserBookmark } from '../markets/entities/user-bookmark.entity';
+import {
+  ReferralStatus,
+  UserReferral,
+} from './entities/user-referral.entity';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -31,6 +35,7 @@ describe('UsersService', () => {
   let predictionsRepository: Repository<Prediction>;
   let participantsRepository: Repository<CompetitionParticipant>;
   let marketsRepository: Repository<Market>;
+  let referralsRepository: Repository<UserReferral>;
 
   const mockUser: User = {
     id: '123e4567-e89b-12d3-a456-426614174000',
@@ -118,6 +123,17 @@ describe('UsersService', () => {
             delete: jest.fn(),
           },
         },
+        {
+          provide: getRepositoryToken(UserReferral),
+          useValue: {
+            findOne: jest.fn(),
+            find: jest.fn(),
+            create: jest.fn((data: Partial<UserReferral>) => data),
+            save: jest.fn((entity: Partial<UserReferral>) =>
+              Promise.resolve({ id: 'referral-uuid-1', ...entity }),
+            ),
+          },
+        },
       ],
     }).compile();
 
@@ -131,6 +147,9 @@ describe('UsersService', () => {
     );
     marketsRepository = module.get<Repository<Market>>(
       getRepositoryToken(Market),
+    );
+    referralsRepository = module.get<Repository<UserReferral>>(
+      getRepositoryToken(UserReferral),
     );
   });
 
@@ -679,6 +698,134 @@ describe('UsersService', () => {
         followers_count: 0,
         following_count: 0,
       });
+    });
+  });
+
+  describe('claimReferral', () => {
+    it('records a referral relationship', async () => {
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue({
+        id: 'referrer-1',
+      } as User);
+      jest.spyOn(referralsRepository, 'findOne').mockResolvedValue(null);
+
+      const result = await service.claimReferral('referred-1', 'referrer-1');
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Referral recorded successfully',
+      });
+      expect(referralsRepository.create).toHaveBeenCalledWith({
+        referrer_id: 'referrer-1',
+        referred_id: 'referred-1',
+      });
+      expect(referralsRepository.save).toHaveBeenCalled();
+    });
+
+    it('rejects self-referral', async () => {
+      await expect(
+        service.claimReferral('user-1', 'user-1'),
+      ).rejects.toThrow(BadRequestException);
+      expect(repository.findOneBy).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the referrer does not exist', async () => {
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue(null);
+
+      await expect(
+        service.claimReferral('referred-1', 'missing-referrer'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects duplicate attribution when a referral already exists', async () => {
+      jest.spyOn(repository, 'findOneBy').mockResolvedValue({
+        id: 'referrer-1',
+      } as User);
+      jest.spyOn(referralsRepository, 'findOne').mockResolvedValue({
+        id: 'existing-referral',
+      } as UserReferral);
+
+      await expect(
+        service.claimReferral('referred-1', 'referrer-1'),
+      ).rejects.toThrow(ConflictException);
+      expect(referralsRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMyReferrals', () => {
+    it('reports total, pending, and qualified counts', async () => {
+      const referrals: UserReferral[] = [
+        {
+          id: 'r1',
+          referrer_id: 'user-1',
+          referred_id: 'friend-1',
+          status: ReferralStatus.PENDING,
+          qualified_at: null,
+          created_at: new Date(),
+          referred: { username: 'friend1', stellar_address: 'GFRIEND1' },
+        } as UserReferral,
+        {
+          id: 'r2',
+          referrer_id: 'user-1',
+          referred_id: 'friend-2',
+          status: ReferralStatus.QUALIFIED,
+          qualified_at: new Date(),
+          created_at: new Date(),
+          referred: { username: 'friend2', stellar_address: 'GFRIEND2' },
+        } as UserReferral,
+      ];
+      jest.spyOn(referralsRepository, 'find').mockResolvedValue(referrals);
+
+      const result = await service.getMyReferrals('user-1');
+
+      expect(result.referral_code).toBe('user-1');
+      expect(result.total).toBe(2);
+      expect(result.pending).toBe(1);
+      expect(result.qualified).toBe(1);
+      expect(result.referrals).toHaveLength(2);
+      expect(result.referrals[0].referred_username).toBe('friend1');
+    });
+
+    it('returns zeroed counts when the user has no referrals', async () => {
+      jest.spyOn(referralsRepository, 'find').mockResolvedValue([]);
+
+      const result = await service.getMyReferrals('user-1');
+
+      expect(result).toEqual({
+        referral_code: 'user-1',
+        total: 0,
+        pending: 0,
+        qualified: 0,
+        referrals: [],
+      });
+    });
+  });
+
+  describe('recordQualifyingAction', () => {
+    it('advances a pending referral to qualified', async () => {
+      const referral = {
+        id: 'r1',
+        referred_id: 'friend-1',
+        status: ReferralStatus.PENDING,
+        qualified_at: null,
+      } as UserReferral;
+      jest.spyOn(referralsRepository, 'findOne').mockResolvedValue(referral);
+
+      await service.recordQualifyingAction('friend-1');
+
+      expect(referralsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: ReferralStatus.QUALIFIED,
+          qualified_at: expect.any(Date),
+        }),
+      );
+    });
+
+    it('is a no-op when the user has no pending referral', async () => {
+      jest.spyOn(referralsRepository, 'findOne').mockResolvedValue(null);
+
+      await service.recordQualifyingAction('friend-1');
+
+      expect(referralsRepository.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -16,6 +16,14 @@ import {
 import { User } from './entities/user.entity';
 import { UserPreferences } from './entities/user-preferences.entity';
 import { UserFollow } from './entities/user-follow.entity';
+import {
+  ReferralStatus,
+  UserReferral,
+} from './entities/user-referral.entity';
+import {
+  ClaimReferralResponseDto,
+  MyReferralsResponseDto,
+} from './dto/referral.dto';
 import { Market } from '../markets/entities/market.entity';
 import { Notification } from '../notifications/entities/notification.entity';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -72,6 +80,8 @@ export class UsersService {
     private readonly participantsRepository: Repository<CompetitionParticipant>,
     @InjectRepository(UserBookmark)
     private readonly userBookmarksRepository: Repository<UserBookmark>,
+    @InjectRepository(UserReferral)
+    private readonly referralsRepository: Repository<UserReferral>,
   ) {}
 
   async findAll(): Promise<User[]> {
@@ -551,5 +561,108 @@ export class UsersService {
       avatar_url: user.avatar_url,
       reputation_score: user.reputation_score,
     };
+  }
+
+  /**
+   * Record that `userId` was referred by `referrerId`. A user's own ID
+   * doubles as their shareable referral code, so this just links two
+   * existing accounts - no separate code table is needed. Each user can be
+   * the "referred" side of at most one relationship (enforced by the
+   * unique constraint on referred_id as well as this check), and
+   * self-referral is rejected outright.
+   */
+  async claimReferral(
+    userId: string,
+    referrerId: string,
+  ): Promise<ClaimReferralResponseDto> {
+    if (referrerId === userId) {
+      throw new BadRequestException('You cannot refer yourself');
+    }
+
+    const referrer = await this.usersRepository.findOneBy({ id: referrerId });
+    if (!referrer) {
+      throw new NotFoundException('Referrer not found');
+    }
+
+    const existing = await this.referralsRepository.findOne({
+      where: { referred_id: userId },
+    });
+    if (existing) {
+      throw new ConflictException(
+        'A referral has already been recorded for this account',
+      );
+    }
+
+    await this.referralsRepository.save(
+      this.referralsRepository.create({
+        referrer_id: referrerId,
+        referred_id: userId,
+      }),
+    );
+
+    return {
+      success: true,
+      message: 'Referral recorded successfully',
+    };
+  }
+
+  /**
+   * Referrals made by `userId`, with aggregate counts by status. The
+   * `referral_code` returned is simply the user's own ID - share it as a
+   * link/param for others to submit via claimReferral.
+   */
+  async getMyReferrals(userId: string): Promise<MyReferralsResponseDto> {
+    const referrals = await this.referralsRepository.find({
+      where: { referrer_id: userId },
+      relations: ['referred'],
+      order: { created_at: 'DESC' },
+    });
+
+    let pending = 0;
+    let qualified = 0;
+    for (const referral of referrals) {
+      if (referral.status === ReferralStatus.QUALIFIED) {
+        qualified++;
+      } else {
+        pending++;
+      }
+    }
+
+    return {
+      referral_code: userId,
+      total: referrals.length,
+      pending,
+      qualified,
+      referrals: referrals.map((referral) => ({
+        id: referral.id,
+        referred_id: referral.referred_id,
+        referred_username: referral.referred?.username ?? null,
+        referred_stellar_address: referral.referred?.stellar_address ?? '',
+        status: referral.status,
+        created_at: referral.created_at,
+        qualified_at: referral.qualified_at,
+      })),
+    };
+  }
+
+  /**
+   * Advances a referred user's PENDING referral (if any) to QUALIFIED.
+   * Idempotent: a no-op if the user isn't a pending referral (already
+   * qualified, or was never referred). Intended to be called by other
+   * modules when a referred user completes a meaningful first action
+   * (e.g. their first prediction).
+   */
+  async recordQualifyingAction(userId: string): Promise<void> {
+    const referral = await this.referralsRepository.findOne({
+      where: { referred_id: userId, status: ReferralStatus.PENDING },
+    });
+
+    if (!referral) {
+      return;
+    }
+
+    referral.status = ReferralStatus.QUALIFIED;
+    referral.qualified_at = new Date();
+    await this.referralsRepository.save(referral);
   }
 }

--- a/contracts/open-market/ARCHITECTURE.md
+++ b/contracts/open-market/ARCHITECTURE.md
@@ -18,7 +18,7 @@ The backend calls the contract via Soroban RPC (using the `@stellar/stellar-sdk`
 | `escrow.rs` | XLM locking, refunds, payouts, reentrancy guard, treasury | `lock_stake`, `refund`, `release_payout`, `get_contract_balance`, `assert_escrow_solvent`, `add_to_treasury_balance` |
 | `season.rs` | Seasons, leaderboard snapshots, reward distribution, season points | `create_season`, `finalize_season`, `update_leaderboard`, `get_leaderboard`, `reset_season_points`, `calculate_points` |
 | `invite.rs` | Invite code generation, redemption, revocation | `generate_invite_code`, `redeem_invite_code`, `revoke_invite_code` |
-| `dispute.rs` | Dispute filing and resolution | `raise_dispute`, `resolve_dispute` |
+| `dispute.rs` | Dispute filing/resolution, appeals, and weighted arbiter quorum voting | `raise_dispute`, `resolve_dispute`, `appeal_dispute`, `resolve_appeal`, `stake_as_arbiter`, `assign_arbiters`, `cast_arbiter_vote`, `finalize_arbiter_vote`, `get_arbiter_tally` |
 | `governance.rs` | Proposals, voting, execution | `create_proposal`, `vote`, `execute_proposal` |
 | `liquidity.rs` | AMM pool, LP tokens, swaps, fee distribution | `add_liquidity`, `remove_liquidity`, `swap_outcome`, `get_outcome_price` |
 | `reputation.rs` | Creator stats and reputation scoring | `on_market_created`, `on_market_resolved`, `calculate_creator_reputation`, `get_creator_stats` |

--- a/contracts/open-market/STORAGE_SCHEMA.md
+++ b/contracts/open-market/STORAGE_SCHEMA.md
@@ -188,13 +188,38 @@ Stored at `DataKey::InviteCode(code)`.
 
 ### `Dispute`
 
-Stored at `DataKey::Dispute(market_id)`.
+Stored at `DataKey::Dispute(market_id)`. Removed from storage once resolved
+(via `resolve_dispute`) or finalized (via `finalize_arbiter_vote`).
 
 | Field | Type | Description |
 |---|---|---|
 | `disputer` | `Address` | Wallet that filed the dispute |
 | `bond` | `i128` | XLM bond posted with the dispute in stroops |
 | `filed_at` | `u64` | Ledger timestamp when the dispute was filed |
+| `appeal_tier` | `u32` | Number of times this dispute has been appealed (max 2) |
+| `appealer` | `Option<Address>` | Wallet that filed the current appeal, if any |
+| `appeal_bond` | `i128` | XLM bond posted with the current appeal, in stroops |
+| `arbiters` | `Vec<ArbiterAssignment>` | Weighted arbiter panel assigned via `assign_arbiters`; empty until assigned |
+| `quorum_bps` | `u32` | Quorum threshold (bps of total assigned weight) snapshotted at assignment |
+| `voting_deadline` | `u64` | Ledger timestamp after which `finalize_arbiter_vote` becomes callable |
+| `arbiters_finalized` | `bool` | True once the arbiter panel has been finalized |
+
+#### `ArbiterAssignment` (embedded in `Dispute.arbiters`)
+
+| Field | Type | Description |
+|---|---|---|
+| `arbiter` | `Address` | The assigned arbiter's wallet |
+| `weight` | `i128` | Voting weight snapshotted at assignment (stake × reputation multiplier) |
+| `voted` | `bool` | Whether this arbiter has cast their vote |
+| `vote_uphold` | `bool` | The vote itself; meaningful only when `voted` is true |
+
+#### Arbiter stake (raw tuple key, not a `DataKey` variant)
+
+`DataKey` is a `#[contracttype]` union already at its 50-variant XDR cap (see
+`reputation::trusted_creator_key` for the established precedent), so each
+arbiter's staked bond is stored under a raw `(Symbol("arbstk"), Address)`
+tuple key rather than a new `DataKey` variant. Value: `i128`, deposited via
+`stake_as_arbiter` and read via `get_arbiter_stake`.
 
 ---
 

--- a/contracts/open-market/src/config.rs
+++ b/contracts/open-market/src/config.rs
@@ -218,6 +218,23 @@ pub struct Config {
     /// cut redirected to liquidity providers instead of the treasury.
     /// Defaults to `0` at initialization. See `treasury_split_bps`.
     pub lp_split_bps: u32,
+    /// Fraction (bps, 0-10000) of a dispute's total assigned arbiter weight
+    /// that must have voted before `dispute::finalize_arbiter_vote` will
+    /// settle the panel. Snapshotted onto each `Dispute` when its panel is
+    /// assigned via `dispute::assign_arbiters`. Admin-configurable via
+    /// `set_arbiter_config`. Defaults to `5000` (50%).
+    pub arbiter_quorum_bps: u32,
+    /// Share (bps, 0-10000) of an assigned arbiter's staked bond
+    /// (`dispute::get_arbiter_stake`) slashed when they fail to vote before
+    /// their dispute's `voting_deadline`. The slashed amount is
+    /// redistributed to arbiters who did vote, proportional to their
+    /// weight. Admin-configurable via `set_arbiter_config`. Defaults to
+    /// `1000` (10%).
+    pub arbiter_slash_bps: u32,
+    /// Duration (seconds) of the voting window granted to an arbiter panel
+    /// once assigned via `dispute::assign_arbiters`. Admin-configurable via
+    /// `set_arbiter_config`. Defaults to `172_800` (~2 days).
+    pub arbiter_voting_period_seconds: u64,
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────
@@ -348,6 +365,9 @@ pub fn initialize(
         treasury_address: admin_for_treasury,
         treasury_split_bps: 10_000, // 100% to treasury, preserving prior behaviour
         lp_split_bps: 0,
+        arbiter_quorum_bps: 5000, // 50% of assigned weight must vote
+        arbiter_slash_bps: 1000,  // 10% of stake slashed for a missed vote
+        arbiter_voting_period_seconds: 172_800, // ~2 days
     };
 
     env.storage().persistent().set(&DataKey::Config, &config);
@@ -928,6 +948,57 @@ fn emit_treasury_split_updated(
             new_treasury_split_bps,
             new_lp_split_bps,
         ),
+    );
+}
+
+/// Update the arbiter quorum threshold, slash share, and voting period used
+/// by `dispute::assign_arbiters` / `dispute::finalize_arbiter_vote`. Caller
+/// must be the stored admin. Changes only affect panels assigned after this
+/// call - already-assigned panels keep their snapshotted values.
+pub fn set_arbiter_config(
+    env: &Env,
+    admin: Address,
+    quorum_bps: u32,
+    slash_bps: u32,
+    voting_period_seconds: u64,
+) -> Result<(), InsightArenaError> {
+    let mut config = load_config(env)?;
+
+    admin.require_auth();
+    if admin != config.admin {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    if quorum_bps > 10_000 || quorum_bps == 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+    if slash_bps > 10_000 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+    if voting_period_seconds == 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    config.arbiter_quorum_bps = quorum_bps;
+    config.arbiter_slash_bps = slash_bps;
+    config.arbiter_voting_period_seconds = voting_period_seconds;
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    emit_arbiter_config_updated(env, quorum_bps, slash_bps, voting_period_seconds);
+
+    Ok(())
+}
+
+fn emit_arbiter_config_updated(
+    env: &Env,
+    quorum_bps: u32,
+    slash_bps: u32,
+    voting_period_seconds: u64,
+) {
+    env.events().publish(
+        (symbol_short!("cfg"), symbol_short!("arb_upd")),
+        (quorum_bps, slash_bps, voting_period_seconds),
     );
 }
 

--- a/contracts/open-market/src/dispute.rs
+++ b/contracts/open-market/src/dispute.rs
@@ -1,11 +1,11 @@
-use soroban_sdk::{symbol_short, Address, Env, Vec};
+use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
 use crate::config;
 use crate::errors::InsightArenaError;
 use crate::escrow;
 use crate::market;
 use crate::reputation;
-use crate::storage_types::{DataKey, Dispute};
+use crate::storage_types::{ArbiterAssignment, ArbiterTally, DataKey, Dispute, UserProfile};
 
 fn bump_dispute(env: &Env, market_id: u64) {
     config::extend_market_ttl(env, market_id);
@@ -105,7 +105,7 @@ pub fn raise_dispute(
 
     escrow::lock_stake(&env, &disputer, bond)?;
 
-    let dispute = Dispute::new(disputer.clone(), bond, now);
+    let dispute = Dispute::new(&env, disputer.clone(), bond, now);
     env.storage()
         .persistent()
         .set(&DataKey::Dispute(market_id), &dispute);
@@ -332,6 +332,493 @@ pub fn resolve_appeal(
     bump_dispute(&env, market_id);
 
     emit_appeal_resolved(&env, market_id, &admin, uphold, dispute.appeal_tier);
+
+    Ok(())
+}
+
+// ── Weighted arbiter quorum voting ────────────────────────────────────────────
+//
+// A separate, opt-in resolution path alongside the flat admin `resolve_dispute`
+// above: an admin assigns a weighted panel of arbiters to a pending dispute,
+// each arbiter casts one vote, and once assigned weight meeting quorum has
+// voted the panel can be finalized. Arbiters who never vote are slashed and
+// the slashed stake is redistributed to those who did. Purely advisory input
+// is not supported here — once assigned, a panel is the sole path to
+// resolving that dispute (admin's plain `resolve_dispute` no longer applies,
+// since the dispute now carries a live arbiter panel).
+
+/// Raw (non-`DataKey`) storage key for an arbiter's staked bond. `DataKey` is
+/// a `#[contracttype]` union already at its 50-variant XDR cap (see
+/// `reputation::trusted_creator_key` for the established precedent), so this
+/// deliberately bypasses it with a plain tuple key instead of adding a
+/// variant.
+fn arbiter_stake_key(arbiter: &Address) -> (Symbol, Address) {
+    (symbol_short!("arbstk"), arbiter.clone())
+}
+
+/// Current staked bond (stroops) `arbiter` has deposited via
+/// `stake_as_arbiter`. `0` if they have never staked.
+pub fn get_arbiter_stake(env: &Env, arbiter: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&arbiter_stake_key(arbiter))
+        .unwrap_or(0)
+}
+
+fn set_arbiter_stake(env: &Env, arbiter: &Address, amount: i128) {
+    let key = arbiter_stake_key(arbiter);
+    env.storage().persistent().set(&key, &amount);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, config::PERSISTENT_THRESHOLD, config::PERSISTENT_BUMP);
+}
+
+/// Deposit `amount` as a bond making `arbiter` eligible for panel assignment
+/// via `assign_arbiters`. Cumulative: repeated calls add to the existing
+/// balance. There is deliberately no withdrawal path in this iteration —
+/// stake only ever moves via this deposit or via slashing/redistribution at
+/// `finalize_arbiter_vote`, so a would-be non-voter cannot dodge a slash by
+/// withdrawing between assignment and finalization.
+pub fn stake_as_arbiter(env: Env, arbiter: Address, amount: i128) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(&env)?;
+
+    if amount <= 0 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    escrow::lock_stake(&env, &arbiter, amount)?;
+
+    let new_balance = get_arbiter_stake(&env, &arbiter)
+        .checked_add(amount)
+        .ok_or(InsightArenaError::Overflow)?;
+    set_arbiter_stake(&env, &arbiter, new_balance);
+
+    emit_arbiter_staked(&env, &arbiter, amount, new_balance);
+
+    Ok(())
+}
+
+fn emit_arbiter_staked(env: &Env, arbiter: &Address, amount: i128, new_balance: i128) {
+    env.events().publish(
+        (symbol_short!("arb"), symbol_short!("staked")),
+        (arbiter.clone(), amount, new_balance),
+    );
+}
+
+fn get_reputation_score(env: &Env, address: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get::<DataKey, UserProfile>(&DataKey::User(address.clone()))
+        .map(|profile| profile.reputation_score)
+        .unwrap_or(0)
+}
+
+/// Voting weight for an arbiter: their staked bond scaled by a reputation
+/// multiplier of `10_000 + reputation_score * 100` bps. `reputation_score` is
+/// clamped to `[0, 100]` (see `UserProfile::reputation_score`), so the
+/// multiplier ranges from 1.0x at zero reputation up to 2.0x at a perfect
+/// score — a bonus for a strong track record, never a penalty that could
+/// zero out an otherwise-legitimate stake.
+fn compute_arbiter_weight(env: &Env, arbiter: &Address, stake: i128) -> i128 {
+    let reputation_score = get_reputation_score(env, arbiter);
+    let multiplier_bps: i128 = 10_000_i128.saturating_add((reputation_score as i128).saturating_mul(100));
+    stake.saturating_mul(multiplier_bps) / 10_000
+}
+
+fn emit_arbiters_assigned(env: &Env, market_id: u64, total_weight: i128, voting_deadline: u64) {
+    env.events().publish(
+        (symbol_short!("arb"), symbol_short!("assigned")),
+        (market_id, total_weight, voting_deadline),
+    );
+}
+
+/// Assign a weighted arbiter panel to a pending dispute (admin-only). Each
+/// address in `arbiters` must have a positive `stake_as_arbiter` balance;
+/// their voting weight is computed and snapshotted immediately (see
+/// `compute_arbiter_weight`) so it is immune to any later change in their
+/// stake or reputation. Can only be called once per dispute — the same
+/// dispute record backs both the flat-majority and weighted-quorum paths, so
+/// a panel is a one-way commitment for that dispute.
+pub fn assign_arbiters(
+    env: Env,
+    admin: Address,
+    market_id: u64,
+    arbiters: Vec<Address>,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(&env)?;
+    require_admin(&env, &admin)?;
+
+    let mut dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(market_id))
+        .ok_or(InsightArenaError::DisputeNotFound)?;
+
+    if !dispute.arbiters.is_empty() {
+        // A panel has already been assigned to this dispute. Reuses
+        // DisputeAlreadyFiled (error enum is at its 50-case cap).
+        return Err(InsightArenaError::DisputeAlreadyFiled);
+    }
+
+    if arbiters.is_empty() {
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    let mut assignments: Vec<ArbiterAssignment> = Vec::new(&env);
+    let mut total_weight: i128 = 0;
+
+    for arbiter in arbiters.iter() {
+        for existing in assignments.iter() {
+            if existing.arbiter == arbiter {
+                // Duplicate address in the input list.
+                return Err(InsightArenaError::InvalidInput);
+            }
+        }
+
+        let stake = get_arbiter_stake(&env, &arbiter);
+        if stake <= 0 {
+            // Not an eligible arbiter - they must stake first.
+            return Err(InsightArenaError::InvalidInput);
+        }
+
+        let weight = compute_arbiter_weight(&env, &arbiter, stake);
+        total_weight = total_weight
+            .checked_add(weight)
+            .ok_or(InsightArenaError::Overflow)?;
+
+        assignments.push_back(ArbiterAssignment {
+            arbiter: arbiter.clone(),
+            weight,
+            voted: false,
+            vote_uphold: false,
+        });
+    }
+
+    let cfg = config::get_config(&env)?;
+    let voting_deadline = env
+        .ledger()
+        .timestamp()
+        .checked_add(cfg.arbiter_voting_period_seconds)
+        .ok_or(InsightArenaError::Overflow)?;
+
+    dispute.arbiters = assignments;
+    dispute.quorum_bps = cfg.arbiter_quorum_bps;
+    dispute.voting_deadline = voting_deadline;
+    dispute.arbiters_finalized = false;
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(market_id), &dispute);
+    bump_dispute(&env, market_id);
+
+    emit_arbiters_assigned(&env, market_id, total_weight, voting_deadline);
+
+    Ok(())
+}
+
+fn emit_arbiter_voted(env: &Env, market_id: u64, arbiter: &Address, uphold: bool) {
+    env.events().publish(
+        (symbol_short!("arb"), symbol_short!("voted")),
+        (market_id, arbiter.clone(), uphold),
+    );
+}
+
+/// Cast a single vote as an assigned arbiter. Each arbiter gets exactly one
+/// vote per dispute, must vote before `voting_deadline`, and cannot change
+/// their vote once cast.
+pub fn cast_arbiter_vote(
+    env: Env,
+    arbiter: Address,
+    market_id: u64,
+    uphold: bool,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(&env)?;
+    arbiter.require_auth();
+
+    let mut dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(market_id))
+        .ok_or(InsightArenaError::DisputeNotFound)?;
+
+    if dispute.arbiters_finalized {
+        return Err(InsightArenaError::MarketAlreadyResolved);
+    }
+
+    if env.ledger().timestamp() > dispute.voting_deadline {
+        return Err(InsightArenaError::DisputeWindowClosed);
+    }
+
+    let mut index: Option<u32> = None;
+    for i in 0..dispute.arbiters.len() {
+        if dispute.arbiters.get(i).unwrap().arbiter == arbiter {
+            index = Some(i);
+            break;
+        }
+    }
+
+    // Not a member of this dispute's panel. Reuses Unauthorized, consistent
+    // with the role-check-failure convention documented on that variant.
+    let i = index.ok_or(InsightArenaError::Unauthorized)?;
+
+    let mut assignment = dispute.arbiters.get(i).unwrap();
+    if assignment.voted {
+        // Reuses AlreadyPredicted: the arbiter's one allowed vote on this
+        // dispute has already been cast (error enum is at its 50-case cap).
+        return Err(InsightArenaError::AlreadyPredicted);
+    }
+
+    assignment.voted = true;
+    assignment.vote_uphold = uphold;
+    dispute.arbiters.set(i, assignment);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(market_id), &dispute);
+    bump_dispute(&env, market_id);
+
+    emit_arbiter_voted(&env, market_id, &arbiter, uphold);
+
+    Ok(())
+}
+
+fn build_tally(market_id: u64, dispute: &Dispute) -> ArbiterTally {
+    let mut total_weight: i128 = 0;
+    let mut voted_weight: i128 = 0;
+    let mut uphold_weight: i128 = 0;
+    let mut reject_weight: i128 = 0;
+
+    for assignment in dispute.arbiters.iter() {
+        total_weight = total_weight.saturating_add(assignment.weight);
+        if assignment.voted {
+            voted_weight = voted_weight.saturating_add(assignment.weight);
+            if assignment.vote_uphold {
+                uphold_weight = uphold_weight.saturating_add(assignment.weight);
+            } else {
+                reject_weight = reject_weight.saturating_add(assignment.weight);
+            }
+        }
+    }
+
+    let quorum_met = total_weight > 0
+        && voted_weight.saturating_mul(10_000) >= total_weight.saturating_mul(dispute.quorum_bps as i128);
+
+    ArbiterTally {
+        market_id,
+        total_weight,
+        voted_weight,
+        uphold_weight,
+        reject_weight,
+        quorum_bps: dispute.quorum_bps,
+        quorum_met,
+        voting_deadline: dispute.voting_deadline,
+        finalized: dispute.arbiters_finalized,
+        arbiters: dispute.arbiters.clone(),
+    }
+}
+
+/// Read-only view of a dispute's arbiter panel: running tally, quorum
+/// progress, and per-arbiter participation. Safe to call at any point after
+/// a panel has been assigned, including after finalization (until the
+/// dispute record itself is cleaned up, mirroring `get_dispute`).
+pub fn get_arbiter_tally(env: Env, market_id: u64) -> Result<ArbiterTally, InsightArenaError> {
+    let dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(market_id))
+        .ok_or(InsightArenaError::DisputeNotFound)?;
+    bump_dispute(&env, market_id);
+    Ok(build_tally(market_id, &dispute))
+}
+
+fn count_voters(arbiters: &Vec<ArbiterAssignment>) -> i128 {
+    let mut n: i128 = 0;
+    for assignment in arbiters.iter() {
+        if assignment.voted {
+            n = n.saturating_add(1);
+        }
+    }
+    n
+}
+
+/// Slash every non-voting arbiter's stake by `Config::arbiter_slash_bps` and
+/// redistribute the total slashed amount to voting arbiters, proportional to
+/// their weight. The last voter (in list order) absorbs the rounding
+/// remainder, guaranteeing the redistributed total exactly equals the
+/// slashed total.
+fn slash_and_redistribute(env: &Env, arbiters: &Vec<ArbiterAssignment>) -> Result<(), InsightArenaError> {
+    let cfg = config::get_config(env)?;
+    let slash_bps = cfg.arbiter_slash_bps as i128;
+
+    let mut voter_weight_total: i128 = 0;
+    for assignment in arbiters.iter() {
+        if assignment.voted {
+            voter_weight_total = voter_weight_total.saturating_add(assignment.weight);
+        }
+    }
+
+    // Can only be zero if no one voted, which finalize_arbiter_vote already
+    // rules out via its quorum check (quorum_bps > 0 forces voted_weight >
+    // 0). Guarded here anyway so this helper is safe to call standalone.
+    if voter_weight_total == 0 {
+        return Ok(());
+    }
+
+    let mut total_slashed: i128 = 0;
+    for assignment in arbiters.iter() {
+        if !assignment.voted {
+            let stake = get_arbiter_stake(env, &assignment.arbiter);
+            let slash_amount = stake.saturating_mul(slash_bps) / 10_000;
+            if slash_amount > 0 {
+                set_arbiter_stake(env, &assignment.arbiter, stake - slash_amount);
+                total_slashed = total_slashed.saturating_add(slash_amount);
+            }
+        }
+    }
+
+    if total_slashed == 0 {
+        return Ok(());
+    }
+
+    let total_voters = count_voters(arbiters);
+    let mut voters_seen: i128 = 0;
+    let mut distributed: i128 = 0;
+    for assignment in arbiters.iter() {
+        if !assignment.voted {
+            continue;
+        }
+        voters_seen = voters_seen.saturating_add(1);
+        let share = if voters_seen == total_voters {
+            total_slashed - distributed
+        } else {
+            total_slashed.saturating_mul(assignment.weight) / voter_weight_total
+        };
+        if share > 0 {
+            let stake = get_arbiter_stake(env, &assignment.arbiter);
+            set_arbiter_stake(env, &assignment.arbiter, stake.saturating_add(share));
+            distributed = distributed.saturating_add(share);
+        }
+    }
+
+    emit_arbiters_slashed(env, total_slashed, distributed);
+
+    Ok(())
+}
+
+fn emit_arbiters_slashed(env: &Env, total_slashed: i128, total_redistributed: i128) {
+    env.events().publish(
+        (symbol_short!("arb"), symbol_short!("slashed")),
+        (total_slashed, total_redistributed),
+    );
+}
+
+fn emit_arbiter_vote_finalized(
+    env: &Env,
+    market_id: u64,
+    caller: &Address,
+    uphold: bool,
+    total_weight: i128,
+    voted_weight: i128,
+) {
+    env.events().publish(
+        (symbol_short!("arb"), symbol_short!("final")),
+        (market_id, caller.clone(), uphold, total_weight, voted_weight),
+    );
+}
+
+/// Finalize a dispute's arbiter panel (admin-only). Requires both:
+/// - the voting window to have closed (`now >= voting_deadline`), and
+/// - assigned weight meeting or exceeding quorum to have voted.
+///
+/// Either condition failing reuses `TimelockNotElapsed` (error enum is at
+/// its 50-case cap) — both cases mean "the panel isn't ready to settle yet".
+///
+/// On success: non-voters are slashed and redistributed to voters (see
+/// `slash_and_redistribute`), then the dispute is settled exactly like
+/// `resolve_dispute` — uphold refunds the disputer's bond and reopens the
+/// market, reject slashes the disputer's bond. Ties (`uphold_weight ==
+/// reject_weight`) resolve to reject, preserving the original market
+/// resolution as the safe default.
+pub fn finalize_arbiter_vote(
+    env: Env,
+    caller: Address,
+    market_id: u64,
+) -> Result<(), InsightArenaError> {
+    config::ensure_not_paused(&env)?;
+    require_admin(&env, &caller)?;
+
+    let dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(market_id))
+        .ok_or(InsightArenaError::DisputeNotFound)?;
+
+    if dispute.arbiters.is_empty() {
+        // No panel was ever assigned to this dispute.
+        return Err(InsightArenaError::InvalidInput);
+    }
+
+    let now = env.ledger().timestamp();
+    let tally = build_tally(market_id, &dispute);
+
+    if now < dispute.voting_deadline || !tally.quorum_met {
+        return Err(InsightArenaError::TimelockNotElapsed);
+    }
+
+    slash_and_redistribute(&env, &dispute.arbiters)?;
+
+    let uphold = tally.uphold_weight > tally.reject_weight;
+
+    if uphold {
+        escrow::refund(&env, &dispute.disputer, dispute.bond)?;
+
+        let mut market = market::get_market(&env, market_id)?;
+        market.is_resolved = false;
+        market.resolved_outcome = None;
+        market.resolved_at = None;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Market(market_id), &market);
+        config::extend_market_ttl(&env, market_id);
+    } else {
+        escrow::slash_funds(&env, dispute.bond)?;
+    }
+
+    // Remove market_id from the active dispute list, mirroring
+    // resolve_dispute's cleanup.
+    let active_list: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ActiveDisputeList)
+        .unwrap_or_else(|| Vec::new(&env));
+    let mut new_list: Vec<u64> = Vec::new(&env);
+    for id in active_list.iter() {
+        if id != market_id {
+            new_list.push_back(id);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::ActiveDisputeList, &new_list);
+    bump_active_dispute_list(&env);
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Dispute(market_id));
+
+    let current_count = get_open_dispute_count(&env);
+    if current_count > 0 {
+        set_open_dispute_count(&env, current_count - 1);
+    }
+
+    emit_arbiter_vote_finalized(
+        &env,
+        market_id,
+        &caller,
+        uphold,
+        tally.total_weight,
+        tally.voted_weight,
+    );
 
     Ok(())
 }

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::storage_types::ProposalState;
 pub use crate::liquidity::{calculate_liquidity_value, calculate_lp_tokens, calculate_swap_output};
 pub use crate::market::CreateMarketParams;
 pub use crate::storage_types::{
-    BatchPredictionRequest,
+    ArbiterAssignment, ArbiterTally, BatchPredictionRequest,
     ConditionalChain, ConditionalMarket, CreatorLeaderboardEntry, CreatorStats, DataKey,
     DependencyStatus, Dispute, Event, EventMatch, EventPrediction, FeeTier, FeeTierConfig,
     InviteCode, LPPosition, LeaderboardEntry, LeaderboardSnapshot, LiquidityPool, Market,
@@ -359,6 +359,73 @@ impl InsightArenaContract {
     /// Get the total count of currently open disputes.
     pub fn get_open_dispute_count(env: Env) -> u32 {
         dispute::get_open_dispute_count(&env)
+    }
+
+    // ── Weighted arbiter quorum voting ───────────────────────────────────────
+
+    /// Deposit a bond making `arbiter` eligible for panel assignment via
+    /// `assign_arbiters`. Cumulative; no withdrawal path in this iteration.
+    pub fn stake_as_arbiter(env: Env, arbiter: Address, amount: i128) -> Result<(), InsightArenaError> {
+        dispute::stake_as_arbiter(env, arbiter, amount)
+    }
+
+    /// Return `arbiter`'s current staked bond (stroops). `0` if never staked.
+    pub fn get_arbiter_stake(env: Env, arbiter: Address) -> i128 {
+        dispute::get_arbiter_stake(&env, &arbiter)
+    }
+
+    /// Assign a weighted arbiter panel to a pending dispute (admin-only).
+    /// Each address must have a positive arbiter stake; weight is snapshotted
+    /// at assignment time from stake and current reputation.
+    pub fn assign_arbiters(
+        env: Env,
+        admin: Address,
+        market_id: u64,
+        arbiters: Vec<Address>,
+    ) -> Result<(), InsightArenaError> {
+        dispute::assign_arbiters(env, admin, market_id, arbiters)
+    }
+
+    /// Cast a single vote as an assigned arbiter on a dispute.
+    pub fn cast_arbiter_vote(
+        env: Env,
+        arbiter: Address,
+        market_id: u64,
+        uphold: bool,
+    ) -> Result<(), InsightArenaError> {
+        dispute::cast_arbiter_vote(env, arbiter, market_id, uphold)
+    }
+
+    /// Read-only tally, quorum progress, and per-arbiter participation for a
+    /// dispute's arbiter panel.
+    pub fn get_arbiter_tally(
+        env: Env,
+        market_id: u64,
+    ) -> Result<crate::storage_types::ArbiterTally, InsightArenaError> {
+        dispute::get_arbiter_tally(env, market_id)
+    }
+
+    /// Finalize a dispute's arbiter panel (admin-only): requires the voting
+    /// window closed and quorum met, slashes non-voters and redistributes to
+    /// voters, then settles the dispute per the vote outcome.
+    pub fn finalize_arbiter_vote(
+        env: Env,
+        caller: Address,
+        market_id: u64,
+    ) -> Result<(), InsightArenaError> {
+        dispute::finalize_arbiter_vote(env, caller, market_id)
+    }
+
+    /// Update the arbiter quorum threshold, slash share, and voting period
+    /// (admin-only). Only affects panels assigned after this call.
+    pub fn set_arbiter_config(
+        env: Env,
+        admin: Address,
+        quorum_bps: u32,
+        slash_bps: u32,
+        voting_period_seconds: u64,
+    ) -> Result<(), InsightArenaError> {
+        config::set_arbiter_config(&env, admin, quorum_bps, slash_bps, voting_period_seconds)
     }
 
     // ── Prediction ────────────────────────────────────────────────────────────

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -149,10 +149,28 @@ pub struct Dispute {
     pub appeal_tier: u32,
     pub appealer: Option<Address>,
     pub appeal_bond: i128,
+    /// Arbiters assigned to weigh in on this dispute via
+    /// `dispute::assign_arbiters`, with per-arbiter weight snapshotted at
+    /// assignment time. Empty until a panel is assigned; the dispute can
+    /// still be settled directly by admin via `resolve_dispute` if no panel
+    /// is ever assigned.
+    pub arbiters: Vec<ArbiterAssignment>,
+    /// Fraction (bps, of total assigned weight) of weight that must have
+    /// voted before `dispute::finalize_arbiter_vote` will settle the panel.
+    /// Snapshotted from `Config::arbiter_quorum_bps` when the panel is
+    /// assigned, so a later config change never retroactively affects an
+    /// in-flight vote.
+    pub quorum_bps: u32,
+    /// Ledger timestamp after which `dispute::finalize_arbiter_vote`
+    /// becomes callable. Set when the panel is assigned.
+    pub voting_deadline: u64,
+    /// True once `dispute::finalize_arbiter_vote` has settled this
+    /// dispute's arbiter panel.
+    pub arbiters_finalized: bool,
 }
 
 impl Dispute {
-    pub fn new(disputer: Address, bond: i128, filed_at: u64) -> Self {
+    pub fn new(env: &Env, disputer: Address, bond: i128, filed_at: u64) -> Self {
         Self {
             disputer,
             bond,
@@ -160,8 +178,47 @@ impl Dispute {
             appeal_tier: 0,
             appealer: None,
             appeal_bond: 0,
+            arbiters: Vec::new(env),
+            quorum_bps: 0,
+            voting_deadline: 0,
+            arbiters_finalized: false,
         }
     }
+}
+
+/// A single arbiter's assignment to a dispute's panel. `weight` is a
+/// snapshot (stake at assignment time scaled by a reputation multiplier)
+/// and never changes afterward, even if the arbiter's live stake or
+/// reputation later changes. See `dispute::assign_arbiters`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArbiterAssignment {
+    pub arbiter: Address,
+    pub weight: i128,
+    pub voted: bool,
+    /// Meaningful only when `voted` is true. `true` = uphold the dispute
+    /// (the disputer was right, market gets reopened); `false` = reject it
+    /// (the original resolution stands).
+    pub vote_uphold: bool,
+}
+
+/// Read-only tally for a dispute's arbiter panel, returned by
+/// `dispute::get_arbiter_tally`. Recomputed on every call from the stored
+/// `Dispute.arbiters` list rather than cached, so it always reflects the
+/// latest votes.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArbiterTally {
+    pub market_id: u64,
+    pub total_weight: i128,
+    pub voted_weight: i128,
+    pub uphold_weight: i128,
+    pub reject_weight: i128,
+    pub quorum_bps: u32,
+    pub quorum_met: bool,
+    pub voting_deadline: u64,
+    pub finalized: bool,
+    pub arbiters: Vec<ArbiterAssignment>,
 }
 
 #[contracttype]

--- a/contracts/open-market/tests/arbiter_vote_tests.rs
+++ b/contracts/open-market/tests/arbiter_vote_tests.rs
@@ -1,0 +1,511 @@
+use insightarena_contract::{
+    CreateMarketParams, InsightArenaContract, InsightArenaContractClient, InsightArenaError,
+};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+use soroban_sdk::{symbol_short, vec, Address, BytesN, Env, String, Symbol};
+
+fn register_token(env: &Env) -> Address {
+    let token_admin = Address::generate(env);
+    env.register_stellar_asset_contract_v2(token_admin)
+        .address()
+}
+
+fn deploy(env: &Env) -> (InsightArenaContractClient<'_>, Address, Address, Address) {
+    let id = env.register(InsightArenaContract, ());
+    let client = InsightArenaContractClient::new(env, &id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+    let xlm_token = register_token(env);
+    env.mock_all_auths();
+    client.initialize(&admin, &oracle, &200_u32, &xlm_token);
+    (client, admin, oracle, xlm_token)
+}
+
+fn market_params(env: &Env) -> CreateMarketParams {
+    let now = env.ledger().timestamp();
+    CreateMarketParams {
+        title: String::from_str(env, "Arbiter vote test market"),
+        description: String::from_str(env, "For arbiter quorum voting tests"),
+        category: Symbol::new(env, "Sports"),
+        outcomes: vec![env, symbol_short!("yes"), symbol_short!("no")],
+        end_time: now + 10,
+        resolution_time: now + 20,
+        dispute_window: 86_400,
+        creator_fee_bps: 100,
+        min_stake: 10_000_000,
+        max_stake: 100_000_000,
+        is_public: true,
+        metadata_hash: BytesN::from_array(env, &[0u8; 32]),
+    }
+}
+
+/// Creates + resolves a market, then raises a dispute against it. Returns
+/// the market id and the disputer's bond amount.
+fn setup_disputed_market(
+    env: &Env,
+    client: &InsightArenaContractClient<'_>,
+    oracle: &Address,
+    xlm_token: &Address,
+) -> (u64, Address, i128) {
+    let creator = Address::generate(env);
+    let disputer = Address::generate(env);
+
+    let id = client.create_market(&creator, &market_params(env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 20);
+    client.resolve_market(oracle, &id, &symbol_short!("yes"));
+
+    let bond = 15_000_000_i128;
+    StellarAssetClient::new(env, xlm_token).mint(&disputer, &bond);
+    TokenClient::new(env, xlm_token).approve(&disputer, &client.address, &bond, &9999);
+    client.raise_dispute(&disputer, &id, &bond);
+
+    (id, disputer, bond)
+}
+
+fn fund_and_stake_arbiter(
+    env: &Env,
+    client: &InsightArenaContractClient<'_>,
+    xlm_token: &Address,
+    amount: i128,
+) -> Address {
+    let arbiter = Address::generate(env);
+    StellarAssetClient::new(env, xlm_token).mint(&arbiter, &amount);
+    TokenClient::new(env, xlm_token).approve(&arbiter, &client.address, &amount, &9999);
+    client.stake_as_arbiter(&arbiter, &amount);
+    arbiter
+}
+
+// ── Staking ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn stake_as_arbiter_accumulates_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy(&env);
+
+    let arbiter = Address::generate(&env);
+    StellarAssetClient::new(&env, &xlm_token).mint(&arbiter, &50_000_000);
+    TokenClient::new(&env, &xlm_token).approve(&arbiter, &client.address, &50_000_000, &9999);
+
+    client.stake_as_arbiter(&arbiter, &20_000_000);
+    assert_eq!(client.get_arbiter_stake(&arbiter), 20_000_000);
+
+    client.stake_as_arbiter(&arbiter, &10_000_000);
+    assert_eq!(client.get_arbiter_stake(&arbiter), 30_000_000);
+}
+
+#[test]
+fn stake_as_arbiter_rejects_non_positive_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _xlm_token) = deploy(&env);
+    let arbiter = Address::generate(&env);
+
+    let result = client.try_stake_as_arbiter(&arbiter, &0);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+// ── Weighting (snapshot at assignment) ────────────────────────────────────────
+
+#[test]
+fn assign_arbiters_snapshots_weight_immune_to_later_stake_changes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 40_000_000);
+
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter.clone()]);
+
+    let tally_before = client.get_arbiter_tally(&market_id);
+    let weight_before = tally_before.arbiters.get(0).unwrap().weight;
+    // No UserProfile yet => reputation_score 0 => 1.0x multiplier => weight
+    // equals the raw staked amount.
+    assert_eq!(weight_before, 40_000_000);
+
+    // Increase stake after assignment - the panel's snapshotted weight must
+    // not move.
+    StellarAssetClient::new(&env, &xlm_token).mint(&arbiter, &1_000_000_000);
+    TokenClient::new(&env, &xlm_token).approve(&arbiter, &client.address, &1_000_000_000, &9999);
+    client.stake_as_arbiter(&arbiter, &1_000_000_000);
+
+    let tally_after = client.get_arbiter_tally(&market_id);
+    let weight_after = tally_after.arbiters.get(0).unwrap().weight;
+    assert_eq!(weight_after, weight_before);
+}
+
+#[test]
+fn assign_arbiters_rejects_zero_stake_candidate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let unstaked = Address::generate(&env);
+
+    let result = client.try_assign_arbiters(&admin, &market_id, &vec![&env, unstaked]);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn assign_arbiters_rejects_duplicate_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+
+    let result = client.try_assign_arbiters(
+        &admin,
+        &market_id,
+        &vec![&env, arbiter.clone(), arbiter],
+    );
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}
+
+#[test]
+fn assign_arbiters_rejects_second_assignment_to_same_dispute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter_a = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let arbiter_b = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter_a]);
+
+    let result = client.try_assign_arbiters(&admin, &market_id, &vec![&env, arbiter_b]);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::DisputeAlreadyFiled))
+    ));
+}
+
+// ── Quorum gating ──────────────────────────────────────────────────────────────
+
+#[test]
+fn cannot_finalize_before_voting_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter.clone()]);
+    client.cast_arbiter_vote(&arbiter, &market_id, &true);
+
+    // Quorum is met (the only arbiter voted) but the deadline hasn't passed.
+    let result = client.try_finalize_arbiter_vote(&admin, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TimelockNotElapsed))
+    ));
+}
+
+#[test]
+fn cannot_finalize_when_quorum_not_met_even_after_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    // Two equally-weighted arbiters, quorum defaults to 50%; if neither
+    // votes, 0% of weight has voted and quorum is never met.
+    let arbiter_a = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let arbiter_b = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter_a, arbiter_b]);
+
+    let tally = client.get_arbiter_tally(&market_id);
+    env.ledger()
+        .set_timestamp(tally.voting_deadline + 1);
+
+    let result = client.try_finalize_arbiter_vote(&admin, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TimelockNotElapsed))
+    ));
+}
+
+#[test]
+fn get_arbiter_tally_reports_quorum_progress() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter_a = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let arbiter_b = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter_a.clone(), arbiter_b]);
+
+    let before = client.get_arbiter_tally(&market_id);
+    assert!(!before.quorum_met);
+    assert_eq!(before.voted_weight, 0);
+
+    client.cast_arbiter_vote(&arbiter_a, &market_id, &true);
+
+    let after = client.get_arbiter_tally(&market_id);
+    assert!(after.quorum_met); // 50% of weight voted, default quorum is 50%
+    assert_eq!(after.voted_weight, after.total_weight / 2);
+    assert_eq!(after.uphold_weight, after.total_weight / 2);
+}
+
+// ── Voting rules ───────────────────────────────────────────────────────────────
+
+#[test]
+fn cast_arbiter_vote_rejects_non_panel_member() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter]);
+
+    let outsider = Address::generate(&env);
+    let result = client.try_cast_arbiter_vote(&outsider, &market_id, &true);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+#[test]
+fn cast_arbiter_vote_rejects_double_vote() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter.clone()]);
+    client.cast_arbiter_vote(&arbiter, &market_id, &true);
+
+    let result = client.try_cast_arbiter_vote(&arbiter, &market_id, &false);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::AlreadyPredicted))
+    ));
+}
+
+#[test]
+fn cast_arbiter_vote_rejects_after_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter.clone()]);
+
+    let tally = client.get_arbiter_tally(&market_id);
+    env.ledger().set_timestamp(tally.voting_deadline + 1);
+
+    let result = client.try_cast_arbiter_vote(&arbiter, &market_id, &true);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::DisputeWindowClosed))
+    ));
+}
+
+// ── Finalize: uphold / reject / tie ───────────────────────────────────────────
+
+#[test]
+fn finalize_uphold_refunds_bond_and_reopens_market() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, disputer, bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter_a = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let arbiter_b = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let arbiter_c = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(
+        &admin,
+        &market_id,
+        &vec![&env, arbiter_a.clone(), arbiter_b.clone(), arbiter_c],
+    );
+
+    client.cast_arbiter_vote(&arbiter_a, &market_id, &true);
+    client.cast_arbiter_vote(&arbiter_b, &market_id, &true);
+    // arbiter_c never votes - will be slashed.
+
+    let tally = client.get_arbiter_tally(&market_id);
+    env.ledger().set_timestamp(tally.voting_deadline + 1);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    let disputer_before = token.balance(&disputer);
+
+    client.finalize_arbiter_vote(&admin, &market_id);
+
+    assert_eq!(token.balance(&disputer), disputer_before + bond);
+    let market = client.get_market(&market_id);
+    assert!(!market.is_resolved);
+    assert_eq!(market.resolved_outcome, None);
+
+    // The dispute record is cleaned up once finalized, mirroring resolve_dispute.
+    let result = client.try_get_dispute(&market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::DisputeNotFound))
+    ));
+}
+
+#[test]
+fn finalize_reject_slashes_disputer_bond() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter_a = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let arbiter_b = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter_a.clone(), arbiter_b.clone()]);
+
+    client.cast_arbiter_vote(&arbiter_a, &market_id, &false);
+    client.cast_arbiter_vote(&arbiter_b, &market_id, &false);
+
+    let tally = client.get_arbiter_tally(&market_id);
+    env.ledger().set_timestamp(tally.voting_deadline + 1);
+
+    let treasury_before = client.get_treasury_balance();
+    let insurance_before = client.get_insurance_pool_balance();
+
+    client.finalize_arbiter_vote(&admin, &market_id);
+
+    let treasury_after = client.get_treasury_balance();
+    let insurance_after = client.get_insurance_pool_balance();
+    let insurance_share = bond * 1000 / 10_000; // default 10% insurance split
+    let treasury_share = bond - insurance_share;
+    assert_eq!(treasury_after, treasury_before + treasury_share);
+    assert_eq!(insurance_after, insurance_before + insurance_share);
+
+    let market = client.get_market(&market_id);
+    assert!(market.is_resolved);
+}
+
+#[test]
+fn tie_vote_resolves_to_reject() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    // Two equally-staked arbiters, one uphold, one reject: a dead-even tie.
+    let arbiter_a = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let arbiter_b = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter_a.clone(), arbiter_b.clone()]);
+
+    client.cast_arbiter_vote(&arbiter_a, &market_id, &true);
+    client.cast_arbiter_vote(&arbiter_b, &market_id, &false);
+
+    let tally = client.get_arbiter_tally(&market_id);
+    assert_eq!(tally.uphold_weight, tally.reject_weight);
+
+    env.ledger().set_timestamp(tally.voting_deadline + 1);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    let disputer_before = token.balance(&disputer);
+
+    client.finalize_arbiter_vote(&admin, &market_id);
+
+    // Ties resolve to reject: no refund, market stays resolved.
+    assert_eq!(token.balance(&disputer), disputer_before);
+    let market = client.get_market(&market_id);
+    assert!(market.is_resolved);
+}
+
+// ── Slashing accounting ────────────────────────────────────────────────────────
+
+#[test]
+fn non_voter_slashed_amount_exactly_equals_amount_redistributed_to_voters() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let stake_amount = 10_000_000_i128;
+    let arbiter_a = fund_and_stake_arbiter(&env, &client, &xlm_token, stake_amount);
+    let arbiter_b = fund_and_stake_arbiter(&env, &client, &xlm_token, stake_amount);
+    let arbiter_c = fund_and_stake_arbiter(&env, &client, &xlm_token, stake_amount);
+    client.assign_arbiters(
+        &admin,
+        &market_id,
+        &vec![&env, arbiter_a.clone(), arbiter_b.clone(), arbiter_c.clone()],
+    );
+
+    let total_stake_before = client.get_arbiter_stake(&arbiter_a)
+        + client.get_arbiter_stake(&arbiter_b)
+        + client.get_arbiter_stake(&arbiter_c);
+
+    client.cast_arbiter_vote(&arbiter_a, &market_id, &true);
+    client.cast_arbiter_vote(&arbiter_b, &market_id, &true);
+    // arbiter_c does not vote and will be slashed 10% (default arbiter_slash_bps).
+
+    let tally = client.get_arbiter_tally(&market_id);
+    env.ledger().set_timestamp(tally.voting_deadline + 1);
+
+    client.finalize_arbiter_vote(&admin, &market_id);
+
+    let expected_slash = stake_amount * 1000 / 10_000; // 10%
+    assert_eq!(client.get_arbiter_stake(&arbiter_c), stake_amount - expected_slash);
+
+    // The arbiter-stake ledger is a closed system: slashing only moves
+    // stake between arbiters, so the total across all three must be
+    // unchanged (slashed amount == redistributed amount, exactly).
+    let total_stake_after = client.get_arbiter_stake(&arbiter_a)
+        + client.get_arbiter_stake(&arbiter_b)
+        + client.get_arbiter_stake(&arbiter_c);
+    assert_eq!(total_stake_after, total_stake_before);
+
+    // Both voters received a strictly positive share of the slash.
+    assert!(client.get_arbiter_stake(&arbiter_a) > stake_amount);
+    assert!(client.get_arbiter_stake(&arbiter_b) > stake_amount);
+}
+
+// ── Admin gating ────────────────────────────────────────────────────────────────
+
+#[test]
+fn assign_arbiters_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    let not_admin = Address::generate(&env);
+
+    let result = client.try_assign_arbiters(&not_admin, &market_id, &vec![&env, arbiter]);
+    assert!(matches!(result, Err(Ok(InsightArenaError::Unauthorized))));
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_arbiter_config_updates_values_used_by_new_panels() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let (market_id, _disputer, _bond) = setup_disputed_market(&env, &client, &oracle, &xlm_token);
+
+    client.set_arbiter_config(&admin, &7000_u32, &2000_u32, &3600_u64);
+
+    let arbiter = fund_and_stake_arbiter(&env, &client, &xlm_token, 10_000_000);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter]);
+
+    let tally = client.get_arbiter_tally(&market_id);
+    assert_eq!(tally.quorum_bps, 7000);
+}
+
+#[test]
+fn set_arbiter_config_rejects_invalid_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, _xlm_token) = deploy(&env);
+
+    let result = client.try_set_arbiter_config(&admin, &0_u32, &1000_u32, &3600_u64);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+
+    let result = client.try_set_arbiter_config(&admin, &5000_u32, &10_001_u32, &3600_u64);
+    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+}


### PR DESCRIPTION
## Summary

Implements four independent tasks:

### [Backend] Prediction Pattern Fraud Signals
Closes #1389

- Computes per-user timing-clustering and counterparty-concentration signals over prediction behavior.
- Flags accounts exceeding configurable thresholds (env-configurable) as advisory `PredictionFraudFlag` records — never auto-enforced.
- Exposes flags to admins via `GET /admin/predictions/fraud-flags` (filterable by status/signal_type/user).
- Files: `backend/src/predictions/predictions.service.ts`, `backend/src/predictions/entities/prediction-fraud-flag.entity.ts`, `backend/src/admin/admin.service.ts`, `backend/src/admin/admin.controller.ts`.

### [Backend] Dispute SLA Timers and Escalation
Closes #1394

- Each dispute now tracks an SLA deadline per stage (`initial_review` → `escalated`).
- An hourly scheduler (`DisputesService.runSlaCheck`) detects approaching/breached SLAs, notifies the assigned arbiter and all admins, and escalates breached disputes into a second SLA window per configurable policy.
- New `PATCH /admin/disputes/:id/assign-arbiter` endpoint to assign an admin/moderator as the dispute's arbiter.
- Files: `backend/src/disputes/disputes.service.ts`, `backend/src/disputes/entities/dispute.entity.ts`, `backend/src/notifications/notification-generator.service.ts`.

### [Backend] Referral Tracking API
Closes #1390

- Records referrer→referred relationships via `POST /users/me/referrals/claim` (a user's own ID doubles as their shareable referral code).
- Rejects self-referral and duplicate attribution (unique constraint on the referred side).
- `GET /users/me/referrals` reports counts and per-referral status.
- A referred user's first prediction submission advances their referral from `pending` to `qualified`.
- Files: `backend/src/users/users.service.ts`, `backend/src/users/users.controller.ts`, `backend/src/users/entities/user-referral.entity.ts`, `backend/src/users/dto/referral.dto.ts`.

### [Contract] Weighted Arbiter Quorum Voting with Slashing
Closes #1359

- Admins assign a panel of arbiters to a pending dispute (`assign_arbiters`); each arbiter's voting weight (staked bond × reputation multiplier) is snapshotted at assignment, immune to later stake/reputation changes.
- `finalize_arbiter_vote` requires assigned weight meeting a configurable quorum (`Config::arbiter_quorum_bps`) *and* the voting deadline to have passed.
- Non-voting arbiters are slashed by `Config::arbiter_slash_bps`; the slashed amount is redistributed to voters exactly (verified in tests).
- Ties resolve to reject, preserving the original market resolution as the safe default.
- `get_arbiter_tally` exposes a read-only tally, quorum progress, and per-arbiter participation.
- Files: `contracts/open-market/src/dispute.rs`, `contracts/open-market/src/storage_types.rs`, `contracts/open-market/src/config.rs`.
- Note: both `DataKey` and `InsightArenaError` are already at their 50-variant XDR cap, so this reuses the existing raw-tuple-key pattern (see `reputation::trusted_creator_key`) for arbiter stake storage, and documents each reused error variant inline.

## Test plan

- [ ] `cd backend && npm test` — unit tests added/updated in `predictions.service.spec.ts`, `disputes.service.spec.ts`, `users.service.spec.ts`, `admin.service.spec.ts`.
- [ ] `cd contracts/open-market && cargo test` — new `tests/arbiter_vote_tests.rs` covers staking, weight snapshotting, quorum gating, tie resolution, and exact slash/redistribution accounting.
- [ ] Run new migrations against a local Postgres instance.
- [ ] Manually exercise `POST /users/me/referrals/claim` and `GET /admin/predictions/fraud-flags` against a running backend.
