### PR TITLE
Multi-Tier Dispute Escalation with Reputation-Weighted Quorum

### DIFF
--- a/backend/src/disputes/disputes.controller.ts
+++ b/backend/src/disputes/disputes.controller.ts
@@ -20,6 +20,7 @@ import {
 import { DisputesService } from './disputes.service';
 import { CreateDisputeDto } from './dto/create-dispute.dto';
 import { AttachEvidenceDto } from './dto/attach-evidence.dto';
+import { CastVoteDto } from './dto/cast-vote.dto';
 import { Dispute, DisputeStatus } from './entities/dispute.entity';
 import { DisputeEvidence } from './entities/dispute-evidence.entity';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
@@ -186,6 +187,72 @@ export class DisputesController {
     @CurrentUser() user: User,
   ): Promise<DisputeEvidence> {
     return this.disputesService.attachEvidence(id, attachEvidenceDto, user);
+  }
+
+  @Post(':id/vote')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Cast a reputation-weighted vote on a pending dispute. The tier ' +
+      'finalizes automatically once weighted participation meets quorum.',
+  })
+  @ApiParam({ name: 'id', description: 'Dispute ID' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Vote recorded; dispute returned (resolved if quorum reached)',
+    type: Dispute,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Voting is closed, or the voter has no wallet address',
+  })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description: 'This address has already voted in this dispute',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Dispute not found',
+  })
+  async vote(
+    @Param('id') id: string,
+    @Body() castVoteDto: CastVoteDto,
+    @CurrentUser() user: User,
+  ): Promise<Dispute> {
+    return this.disputesService.castVote(id, castVoteDto, user);
+  }
+
+  @Post(':id/escalate')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary:
+      'Escalate a resolved dispute tier to the next tier. Allowed only ' +
+      'after the tier resolves and within the escalation window.',
+  })
+  @ApiParam({ name: 'id', description: 'Dispute ID' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Dispute escalated; the new higher-tier dispute is returned',
+    type: Dispute,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description:
+      'Dispute is not resolved, at max tier, or the escalation window passed',
+  })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description: 'This dispute has already been escalated',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Dispute not found',
+  })
+  async escalate(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+  ): Promise<Dispute> {
+    return this.disputesService.escalate(id, user);
   }
 
   @Get(':id/evidence')

--- a/backend/src/disputes/disputes.module.ts
+++ b/backend/src/disputes/disputes.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Dispute } from './entities/dispute.entity';
 import { DisputeEvidence } from './entities/dispute-evidence.entity';
+import { DisputeVote } from './entities/dispute-vote.entity';
 import { DisputesService } from './disputes.service';
 import { DisputesController } from './disputes.controller';
 import { AdminDisputesController } from './admin-disputes.controller';
@@ -12,7 +13,13 @@ import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Dispute, DisputeEvidence, Market, User]),
+    TypeOrmModule.forFeature([
+      Dispute,
+      DisputeEvidence,
+      DisputeVote,
+      Market,
+      User,
+    ]),
     SorobanModule,
     NotificationsModule,
   ],

--- a/backend/src/disputes/disputes.service.spec.ts
+++ b/backend/src/disputes/disputes.service.spec.ts
@@ -7,7 +7,7 @@ import {
   BadRequestException,
   ForbiddenException,
 } from '@nestjs/common';
-import { DisputesService } from './disputes.service';
+import { DisputesService, MAX_TIER } from './disputes.service';
 import {
   Dispute,
   DisputeStatus,
@@ -15,6 +15,7 @@ import {
   DisputeSlaStage,
 } from './entities/dispute.entity';
 import { DisputeEvidence } from './entities/dispute-evidence.entity';
+import { DisputeVote } from './entities/dispute-vote.entity';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
 import { SorobanService } from '../soroban/soroban.service';
@@ -29,6 +30,7 @@ describe('DisputesService', () => {
   let disputesRepository: Repository<Dispute>;
   let marketsRepository: Repository<Market>;
   let evidenceRepository: Repository<DisputeEvidence>;
+  let votesRepository: Repository<DisputeVote>;
   let usersRepository: Repository<User>;
   let sorobanService: SorobanService;
   let notificationGenerator: jest.Mocked<NotificationGeneratorService>;
@@ -103,6 +105,15 @@ describe('DisputesService', () => {
           },
         },
         {
+          provide: getRepositoryToken(DisputeVote),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn((v: DisputeVote) => v),
+            save: jest.fn((v: DisputeVote) => Promise.resolve(v)),
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
           provide: getRepositoryToken(User),
           useValue: {
             findOne: jest.fn(),
@@ -141,6 +152,9 @@ describe('DisputesService', () => {
     );
     evidenceRepository = module.get<Repository<DisputeEvidence>>(
       getRepositoryToken(DisputeEvidence),
+    );
+    votesRepository = module.get<Repository<DisputeVote>>(
+      getRepositoryToken(DisputeVote),
     );
     usersRepository = module.get<Repository<User>>(getRepositoryToken(User));
     sorobanService = module.get<SorobanService>(SorobanService);
@@ -704,7 +718,11 @@ describe('DisputesService', () => {
       jest.spyOn(usersRepository, 'findOne').mockResolvedValue(null);
 
       await expect(
-        service.assignArbiter('dispute-123', 'missing-user', 'requesting-admin'),
+        service.assignArbiter(
+          'dispute-123',
+          'missing-user',
+          'requesting-admin',
+        ),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -848,9 +866,7 @@ describe('DisputesService', () => {
       expect(dispute.slaStage).toBe(DisputeSlaStage.ESCALATED);
       expect(
         notificationGenerator.notifyDisputeSlaBreached,
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({ escalated: false }),
-      );
+      ).toHaveBeenCalledWith(expect.objectContaining({ escalated: false }));
     });
 
     it('never changes dispute status - SLA tracking is advisory only', async () => {
@@ -864,6 +880,318 @@ describe('DisputesService', () => {
       await service.runSlaCheck();
 
       expect(dispute.status).toBe(DisputeStatus.PENDING);
+    });
+  });
+
+  describe('castVote', () => {
+    const makeVoter = (overrides: Partial<User> = {}): User =>
+      ({
+        id: 'voter-1',
+        stellar_address: 'GVOTER1',
+        reputation_score: 50,
+        ...overrides,
+      }) as User;
+
+    const makePendingTierDispute = (
+      overrides: Partial<Dispute> = {},
+    ): Dispute =>
+      ({
+        id: 'dispute-vote-1',
+        marketId: 'market-123',
+        status: DisputeStatus.PENDING,
+        tier: 1,
+        quorumThreshold: 100,
+        resolution: null,
+        escalatedFromId: null,
+        ...overrides,
+      }) as Dispute;
+
+    const makeVote = (
+      outcome: DisputeResolution,
+      weight: number,
+    ): DisputeVote =>
+      ({
+        outcome,
+        weight,
+        disputeId: 'dispute-vote-1',
+      }) as DisputeVote;
+
+    it('records a reputation-weighted vote and leaves the dispute open below quorum', async () => {
+      const dispute = makePendingTierDispute();
+      const voter = makeVoter({ reputation_score: 40 });
+      jest.spyOn(service, 'findOne').mockResolvedValue(dispute);
+      jest.spyOn(votesRepository, 'findOne').mockResolvedValue(null);
+      // A single 40-weight vote against a quorum of 100.
+      jest
+        .spyOn(votesRepository, 'find')
+        .mockResolvedValue([makeVote(DisputeResolution.OVERTURNED, 40)]);
+      const disputeSaveSpy = jest.spyOn(disputesRepository, 'save');
+
+      await service.castVote(
+        'dispute-vote-1',
+        { outcome: DisputeResolution.OVERTURNED },
+        voter,
+      );
+
+      expect(votesRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          disputeId: 'dispute-vote-1',
+          voterId: 'voter-1',
+          voterAddress: 'GVOTER1',
+          outcome: DisputeResolution.OVERTURNED,
+          weight: 40,
+          tier: 1,
+        }),
+      );
+      // Below quorum: the tier is not finalized.
+      expect(disputeSaveSpy).not.toHaveBeenCalled();
+    });
+
+    it('finalizes to the weighted-majority outcome once quorum is met', async () => {
+      const dispute = makePendingTierDispute({ quorumThreshold: 100 });
+      const voter = makeVoter({ reputation_score: 60 });
+      jest.spyOn(service, 'findOne').mockResolvedValue(dispute);
+      jest.spyOn(votesRepository, 'findOne').mockResolvedValue(null);
+      jest
+        .spyOn(votesRepository, 'find')
+        .mockResolvedValue([
+          makeVote(DisputeResolution.OVERTURNED, 70),
+          makeVote(DisputeResolution.UPHELD, 40),
+        ]);
+      const disputeSaveSpy = jest
+        .spyOn(disputesRepository, 'save')
+        .mockImplementation((d) => Promise.resolve(d as Dispute));
+
+      await service.castVote(
+        'dispute-vote-1',
+        { outcome: DisputeResolution.OVERTURNED },
+        voter,
+      );
+
+      // Total weight 110 >= 100 quorum, overturned (70) beats upheld (40).
+      expect(disputeSaveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: DisputeStatus.RESOLVED,
+          resolution: DisputeResolution.OVERTURNED,
+          resolvedAt: expect.any(Date),
+        }),
+      );
+    });
+
+    it('lets reputation weighting flip the outcome vs 1-address-1-vote', async () => {
+      const dispute = makePendingTierDispute({ quorumThreshold: 100 });
+      jest.spyOn(service, 'findOne').mockResolvedValue(dispute);
+      jest.spyOn(votesRepository, 'findOne').mockResolvedValue(null);
+      // Three low-rep addresses uphold (naive count: UPHELD 3 vs OVERTURNED 1)
+      // but one high-rep address overturns (weighted: 100 vs 3).
+      jest
+        .spyOn(votesRepository, 'find')
+        .mockResolvedValue([
+          makeVote(DisputeResolution.UPHELD, 1),
+          makeVote(DisputeResolution.UPHELD, 1),
+          makeVote(DisputeResolution.UPHELD, 1),
+          makeVote(DisputeResolution.OVERTURNED, 100),
+        ]);
+      const disputeSaveSpy = jest
+        .spyOn(disputesRepository, 'save')
+        .mockImplementation((d) => Promise.resolve(d as Dispute));
+
+      await service.castVote(
+        'dispute-vote-1',
+        { outcome: DisputeResolution.OVERTURNED },
+        makeVoter({ reputation_score: 100, stellar_address: 'GWHALE' }),
+      );
+
+      expect(disputeSaveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: DisputeStatus.RESOLVED,
+          resolution: DisputeResolution.OVERTURNED,
+        }),
+      );
+    });
+
+    it('throws BadRequestException when voting on a non-pending dispute', async () => {
+      jest
+        .spyOn(service, 'findOne')
+        .mockResolvedValue(
+          makePendingTierDispute({ status: DisputeStatus.RESOLVED }),
+        );
+
+      await expect(
+        service.castVote(
+          'dispute-vote-1',
+          { outcome: DisputeResolution.UPHELD },
+          makeVoter(),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when the voter has no wallet address', async () => {
+      jest
+        .spyOn(service, 'findOne')
+        .mockResolvedValue(makePendingTierDispute());
+
+      await expect(
+        service.castVote(
+          'dispute-vote-1',
+          { outcome: DisputeResolution.UPHELD },
+          makeVoter({ stellar_address: undefined as unknown as string }),
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a second vote from the same address across tiers', async () => {
+      // Tier-2 dispute escalated from a tier-1 dispute; the address already
+      // voted at tier 1, so the chain-wide lookup returns an existing vote.
+      const tier2 = makePendingTierDispute({
+        id: 'dispute-tier2',
+        tier: 2,
+        escalatedFromId: 'dispute-tier1',
+      });
+      jest.spyOn(service, 'findOne').mockResolvedValue(tier2);
+      jest.spyOn(disputesRepository, 'findOne').mockResolvedValue({
+        id: 'dispute-tier1',
+        escalatedFromId: null,
+      } as Dispute);
+      jest
+        .spyOn(votesRepository, 'findOne')
+        .mockResolvedValue({ id: 'existing-vote' } as DisputeVote);
+
+      await expect(
+        service.castVote(
+          'dispute-tier2',
+          { outcome: DisputeResolution.UPHELD },
+          makeVoter(),
+        ),
+      ).rejects.toThrow(ConflictException);
+
+      // The double-vote lookup spans the whole chain (tier 2 + tier 1).
+      expect(votesRepository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ voterAddress: 'GVOTER1' }),
+        }),
+      );
+    });
+
+    it('treats a negative reputation score as zero weight', async () => {
+      const dispute = makePendingTierDispute();
+      jest.spyOn(service, 'findOne').mockResolvedValue(dispute);
+      jest.spyOn(votesRepository, 'findOne').mockResolvedValue(null);
+      jest.spyOn(votesRepository, 'find').mockResolvedValue([]);
+
+      await service.castVote(
+        'dispute-vote-1',
+        { outcome: DisputeResolution.UPHELD },
+        makeVoter({ reputation_score: -10 }),
+      );
+
+      expect(votesRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ weight: 0 }),
+      );
+    });
+  });
+
+  describe('escalate', () => {
+    const makeResolvedTierDispute = (
+      overrides: Partial<Dispute> = {},
+    ): Dispute =>
+      ({
+        id: 'dispute-esc-1',
+        marketId: 'market-123',
+        disputantId: 'user-123',
+        reason: 'Escalation reason',
+        status: DisputeStatus.RESOLVED,
+        resolution: DisputeResolution.UPHELD,
+        resolvedAt: new Date(),
+        tier: 1,
+        quorumThreshold: 100,
+        escalatedFromId: null,
+        ...overrides,
+      }) as Dispute;
+
+    const mockEscalator = { id: 'escalator-1' } as User;
+
+    it('creates a higher-tier dispute within the escalation window', async () => {
+      const tier1 = makeResolvedTierDispute();
+      const escalated = makeResolvedTierDispute({
+        id: 'dispute-esc-2',
+        tier: 2,
+        status: DisputeStatus.PENDING,
+      });
+      jest
+        .spyOn(service, 'findOne')
+        .mockResolvedValueOnce(tier1)
+        .mockResolvedValueOnce(escalated);
+      // No existing escalation of this tier.
+      jest.spyOn(disputesRepository, 'findOne').mockResolvedValue(null);
+      jest
+        .spyOn(disputesRepository, 'create')
+        .mockImplementation((d) => d as Dispute);
+      jest.spyOn(disputesRepository, 'save').mockResolvedValue(escalated);
+
+      const result = await service.escalate('dispute-esc-1', mockEscalator);
+
+      expect(disputesRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketId: 'market-123',
+          disputantId: 'user-123',
+          reason: 'Escalation reason',
+          status: DisputeStatus.PENDING,
+          tier: 2,
+          quorumThreshold: 200, // tier-1 quorum (100) x multiplier (2)
+          escalatedFromId: 'dispute-esc-1',
+        }),
+      );
+      expect(result).toEqual(escalated);
+    });
+
+    it('throws BadRequestException when the dispute is not resolved', async () => {
+      jest
+        .spyOn(service, 'findOne')
+        .mockResolvedValue(
+          makeResolvedTierDispute({ status: DisputeStatus.PENDING }),
+        );
+
+      await expect(
+        service.escalate('dispute-esc-1', mockEscalator),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when escalating past MAX_TIER', async () => {
+      jest
+        .spyOn(service, 'findOne')
+        .mockResolvedValue(makeResolvedTierDispute({ tier: MAX_TIER }));
+
+      await expect(
+        service.escalate('dispute-esc-1', mockEscalator),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when the escalation window has passed', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue(
+        makeResolvedTierDispute({
+          resolvedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), // 30 days ago
+        }),
+      );
+
+      await expect(
+        service.escalate('dispute-esc-1', mockEscalator),
+      ).rejects.toThrow(
+        new BadRequestException('Escalation window has passed'),
+      );
+    });
+
+    it('throws ConflictException when the tier was already escalated', async () => {
+      jest
+        .spyOn(service, 'findOne')
+        .mockResolvedValue(makeResolvedTierDispute());
+      jest
+        .spyOn(disputesRepository, 'findOne')
+        .mockResolvedValue({ id: 'dispute-esc-2' } as Dispute);
+
+      await expect(
+        service.escalate('dispute-esc-1', mockEscalator),
+      ).rejects.toThrow(ConflictException);
     });
   });
 });

--- a/backend/src/disputes/disputes.service.ts
+++ b/backend/src/disputes/disputes.service.ts
@@ -7,7 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
 import {
@@ -17,9 +17,11 @@ import {
   DisputeSlaStage,
 } from './entities/dispute.entity';
 import { DisputeEvidence } from './entities/dispute-evidence.entity';
+import { DisputeVote } from './entities/dispute-vote.entity';
 import { CreateDisputeDto } from './dto/create-dispute.dto';
 import { ResolveDisputeDto } from './dto/resolve-dispute.dto';
 import { AttachEvidenceDto } from './dto/attach-evidence.dto';
+import { CastVoteDto } from './dto/cast-vote.dto';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
 import { Role } from '../common/enums/role.enum';
@@ -40,6 +42,18 @@ const DEFAULT_SLA_ESCALATION_HOURS = 24;
 const DEFAULT_SLA_APPROACHING_WINDOW_HOURS = 6;
 const DEFAULT_SLA_REESCALATION_INTERVAL_HOURS = 24;
 
+/**
+ * Highest tier a dispute may be escalated to. A tier-MAX_TIER dispute is
+ * terminal: escalation past it is rejected.
+ */
+export const MAX_TIER = 3;
+/** How long after a tier resolves it may still be escalated, in hours. */
+const DEFAULT_ESCALATION_WINDOW_HOURS = 72;
+/** Reputation-weighted participation required to finalize a tier-1 dispute. */
+const DEFAULT_TIER1_QUORUM = 100;
+/** Each successive tier multiplies the required quorum by this factor. */
+const DEFAULT_QUORUM_TIER_MULTIPLIER = 2;
+
 @Injectable()
 export class DisputesService {
   private readonly logger = new Logger(DisputesService.name);
@@ -56,6 +70,8 @@ export class DisputesService {
     private readonly marketsRepository: Repository<Market>,
     @InjectRepository(DisputeEvidence)
     private readonly evidenceRepository: Repository<DisputeEvidence>,
+    @InjectRepository(DisputeVote)
+    private readonly votesRepository: Repository<DisputeVote>,
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
     private readonly sorobanService: SorobanService,
@@ -122,7 +138,7 @@ export class DisputesService {
     const slaDeadline = new Date();
     slaDeadline.setHours(
       slaDeadline.getHours() +
-        this.getSlaHoursConfig(
+        this.getNumericConfig(
           'DISPUTE_SLA_INITIAL_REVIEW_HOURS',
           DEFAULT_SLA_INITIAL_REVIEW_HOURS,
         ),
@@ -133,6 +149,8 @@ export class DisputesService {
       disputantId: user.id,
       reason,
       status: DisputeStatus.PENDING,
+      tier: 1,
+      quorumThreshold: this.quorumForTier(1),
       slaStage: DisputeSlaStage.INITIAL_REVIEW,
       slaDeadline,
     });
@@ -191,6 +209,223 @@ export class DisputesService {
     }
 
     return this.findOne(id);
+  }
+
+  /**
+   * Cast a reputation-weighted vote on a pending dispute tier.
+   *
+   * Each vote is weighted by the voter's reputation score (snapshotted at
+   * cast time), so a small brigade of low-reputation addresses cannot swing
+   * an outcome the way it could under naive 1-address-1-vote. A given wallet
+   * address may vote at most once across the entire escalation chain (this
+   * tier plus every lower tier it escalated from). Once the summed weight of
+   * a tier's votes reaches its quorum threshold, the tier finalizes to the
+   * outcome carrying the most weight; until then it stays open.
+   */
+  async castVote(
+    disputeId: string,
+    dto: CastVoteDto,
+    user: User,
+  ): Promise<Dispute> {
+    const dispute = await this.findOne(disputeId);
+
+    if (dispute.status !== DisputeStatus.PENDING) {
+      throw new BadRequestException('Voting is closed for this dispute');
+    }
+
+    const voterAddress = user.stellar_address;
+    if (!voterAddress) {
+      throw new BadRequestException(
+        'Voter must have a wallet address to vote on a dispute',
+      );
+    }
+
+    // Reject a second vote from the same address anywhere in the chain.
+    const chainIds = await this.getChainDisputeIds(dispute);
+    const existingVote = await this.votesRepository.findOne({
+      where: { voterAddress, disputeId: In(chainIds) },
+    });
+    if (existingVote) {
+      throw new ConflictException(
+        'This address has already voted in this dispute',
+      );
+    }
+
+    const weight = Math.max(0, user.reputation_score ?? 0);
+    const vote = this.votesRepository.create({
+      disputeId,
+      voterId: user.id,
+      voterAddress,
+      outcome: dto.outcome,
+      weight,
+      tier: dispute.tier,
+    });
+    await this.votesRepository.save(vote);
+
+    await this.tryFinalizeByQuorum(dispute);
+
+    return this.findOne(disputeId);
+  }
+
+  /**
+   * Escalate a resolved dispute tier to the next tier. Only permitted once a
+   * tier has resolved and only within the escalation window that follows its
+   * resolution. A fresh dispute is created one tier up, linked back to this
+   * one via {@link Dispute.escalatedFrom}, with a higher quorum threshold.
+   * Escalation past {@link MAX_TIER}, outside the window, or of an
+   * already-escalated tier is rejected.
+   */
+  async escalate(disputeId: string, user: User): Promise<Dispute> {
+    const dispute = await this.findOne(disputeId);
+
+    if (dispute.status !== DisputeStatus.RESOLVED) {
+      throw new BadRequestException(
+        'Only a resolved dispute tier can be escalated',
+      );
+    }
+
+    if (dispute.tier >= MAX_TIER) {
+      throw new BadRequestException(
+        `Dispute has reached the maximum tier (${MAX_TIER})`,
+      );
+    }
+
+    if (!dispute.resolvedAt) {
+      throw new BadRequestException(
+        'Resolved dispute is missing a resolution timestamp',
+      );
+    }
+
+    const windowHours = this.getNumericConfig(
+      'DISPUTE_ESCALATION_WINDOW_HOURS',
+      DEFAULT_ESCALATION_WINDOW_HOURS,
+    );
+    const windowEnd = new Date(
+      dispute.resolvedAt.getTime() + windowHours * 60 * 60 * 1000,
+    );
+    if (new Date() > windowEnd) {
+      throw new BadRequestException('Escalation window has passed');
+    }
+
+    // A tier can only be escalated once - guard against duplicate chains.
+    const existingEscalation = await this.disputesRepository.findOne({
+      where: { escalatedFromId: disputeId },
+    });
+    if (existingEscalation) {
+      throw new ConflictException('This dispute has already been escalated');
+    }
+
+    const nextTier = dispute.tier + 1;
+    const slaDeadline = new Date();
+    slaDeadline.setHours(
+      slaDeadline.getHours() +
+        this.getNumericConfig(
+          'DISPUTE_SLA_INITIAL_REVIEW_HOURS',
+          DEFAULT_SLA_INITIAL_REVIEW_HOURS,
+        ),
+    );
+
+    const escalated = this.disputesRepository.create({
+      marketId: dispute.marketId,
+      disputantId: dispute.disputantId,
+      reason: dispute.reason,
+      status: DisputeStatus.PENDING,
+      tier: nextTier,
+      quorumThreshold: this.quorumForTier(nextTier),
+      escalatedFromId: dispute.id,
+      slaStage: DisputeSlaStage.INITIAL_REVIEW,
+      slaDeadline,
+    });
+
+    const saved = await this.disputesRepository.save(escalated);
+
+    this.logger.log(
+      `Dispute ${disputeId} (tier ${dispute.tier}) escalated to tier ` +
+        `${nextTier} as dispute ${saved.id} by user ${user.id}`,
+    );
+
+    return this.findOne(saved.id);
+  }
+
+  /**
+   * Reputation-weighted quorum for a given tier. Higher tiers require more
+   * weighted participation before they can finalize.
+   */
+  private quorumForTier(tier: number): number {
+    const base = this.getNumericConfig(
+      'DISPUTE_TIER1_QUORUM',
+      DEFAULT_TIER1_QUORUM,
+    );
+    const multiplier = this.getNumericConfig(
+      'DISPUTE_QUORUM_TIER_MULTIPLIER',
+      DEFAULT_QUORUM_TIER_MULTIPLIER,
+    );
+    return Math.round(base * Math.pow(multiplier, tier - 1));
+  }
+
+  /**
+   * IDs of every dispute in this tier's escalation chain: itself plus each
+   * lower tier it was escalated from, walking the {@link Dispute.escalatedFrom}
+   * links up to the tier-1 root. Used to enforce one-vote-per-address across
+   * the whole chain.
+   */
+  private async getChainDisputeIds(dispute: Dispute): Promise<string[]> {
+    const ids = [dispute.id];
+    let parentId = dispute.escalatedFromId;
+
+    while (parentId) {
+      ids.push(parentId);
+      const parent = await this.disputesRepository.findOne({
+        where: { id: parentId },
+        select: ['id', 'escalatedFromId'],
+      });
+      parentId = parent?.escalatedFromId ?? null;
+    }
+
+    return ids;
+  }
+
+  /**
+   * Finalize a tier once its votes' summed weight meets quorum. Tallies the
+   * reputation-weighted votes; if participation is still below the threshold
+   * the dispute is left open. Ties favour the status quo (UPHELD).
+   */
+  private async tryFinalizeByQuorum(dispute: Dispute): Promise<void> {
+    const votes = await this.votesRepository.find({
+      where: { disputeId: dispute.id },
+    });
+
+    let totalWeight = 0;
+    let upheldWeight = 0;
+    let overturnedWeight = 0;
+    for (const vote of votes) {
+      totalWeight += vote.weight;
+      if (vote.outcome === DisputeResolution.OVERTURNED) {
+        overturnedWeight += vote.weight;
+      } else {
+        upheldWeight += vote.weight;
+      }
+    }
+
+    if (totalWeight < dispute.quorumThreshold) {
+      // Below quorum - the dispute stays open.
+      return;
+    }
+
+    const resolution =
+      overturnedWeight > upheldWeight
+        ? DisputeResolution.OVERTURNED
+        : DisputeResolution.UPHELD;
+
+    dispute.status = DisputeStatus.RESOLVED;
+    dispute.resolution = resolution;
+    dispute.resolvedAt = new Date();
+    await this.disputesRepository.save(dispute);
+
+    this.logger.log(
+      `Dispute ${dispute.id} (tier ${dispute.tier}) reached quorum ` +
+        `(${totalWeight}/${dispute.quorumThreshold}) and resolved as ${resolution}`,
+    );
   }
 
   /**
@@ -543,11 +778,11 @@ export class DisputesService {
     dispute: Dispute,
     now: Date,
   ): Promise<'none' | 'approaching' | 'breached' | 'escalated'> {
-    const approachingWindowHours = this.getSlaHoursConfig(
+    const approachingWindowHours = this.getNumericConfig(
       'DISPUTE_SLA_APPROACHING_WINDOW_HOURS',
       DEFAULT_SLA_APPROACHING_WINDOW_HOURS,
     );
-    const reescalationIntervalHours = this.getSlaHoursConfig(
+    const reescalationIntervalHours = this.getNumericConfig(
       'DISPUTE_SLA_REESCALATION_INTERVAL_HOURS',
       DEFAULT_SLA_REESCALATION_INTERVAL_HOURS,
     );
@@ -576,7 +811,7 @@ export class DisputesService {
 
       if (dispute.slaStage === DisputeSlaStage.INITIAL_REVIEW) {
         dispute.slaStage = DisputeSlaStage.ESCALATED;
-        const escalationHours = this.getSlaHoursConfig(
+        const escalationHours = this.getNumericConfig(
           'DISPUTE_SLA_ESCALATION_HOURS',
           DEFAULT_SLA_ESCALATION_HOURS,
         );
@@ -656,7 +891,7 @@ export class DisputesService {
     return Array.from(addresses);
   }
 
-  private getSlaHoursConfig(key: string, fallback: number): number {
+  private getNumericConfig(key: string, fallback: number): number {
     const raw = this.configService.get<string>(key);
     const parsed = raw !== undefined ? parseFloat(raw) : NaN;
     return Number.isFinite(parsed) ? parsed : fallback;

--- a/backend/src/disputes/dto/cast-vote.dto.ts
+++ b/backend/src/disputes/dto/cast-vote.dto.ts
@@ -1,0 +1,14 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { DisputeResolution } from '../entities/dispute.entity';
+
+export class CastVoteDto {
+  @ApiProperty({
+    description: 'The outcome this voter supports for the dispute',
+    enum: DisputeResolution,
+    example: DisputeResolution.OVERTURNED,
+  })
+  @IsEnum(DisputeResolution)
+  @IsNotEmpty()
+  outcome: DisputeResolution;
+}

--- a/backend/src/disputes/entities/dispute-vote.entity.ts
+++ b/backend/src/disputes/entities/dispute-vote.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+  Index,
+  JoinColumn,
+} from 'typeorm';
+import { Dispute, DisputeResolution } from './dispute.entity';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * A single reputation-weighted vote cast on a dispute tier. Voting is the
+ * mechanism by which a tier reaches quorum and finalizes. Each vote snapshots
+ * the voter's reputation as its {@link weight} at cast time so later reputation
+ * changes cannot retroactively alter an already-tallied outcome.
+ *
+ * A voter (identified by wallet address) may vote at most once across the
+ * whole escalation chain, enforced both at the application layer and by the
+ * unique (dispute, address) index below combined with a chain-wide lookup.
+ */
+@Entity('dispute_votes')
+@Index(['disputeId'])
+@Index(['voterAddress'])
+@Index(['disputeId', 'voterAddress'], { unique: true })
+export class DisputeVote {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'dispute_id' })
+  @Index()
+  disputeId: string;
+
+  @Column({ name: 'voter_id' })
+  voterId: string;
+
+  /** Wallet address of the voter; the identity used for double-vote checks. */
+  @Column({ name: 'voter_address' })
+  @Index()
+  voterAddress: string;
+
+  @Column({ type: 'enum', enum: DisputeResolution })
+  outcome: DisputeResolution;
+
+  /** Reputation-derived weight of this vote, snapshotted at cast time. */
+  @Column({ type: 'int', default: 0 })
+  weight: number;
+
+  /** Tier of the dispute at which this vote was cast. */
+  @Column({ type: 'int', default: 1 })
+  tier: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @ManyToOne(() => Dispute, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'dispute_id', referencedColumnName: 'id' })
+  dispute: Dispute;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'voter_id', referencedColumnName: 'id' })
+  voter: User;
+}

--- a/backend/src/disputes/entities/dispute.entity.ts
+++ b/backend/src/disputes/entities/dispute.entity.ts
@@ -125,6 +125,29 @@ export class Dispute {
   @Index()
   assignedArbiterId: string | null;
 
+  /**
+   * Escalation tier of this dispute. Tier 1 is the initial round; each
+   * escalation creates a fresh dispute one tier higher, linked back to the
+   * tier it came from via {@link escalatedFrom}. Escalation past the
+   * service's MAX_TIER is rejected.
+   */
+  @Column({ name: 'tier', type: 'int', default: 1 })
+  @Index()
+  tier: number;
+
+  /**
+   * Reputation-weighted participation required before this tier can be
+   * finalized. Votes are weighted by voter reputation; the tier only
+   * resolves once the summed weight of its votes meets this threshold.
+   * Higher tiers carry a higher quorum.
+   */
+  @Column({ name: 'quorum_threshold', type: 'int', default: 0 })
+  quorumThreshold: number;
+
+  @Column({ name: 'escalated_from_id', type: 'uuid', nullable: true })
+  @Index()
+  escalatedFromId: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
@@ -144,4 +167,14 @@ export class Dispute {
   @ManyToOne(() => User, { eager: true, nullable: true })
   @JoinColumn({ name: 'assigned_arbiter_id', referencedColumnName: 'id' })
   assignedArbiter: User | null;
+
+  /**
+   * The lower-tier dispute this one was escalated from, if any. A tier-1
+   * dispute has a null reference; every escalation points back to its
+   * immediate predecessor, forming a linear chain used for cross-tier
+   * double-voting checks.
+   */
+  @ManyToOne(() => Dispute, { nullable: true })
+  @JoinColumn({ name: 'escalated_from_id', referencedColumnName: 'id' })
+  escalatedFrom: Dispute | null;
 }

--- a/backend/src/migrations/1777800000000-AddDisputeTieredEscalation.ts
+++ b/backend/src/migrations/1777800000000-AddDisputeTieredEscalation.ts
@@ -1,0 +1,156 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableColumn,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+/**
+ * Adds tiered, reputation-weighted escalation to disputes:
+ *  - `tier`, `quorum_threshold`, and a self-referencing `escalated_from_id`
+ *    on the `disputes` table;
+ *  - a `dispute_votes` table holding one reputation-weighted vote per address
+ *    per dispute.
+ */
+export class AddDisputeTieredEscalation1777800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('disputes', [
+      new TableColumn({
+        name: 'tier',
+        type: 'int',
+        default: 1,
+        isNullable: false,
+      }),
+      new TableColumn({
+        name: 'quorum_threshold',
+        type: 'int',
+        default: 0,
+        isNullable: false,
+      }),
+      new TableColumn({
+        name: 'escalated_from_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    ]);
+
+    await queryRunner.createIndex(
+      'disputes',
+      new TableIndex({
+        name: 'IDX_disputes_tier',
+        columnNames: ['tier'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'disputes',
+      new TableIndex({
+        name: 'IDX_disputes_escalated_from_id',
+        columnNames: ['escalated_from_id'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'disputes',
+      new TableForeignKey({
+        name: 'FK_disputes_escalated_from_id',
+        columnNames: ['escalated_from_id'],
+        referencedTableName: 'disputes',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'dispute_votes',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'dispute_id', type: 'uuid', isNullable: false },
+          { name: 'voter_id', type: 'uuid', isNullable: false },
+          { name: 'voter_address', type: 'varchar', isNullable: false },
+          { name: 'outcome', type: 'varchar', length: '20', isNullable: false },
+          { name: 'weight', type: 'int', default: 0, isNullable: false },
+          { name: 'tier', type: 'int', default: 1, isNullable: false },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'now()',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'dispute_votes',
+      new TableIndex({
+        name: 'IDX_dispute_votes_dispute_id',
+        columnNames: ['dispute_id'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'dispute_votes',
+      new TableIndex({
+        name: 'IDX_dispute_votes_voter_address',
+        columnNames: ['voter_address'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'dispute_votes',
+      new TableIndex({
+        name: 'UQ_dispute_votes_dispute_address',
+        columnNames: ['dispute_id', 'voter_address'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'dispute_votes',
+      new TableForeignKey({
+        name: 'FK_dispute_votes_dispute_id',
+        columnNames: ['dispute_id'],
+        referencedTableName: 'disputes',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'dispute_votes',
+      new TableForeignKey({
+        name: 'FK_dispute_votes_voter_id',
+        columnNames: ['voter_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('dispute_votes', true);
+
+    await queryRunner.dropForeignKey(
+      'disputes',
+      'FK_disputes_escalated_from_id',
+    );
+    await queryRunner.dropIndex('disputes', 'IDX_disputes_escalated_from_id');
+    await queryRunner.dropIndex('disputes', 'IDX_disputes_tier');
+    await queryRunner.dropColumns('disputes', [
+      'escalated_from_id',
+      'quorum_threshold',
+      'tier',
+    ]);
+  }
+}


### PR DESCRIPTION


Disputes resolved in a single round with flat, 1-address-1-vote counting. There
was no escalation to higher tiers and no reputation weighting, so a low-stakes
brigade of throwaway addresses could swing an outcome. This introduces tiered
escalation with a reputation-weighted quorum.

## What changed

### Entity — `src/disputes/entities/dispute.entity.ts`
- `tier` (int, default `1`, indexed) — the dispute's escalation tier.
- `quorumThreshold` (int) — reputation-weighted participation required before a
  tier can finalize.
- `escalatedFromId` + `escalatedFrom` self-reference (`ManyToOne` → `Dispute`) —
  links each escalation back to the tier it came from, forming a linear chain to
  the tier-1 root.

### New entity — `src/disputes/entities/dispute-vote.entity.ts`
One reputation-weighted vote per address per dispute: `disputeId`, `voterId`,
`voterAddress`, `outcome`, `weight` (voter reputation snapshotted at cast time),
and `tier`. Enforced by a unique `(dispute_id, voter_address)` index.

### Service — `src/disputes/disputes.service.ts`
- **`castVote()`** — weights each vote by `Math.max(0, reputation_score)`,
  rejects voting on non-pending disputes and voters without a wallet address,
  and blocks double-voting **across the entire escalation chain** (walks
  `escalatedFrom` up to the root before checking for an existing vote).
- **`tryFinalizeByQuorum()`** — tallies the weighted votes; **stays open while
  below quorum**, otherwise finalizes to the outcome carrying the most weight.
  Ties favour the status quo (`UPHELD`).
- **`escalate()`** — permitted only after a tier is `RESOLVED` and only within
  the escalation window (`resolvedAt + DISPUTE_ESCALATION_WINDOW_HOURS`, default
  72h). Rejects escalation past `MAX_TIER` (3), outside the window, and duplicate
  escalations. Creates the next-tier dispute with a scaled quorum
  (`quorumForTier`: base `100` × `2^(tier-1)`).
- **`create()`** now seeds `tier: 1` and `quorumThreshold`.
- Renamed the internal numeric-config helper `getSlaHoursConfig` →
  `getNumericConfig` (now also used for quorum/window config).

### Controller — `src/disputes/disputes.controller.ts`
- `POST /disputes/:id/vote` — cast a reputation-weighted vote.
- `POST /disputes/:id/escalate` — escalate a resolved tier to the next tier.

> **Note:** these endpoints live on the public `disputes` controller (mounted at
> `/disputes`) rather than `admin-disputes.controller.ts` (mounted at
> `/admin/disputes`), so the route matches the required `POST /disputes/:id/escalate`
> path. Voting and escalation are community actions, not admin-only.

### Wiring & schema
- `src/disputes/disputes.module.ts` registers `DisputeVote`.
- New migration `src/migrations/1777800000000-AddDisputeTieredEscalation.ts` adds
  the new `disputes` columns, the `dispute_votes` table, indexes, and foreign keys.
  Required because `synchronize` is `false`.

## Configuration

| Env var | Default | Purpose |
| --- | --- | --- |
| `DISPUTE_TIER1_QUORUM` | `100` | Weighted participation to finalize a tier-1 dispute |
| `DISPUTE_QUORUM_TIER_MULTIPLIER` | `2` | Quorum multiplier applied per tier |
| `DISPUTE_ESCALATION_WINDOW_HOURS` | `72` | Window after resolution during which escalation is allowed |

`MAX_TIER` is `3` (constant).

## Acceptance criteria

- [x] Disputes below quorum cannot finalize and stay open.
- [x] Reputation weighting changes the winning outcome vs naive 1-address-1-vote.
- [x] Escalation past max tier or outside the window is rejected.
- [x] Service tests cover quorum math, weighting, and the escalation state machine.

## Testing

- `npx jest src/disputes/` — **61 passed** (includes new `castVote` and
  `escalate` suites: below/at-quorum finalization, weighting flipping the
  outcome, cross-tier double-vote rejection, non-pending/addressless guards,
  negative-reputation → zero weight, and the full escalation state machine).
- `npx eslint src/disputes/ src/migrations/1777800000000-AddDisputeTieredEscalation.ts` — clean.
- `tsc --noEmit` — no type errors in the changed source files.

## Migration notes

Run the new migration to apply the schema changes:

```bash
npm run migration:run
```

The migration is reversible via its `down()` (drops `dispute_votes` and the new
`disputes` columns/indexes/FKs).


closes #1305
