### PR TITLE
feat(websocket): live odds WebSocket channel per market (#1361)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,7 @@ DISPUTE_SLA_APPROACHING_WINDOW_HOURS=6
 # Minimum hours between repeat "still breached" notifications once a
 # dispute is in its terminal escalated stage.
 DISPUTE_SLA_REESCALATION_INTERVAL_HOURS=24
+
+# Live Odds WebSocket Channel (#1361)
+# Maximum broadcast frequency per market in milliseconds (default: 500 ms).
+ODDS_THROTTLE_MS=500

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -175,6 +175,11 @@ class EnvironmentVariables {
   @IsOptional()
   @IsNumber()
   MATCH_RESULTS_POLL_INTERVAL_MS?: number;
+
+  // Live odds WebSocket channel throttle (#1361)
+  @IsOptional()
+  @IsNumber()
+  ODDS_THROTTLE_MS?: number;
 }
 
 export function validate(config: Record<string, unknown>) {

--- a/backend/src/websocket/events.gateway.ts
+++ b/backend/src/websocket/events.gateway.ts
@@ -1,4 +1,10 @@
-import { Inject, Logger, OnModuleDestroy, forwardRef } from '@nestjs/common';
+import {
+  Inject,
+  Logger,
+  OnModuleDestroy,
+  Optional,
+  forwardRef,
+} from '@nestjs/common';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
@@ -12,10 +18,15 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import { OddsBroadcasterService } from './odds-broadcaster.service';
 
 interface AuthenticatedSocket extends Socket {
   userAddress?: string;
 }
+
+/** UUID v4 pattern used to validate market room subscriptions. */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 @WebSocketGateway({
   cors: { origin: '*', credentials: true },
@@ -31,6 +42,8 @@ export class EventsGateway
   private readonly connections = new Map<string, string>(); // socketId → userAddress
   private readonly rateLimits = new Map<string, number>(); // socketId → message count
   private readonly heartbeats = new Map<string, NodeJS.Timeout>();
+  /** Tracks which market rooms each socket has subscribed to for cleanup on disconnect. */
+  private readonly socketMarkets = new Map<string, Set<string>>(); // socketId → Set<marketId>
   private readonly RATE_LIMIT = 60; // messages per minute
   private readonly RATE_WINDOW = 60_000;
 
@@ -39,6 +52,7 @@ export class EventsGateway
     private readonly configService: ConfigService,
     @Inject(forwardRef(() => AnalyticsService))
     private readonly analyticsService: AnalyticsService,
+    @Optional() private readonly oddsBroadcaster?: OddsBroadcasterService,
   ) {}
 
   async handleConnection(client: AuthenticatedSocket): Promise<void> {
@@ -106,6 +120,16 @@ export class EventsGateway
     this.rateLimits.delete(client.id);
     this.analyticsService.removeActiveSession(client.id);
     this.broadcastActiveUsers();
+
+    // Unsubscribe the socket from all market rooms it had joined.
+    const markets = this.socketMarkets.get(client.id);
+    if (markets) {
+      for (const marketId of markets) {
+        this.oddsBroadcaster?.onUnsubscribe(marketId);
+      }
+      this.socketMarkets.delete(client.id);
+    }
+
     this.logger.log(`Client disconnected: ${client.id}`);
   }
 
@@ -114,6 +138,7 @@ export class EventsGateway
       clearInterval(heartbeat);
     }
     this.heartbeats.clear();
+    this.socketMarkets.clear();
   }
 
   @SubscribeMessage('join')
@@ -194,6 +219,86 @@ export class EventsGateway
     if (!heartbeat) return;
     clearInterval(heartbeat);
     this.heartbeats.delete(socketId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Live odds subscription handlers (#1361)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Join a per-market odds room.
+   *
+   * Client sends: `{ event: 'subscribe:market', data: '<market-uuid>' }`
+   * Server responds with: `{ event: 'subscribed:market', data: { market_id } }`
+   * and starts delivering `odds:update` events to the room.
+   */
+  @SubscribeMessage('subscribe:market')
+  async handleSubscribeMarket(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() marketId: string,
+  ): Promise<void> {
+    if (!this.checkRateLimit(client.id)) {
+      client.emit('error', { message: 'Rate limit exceeded' });
+      client.disconnect();
+      return;
+    }
+
+    if (!marketId || !UUID_RE.test(marketId)) {
+      client.emit('error', { message: 'Invalid market id' });
+      return;
+    }
+
+    const room = `market:${marketId}`;
+    await client.join(room);
+
+    // Track this subscription on the socket for disconnect cleanup.
+    if (!this.socketMarkets.has(client.id)) {
+      this.socketMarkets.set(client.id, new Set());
+    }
+    const markets = this.socketMarkets.get(client.id)!;
+
+    // Only register with the broadcaster once per socket per market.
+    if (!markets.has(marketId)) {
+      markets.add(marketId);
+      this.oddsBroadcaster?.onSubscribe(marketId);
+    }
+
+    client.emit('subscribed:market', { market_id: marketId });
+    this.logger.debug(`${client.id} subscribed to market:${marketId}`);
+    this.trackActivity(client);
+  }
+
+  /**
+   * Leave a per-market odds room.
+   *
+   * Client sends: `{ event: 'unsubscribe:market', data: '<market-uuid>' }`
+   * Server responds with: `{ event: 'unsubscribed:market', data: { market_id } }`
+   */
+  @SubscribeMessage('unsubscribe:market')
+  async handleUnsubscribeMarket(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() marketId: string,
+  ): Promise<void> {
+    if (!marketId || !UUID_RE.test(marketId)) {
+      client.emit('error', { message: 'Invalid market id' });
+      return;
+    }
+
+    const room = `market:${marketId}`;
+    await client.leave(room);
+
+    const markets = this.socketMarkets.get(client.id);
+    if (markets?.has(marketId)) {
+      markets.delete(marketId);
+      this.oddsBroadcaster?.onUnsubscribe(marketId);
+      if (markets.size === 0) {
+        this.socketMarkets.delete(client.id);
+      }
+    }
+
+    client.emit('unsubscribed:market', { market_id: marketId });
+    this.logger.debug(`${client.id} unsubscribed from market:${marketId}`);
+    this.trackActivity(client);
   }
 
   getServer(): Server {

--- a/backend/src/websocket/odds-broadcaster.service.ts
+++ b/backend/src/websocket/odds-broadcaster.service.ts
@@ -1,0 +1,204 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  Optional,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EventsGateway } from './events.gateway';
+import { PredictionStatsDto } from '../markets/dto/prediction-stats.dto';
+
+export interface OddsUpdatePayload {
+  market_id: string;
+  odds: PredictionStatsDto[];
+  timestamp: string;
+}
+
+/**
+ * OddsBroadcasterService
+ *
+ * Manages per-market subscriber counts, per-market throttle timers, and
+ * broadcasting of live-odds updates to `market:{uuid}` rooms.
+ *
+ * Design:
+ * - subscriberCount tracks how many sockets are in each market room so that
+ *   empty rooms are cleaned up when the last subscriber leaves.
+ * - pendingBroadcast holds the most-recent odds payload queued for a market
+ *   that is already inside its throttle window.
+ * - throttleTimer holds the active NodeJS.Timeout for the trailing broadcast,
+ *   keyed by market_id.
+ *
+ * Throttle behaviour (leading + trailing):
+ * 1. If no timer is running for the market, emit immediately and start a timer.
+ * 2. If a timer is already running, replace the pending payload so that the
+ *    most-recent data is sent when the timer fires.
+ * This ensures clients receive odds within THROTTLE_MS of the last change,
+ * rather than only on the very first update or on a fixed schedule.
+ */
+@Injectable()
+export class OddsBroadcasterService implements OnModuleDestroy {
+  private readonly logger = new Logger(OddsBroadcasterService.name);
+
+  /** Number of active socket subscribers per market room. */
+  private readonly subscriberCount = new Map<string, number>();
+
+  /** Latest pending odds payload waiting for the throttle window to close. */
+  private readonly pendingBroadcast = new Map<string, OddsUpdatePayload>();
+
+  /** Active trailing-edge throttle timers keyed by market_id. */
+  private readonly throttleTimer = new Map<string, NodeJS.Timeout>();
+
+  private readonly throttleMs: number;
+
+  constructor(
+    private readonly gateway: EventsGateway,
+    @Optional() private readonly configService?: ConfigService,
+  ) {
+    this.throttleMs =
+      this.configService?.get<number>('ODDS_THROTTLE_MS') ?? 500;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API used by EventsGateway
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Record a new subscriber for market `marketId`.
+   * Called by EventsGateway when a client sends `subscribe:market`.
+   */
+  onSubscribe(marketId: string): void {
+    const current = this.subscriberCount.get(marketId) ?? 0;
+    this.subscriberCount.set(marketId, current + 1);
+    this.logger.debug(
+      `[odds] subscribe market:${marketId} — subscribers: ${current + 1}`,
+    );
+  }
+
+  /**
+   * Record a subscriber leaving market `marketId`.
+   * Called by EventsGateway when a client sends `unsubscribe:market` or
+   * disconnects while subscribed.
+   * Cleans up the room state when the last subscriber leaves.
+   */
+  onUnsubscribe(marketId: string): void {
+    const current = this.subscriberCount.get(marketId) ?? 0;
+    const next = Math.max(0, current - 1);
+
+    if (next === 0) {
+      this.cleanupMarket(marketId);
+    } else {
+      this.subscriberCount.set(marketId, next);
+    }
+
+    this.logger.debug(
+      `[odds] unsubscribe market:${marketId} — subscribers: ${next}`,
+    );
+  }
+
+  /**
+   * Return the number of active subscribers for a market room.
+   * Primarily used in tests and health checks.
+   */
+  getSubscriberCount(marketId: string): number {
+    return this.subscriberCount.get(marketId) ?? 0;
+  }
+
+  /**
+   * Return true when at least one subscriber is listening to the market room.
+   */
+  hasSubscribers(marketId: string): boolean {
+    return (this.subscriberCount.get(marketId) ?? 0) > 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Broadcast logic (called by MarketsService)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Broadcast a live-odds update to subscribers of `market:{marketId}`.
+   *
+   * Uses a leading+trailing throttle:
+   * - If no timer is active: emit immediately, then start the throttle window.
+   * - If a timer is already active: store the payload so it is sent when the
+   *   window closes (most-recent data wins).
+   *
+   * No-ops when there are no subscribers, avoiding unnecessary allocations.
+   */
+  broadcastOddsUpdate(
+    marketId: string,
+    odds: PredictionStatsDto[],
+  ): void {
+    // Skip entirely when nobody is listening.
+    if (!this.hasSubscribers(marketId)) {
+      return;
+    }
+
+    const payload: OddsUpdatePayload = {
+      market_id: marketId,
+      odds,
+      timestamp: new Date().toISOString(),
+    };
+
+    if (!this.throttleTimer.has(marketId)) {
+      // Leading edge: emit now and open the throttle window.
+      this.emit(marketId, payload);
+
+      const timer = setTimeout(() => {
+        this.throttleTimer.delete(marketId);
+
+        // Trailing edge: if an update arrived during the window, send it now.
+        const pending = this.pendingBroadcast.get(marketId);
+        if (pending) {
+          this.pendingBroadcast.delete(marketId);
+          this.emit(marketId, pending);
+        }
+      }, this.throttleMs);
+
+      // Prevent the timer from keeping the Node.js event loop alive during tests.
+      timer.unref?.();
+      this.throttleTimer.set(marketId, timer);
+    } else {
+      // Inside the throttle window — queue the latest payload.
+      this.pendingBroadcast.set(marketId, payload);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
+
+  /** Remove all state for a market (called when the last subscriber leaves). */
+  private cleanupMarket(marketId: string): void {
+    this.subscriberCount.delete(marketId);
+    this.pendingBroadcast.delete(marketId);
+
+    const timer = this.throttleTimer.get(marketId);
+    if (timer) {
+      clearTimeout(timer);
+      this.throttleTimer.delete(marketId);
+    }
+
+    this.logger.debug(`[odds] cleaned up market:${marketId}`);
+  }
+
+  /** Flush all state on module shutdown. */
+  onModuleDestroy(): void {
+    for (const timer of this.throttleTimer.values()) {
+      clearTimeout(timer);
+    }
+    this.throttleTimer.clear();
+    this.pendingBroadcast.clear();
+    this.subscriberCount.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private emit(marketId: string, payload: OddsUpdatePayload): void {
+    this.gateway.server.to(`market:${marketId}`).emit('odds:update', payload);
+    this.logger.debug(
+      `[odds] emitted odds:update → market:${marketId} (${payload.odds.length} outcomes)`,
+    );
+  }
+}

--- a/backend/src/websocket/websocket.module.ts
+++ b/backend/src/websocket/websocket.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EventsGateway } from './events.gateway';
 import { BroadcasterService } from './broadcaster.service';
 import { NotificationBroadcasterService } from './notification-broadcaster.service';
+import { OddsBroadcasterService } from './odds-broadcaster.service';
 
 @Module({
   imports: [
@@ -21,7 +22,8 @@ import { NotificationBroadcasterService } from './notification-broadcaster.servi
     EventsGateway,
     BroadcasterService,
     NotificationBroadcasterService,
+    OddsBroadcasterService,
   ],
-  exports: [BroadcasterService, NotificationBroadcasterService],
+  exports: [BroadcasterService, NotificationBroadcasterService, OddsBroadcasterService],
 })
 export class WebsocketModule {}


### PR DESCRIPTION
- Add ODDS_THROTTLE_MS env var (default 500ms) to env.validation.ts and .env.example
- Add OddsBroadcasterService with per-market subscriber tracking, leading+trailing throttle, and automatic room cleanup on last unsubscribe
- Add subscribe:market / unsubscribe:market handlers to EventsGateway; track per-socket market subscriptions for clean disconnect handling
- Register and export OddsBroadcasterService from WebsocketModule

closes #1361