### PR TITLE
feat: add per-row validation and inline editing to BulkMatchUpload (Closes #1519)

### DIFF
--- a/frontend/src/app/(authenticated)/creator-events/[id]/matches/page.tsx
+++ b/frontend/src/app/(authenticated)/creator-events/[id]/matches/page.tsx
@@ -372,6 +372,10 @@ export default function MatchManagementPage() {
               currentMatchCount={matches.length}
               maxMatches={MAX_MATCHES}
               onImport={handleBulkImport}
+              existingMatches={matches.map((m) => ({
+                teamA: m.teamA,
+                teamB: m.teamB,
+              }))}
             />
           </section>
         )}

--- a/frontend/src/component/creator-events/BulkMatchUpload.test.tsx
+++ b/frontend/src/component/creator-events/BulkMatchUpload.test.tsx
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import BulkMatchUpload, { parseCSV } from "./BulkMatchUpload";
+
+const futureTime = () => new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+const pastTime = () => new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+
+describe("parseCSV", () => {
+  it("parses valid rows without errors", () => {
+    const csv = `Green Lions,Blue Sharks,${futureTime()}`;
+    const rows = parseCSV(csv, []);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].errors).toEqual([]);
+    expect(rows[0]).toMatchObject({ teamA: "Green Lions", teamB: "Blue Sharks" });
+  });
+
+  it("flags missing team names", () => {
+    const rows = parseCSV(`,Blue Sharks,${futureTime()}`, []);
+
+    expect(rows[0].errors).toContain("Team A is required.");
+  });
+
+  it("flags empty match time", () => {
+    const rows = parseCSV("Green Lions,Blue Sharks,", []);
+
+    expect(rows[0].errors).toContain("Match time is required.");
+  });
+
+  it("flags invalid ISO 8601 dates", () => {
+    const rows = parseCSV("Green Lions,Blue Sharks,not-a-date", []);
+
+    expect(rows[0].errors).toContain("Invalid ISO 8601 date.");
+  });
+
+  it("flags match times in the past", () => {
+    const rows = parseCSV(`Green Lions,Blue Sharks,${pastTime()}`, []);
+
+    expect(rows[0].errors).toContain("Match time must be in the future.");
+  });
+
+  it("flags identical team names", () => {
+    const rows = parseCSV(`Same Team,Same Team,${futureTime()}`, []);
+
+    expect(rows[0].errors).toContain("Team names must be different.");
+  });
+
+  it("flags rows that duplicate existing matches", () => {
+    const existing = [{ teamA: "Green Lions", teamB: "Blue Sharks" }];
+    const rows = parseCSV(`Green Lions,Blue Sharks,${futureTime()}`, existing);
+
+    expect(rows[0].errors).toContain(
+      'Duplicate match: "Green Lions" vs "Blue Sharks" already exists.',
+    );
+  });
+
+  it("flags duplicate rows within the same file", () => {
+    const csv = `Red Hawks,White Wolves,${futureTime()}\nRed Hawks,White Wolves,${futureTime()}`;
+    const rows = parseCSV(csv, []);
+
+    expect(rows[1].errors).toContain('Duplicate: row 1 already has "Red Hawks" vs "White Wolves".');
+  });
+
+  it("enforces the max team name length", () => {
+    const longTeam = "A".repeat(101);
+    const rows = parseCSV(`${longTeam},Blue Sharks,${futureTime()}`, []);
+
+    expect(rows[0].errors.some((e) => e.includes("Team A must be at most 100"))).toBe(true);
+  });
+
+  it("yields per-row errors for a mixed valid/invalid file", () => {
+    const csv = [
+      `Green Lions,Blue Sharks,${futureTime()}`, // valid
+      `,Blue Sharks,${futureTime()}`,            // missing team A
+      `Red Hawks,red hawks,${futureTime()}`,     // identical team names
+    ].join("\n");
+
+    const rows = parseCSV(csv, []);
+
+    expect(rows[0].errors).toEqual([]);
+    expect(rows[1].errors).toContain("Team A is required.");
+    expect(rows[2].errors).toContain("Team names must be different.");
+  });
+});
+
+describe("BulkMatchUpload", () => {
+  const onImport = vi.fn().mockResolvedValue(undefined);
+
+  function uploadFile(container: HTMLElement, content: string) {
+    const file = new File([content], "matches.csv", { type: "text/csv" });
+    const input = container.querySelector('input[type="file"]');
+    if (!input) throw new Error("File input not found");
+    fireEvent.change(input, { target: { files: [file] } });
+  }
+
+  it("renders the file upload prompt", () => {
+    render(<BulkMatchUpload currentMatchCount={0} onImport={onImport} />);
+
+    expect(screen.getByText("Bulk Add Matches")).toBeInTheDocument();
+    expect(screen.getByText("Click to upload CSV")).toBeInTheDocument();
+  });
+
+  it("shows valid and error counts after uploading a mixed file", async () => {
+    const { container } = render(<BulkMatchUpload currentMatchCount={0} onImport={onImport} />);
+
+    const csv = [
+      `Green Lions,Blue Sharks,${futureTime()}`,
+      `,Blue Sharks,${futureTime()}`,
+    ].join("\n");
+    uploadFile(container, csv);
+
+    await waitFor(() => expect(screen.getByText(/1 valid/)).toBeInTheDocument());
+    expect(screen.getByText(/1 error/)).toBeInTheDocument();
+  });
+
+  it("shows per-row error messages in the table", async () => {
+    const { container } = render(<BulkMatchUpload currentMatchCount={0} onImport={onImport} />);
+
+    uploadFile(container, `,Blue Sharks,${futureTime()}`);
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/Team A is required/).length).toBeGreaterThan(0),
+    );
+  });
+
+  it("provides an edit action for invalid rows and allows fixing them", async () => {
+    const { container } = render(<BulkMatchUpload currentMatchCount={0} onImport={onImport} />);
+
+    const csv = [
+      `Green Lions,Blue Sharks,${futureTime()}`,
+      `,Blue Sharks,${futureTime()}`,
+    ].join("\n");
+    uploadFile(container, csv);
+
+    await waitFor(() => expect(screen.getAllByRole("button").length).toBeGreaterThan(0));
+
+    // Find the edit button (pencil icon) — it only renders for invalid rows
+    const editButtons = await screen.findAllByTitle("Edit row");
+    expect(editButtons).toHaveLength(1);
+    fireEvent.click(editButtons[0]);
+
+    // The row enters editing mode with input fields
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+
+    // Fix team A
+    fireEvent.change(inputs[0], { target: { value: "Fixed Lions" } });
+
+    // Save
+    fireEvent.click(screen.getByTitle("Save"));
+
+    // Error should disappear, valid count becomes 2
+    await waitFor(() => expect(screen.getByText(/2 valid/)).toBeInTheDocument());
+    expect(screen.queryByText("Team A is required.")).not.toBeInTheDocument();
+  });
+
+  it("imports only valid rows when a mixed file is submitted", async () => {
+    const { container } = render(<BulkMatchUpload currentMatchCount={0} onImport={onImport} />);
+
+    const csv = [
+      `Green Lions,Blue Sharks,${futureTime()}`,
+      `,Blue Sharks,${futureTime()}`,
+    ].join("\n");
+    uploadFile(container, csv);
+
+    await waitFor(() => expect(screen.getByText(/1 valid/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText(/^Import 1 Match/));
+
+    await waitFor(() =>
+      expect(onImport).toHaveBeenCalledWith([
+        { teamA: "Green Lions", teamB: "Blue Sharks", matchTime: expect.any(String) },
+      ]),
+    );
+  });
+
+  it("disables the import button when there are no valid rows", async () => {
+    const { container } = render(<BulkMatchUpload currentMatchCount={0} onImport={onImport} />);
+
+    uploadFile(container, `,Blue Sharks,${futureTime()}`);
+
+    await waitFor(() => expect(screen.getByText(/0 valid/)).toBeInTheDocument());
+
+    const importButton = screen.getByText(/^Import 0 Matches/);
+    expect(importButton).toBeDisabled();
+  });
+});

--- a/frontend/src/component/creator-events/BulkMatchUpload.tsx
+++ b/frontend/src/component/creator-events/BulkMatchUpload.tsx
@@ -1,52 +1,126 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { Upload, X, Check, AlertCircle, Loader2 } from "lucide-react";
+import { useState, useRef, useCallback, useMemo } from "react";
+import { Upload, X, Check, AlertCircle, Loader2, Pencil, Save } from "lucide-react";
 import { Button } from "@/component/ui/button";
+import { validators } from "@/lib/validators";
 import type { MatchFormData } from "./AddMatchForm";
 
 interface ParsedRow {
   teamA: string;
   teamB: string;
   matchTime: string;
-  error?: string;
+  errors: string[];
+}
+
+interface ExistingMatch {
+  teamA: string;
+  teamB: string;
 }
 
 interface BulkMatchUploadProps {
   currentMatchCount: number;
   maxMatches?: number;
   onImport: (matches: MatchFormData[]) => Promise<void>;
+  existingMatches?: ExistingMatch[];
 }
 
-function parseCSV(raw: string): ParsedRow[] {
+const MAX_TEAM_NAME = 100;
+
+// Shared validators for bulk match rows
+const validateTeamA = validators.compose(
+  validators.required("Team A"),
+  validators.maxLength(MAX_TEAM_NAME, "Team A"),
+);
+
+const validateTeamB = validators.compose(
+  validators.required("Team B"),
+  validators.maxLength(MAX_TEAM_NAME, "Team B"),
+);
+
+function validateMatchTimeRaw(value: string): string | undefined {
+  if (!value) return "Match time is required.";
+  const dt = new Date(value);
+  if (isNaN(dt.getTime())) return "Invalid ISO 8601 date.";
+  if (dt <= new Date()) return "Match time must be in the future.";
+  return undefined;
+}
+
+function validateDuplicate(
+  teamA: string,
+  teamB: string,
+  existing: ExistingMatch[],
+  currentIndex: number,
+  allRows: ParsedRow[],
+): string | undefined {
+  // Check against existing matches in the event
+  const lowerA = teamA.toLowerCase().trim();
+  const lowerB = teamB.toLowerCase().trim();
+  for (const match of existing) {
+    if (
+      match.teamA.toLowerCase() === lowerA &&
+      match.teamB.toLowerCase() === lowerB
+    ) {
+      return `Duplicate match: "${teamA}" vs "${teamB}" already exists.`;
+    }
+  }
+  // Check against other rows in the same CSV
+  for (let i = 0; i < allRows.length; i++) {
+    if (i === currentIndex) continue;
+    if (
+      allRows[i].teamA.toLowerCase().trim() === lowerA &&
+      allRows[i].teamB.toLowerCase().trim() === lowerB
+    ) {
+      return `Duplicate: row ${i + 1} already has "${teamA}" vs "${teamB}".`;
+    }
+  }
+  return undefined;
+}
+
+export function parseCSV(
+  raw: string,
+  existing: ExistingMatch[],
+): ParsedRow[] {
   const lines = raw
     .split("\n")
     .map((l) => l.trim())
     .filter(Boolean);
 
-  return lines.map((line, idx) => {
+  // First pass: parse all rows to build the full list for cross-row duplicate check
+  const parsed: { teamA: string; teamB: string; matchTime: string }[] = lines.map((line) => {
     const cols = line.split(",").map((c) => c.trim());
     const [teamA = "", teamB = "", matchTime = ""] = cols;
+    return { teamA, teamB, matchTime };
+  });
+
+  // Second pass: validate each row
+  return parsed.map((row, idx) => {
     const errors: string[] = [];
 
-    if (!teamA) errors.push("Team A is empty");
-    if (!teamB) errors.push("Team B is empty");
-    if (teamA && teamB && teamA.toLowerCase() === teamB.toLowerCase())
-      errors.push("Team names must be different");
-    if (!matchTime) {
-      errors.push("Match time is missing");
-    } else {
-      const dt = new Date(matchTime);
-      if (isNaN(dt.getTime())) errors.push("Invalid ISO 8601 date");
-      else if (dt <= new Date()) errors.push("Match time must be in the future");
+    const teamAErr = validateTeamA(row.teamA);
+    if (teamAErr) errors.push(teamAErr);
+
+    const teamBErr = validateTeamB(row.teamB);
+    if (teamBErr) errors.push(teamBErr);
+
+    // Cross-check teams are different
+    if (row.teamA && row.teamB && row.teamA.toLowerCase() === row.teamB.toLowerCase()) {
+      errors.push("Team names must be different.");
     }
 
-    return {
-      teamA,
-      teamB,
-      matchTime,
-      error: errors.length > 0 ? errors.join("; ") : undefined,
-    };
+    const timeErr = validateMatchTimeRaw(row.matchTime);
+    if (timeErr) errors.push(timeErr);
+
+    // Duplicate check
+    const dupErr = validateDuplicate(row.teamA, row.teamB, existing, idx, parsed.map((p) => ({
+      teamA: p.teamA,
+      teamB: p.teamB,
+      matchTime: p.matchTime,
+      errors: [],
+    })));
+    if (dupErr) errors.push(dupErr);
+
+    return { ...row, errors };
   });
 }
 
@@ -54,6 +128,7 @@ export default function BulkMatchUpload({
   currentMatchCount,
   maxMatches = 100,
   onImport,
+  existingMatches = [],
 }: BulkMatchUploadProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<ParsedRow[] | null>(null);
@@ -61,36 +136,94 @@ export default function BulkMatchUpload({
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editValues, setEditValues] = useState<{ teamA: string; teamB: string; matchTime: string } | null>(null);
 
-  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
     setFileName(file.name);
     setImportError(null);
     setImportSuccess(false);
+    setEditingIndex(null);
+    setEditValues(null);
 
     const reader = new FileReader();
     reader.onload = (ev) => {
       const text = ev.target?.result as string;
-      const rows = parseCSV(text);
+      const rows = parseCSV(text, existingMatches);
       setPreview(rows);
     };
     reader.readAsText(file);
-  }
+  }, [existingMatches]);
 
   function handleClear() {
     setPreview(null);
     setFileName(null);
     setImportError(null);
     setImportSuccess(false);
+    setEditingIndex(null);
+    setEditValues(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function startEdit(row: ParsedRow, idx: number) {
+    setEditingIndex(idx);
+    setEditValues({ teamA: row.teamA, teamB: row.teamB, matchTime: row.matchTime });
+  }
+
+  function cancelEdit() {
+    setEditingIndex(null);
+    setEditValues(null);
+  }
+
+  function confirmEdit() {
+    if (editingIndex === null || !editValues || !preview) return;
+
+    const updated = [...preview];
+    updated[editingIndex] = {
+      teamA: editValues.teamA,
+      teamB: editValues.teamB,
+      matchTime: editValues.matchTime,
+      errors: [], // will be re-validated
+    };
+
+    // Re-validate the entire list after edit
+    const revalidated = updated.map((row, idx) => {
+      const errors: string[] = [];
+
+      const teamAErr = validateTeamA(row.teamA);
+      if (teamAErr) errors.push(teamAErr);
+
+      const teamBErr = validateTeamB(row.teamB);
+      if (teamBErr) errors.push(teamBErr);
+
+      if (row.teamA && row.teamB && row.teamA.toLowerCase() === row.teamB.toLowerCase()) {
+        errors.push("Team names must be different.");
+      }
+
+      const timeErr = validateMatchTimeRaw(row.matchTime);
+      if (timeErr) errors.push(timeErr);
+
+      const dupErr = validateDuplicate(
+        row.teamA, row.teamB, existingMatches, idx,
+        updated.map((p) => ({ teamA: p.teamA, teamB: p.teamB, matchTime: p.matchTime, errors: [] })),
+      );
+      if (dupErr) errors.push(dupErr);
+
+      return { ...row, errors };
+    });
+
+    setPreview(revalidated);
+    setEditingIndex(null);
+    setEditValues(null);
   }
 
   async function handleImportAll() {
     if (!preview) return;
 
-    const valid = preview.filter((r) => !r.error);
+    const valid = preview.filter((r) => r.errors.length === 0);
     if (valid.length === 0) {
       setImportError("No valid rows to import.");
       return;
@@ -124,8 +257,15 @@ export default function BulkMatchUpload({
     }
   }
 
-  const validCount = preview?.filter((r) => !r.error).length ?? 0;
-  const errorCount = preview?.filter((r) => r.error).length ?? 0;
+  const validCount = useMemo(
+    () => preview?.filter((r) => r.errors.length === 0).length ?? 0,
+    [preview],
+  );
+  const errorCount = useMemo(
+    () => preview?.filter((r) => r.errors.length > 0).length ?? 0,
+    [preview],
+  );
+  const hasErrors = errorCount > 0;
 
   return (
     <div className="space-y-4 rounded-3xl border border-white/10 bg-slate-900/80 p-6">
@@ -189,21 +329,31 @@ export default function BulkMatchUpload({
 
       {preview && preview.length > 0 && (
         <div className="space-y-3">
+          {hasErrors && (
+            <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-300">
+              <AlertCircle className="mr-2 inline-block h-4 w-4" />
+              {errorCount} row{errorCount !== 1 ? "s" : ""} ha{errorCount === 1 ? "s" : "ve"} errors.
+              Fix the errors or submit only the valid rows.
+            </div>
+          )}
+
           <div className="flex items-center gap-4 text-sm">
             <span className="text-emerald-400">✓ {validCount} valid</span>
-            {errorCount > 0 && (
-              <span className="text-rose-400">✗ {errorCount} errors</span>
+            {hasErrors && (
+              <span className="text-rose-400">✗ {errorCount} error{errorCount !== 1 ? "s" : ""}</span>
             )}
           </div>
 
-          <div className="max-h-60 overflow-y-auto rounded-2xl border border-white/10 bg-slate-950/80">
+          <div className="max-h-80 overflow-y-auto rounded-2xl border border-white/10 bg-slate-950/80">
             <table className="w-full text-sm">
-              <thead className="sticky top-0 border-b border-white/10 bg-slate-950">
+              <thead className="sticky top-0 z-10 border-b border-white/10 bg-slate-950">
                 <tr className="text-left text-xs uppercase tracking-[0.15em] text-slate-500">
+                  <th className="px-4 py-2">#</th>
                   <th className="px-4 py-2">Team A</th>
                   <th className="px-4 py-2">Team B</th>
                   <th className="px-4 py-2">Match Time</th>
                   <th className="px-4 py-2">Status</th>
+                  <th className="px-4 py-2">Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -211,34 +361,135 @@ export default function BulkMatchUpload({
                   <tr
                     key={idx}
                     className={`border-b border-white/5 ${
-                      row.error ? "bg-rose-500/5" : ""
+                      row.errors.length > 0 ? "bg-rose-500/5" : ""
                     }`}
                   >
-                    <td className="px-4 py-2 text-white">
-                      {row.teamA || <span className="text-slate-500">—</span>}
-                    </td>
-                    <td className="px-4 py-2 text-white">
-                      {row.teamB || <span className="text-slate-500">—</span>}
-                    </td>
-                    <td className="px-4 py-2 font-mono text-xs text-slate-300">
-                      {row.matchTime || <span className="text-slate-500">—</span>}
-                    </td>
-                    <td className="px-4 py-2">
-                      {row.error ? (
-                        <span className="text-xs text-rose-400" title={row.error}>
-                          ✗ Error
-                        </span>
-                      ) : (
-                        <span className="text-xs text-emerald-400">✓ OK</span>
-                      )}
-                    </td>
+                    {editingIndex === idx && editValues ? (
+                      <>
+                        <td className="px-4 py-2 text-xs text-slate-500">{idx + 1}</td>
+                        <td className="px-4 py-2">
+                          <input
+                            type="text"
+                            value={editValues.teamA}
+                            onChange={(e) =>
+                              setEditValues((prev) => prev ? { ...prev, teamA: e.target.value } : null)
+                            }
+                            maxLength={MAX_TEAM_NAME}
+                            className="w-full rounded-lg border border-white/20 bg-slate-900/90 px-2 py-1 text-xs text-white outline-none focus:border-amber-400"
+                          />
+                        </td>
+                        <td className="px-4 py-2">
+                          <input
+                            type="text"
+                            value={editValues.teamB}
+                            onChange={(e) =>
+                              setEditValues((prev) => prev ? { ...prev, teamB: e.target.value } : null)
+                            }
+                            maxLength={MAX_TEAM_NAME}
+                            className="w-full rounded-lg border border-white/20 bg-slate-900/90 px-2 py-1 text-xs text-white outline-none focus:border-amber-400"
+                          />
+                        </td>
+                        <td className="px-4 py-2">
+                          <input
+                            type="text"
+                            value={editValues.matchTime}
+                            onChange={(e) =>
+                              setEditValues((prev) => prev ? { ...prev, matchTime: e.target.value } : null)
+                            }
+                            placeholder="2026-01-01T12:00:00Z"
+                            className="w-full rounded-lg border border-white/20 bg-slate-900/90 px-2 py-1 font-mono text-xs text-white outline-none focus:border-amber-400"
+                          />
+                        </td>
+                        <td className="px-4 py-2">
+                          <span className="text-xs text-amber-400">Editing</span>
+                        </td>
+                        <td className="px-4 py-2">
+                          <div className="flex items-center gap-1">
+                            <button
+                              type="button"
+                              onClick={confirmEdit}
+                              className="rounded p-1 text-emerald-400 hover:bg-emerald-500/10"
+                              title="Save"
+                            >
+                              <Save className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={cancelEdit}
+                              className="rounded p-1 text-slate-400 hover:bg-white/10"
+                              title="Cancel"
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
+                        </td>
+                      </>
+                    ) : (
+                      <>
+                        <td className="px-4 py-2 text-xs text-slate-500">{idx + 1}</td>
+                        <td className="px-4 py-2 text-white">
+                          {row.teamA || <span className="text-slate-500">—</span>}
+                        </td>
+                        <td className="px-4 py-2 text-white">
+                          {row.teamB || <span className="text-slate-500">—</span>}
+                        </td>
+                        <td className="px-4 py-2 font-mono text-xs text-slate-300">
+                          {row.matchTime || <span className="text-slate-500">—</span>}
+                        </td>
+                        <td className="px-4 py-2">
+                          <div className="flex flex-col gap-0.5">
+                            {row.errors.length > 0 ? (
+                              row.errors.map((err, i) => (
+                                <span
+                                  key={i}
+                                  className="block max-w-[200px] truncate text-xs text-rose-400"
+                                  title={err}
+                                >
+                                  ✗ {err}
+                                </span>
+                              ))
+                            ) : (
+                              <span className="text-xs text-emerald-400">✓ OK</span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-2">
+                          {row.errors.length > 0 && (
+                            <button
+                              type="button"
+                              onClick={() => startEdit(row, idx)}
+                              className="rounded p-1 text-slate-400 hover:bg-white/10 hover:text-white"
+                              title="Edit row"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                          )}
+                        </td>
+                      </>
+                    )}
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
 
-          <div className="flex justify-end">
+          <div className="flex items-center justify-end gap-3">
+            {hasErrors && validCount > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleImportAll}
+                disabled={isImporting}
+                className="rounded-full border border-white/20 px-5 text-sm text-white hover:bg-white/10"
+              >
+                {isImporting ? (
+                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                ) : (
+                  <Check className="mr-1.5 h-4 w-4" />
+                )}
+                Submit {validCount} Valid Row{validCount !== 1 ? "s" : ""} Only
+              </Button>
+            )}
             <Button
               type="button"
               onClick={handleImportAll}


### PR DESCRIPTION
## Summary

Implements per-row client-side validation for bulk CSV match uploads, with inline editing for failed rows and the ability to submit only the valid rows.

Closes #1519

## Changes

### `BulkMatchUpload.tsx`
- **Reuses shared validators** from `lib/validators.ts` (`required`, `maxLength`, `compose`) instead of inline ad-hoc checks.
- **Per-row validation**: each row is checked for:
  - Team A / Team B present (with 100-char max length)
  - Valid ISO 8601 match time in the future
  - Team names must be different
  - **Duplicate detection**: against existing matches in the event (via new `existingMatches` prop) AND against other rows in the same file
- **Per-row error messages**: error text is now visible inline in the status column (previously hidden behind a `title` tooltip).
- **Inline editing**: invalid rows get an edit (pencil) action that switches the row to editable inputs; saving re-validates the whole file (duplicates are re-checked against the edited values).
- **"Submit Valid Rows Only"** secondary button appears when a file has a mix of valid and invalid rows — users can import valid rows immediately while fixing the rest.
- Main import button stays disabled until there is at least one valid row, and never submits rows with errors.

### `matches/page.tsx`
- Passes the existing matches (`{ teamA, teamB }[]`) to `BulkMatchUpload` so duplicate detection works against matches already in the event.

### `BulkMatchUpload.test.tsx` (new)
10 unit tests for `parseCSV` + 6 component tests covering:
- Mixed valid/invalid files yield correct per-row errors
- Error messages rendered for each failing row
- Inline edit → fix → re-validate flow (2 valid after save)
- Import only submits valid rows
- Import button disabled when no valid rows

## Test results

```
Test Files  5 passed (5)
Tests     31 passed (31)
```