### PR TITLE
feat: sync favorites across devices with server persistence (Closes #1524)

### DIFF
--- a/frontend/src/context/FavoritesContext.test.tsx
+++ b/frontend/src/context/FavoritesContext.test.tsx
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useFavorites, FavoritesProvider, mergeFavorites } from "./FavoritesContext";
+import { useWallet } from "./WalletContext";
+
+// --- Unit tests for mergeFavorites ---
+
+describe("mergeFavorites", () => {
+  it("returns the union of two sets", () => {
+    const local = new Set(["a", "b"]);
+    const server = new Set(["c", "d"]);
+    expect(Array.from(mergeFavorites(local, server)).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("deduplicates overlapping IDs", () => {
+    const local = new Set(["a", "b", "c"]);
+    const server = new Set(["c", "d", "e"]);
+    expect(Array.from(mergeFavorites(local, server)).sort()).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("handles empty local set", () => {
+    const local = new Set<string>();
+    const server = new Set(["a", "b"]);
+    expect(Array.from(mergeFavorites(local, server)).sort()).toEqual(["a", "b"]);
+  });
+
+  it("handles empty server set", () => {
+    const local = new Set(["a", "b"]);
+    const server = new Set<string>();
+    expect(Array.from(mergeFavorites(local, server)).sort()).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the original sets", () => {
+    const local = new Set(["a"]);
+    const server = new Set(["b"]);
+    const merged = mergeFavorites(local, server);
+    expect(Array.from(merged)).toEqual(["a", "b"]);
+    expect(Array.from(local)).toEqual(["a"]);
+    expect(Array.from(server)).toEqual(["b"]);
+  });
+});
+
+// --- Integration tests for FavoritesProvider + useFavorites ---
+
+vi.mock("@/lib/api", () => ({
+  fetchServerFavorites: vi.fn(),
+  addServerFavorite: vi.fn(),
+  removeServerFavorite: vi.fn(),
+}));
+
+vi.mock("./WalletContext", () => ({
+  useWallet: vi.fn(),
+}));
+
+import { fetchServerFavorites, addServerFavorite, removeServerFavorite } from "@/lib/api";
+
+const mockedUseWallet = vi.mocked(useWallet);
+const mockedFetchServer = vi.mocked(fetchServerFavorites);
+const mockedAddServer = vi.mocked(addServerFavorite);
+const mockedRemoveServer = vi.mocked(removeServerFavorite);
+
+function mockWallet(overrides: Partial<ReturnType<typeof useWallet>> = {}) {
+  mockedUseWallet.mockReturnValue({
+    address: null,
+    isAuthenticated: false,
+    isFreighterInstalled: false,
+    isAuthenticating: false,
+    isRestoring: false,
+    user: null,
+    token: null,
+    authError: null,
+    openConnectModal: vi.fn(),
+    closeConnectModal: vi.fn(),
+    isConnectModalOpen: false,
+    authenticate: vi.fn(),
+    logout: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useWallet>);
+}
+
+function renderFavoritesHook() {
+  return renderHook(() => useFavorites(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <FavoritesProvider>{children}</FavoritesProvider>
+    ),
+  });
+}
+
+describe("useFavorites — unauthenticated (guest)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockWallet({ address: null, isAuthenticated: false });
+  });
+
+  it("starts with an empty set and no sync error", async () => {
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.favoriteIds.size).toBe(0);
+    expect(result.current.syncError).toBe(false);
+    expect(mockedFetchServer).not.toHaveBeenCalled();
+  });
+
+  it("persists added favorites to localStorage", async () => {
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.addFavorite("market-1");
+    });
+
+    expect(result.current.favoriteIds.has("market-1")).toBe(true);
+    // Should NOT call the server for unauthenticated users
+    expect(mockedAddServer).not.toHaveBeenCalled();
+  });
+
+  it("removes favorites locally", async () => {
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.addFavorite("market-1");
+      result.current.removeFavorite("market-1");
+    });
+
+    expect(result.current.favoriteIds.has("market-1")).toBe(false);
+  });
+});
+
+describe("useFavorites — authenticated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockedFetchServer.mockResolvedValue(new Set());
+    mockedAddServer.mockResolvedValue(undefined);
+    mockedRemoveServer.mockResolvedValue(undefined);
+    mockWallet({
+      address: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
+      isAuthenticated: true,
+    });
+  });
+
+  it("loads server favorites on mount and merges with local", async () => {
+    // Pre-populate localStorage with a local favorite
+    localStorage.setItem(
+      "insightarena.favorites.GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
+      JSON.stringify(["local-1"]),
+    );
+    mockedFetchServer.mockResolvedValue(new Set(["server-1", "server-2"]));
+
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.favoriteIds.has("local-1")).toBe(true);
+    expect(result.current.favoriteIds.has("server-1")).toBe(true);
+    expect(result.current.favoriteIds.has("server-2")).toBe(true);
+    expect(result.current.favoriteIds.size).toBe(3);
+  });
+
+  it("calls the server when adding a favorite (optimistic)", async () => {
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.addFavorite("market-1");
+    });
+
+    // Optimistic: local state updated immediately
+    expect(result.current.favoriteIds.has("market-1")).toBe(true);
+    expect(mockedAddServer).toHaveBeenCalledWith("market-1");
+  });
+
+  it("rolls back on server failure when adding", async () => {
+    mockedAddServer.mockRejectedValue(new Error("network error"));
+
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.addFavorite("market-1");
+    });
+
+    // Optimistic update applied
+    expect(result.current.favoriteIds.has("market-1")).toBe(true);
+
+    // Wait for the catch handler to roll back
+    await waitFor(() => expect(result.current.favoriteIds.has("market-1")).toBe(false));
+    expect(result.current.syncError).toBe(true);
+  });
+
+  it("calls the server when removing a favorite (optimistic)", async () => {
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // First add
+    act(() => {
+      result.current.addFavorite("market-1");
+    });
+
+    // Then remove
+    act(() => {
+      result.current.removeFavorite("market-1");
+    });
+
+    expect(result.current.favoriteIds.has("market-1")).toBe(false);
+    expect(mockedRemoveServer).toHaveBeenCalledWith("market-1");
+  });
+
+  it("rolls back on server failure when removing", async () => {
+    mockedRemoveServer.mockRejectedValue(new Error("network error"));
+
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Add first
+    act(() => {
+      result.current.addFavorite("market-1");
+    });
+
+    // Then remove (will fail)
+    act(() => {
+      result.current.removeFavorite("market-1");
+    });
+
+    // Optimistic: removed immediately
+    expect(result.current.favoriteIds.has("market-1")).toBe(false);
+
+    // Wait for rollback (re-add)
+    await waitFor(() => expect(result.current.favoriteIds.has("market-1")).toBe(true));
+    expect(result.current.syncError).toBe(true);
+  });
+
+  it("falls back to local-only when the server is unreachable on load", async () => {
+    mockedFetchServer.mockRejectedValue(new Error("network error"));
+
+    // Pre-populate localStorage
+    localStorage.setItem(
+      "insightarena.favorites.GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
+      JSON.stringify(["local-1"]),
+    );
+
+    const { result } = renderFavoritesHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.favoriteIds.has("local-1")).toBe(true);
+    expect(result.current.syncError).toBe(true);
+  });
+});

--- a/frontend/src/context/FavoritesContext.tsx
+++ b/frontend/src/context/FavoritesContext.tsx
@@ -6,9 +6,15 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useWallet } from "./WalletContext";
+import {
+  fetchServerFavorites,
+  addServerFavorite as addServer,
+  removeServerFavorite as removeServer,
+} from "@/lib/api";
 
 export interface FavoritesContextValue {
   favoriteIds: Set<string>;
@@ -17,6 +23,8 @@ export interface FavoritesContextValue {
   addFavorite: (marketId: string) => void;
   removeFavorite: (marketId: string) => void;
   isLoading: boolean;
+  /** Whether the last sync operation failed */
+  syncError: boolean;
 }
 
 const DEFAULT_CONTEXT_VALUE: FavoritesContextValue = {
@@ -26,6 +34,7 @@ const DEFAULT_CONTEXT_VALUE: FavoritesContextValue = {
   addFavorite: () => {},
   removeFavorite: () => {},
   isLoading: false,
+  syncError: false,
 };
 
 const FavoritesContext = createContext<FavoritesContextValue>(
@@ -60,20 +69,62 @@ function writeStoredFavorites(key: string, favorites: Set<string>) {
   }
 }
 
+/**
+ * Merge two sets of favorite IDs (union, deduplicated).
+ * Exported for testing.
+ */
+export function mergeFavorites(
+  local: Set<string>,
+  server: Set<string>,
+): Set<string> {
+  const merged = new Set(local);
+  for (const id of server) {
+    merged.add(id);
+  }
+  return merged;
+}
+
 export function FavoritesProvider({ children }: { children: React.ReactNode }) {
-  const { address } = useWallet();
+  const { address, isAuthenticated } = useWallet();
   const [favoriteIds, setFavoriteIds] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(true);
+  const [syncError, setSyncError] = useState(false);
+  // Track the previous address to detect login/logout transitions
+  const prevAddressRef = useRef<string | null>(null);
 
   const storageKey = getStorageKey(address);
 
-  // Load favorites from localStorage on mount and when address changes
+  // Load favorites: on mount, on address change, and on auth state change
   useEffect(() => {
-    setIsLoading(true);
-    const stored = readStoredFavorites(storageKey);
-    setFavoriteIds(stored);
-    setIsLoading(false);
-  }, [storageKey]);
+    const load = async () => {
+      setIsLoading(true);
+      setSyncError(false);
+
+      const local = readStoredFavorites(storageKey);
+
+      if (isAuthenticated && address) {
+        try {
+          const server = await fetchServerFavorites();
+          const merged = mergeFavorites(local, server);
+          setFavoriteIds(merged);
+          // Persist the merged result back to localStorage
+          writeStoredFavorites(storageKey, merged);
+        } catch {
+          // Server unavailable — fall back to local-only
+          setFavoriteIds(local);
+          setSyncError(true);
+        }
+      } else {
+        // Guest or unauthenticated — localStorage only
+        setFavoriteIds(local);
+      }
+
+      setIsLoading(false);
+    };
+
+    load();
+    prevAddressRef.current = address;
+  }, [storageKey, isAuthenticated, address]);
 
   const isFavorite = useCallback(
     (marketId: string) => favoriteIds.has(marketId),
@@ -82,42 +133,65 @@ export function FavoritesProvider({ children }: { children: React.ReactNode }) {
 
   const addFavorite = useCallback(
     (marketId: string) => {
+      // Optimistic update
       setFavoriteIds((prev) => {
         const updated = new Set(prev);
         updated.add(marketId);
         writeStoredFavorites(storageKey, updated);
         return updated;
       });
+
+      // Persist to server (fire-and-forget with rollback on failure)
+      if (isAuthenticated) {
+        addServer(marketId).catch(() => {
+          setFavoriteIds((prev) => {
+            const rolledBack = new Set(prev);
+            rolledBack.delete(marketId);
+            writeStoredFavorites(storageKey, rolledBack);
+            return rolledBack;
+          });
+          setSyncError(true);
+        });
+      }
     },
-    [storageKey],
+    [storageKey, isAuthenticated],
   );
 
   const removeFavorite = useCallback(
     (marketId: string) => {
+      // Optimistic update
       setFavoriteIds((prev) => {
         const updated = new Set(prev);
         updated.delete(marketId);
         writeStoredFavorites(storageKey, updated);
         return updated;
       });
+
+      // Persist to server (fire-and-forget with rollback on failure)
+      if (isAuthenticated) {
+        removeServer(marketId).catch(() => {
+          setFavoriteIds((prev) => {
+            const rolledBack = new Set(prev);
+            rolledBack.add(marketId);
+            writeStoredFavorites(storageKey, rolledBack);
+            return rolledBack;
+          });
+          setSyncError(true);
+        });
+      }
     },
-    [storageKey],
+    [storageKey, isAuthenticated],
   );
 
   const toggleFavorite = useCallback(
     (marketId: string) => {
-      setFavoriteIds((prev) => {
-        const updated = new Set(prev);
-        if (updated.has(marketId)) {
-          updated.delete(marketId);
-        } else {
-          updated.add(marketId);
-        }
-        writeStoredFavorites(storageKey, updated);
-        return updated;
-      });
+      if (favoriteIds.has(marketId)) {
+        removeFavorite(marketId);
+      } else {
+        addFavorite(marketId);
+      }
     },
-    [storageKey],
+    [favoriteIds, addFavorite, removeFavorite],
   );
 
   const value = useMemo<FavoritesContextValue>(
@@ -128,6 +202,7 @@ export function FavoritesProvider({ children }: { children: React.ReactNode }) {
       addFavorite,
       removeFavorite,
       isLoading,
+      syncError,
     }),
     [
       favoriteIds,
@@ -136,6 +211,7 @@ export function FavoritesProvider({ children }: { children: React.ReactNode }) {
       addFavorite,
       removeFavorite,
       isLoading,
+      syncError,
     ],
   );
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -98,3 +98,31 @@ export const apiClient = {
   patch: <T>(path: string, body?: unknown, options?: ApiOptions) => request<T>(path, 'PATCH', { ...options, body }),
   delete: <T>(path: string, options?: ApiOptions) => request<T>(path, 'DELETE', options),
 };
+
+/**
+ * Favorites persistence helpers.
+ *
+ * Expected backend contract:
+ *  - GET    /favorites        → { "marketIds": string[] } (or string[])
+ *  - POST   /favorites        → 200/204 (body: { marketId })
+ *  - DELETE /favorites/:id    → 200/204
+ */
+export interface FavoritesResponse {
+  marketIds?: string[];
+}
+
+export async function fetchServerFavorites(
+  options?: { signal?: AbortSignal },
+): Promise<Set<string>> {
+  const data = await apiClient.get<FavoritesResponse | string[]>('/favorites', options);
+  if (Array.isArray(data)) return new Set(data);
+  return new Set(data?.marketIds ?? []);
+}
+
+export async function addServerFavorite(marketId: string): Promise<void> {
+  await apiClient.post<void>(`/favorites`, { marketId });
+}
+
+export async function removeServerFavorite(marketId: string): Promise<void> {
+  await apiClient.delete<void>(`/favorites/${encodeURIComponent(marketId)}`);
+}


### PR DESCRIPTION
## Summary

Syncs the user's watchlist/favorites across devices by persisting favorites to the backend for authenticated users, while keeping localStorage as an offline cache.

Closes #1524

## Changes

### `FavoritesContext.tsx`
- **Server sync for authenticated users**:
  - On mount / address change: fetches server favorites and merges with localStorage (union, deduplicated) via `mergeFavorites()`.
  - **Optimistic add/remove**: UI updates immediately; server call is fire-and-forget.
  - **Rollback on failure**: if the server call fails, the optimistic update is reverted (removed ID re-added, added ID re-deleted).
  - `syncError` flag exposed so UI can show a warning if server sync fails.
- **Guest/unauthenticated fallback**: localStorage-only behavior preserved exactly as before.
- **`mergeFavorites(local, server)`** exported for testing — union merge that doesn't mutate originals.

### `api.ts`
- Added `fetchServerFavorites()` — `GET /favorites` → `Set<string>`
- Added `addServerFavorite(marketId)` — `POST /favorites` with `{ marketId }`
- Added `removeServerFavorite(marketId)` — `DELETE /favorites/:marketId`
- Expected backend contract documented in JSDoc.

### `FavoritesContext.test.tsx` (new)
- 5 unit tests for `mergeFavorites` (union, dedup, empty edge cases, immutability)
- 8 integration tests covering:
  - Guest: empty start, localStorage-only add/remove, no server calls
  - Authenticated: load + merge server/local on mount
  - Optimistic add → server called; rollback on failure
  - Optimistic remove → server called; rollback on failure
  - Server unreachable on load → local-only fallback + syncError flag

## Test results

```
Test Files  5 passed (5)
Tests      29 passed (29)
```