### PR TITLE
feat(oracle): add per-item progress, preview review, and continue-on-error to batch result submission (Fixes #1526)

### DIFF
--- a/frontend/src/app/(oracle)/oracle/creator-events/page.tsx
+++ b/frontend/src/app/(oracle)/oracle/creator-events/page.tsx
@@ -6,7 +6,10 @@ import PendingMatchesList, {
   type PendingMatch,
 } from "@/component/oracle/PendingMatchesList";
 import SubmitResultForm from "@/component/oracle/SubmitResultForm";
-import BatchResultSubmission from "@/component/oracle/BatchResultSubmission";
+import BatchResultSubmission, {
+  type BatchResultRow,
+  type BatchResultOutcome,
+} from "@/component/oracle/BatchResultSubmission";
 import { Button } from "@/component/ui/button";
 
 type Outcome = "TEAM_A" | "TEAM_B" | "DRAW";
@@ -127,25 +130,55 @@ export default function OracleCreatorEventsPage() {
   }
 
   async function handleBatchSubmit(
-    results: Array<{ matchId: string; outcome: Outcome }>,
-  ) {
+    results: BatchResultRow[],
+  ): Promise<BatchResultOutcome[]> {
     await new Promise((r) => setTimeout(r, 2000));
-    const newResults: SubmittedResult[] = results.map((r) => {
+
+    const outcomes: BatchResultOutcome[] = [];
+    const newResults: SubmittedResult[] = [];
+
+    for (const r of results) {
       const match = pending.find((m) => m.matchId === r.matchId);
-      return {
-        matchId: r.matchId,
-        teamA: match?.teamA ?? "Unknown",
-        teamB: match?.teamB ?? "Unknown",
-        outcome: r.outcome,
-        submittedAt: new Date().toISOString(),
-        txHash: `tx${Date.now().toString(16)}-${r.matchId}`,
-      };
-    });
-    setRecentResults((prev) => [...newResults, ...prev]);
-    setPending((prev) =>
-      prev.filter((m) => !results.some((r) => r.matchId === m.matchId)),
+      if (match) {
+        // Simulate occasional failure (e.g., 1 in 5)
+        if (Math.random() < 0.2) {
+          outcomes.push({
+            matchId: r.matchId,
+            success: false,
+            error: "Chain submission timeout — retry.",
+          });
+        } else {
+          outcomes.push({ matchId: r.matchId, success: true });
+          newResults.push({
+            matchId: r.matchId,
+            teamA: match.teamA,
+            teamB: match.teamB,
+            outcome: r.outcome,
+            submittedAt: new Date().toISOString(),
+            txHash: `tx${Date.now().toString(16)}-${r.matchId}`,
+          });
+        }
+      } else {
+        outcomes.push({
+          matchId: r.matchId,
+          success: false,
+          error: "Match not found in pending list.",
+        });
+      }
+    }
+
+    // Update recent results with only successful ones.
+    if (newResults.length > 0) {
+      setRecentResults((prev) => [...newResults, ...prev]);
+    }
+
+    // Remove successful matches from pending.
+    const successfulIds = new Set(
+      outcomes.filter((o) => o.success).map((o) => o.matchId),
     );
-    setSelectedIds(new Set());
+    setPending((prev) => prev.filter((m) => !successfulIds.has(m.matchId)));
+
+    return outcomes;
   }
 
   function toggleSelect(id: string) {

--- a/frontend/src/component/oracle/BatchResultSubmission.test.tsx
+++ b/frontend/src/component/oracle/BatchResultSubmission.test.tsx
@@ -1,0 +1,255 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import BatchResultSubmission, {
+  type BatchResultOutcome,
+  type BatchResultRow,
+} from "./BatchResultSubmission";
+
+let CSV_CONTENT = "";
+
+class MockFileReader {
+  result: string | ArrayBuffer | null = null;
+  onload:
+    | ((this: MockFileReader, ev: { target: MockFileReader }) => void)
+    | null = null;
+
+  readAsText(_file: File) {
+    // jsdom File lacks .text(); read from the captured CSV stub instead.
+    this.result = CSV_CONTENT;
+    if (this.onload) {
+      this.onload.call(this, { target: this });
+    }
+  }
+}
+
+function renderBatch(onSubmit = vi.fn<(r: BatchResultRow[]) => Promise<BatchResultOutcome[]>>()) {
+  const utils = render(<BatchResultSubmission onSubmitBatch={onSubmit} />);
+  return { ...utils, onSubmit };
+}
+
+function uploadCsv(text: string, name = "results.csv") {
+  CSV_CONTENT = text;
+  const input = document.querySelector(
+    'input[type="file"]',
+  ) as HTMLInputElement;
+  const file = new File([text], name, { type: "text/csv" });
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+const CSV_OK = ["mkt-001,TEAM_A,api-1", "mkt-002,TEAM_B,api-2"].join("\n");
+const CSV_MIXED = ["mkt-001,TEAM_A", "mkt-002,INVALID"].join("\n");
+
+describe("BatchResultSubmission", () => {
+  beforeEach(() => {
+    vi.stubGlobal("FileReader", MockFileReader);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("parses CSV into a pre-submit review table with valid and error counts", async () => {
+    renderBatch();
+    uploadCsv(CSV_MIXED);
+
+    await waitFor(() => {
+      expect(screen.getByText("mkt-001")).toBeInTheDocument();
+      expect(screen.getByText("mkt-002")).toBeInTheDocument();
+      expect(screen.getByText("✓ 1 valid")).toBeInTheDocument();
+      expect(screen.getByText("✗ 1 errors")).toBeInTheDocument();
+    });
+
+    // Error row shows "Error" status; valid row shows pending.
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
+  });
+
+  it("shows source column from the optional CSV third field", async () => {
+    renderBatch();
+    uploadCsv(CSV_OK);
+
+    await waitFor(() => {
+      expect(screen.getByText("api-1")).toBeInTheDocument();
+      expect(screen.getByText("api-2")).toBeInTheDocument();
+    });
+  });
+
+  it("marks a row confirmed on success and failed on failure, then retries only failures", async () => {
+    const onSubmit = vi.fn<
+      (r: BatchResultRow[]) => Promise<BatchResultOutcome[]>
+    >(async (rows) =>
+      rows.map((r) =>
+        r.matchId === "mkt-001"
+          ? { matchId: r.matchId, success: true }
+          : { matchId: r.matchId, success: false, error: "rejected by chain" },
+      ),
+    );
+    renderBatch(onSubmit);
+
+    uploadCsv(["mkt-001,TEAM_A", "mkt-002,TEAM_B"].join("\n"));
+
+    await waitFor(() => {
+      expect(screen.getByText("mkt-001")).toBeInTheDocument();
+      expect(screen.getByText("mkt-002")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /submit 2 results/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Confirmed", { selector: "span" })).toBeInTheDocument();
+      expect(screen.getByText("Failed", { selector: "span" })).toBeInTheDocument();
+    });
+
+    // Partial failure message + retry button.
+    expect(
+      screen.getByText(/1 of 2 results failed to submit/i),
+    ).toBeInTheDocument();
+
+    // Retry should submit ONLY the failed match (mkt-002) — not mkt-001.
+    fireEvent.click(screen.getByRole("button", { name: /retry 1 failed/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(2);
+    });
+
+    const secondCall = onSubmit.mock.calls[1][0];
+    expect(secondCall).toHaveLength(1);
+    expect(secondCall[0].matchId).toBe("mkt-002");
+  });
+
+  it("prevents double submit while a batch is in flight", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const onSubmit = vi.fn(async () => {
+      await gate;
+      return [];
+    });
+    renderBatch(onSubmit);
+
+    uploadCsv(["mkt-001,TEAM_A"].join("\n"));
+
+    await waitFor(() => {
+      expect(screen.getByText("mkt-001")).toBeInTheDocument();
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /submit 1 result/i });
+    fireEvent.click(submitBtn);
+    expect(submitBtn).toBeDisabled();
+
+    await act(async () => {
+      release?.();
+    });
+  });
+
+  it("allows editing the outcome of a row in the review table", async () => {
+    renderBatch();
+    uploadCsv(["mkt-001,TEAM_A"].join("\n"));
+
+    await waitFor(() => {
+      expect(screen.getByText("mkt-001")).toBeInTheDocument();
+    });
+
+    // Enter edit mode.
+    fireEvent.click(
+      screen.getByRole("button", { name: /edit outcome for mkt-001/i }),
+    );
+
+    // Pick DRAW from the inline options.
+    fireEvent.click(screen.getByRole("button", { name: "DRAW" }));
+
+    // The row now reflects DRAW.
+    await waitFor(() => {
+      expect(screen.getByText("DRAW")).toBeInTheDocument();
+    });
+
+    // It is still a valid row (1 valid).
+    expect(screen.getByText("✓ 1 valid")).toBeInTheDocument();
+  });
+
+  it("allows removing a row from the review table", async () => {
+    renderBatch();
+    uploadCsv(["mkt-001,TEAM_A", "mkt-002,TEAM_B"].join("\n"));
+
+    await waitFor(() => {
+      expect(screen.getByText("mkt-001")).toBeInTheDocument();
+      expect(screen.getByText("mkt-002")).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove mkt-001/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("mkt-001")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("mkt-002")).toBeInTheDocument();
+    expect(screen.getByText("✓ 1 valid")).toBeInTheDocument();
+  });
+
+  it("asks for confirmation before large batches", async () => {
+    const onSubmit = vi.fn<
+      (r: BatchResultRow[]) => Promise<BatchResultOutcome[]>
+    >(async () => []);
+    renderBatch(onSubmit);
+
+    // 5 rows triggers the confirmation dialog (CONFIRM_BATCH_THRESHOLD = 5).
+    const csv = Array.from(
+      { length: 5 },
+      (_, i) => `mkt-0${i + 1},TEAM_A`,
+    ).join("\n");
+    uploadCsv(csv);
+
+    await waitFor(() => {
+      expect(screen.getByText("mkt-01")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /submit 5 results/i }));
+
+    // Confirmation dialog shown, submission not yet fired.
+    expect(screen.getByText("Submit 5 results?")).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Cancel keeps rows and does not submit.
+    fireEvent.click(screen.getByRole("button", { name: /review/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Confirm submits the whole batch.
+    fireEvent.click(screen.getByRole("button", { name: /submit 5 results/i }));
+    fireEvent.click(screen.getByRole("button", { name: /submit batch/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    expect(onSubmit.mock.calls[0][0]).toHaveLength(5);
+  });
+
+  it("shows overall progress bar after partial success", async () => {
+    const onSubmit = vi.fn(async (rows: BatchResultRow[]) =>
+      rows.map((r) =>
+        r.matchId === "mkt-001"
+          ? { matchId: r.matchId, success: true }
+          : { matchId: r.matchId, success: false, error: "nope" },
+      ),
+    );
+    renderBatch(onSubmit);
+
+    uploadCsv(["mkt-001,TEAM_A", "mkt-002,TEAM_B", "mkt-003,TEAM_A"].join("\n"));
+
+    await waitFor(() => {
+      expect(screen.getByText("mkt-001")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /submit 3 results/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("1 of 3 confirmed")).toBeInTheDocument();
+      expect(screen.getByText("· 2 failed")).toBeInTheDocument();
+    });
+    expect(screen.getByText("33%")).toBeInTheDocument();
+    expect(screen.getByText("1 of 3 confirmed")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/component/oracle/BatchResultSubmission.tsx
+++ b/frontend/src/component/oracle/BatchResultSubmission.tsx
@@ -1,27 +1,57 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { Upload, X, Check, AlertCircle, Loader2 } from "lucide-react";
+import { useRef, useState } from "react";
+import {
+  Upload,
+  X,
+  Check,
+  AlertCircle,
+  Loader2,
+  Pencil,
+  Trash2,
+  RefreshCw,
+} from "lucide-react";
 import { Button } from "@/component/ui/button";
+import { ConfirmDialog } from "@/component/ui/confirm-dialog";
 
 type Outcome = "TEAM_A" | "TEAM_B" | "DRAW";
 
 interface ParsedResult {
+  id: string;
   matchId: string;
   outcome: Outcome | null;
+  source?: string;
   error?: string;
 }
 
-interface BatchResultRow {
+export interface BatchResultRow {
   matchId: string;
   outcome: Outcome;
+  source?: string;
+}
+
+export interface BatchResultOutcome {
+  matchId: string;
+  success: boolean;
+  error?: string;
 }
 
 interface BatchResultSubmissionProps {
-  onSubmitBatch: (results: BatchResultRow[]) => Promise<void>;
+  onSubmitBatch: (results: BatchResultRow[]) => Promise<BatchResultOutcome[]>;
 }
 
+type ItemStatus = "pending" | "submitting" | "confirmed" | "failed";
+
 const VALID_OUTCOMES = new Set<string>(["TEAM_A", "TEAM_B", "DRAW"]);
+const OUTCOME_OPTIONS: Outcome[] = ["TEAM_A", "TEAM_B", "DRAW"];
+const CONFIRM_BATCH_THRESHOLD = 5;
+
+let rowSeq = 0;
+
+function nextRowId() {
+  rowSeq += 1;
+  return `row-${rowSeq}`;
+}
 
 function parseResultCSV(raw: string): ParsedResult[] {
   const lines = raw
@@ -30,7 +60,9 @@ function parseResultCSV(raw: string): ParsedResult[] {
     .filter(Boolean);
 
   return lines.map((line) => {
-    const [matchId = "", outcome = ""] = line.split(",").map((c) => c.trim());
+    const [matchId = "", outcome = "", source = ""] = line
+      .split(",")
+      .map((c) => c.trim());
     const errs: string[] = [];
 
     if (!matchId) errs.push("Match ID is empty");
@@ -42,24 +74,43 @@ function parseResultCSV(raw: string): ParsedResult[] {
     }
 
     return {
+      id: nextRowId(),
       matchId,
       outcome: VALID_OUTCOMES.has(normalizedOutcome)
         ? (normalizedOutcome as Outcome)
         : null,
+      source: source || undefined,
       error: errs.length > 0 ? errs.join("; ") : undefined,
     };
   });
 }
 
+const STATUS_CONTENT: Record<
+  ItemStatus,
+  { label: string; className: string }
+> = {
+  pending: { label: "Pending", className: "text-slate-400" },
+  submitting: { label: "Submitting…", className: "text-sky-300" },
+  confirmed: { label: "Confirmed", className: "text-emerald-400" },
+  failed: { label: "Failed", className: "text-rose-400" },
+};
+
 export default function BatchResultSubmission({
   onSubmitBatch,
 }: BatchResultSubmissionProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<ParsedResult[] | null>(null);
+  const [rows, setRows] = useState<ParsedResult[] | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [statusById, setStatusById] = useState<Record<string, ItemStatus>>({});
+  const [errorsById, setErrorsById] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingSubmit, setPendingSubmit] = useState<BatchResultRow[] | null>(
+    null,
+  );
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -68,54 +119,230 @@ export default function BatchResultSubmission({
     setFileName(file.name);
     setSubmitError(null);
     setSubmitSuccess(false);
+    setEditingId(null);
+    setStatusById({});
+    setErrorsById({});
 
     const reader = new FileReader();
     reader.onload = (ev) => {
       const text = ev.target?.result as string;
-      setPreview(parseResultCSV(text));
+      setRows(parseResultCSV(text));
     };
     reader.readAsText(file);
   }
 
   function handleClear() {
-    setPreview(null);
+    setRows(null);
     setFileName(null);
     setSubmitError(null);
     setSubmitSuccess(false);
+    setEditingId(null);
+    setStatusById({});
+    setErrorsById({});
+    setConfirmOpen(false);
+    setPendingSubmit(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
-  async function handleSubmitAll() {
-    if (!preview) return;
+  function handleRemoveRow(rowId: string) {
+    if (!rows) return;
+    setRows((prev) => prev?.filter((r) => r.id !== rowId) ?? null);
+    setStatusById((prev) => {
+      const next = { ...prev };
+      delete next[rowId];
+      return next;
+    });
+    setErrorsById((prev) => {
+      const next = { ...prev };
+      delete next[rowId];
+      return next;
+    });
+    if (editingId === rowId) setEditingId(null);
+  }
 
-    const valid = preview.filter(
-      (r): r is ParsedResult & { outcome: Outcome } =>
-        !r.error && r.outcome !== null,
+  function handleUpdateOutcome(rowId: string, outcome: Outcome) {
+    if (!rows) return;
+    setRows(
+      (prev) =>
+        prev?.map((r) =>
+          r.id === rowId ? { ...r, outcome, error: undefined } : r,
+        ) ?? null,
     );
+    setStatusById((prev) => {
+      const next = { ...prev };
+      delete next[rowId];
+      return next;
+    });
+    setErrorsById((prev) => {
+      const next = { ...prev };
+      delete next[rowId];
+      return next;
+    });
+    setEditingId(null);
+  }
 
-    if (valid.length === 0) {
-      setSubmitError("No valid rows to submit.");
-      return;
-    }
+  const validCount =
+    rows?.filter((r) => !r.error && r.outcome !== null).length ?? 0;
+  const errorCount = rows?.filter((r) => r.error).length ?? 0;
+
+  function collectValidRows(): BatchResultRow[] {
+    if (!rows) return [];
+    return rows
+      .filter(
+        (r): r is ParsedResult & { outcome: Outcome } =>
+          !r.error && r.outcome !== null,
+      )
+      .map((r) => ({
+        matchId: r.matchId,
+        outcome: r.outcome,
+        source: r.source,
+      }));
+  }
+
+  async function doSubmit(target: BatchResultRow[]) {
+    if (target.length === 0 || !rows) return;
+
+    const targetIds = new Set(target.map((t) => t.matchId));
 
     setIsSubmitting(true);
     setSubmitError(null);
+    setSubmitSuccess(false);
+    setConfirmOpen(false);
+    setPendingSubmit(null);
+
+    setStatusById((prev) => {
+      const next: Record<string, ItemStatus> = { ...prev };
+      rows.forEach((r) => {
+        if (targetIds.has(r.matchId)) next[r.id] = "submitting";
+      });
+      return next;
+    });
+    setErrorsById((prev) => {
+      const next = { ...prev };
+      rows.forEach((r) => {
+        if (targetIds.has(r.matchId)) delete next[r.id];
+      });
+      return next;
+    });
 
     try {
-      await onSubmitBatch(
-        valid.map((r) => ({ matchId: r.matchId, outcome: r.outcome })),
+      const outcomes = await onSubmitBatch(target);
+      const hasExplicitOutcomes = outcomes.length > 0;
+      const outcomeByMatch = new Map<string, BatchResultOutcome>();
+      for (const o of outcomes) {
+        if (o?.matchId != null) {
+          outcomeByMatch.set(o.matchId, o);
+        }
+      }
+
+      const nextStatus: Record<string, ItemStatus> = {};
+      const nextErrors: Record<string, string> = {};
+      rows.forEach((r) => {
+        if (!targetIds.has(r.matchId)) return;
+        if (hasExplicitOutcomes) {
+          const outcome = outcomeByMatch.get(r.matchId);
+          if (outcome?.success) {
+            nextStatus[r.id] = "confirmed";
+          } else {
+            nextStatus[r.id] = "failed";
+            if (outcome?.error) nextErrors[r.id] = outcome.error;
+          }
+        } else {
+          // Legacy callers that resolve without per-item outcomes => all ok.
+          nextStatus[r.id] = "confirmed";
+        }
+      });
+
+      setStatusById((prev) => ({ ...prev, ...nextStatus }));
+      setErrorsById((prev) =>
+        Object.keys(nextErrors).length > 0
+          ? { ...prev, ...nextErrors }
+          : prev,
       );
-      setSubmitSuccess(true);
-      handleClear();
+
+      const failedCount = Object.values(nextStatus).filter(
+        (s) => s === "failed",
+      ).length;
+      const submittedCount = Object.keys(nextStatus).length;
+
+      if (failedCount > 0) {
+        setSubmitError(
+          `${failedCount} of ${submittedCount} result${submittedCount !== 1 ? "s" : ""} failed to submit. You can retry just the failed items below.`,
+        );
+      } else {
+        setSubmitSuccess(true);
+      }
     } catch {
-      setSubmitError("Batch submission failed. Please try again.");
+      // Whole-batch failure (network error / rejected promise).
+      const nextStatus: Record<string, ItemStatus> = {};
+      rows.forEach((r) => {
+        if (targetIds.has(r.matchId)) nextStatus[r.id] = "failed";
+      });
+      const nextErrors: Record<string, string> = {};
+      rows.forEach((r) => {
+        if (targetIds.has(r.matchId)) {
+          nextErrors[r.id] = "Batch submission error. Please retry.";
+        }
+      });
+      setStatusById((prev) => ({ ...prev, ...nextStatus }));
+      setErrorsById((prev) => ({ ...prev, ...nextErrors }));
+      setSubmitError(
+        "Batch submission failed. You can retry the failed items below.",
+      );
     } finally {
       setIsSubmitting(false);
     }
   }
 
-  const validCount = preview?.filter((r) => !r.error && r.outcome).length ?? 0;
-  const errorCount = preview?.filter((r) => r.error).length ?? 0;
+  function handleSubmitAll() {
+    if (!rows || isSubmitting) return;
+    const valid = collectValidRows();
+    if (valid.length === 0) {
+      setSubmitError("No valid rows to submit.");
+      return;
+    }
+
+    // Skip rows already confirmed from a previous pass.
+    const target = valid.filter((r) => {
+      const byId = rows.find((row) => row.matchId === r.matchId);
+      return !byId || statusById[byId.id] !== "confirmed";
+    });
+
+    if (target.length === 0) {
+      setSubmitError("All rows have already been submitted.");
+      return;
+    }
+
+    if (target.length >= CONFIRM_BATCH_THRESHOLD) {
+      setPendingSubmit(target);
+      setConfirmOpen(true);
+      return;
+    }
+    void doSubmit(target);
+  }
+
+  function handleRetryFailed() {
+    if (!rows || isSubmitting) return;
+    const failed = rows
+      .filter((r) => statusById[r.id] === "failed" && r.outcome !== null)
+      .map((r) => ({
+        matchId: r.matchId,
+        outcome: r.outcome as Outcome,
+        source: r.source,
+      }));
+    if (failed.length === 0) return;
+    void doSubmit(failed);
+  }
+
+  const confirmedCount =
+    rows?.filter((r) => statusById[r.id] === "confirmed").length ?? 0;
+  const failedCount =
+    rows?.filter((r) => statusById[r.id] === "failed").length ?? 0;
+  const hasFailed = failedCount > 0;
+  const totalProgress =
+    rows && rows.length > 0
+      ? Math.round((confirmedCount / rows.length) * 100)
+      : 0;
 
   return (
     <div className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/80 p-6">
@@ -138,7 +365,7 @@ export default function BatchResultSubmission({
       <p className="text-sm text-slate-400">
         Upload a CSV with columns:{" "}
         <code className="rounded bg-white/10 px-1.5 py-0.5 text-xs text-amber-300">
-          Match ID, Outcome (TEAM_A | TEAM_B | DRAW)
+          Match ID, Outcome (TEAM_A | TEAM_B | DRAW), Data Source (optional)
         </code>
       </p>
 
@@ -168,7 +395,7 @@ export default function BatchResultSubmission({
       {submitSuccess && (
         <div className="flex items-center gap-2 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-300">
           <Check className="h-4 w-4 shrink-0" />
-          Results submitted successfully.
+          All results submitted successfully.
         </div>
       )}
 
@@ -179,12 +406,41 @@ export default function BatchResultSubmission({
         </div>
       )}
 
-      {preview && preview.length > 0 && (
+      {rows && rows.length > 0 && (
         <div className="space-y-3">
-          <div className="flex items-center gap-4 text-sm">
+          {/* Progress header */}
+          {(confirmedCount > 0 || failedCount > 0) && (
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between text-xs text-slate-400">
+                <span>
+                  {confirmedCount} of {rows.length} confirmed
+                  {hasFailed && (
+                    <span className="text-rose-400">
+                      {" "}
+                      · {failedCount} failed
+                    </span>
+                  )}
+                </span>
+                <span>{totalProgress}%</span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+                <div
+                  className="h-full rounded-full bg-emerald-400/70 transition-all"
+                  style={{ width: `${totalProgress}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-4 text-sm">
             <span className="text-emerald-400">✓ {validCount} valid</span>
             {errorCount > 0 && (
               <span className="text-rose-400">✗ {errorCount} errors</span>
+            )}
+            {!isSubmitting && confirmedCount === 0 && (
+              <span className="text-slate-400">
+                ⏳ {rows.length - (confirmedCount + failedCount)} pending
+              </span>
             )}
           </div>
 
@@ -194,46 +450,119 @@ export default function BatchResultSubmission({
                 <tr className="text-left text-xs uppercase tracking-[0.15em] text-slate-500">
                   <th className="px-4 py-2">Match ID</th>
                   <th className="px-4 py-2">Outcome</th>
+                  <th className="px-4 py-2">Source</th>
                   <th className="px-4 py-2">Status</th>
+                  <th className="px-4 py-2 text-right">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {preview.map((row, idx) => (
-                  <tr
-                    key={idx}
-                    className={`border-b border-white/5 ${
-                      row.error ? "bg-rose-500/5" : ""
-                    }`}
-                  >
-                    <td className="px-4 py-2 font-mono text-xs text-white">
-                      {row.matchId || (
-                        <span className="text-slate-500">—</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2 text-slate-300">
-                      {row.outcome ?? (
-                        <span className="text-slate-500">—</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2">
-                      {row.error ? (
+                {rows.map((row) => {
+                  const status: ItemStatus = statusById[row.id] ?? "pending";
+                  const isEditing = editingId === row.id;
+                  const statusInfo = STATUS_CONTENT[status];
+                  return (
+                    <tr
+                      key={row.id}
+                      className={`border-b border-white/5 ${
+                        row.error ? "bg-rose-500/5" : ""
+                      }`}
+                    >
+                      <td className="px-4 py-2 font-mono text-xs text-white">
+                        {row.matchId || (
+                          <span className="text-slate-500">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2 text-slate-300">
+                        {isEditing ? (
+                          <div className="flex flex-wrap gap-1.5">
+                            {OUTCOME_OPTIONS.map((opt) => (
+                              <button
+                                key={opt}
+                                type="button"
+                                onClick={() => handleUpdateOutcome(row.id, opt)}
+                                className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition ${
+                                  row.outcome === opt
+                                    ? "border-amber-400 bg-amber-400/10 text-amber-300"
+                                    : "border-white/10 bg-white/5 text-slate-300 hover:border-white/20"
+                                }`}
+                              >
+                                {opt}
+                              </button>
+                            ))}
+                          </div>
+                        ) : (
+                          row.outcome ?? (
+                            <span className="text-slate-500">—</span>
+                          )
+                        )}
+                      </td>
+                      <td className="px-4 py-2 text-xs text-slate-400">
+                        {row.source || <span className="text-slate-600">—</span>}
+                      </td>
+                      <td className="px-4 py-2">
                         <span
-                          className="text-xs text-rose-400"
-                          title={row.error}
+                          className={`inline-flex items-center gap-1 text-xs ${statusInfo.className}`}
+                          title={errorsById[row.id]}
                         >
-                          ✗ Error
+                          {status === "submitting" && (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          )}
+                          {status === "confirmed" && (
+                            <Check className="h-3 w-3" />
+                          )}
+                          {status === "failed" && (
+                            <AlertCircle className="h-3 w-3" />
+                          )}
+                          {row.error && status === "pending"
+                            ? "Error"
+                            : statusInfo.label}
                         </span>
-                      ) : (
-                        <span className="text-xs text-emerald-400">✓ OK</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td className="px-4 py-2">
+                        <div className="flex items-center justify-end gap-1">
+                          {!row.error && status !== "submitting" && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setEditingId(isEditing ? null : row.id)
+                              }
+                              className="rounded p-1 text-slate-500 transition hover:bg-white/5 hover:text-white"
+                              aria-label={`Edit outcome for ${row.matchId || row.id}`}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                          )}
+                          {status !== "submitting" && (
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveRow(row.id)}
+                              disabled={isSubmitting}
+                              className="rounded p-1 text-slate-500 transition hover:bg-rose-500/10 hover:text-rose-400 disabled:opacity-40"
+                              aria-label={`Remove ${row.matchId || row.id}`}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
 
-          <div className="flex justify-end">
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            {hasFailed && !isSubmitting && (
+              <Button
+                type="button"
+                onClick={handleRetryFailed}
+                className="rounded-full border border-rose-400/30 bg-rose-500/10 px-6 text-sm text-rose-300 hover:bg-rose-500/20"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Retry {failedCount} Failed
+              </Button>
+            )}
             <Button
               type="button"
               onClick={handleSubmitAll}
@@ -247,11 +576,27 @@ export default function BatchResultSubmission({
               )}
               {isSubmitting
                 ? "Submitting…"
-                : `Submit ${validCount} Result${validCount !== 1 ? "s" : ""}`}
+                : `Submit ${validCount - confirmedCount} Result${validCount - confirmedCount !== 1 ? "s" : ""}`}
             </Button>
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title={`Submit ${pendingSubmit?.length ?? 0} results?`}
+        description={`This batch contains ${pendingSubmit?.length ?? 0} results. Review the table above before confirming — partial failures can be retried individually afterwards.`}
+        confirmLabel="Submit batch"
+        cancelLabel="Review"
+        variant="default"
+        onConfirm={() => {
+          if (pendingSubmit) void doSubmit(pendingSubmit);
+        }}
+        onCancel={() => {
+          setConfirmOpen(false);
+          setPendingSubmit(null);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description

Implements **Oracle Batch Result Submission Preview and Progress** (#1526).

### Changes

**Pre-submit review step**
- Each parsed row shows match ID, outcome, source (optional third CSV column), and status
- Inline outcome editing (click pencil icon → choose TEAM_A/TEAM_B/DRAW)
- Row removal (trash icon) — post-removal counts update immediately

**Per-item progress states**
- pending → submitting (spinner) → confirmed (check) | failed (alert)
- Overall progress bar with confirmed/failed counts
- `onSubmitBatch` now returns `BatchResultOutcome[]` for per-item status reporting

**Continue-on-error**
- Failed items don't abort the batch — they are marked in red with the error message
- "Retry N Failed" button submits only the failed items, leaving confirmed ones untouched
- Whole-batch network errors set all items to "failed" for retry

**Double-submit protection**
- Submit button is disabled during submission
- Large batches (≥5 items) show a confirmation dialog before proceeding

### Tests
8 new tests covering:
- CSV upload → preview table with valid/error counts
- Source column from optional third field
- Mixed success/failure → per-item confirmed/failed states
- Retry submits only failed items
- Button disabled while in-flight
- Outcome editing (inline toggle)
- Row removal
- Confirm dialog for large batches
- Progress bar after partial success

---

Resolves #1526