### PR TITLE
fix(open-market): exclude withdrawer from early-exit fee redistribution

### DIFF
--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -1680,9 +1680,23 @@ pub fn withdraw_position(
     bump_market(env, market_id);
 
     // ── Distribute fee to remaining participants pro-rata ────────────────────
-    // Fee is conserved: distributed = deducted
-    if fee_amount > 0 && market.total_pool > 0 {
-        distribute_early_exit_fee_to_participants(env, market_id, fee_amount, market.total_pool)?;
+    // Fee is conserved: distributed = deducted. The withdrawing predictor's own
+    // (already-reduced) stake must be excluded from both the recipient set and
+    // the pro-rata denominator — otherwise a partial withdrawal would credit
+    // part of the fee straight back to the payer, inflating their tracked
+    // stake_amount above their true remaining balance.
+    let pool_excluding_withdrawer = market
+        .total_pool
+        .checked_sub(if is_full_exit { 0 } else { remaining_stake })
+        .ok_or(InsightArenaError::Overflow)?;
+    if fee_amount > 0 && pool_excluding_withdrawer > 0 {
+        distribute_early_exit_fee_to_participants(
+            env,
+            market_id,
+            &predictor,
+            fee_amount,
+            pool_excluding_withdrawer,
+        )?;
     }
 
     // ── Release refund to predictor via escrow ───────────────────────────────
@@ -1701,11 +1715,16 @@ pub fn withdraw_position(
 
 /// Distribute early-exit fee to remaining participants pro-rata by stake.
 ///
-/// For each remaining predictor in the market, award fee_share = fee * (their_stake / total_remaining_pool).
-/// This is done by iterating through all predictors and accumulating their shares.
+/// For each remaining predictor in the market *other than the one who just
+/// withdrew*, award fee_share = fee * (their_stake / total_remaining_pool).
+/// This is done by iterating through all predictors and accumulating their
+/// shares. `withdrawing_predictor` is always skipped: they are the one paying
+/// the fee, so `total_remaining_pool` must already exclude their stake (see
+/// caller) or the fee would be partially refunded to the payer.
 fn distribute_early_exit_fee_to_participants(
     env: &Env,
     market_id: u64,
+    withdrawing_predictor: &Address,
     total_fee: i128,
     total_remaining_pool: i128,
 ) -> Result<(), InsightArenaError> {
@@ -1724,6 +1743,10 @@ fn distribute_early_exit_fee_to_participants(
 
     while index < predictors.len() {
         if let Some(addr) = predictors.get(index) {
+            if &addr == withdrawing_predictor {
+                index += 1;
+                continue;
+            }
             let pred_key = DataKey::Prediction(market_id, addr.clone());
             if let Some(pred) = env.storage().persistent().get::<DataKey, Prediction>(&pred_key) {
                 // Calculate this participant's share of the fee

--- a/contracts/open-market/tests/cancel_refund_tests.rs
+++ b/contracts/open-market/tests/cancel_refund_tests.rs
@@ -476,6 +476,139 @@ fn bonus_resolve_after_cancel_is_rejected() {
     ));
 }
 
+// ── Partial withdrawal + cancel refund accounting (issue #1511) ───────────────
+
+/// A predictor who partially withdraws before cancellation must be refunded
+/// only the remaining stake (original stake minus the amount already
+/// withdrawn), never the original stake amount.
+#[test]
+fn partial_withdrawal_then_cancel_refunds_only_remainder() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 100_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    // Predictor withdraws 40% of their stake before the market locks.
+    let withdrawal_amount = 40_000_000_i128;
+    let (withdrawn_refund, fee) =
+        client.withdraw_position(&predictor, &market_id, &withdrawal_amount);
+    let remaining_stake = stake - withdrawal_amount;
+
+    // Sanity: the early-exit refund plus fee reconstitutes the withdrawal.
+    assert_eq!(withdrawn_refund + fee, withdrawal_amount);
+
+    // Confirm the predictor's on-chain position now reflects the remainder.
+    let pred = client.get_prediction(&market_id, &predictor);
+    assert_eq!(pred.stake_amount, remaining_stake);
+
+    client.cancel_market(&admin, &market_id);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    let balance_before_claim = token.balance(&predictor);
+
+    let refunded = client.claim_cancel_refund(&predictor, &market_id);
+
+    // Refund must equal the remaining stake, never the original stake.
+    assert_eq!(
+        refunded, remaining_stake,
+        "cancel refund must equal original stake minus already-withdrawn amount"
+    );
+    assert_ne!(
+        refunded, stake,
+        "cancel refund must not equal the original (pre-withdrawal) stake"
+    );
+    assert_eq!(token.balance(&predictor), balance_before_claim + remaining_stake);
+}
+
+/// After a partial-withdrawal-then-cancel refund, a second claim is rejected
+/// and does not pay out again.
+#[test]
+fn partial_withdrawal_then_cancel_double_claim_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 60_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    let withdrawal_amount = 20_000_000_i128;
+    client.withdraw_position(&predictor, &market_id, &withdrawal_amount);
+    let remaining_stake = stake - withdrawal_amount;
+
+    client.cancel_market(&admin, &market_id);
+
+    let refunded = client.claim_cancel_refund(&predictor, &market_id);
+    assert_eq!(refunded, remaining_stake);
+
+    let token = TokenClient::new(&env, &xlm_token);
+    let balance_after_first_claim = token.balance(&predictor);
+
+    let result = client.try_claim_cancel_refund(&predictor, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::RefundAlreadyClaimed))
+    ));
+
+    // No extra funds moved on the rejected second claim.
+    assert_eq!(token.balance(&predictor), balance_after_first_claim);
+}
+
+/// Escrow invariant with a mix of partial withdrawals and full stakes: the
+/// contract balance never goes negative and every refund claim succeeds
+/// without over- or under-paying.
+#[test]
+fn partial_withdrawal_then_cancel_escrow_invariant_holds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let market_id = client.create_market(&creator, &default_params(&env));
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let predictor_a = Address::generate(&env);
+    let predictor_b = Address::generate(&env);
+    let stake_a = 80_000_000_i128;
+    let stake_b = 50_000_000_i128;
+
+    fund(&env, &xlm_token, &predictor_a, stake_a);
+    fund(&env, &xlm_token, &predictor_b, stake_b);
+    client.submit_prediction(&predictor_a, &market_id, &symbol_short!("yes"), &stake_a);
+    client.submit_prediction(&predictor_b, &market_id, &symbol_short!("no"), &stake_b);
+
+    // A partially withdraws; B never withdraws.
+    let withdrawal_amount = 30_000_000_i128;
+    client.withdraw_position(&predictor_a, &market_id, &withdrawal_amount);
+    let remaining_a = stake_a - withdrawal_amount;
+
+    // B may have received a pro-rata early-exit fee credit; read the live stake.
+    let pred_b = client.get_prediction(&market_id, &predictor_b);
+    let remaining_b = pred_b.stake_amount;
+
+    client.cancel_market(&admin, &market_id);
+
+    // Escrow must never go negative through either claim.
+    let refund_a = client.claim_cancel_refund(&predictor_a, &market_id);
+    assert_eq!(refund_a, remaining_a);
+    assert!(token.balance(&client.address) >= 0);
+
+    let refund_b = client.claim_cancel_refund(&predictor_b, &market_id);
+    assert_eq!(refund_b, remaining_b);
+    assert!(token.balance(&client.address) >= 0);
+}
+
 /// `claim_payout` on a cancelled market fails with `MarketNotResolved`, not a
 /// panic — the resolved-payout path is correctly gated.
 #[test]


### PR DESCRIPTION
## Summary
- `withdraw_position` redistributed the early-exit fee to every address in `PredictorList`, which still includes the withdrawing predictor on a partial exit — crediting part of their own fee back into their `stake_amount`
- Since `claim_cancel_refund` trusts `stake_amount` as the refund amount, this inflated the payout on a partial-withdrawal-then-cancel flow above "original stake minus already withdrawn"
- Fix excludes the withdrawing predictor from both the fee recipient set and the pro-rata denominator in `distribute_early_exit_fee_to_participants`

## Test plan
- [x] Added regression tests in `cancel_refund_tests.rs`: correct remainder refund after partial withdrawal + cancel, double-claim rejection, multi-participant escrow solvency invariant
- [x] `cargo test` — full workspace green, 0 failures
- [x] `cargo clippy --lib --tests` — no new warnings

Closes #1511