### PR TITLE
fix(frontend): roll back predictions rejected on chain

### DIFF
--- a/frontend/src/component/OptimisticPredictionIndicator.test.tsx
+++ b/frontend/src/component/OptimisticPredictionIndicator.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OptimisticPredictionIndicator } from "./OptimisticPredictionIndicator";
+
+describe("OptimisticPredictionIndicator", () => {
+  it("announces a rollback and exposes a keyboard-operable retry", () => {
+    const retry = vi.fn();
+    render(
+      <OptimisticPredictionIndicator
+        status="failed"
+        amount={25}
+        direction="no"
+        error="Rejected on-chain"
+        onRetry={retry}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveAttribute("aria-live", "assertive");
+    expect(screen.getByText("Rejected on-chain")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(retry).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/component/OptimisticPredictionIndicator.tsx
+++ b/frontend/src/component/OptimisticPredictionIndicator.tsx
@@ -6,6 +6,7 @@ export interface OptimisticPredictionIndicatorProps {
   amount: number;
   direction: "yes" | "no";
   error?: string;
+  onRetry?: () => void;
   onDismiss?: () => void;
 }
 
@@ -14,6 +15,7 @@ export function OptimisticPredictionIndicator({
   amount,
   direction,
   error,
+  onRetry,
   onDismiss,
 }: OptimisticPredictionIndicatorProps) {
   const isPending = status === "pending";
@@ -37,6 +39,9 @@ export function OptimisticPredictionIndicator({
   return (
     <div
       className={`flex items-center gap-2 rounded-lg border ${bgColor} px-3 py-2 text-sm ${textColor}`}
+      role={isFailed ? "alert" : "status"}
+      aria-live={isFailed ? "assertive" : "polite"}
+      aria-atomic="true"
     >
       {icon}
       <div className="flex-1">
@@ -50,6 +55,15 @@ export function OptimisticPredictionIndicator({
         <div className="text-xs">
           <p>{error}</p>
         </div>
+      )}
+      {isFailed && onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="ml-2 rounded border border-current px-2 py-1 text-xs font-semibold hover:bg-red-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
+        >
+          Retry
+        </button>
       )}
       {onDismiss && (
         <button

--- a/frontend/src/component/ui/toast.tsx
+++ b/frontend/src/component/ui/toast.tsx
@@ -93,6 +93,18 @@ function ToastCard({
       <div className="min-w-0 flex-1">
         {toast.title && <p className="text-sm font-semibold">{toast.title}</p>}
         <p className="text-sm leading-snug break-words opacity-90">{toast.description}</p>
+        {toast.action && (
+          <button
+            type="button"
+            onClick={() => {
+              toast.action?.onClick();
+              onDismiss();
+            }}
+            className="mt-2 rounded-md border border-current px-2.5 py-1 text-xs font-semibold transition hover:bg-current/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
+          >
+            {toast.action.label}
+          </button>
+        )}
       </div>
       <button
         type="button"

--- a/frontend/src/context/PredictionSlipContext.tsx
+++ b/frontend/src/context/PredictionSlipContext.tsx
@@ -30,6 +30,7 @@ export interface PredictionSlipContextValue {
   addItem: (item: Omit<SlipItem, "amount">) => void;
   removeItem: (marketId: string) => void;
   updateAmount: (marketId: string, amount: number) => void;
+  restoreItem: (item: SlipItem) => void;
   clearSlip: () => void;
 }
 
@@ -45,6 +46,7 @@ const DEFAULT_CONTEXT_VALUE: PredictionSlipContextValue = {
   addItem: () => {},
   removeItem: () => {},
   updateAmount: () => {},
+  restoreItem: () => {},
   clearSlip: () => {},
 };
 
@@ -124,6 +126,14 @@ export function PredictionSlipProvider({
     );
   }, []);
 
+  const restoreItem = useCallback((item: SlipItem) => {
+    setItems((prev) => {
+      const withoutStaleCopy = prev.filter((candidate) => candidate.marketId !== item.marketId);
+      return [...withoutStaleCopy, { ...item }];
+    });
+    setIsOpen(true);
+  }, []);
+
   const clearSlip = useCallback(() => {
     setItems([]);
   }, []);
@@ -155,6 +165,7 @@ export function PredictionSlipProvider({
       addItem,
       removeItem,
       updateAmount,
+      restoreItem,
       clearSlip,
     }),
     [
@@ -168,6 +179,7 @@ export function PredictionSlipProvider({
       addItem,
       removeItem,
       updateAmount,
+      restoreItem,
       clearSlip,
     ],
   );

--- a/frontend/src/context/ToastContext.tsx
+++ b/frontend/src/context/ToastContext.tsx
@@ -12,11 +12,16 @@ export interface ToastOptions {
   variant?: ToastVariant;
   /** Milliseconds before auto-dismiss. Pass 0 to disable auto-dismiss. */
   duration?: number;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 
 export interface ToastItem extends Required<Pick<ToastOptions, "description" | "variant" | "duration">> {
   id: string;
   title?: string;
+  action?: ToastOptions["action"];
 }
 
 export interface ToastContextValue {
@@ -81,6 +86,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
         description: options.description,
         variant: options.variant ?? "info",
         duration,
+        action: options.action,
       };
       setToasts((prev) => [...prev, toast]);
       scheduleDismiss(id, duration);

--- a/frontend/src/hooks/useOptimisticPrediction.test.tsx
+++ b/frontend/src/hooks/useOptimisticPrediction.test.tsx
@@ -1,0 +1,93 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PredictionSlipProvider, usePredictionSlip } from "@/context/PredictionSlipContext";
+import { ToastProvider } from "@/context/ToastContext";
+import { useToast } from "./useToast";
+import { useOptimisticPrediction } from "./useOptimisticPrediction";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <ToastProvider>
+      <PredictionSlipProvider>{children}</PredictionSlipProvider>
+    </ToastProvider>
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useOptimisticPrediction", () => {
+  it("adds optimistically, rolls back on chain rejection, and retries with the preserved slip", async () => {
+    vi.useFakeTimers();
+    const failedPoll = vi.fn().mockResolvedValue("failed" as const);
+    const pendingPoll = vi.fn().mockResolvedValue("pending" as const);
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: "prediction-1",
+        transaction: { hash: "hash-1", pollFn: failedPoll },
+      })
+      .mockResolvedValueOnce({
+        id: "prediction-2",
+        transaction: { hash: "hash-2", pollFn: pendingPoll },
+      });
+
+    const { result } = renderHook(
+      () => ({
+        optimistic: useOptimisticPrediction({ onSubmit }),
+        slip: usePredictionSlip(),
+        toast: useToast(),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.slip.addItem({
+        marketId: "market-1",
+        marketTitle: "Will it rain?",
+        category: "weather",
+        outcome: "yes",
+        odds: 1.8,
+      });
+      result.current.slip.updateAmount("market-1", 42);
+    });
+
+    await act(async () => {
+      await result.current.optimistic.addOptimisticPrediction("market-1", 42, "yes");
+    });
+    expect(result.current.optimistic.predictions).toEqual([
+      expect.objectContaining({ id: "prediction-1", status: "pending", amount: 42 }),
+    ]);
+
+    act(() => result.current.slip.clearSlip());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(result.current.optimistic.predictions).toEqual([]);
+    expect(result.current.optimistic.lastRollback).toEqual(
+      expect.objectContaining({ marketId: "market-1", status: "failed", amount: 42 }),
+    );
+    expect(result.current.slip.items).toEqual([
+      expect.objectContaining({ marketId: "market-1", amount: 42, outcome: "yes" }),
+    ]);
+    expect(result.current.toast.toasts.at(-1)?.action?.label).toBe("Retry");
+
+    await act(async () => {
+      result.current.toast.toasts.at(-1)?.action?.onClick();
+      await Promise.resolve();
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    expect(onSubmit).toHaveBeenLastCalledWith({ marketId: "market-1", amount: 42, direction: "yes" });
+    expect(result.current.optimistic.predictions).toEqual([
+      expect.objectContaining({ id: "prediction-2", status: "pending", amount: 42 }),
+    ]);
+    expect(result.current.slip.items).toEqual([
+      expect.objectContaining({ marketId: "market-1", amount: 42, outcome: "yes" }),
+    ]);
+  });
+});

--- a/frontend/src/hooks/useOptimisticPrediction.ts
+++ b/frontend/src/hooks/useOptimisticPrediction.ts
@@ -1,97 +1,190 @@
-import { useCallback, useState } from "react";
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { usePredictionSlip, type SlipItem } from "@/context/PredictionSlipContext";
 import { useToast } from "./useToast";
+import { useTransactionTracker, type TxStatus } from "./useTransactionTracker";
 
 export interface OptimisticPredictionState {
-    id: string;
-    marketId: string;
-    amount: number;
-    direction: "yes" | "no";
-    status: "pending" | "confirmed" | "failed";
-    error?: string;
+  id: string;
+  marketId: string;
+  amount: number;
+  direction: "yes" | "no";
+  status: "pending" | "confirmed";
+  transactionId?: string;
+}
+
+export interface RolledBackPrediction {
+  marketId: string;
+  amount: number;
+  direction: "yes" | "no";
+  status: "failed";
+  error: string;
+  retry: () => void;
+}
+
+interface SubmissionInput {
+  marketId: string;
+  amount: number;
+  direction: "yes" | "no";
+}
+
+interface SubmissionResult {
+  id: string;
+  transaction?: {
+    hash: string;
+    description?: string;
+    pollFn: (hash: string) => Promise<TxStatus>;
+  };
 }
 
 interface UseOptimisticPredictionOptions {
-    onSubmit: (prediction: Omit<OptimisticPredictionState, "id" | "status" | "error">) => Promise<{ id: string }>;
+  onSubmit: (prediction: SubmissionInput) => Promise<SubmissionResult>;
 }
 
-export function useOptimisticPrediction({
-    onSubmit,
-}: UseOptimisticPredictionOptions) {
-    const [predictions, setPredictions] = useState<OptimisticPredictionState[]>([]);
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const toast = useToast();
+interface PendingReconciliation {
+  predictionId: string;
+  input: SubmissionInput;
+  slipItem: SlipItem;
+}
 
-    const addOptimisticPrediction = useCallback(
-        async (marketId: string, amount: number, direction: "yes" | "no") => {
-            const tempId = `temp_${Date.now()}_${Math.random()}`;
+function fallbackSlipItem(input: SubmissionInput): SlipItem {
+  return {
+    marketId: input.marketId,
+    marketTitle: `Market ${input.marketId}`,
+    category: "",
+    outcome: input.direction,
+    odds: 1,
+    amount: input.amount,
+  };
+}
 
-            // Add optimistic prediction
-            setPredictions((prev) => [
-                ...prev,
-                {
-                    id: tempId,
-                    marketId,
-                    amount,
-                    direction,
-                    status: "pending",
-                },
-            ]);
+export function useOptimisticPrediction({ onSubmit }: UseOptimisticPredictionOptions) {
+  const [predictions, setPredictions] = useState<OptimisticPredictionState[]>([]);
+  const [lastRollback, setLastRollback] = useState<RolledBackPrediction | null>(null);
+  const [submittingCount, setSubmittingCount] = useState(0);
+  const toast = useToast();
+  const slip = usePredictionSlip();
+  const tracker = useTransactionTracker();
+  const pendingTransactions = useRef(new Map<string, PendingReconciliation>());
+  const handledTransactions = useRef(new Set<string>());
+  const retryRef = useRef<((input: SubmissionInput) => Promise<string>) | null>(null);
 
-            setIsSubmitting(true);
+  const rollback = useCallback(
+    (predictionId: string, input: SubmissionInput, slipItem: SlipItem, message: string) => {
+      setPredictions((current) => current.filter((prediction) => prediction.id !== predictionId));
+      slip.restoreItem(slipItem);
 
-            try {
-                const result = await onSubmit({ marketId, amount, direction });
+      const retry = () => {
+        setLastRollback(null);
+        void retryRef.current?.(input);
+      };
+      setLastRollback({ ...input, status: "failed", error: message, retry });
+      toast.error(message, {
+        title: "Prediction rolled back",
+        duration: 0,
+        action: { label: "Retry", onClick: retry },
+      });
+    },
+    [slip, toast],
+  );
 
-                // Reconcile with server response
-                setPredictions((prev) =>
-                    prev.map((p) =>
-                        p.id === tempId
-                            ? { ...p, id: result.id, status: "confirmed" }
-                            : p
-                    )
-                );
+  const addOptimisticPrediction = useCallback(
+    async (marketId: string, amount: number, direction: "yes" | "no") => {
+      const input = { marketId, amount, direction };
+      const slipItem = slip.items.find((item) => item.marketId === marketId) || fallbackSlipItem(input);
+      const temporaryId = `temp_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 
-                toast.success("Prediction placed successfully");
-                return result.id;
-            } catch (error) {
-                // Rollback on failure
-                setPredictions((prev) =>
-                    prev.map((p) =>
-                        p.id === tempId
-                            ? {
-                                ...p,
-                                status: "failed",
-                                error: error instanceof Error ? error.message : "Failed to place prediction",
-                            }
-                            : p
-                    )
-                );
+      setPredictions((current) => [
+        ...current,
+        { id: temporaryId, ...input, status: "pending" },
+      ]);
+      setLastRollback(null);
+      setSubmittingCount((count) => count + 1);
 
-                toast.error(
-                    error instanceof Error ? error.message : "Failed to place prediction"
-                );
+      try {
+        const result = await onSubmit(input);
+        if (!result.transaction) {
+          setPredictions((current) =>
+            current.map((prediction) =>
+              prediction.id === temporaryId
+                ? { ...prediction, id: result.id, status: "confirmed" }
+                : prediction,
+            ),
+          );
+          toast.success("Prediction placed successfully");
+          return result.id;
+        }
 
-                // Remove failed prediction after a delay
-                setTimeout(() => {
-                    setPredictions((prev) => prev.filter((p) => p.id !== tempId));
-                }, 3000);
+        const transactionId = tracker.trackTransaction(
+          result.transaction.hash,
+          result.transaction.description || "Place prediction",
+          result.transaction.pollFn,
+        );
+        pendingTransactions.current.set(transactionId, {
+          predictionId: result.id,
+          input,
+          slipItem: { ...slipItem },
+        });
+        setPredictions((current) =>
+          current.map((prediction) =>
+            prediction.id === temporaryId
+              ? { ...prediction, id: result.id, transactionId, status: "pending" }
+              : prediction,
+          ),
+        );
+        return result.id;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to place prediction";
+        rollback(temporaryId, input, slipItem, message);
+        throw error;
+      } finally {
+        setSubmittingCount((count) => Math.max(0, count - 1));
+      }
+    },
+    [onSubmit, rollback, slip.items, toast, tracker],
+  );
+  retryRef.current = (input) => addOptimisticPrediction(input.marketId, input.amount, input.direction);
 
-                throw error;
-            } finally {
-                setIsSubmitting(false);
-            }
-        },
-        [onSubmit, toast]
-    );
+  useEffect(() => {
+    for (const transaction of tracker.transactions) {
+      if (transaction.status === "pending" || handledTransactions.current.has(transaction.id)) continue;
+      const reconciliation = pendingTransactions.current.get(transaction.id);
+      if (!reconciliation) continue;
 
-    const removePrediction = useCallback((id: string) => {
-        setPredictions((prev) => prev.filter((p) => p.id !== id));
-    }, []);
+      handledTransactions.current.add(transaction.id);
+      pendingTransactions.current.delete(transaction.id);
+      if (transaction.status === "confirmed") {
+        setPredictions((current) =>
+          current.map((prediction) =>
+            prediction.id === reconciliation.predictionId
+              ? { ...prediction, status: "confirmed" }
+              : prediction,
+          ),
+        );
+        toast.success("Prediction confirmed on-chain");
+      } else {
+        rollback(
+          reconciliation.predictionId,
+          reconciliation.input,
+          reconciliation.slipItem,
+          transaction.error || "Prediction was rejected on-chain",
+        );
+      }
+    }
+  }, [rollback, toast, tracker.transactions]);
 
-    return {
-        predictions,
-        addOptimisticPrediction,
-        removePrediction,
-        isSubmitting,
-    };
+  const removePrediction = useCallback((id: string) => {
+    setPredictions((current) => current.filter((prediction) => prediction.id !== id));
+  }, []);
+
+  return {
+    predictions,
+    lastRollback,
+    addOptimisticPrediction,
+    removePrediction,
+    isSubmitting: submittingCount > 0,
+    transactions: tracker.transactions,
+  };
 }

--- a/frontend/src/hooks/useTransactionTracker.ts
+++ b/frontend/src/hooks/useTransactionTracker.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export type TxStatus = "pending" | "confirmed" | "failed";
 
@@ -54,6 +54,11 @@ export function useTransactionTracker(): UseTransactionTrackerResult {
   const clearTimer = useCallback((id: string) => {
     const t = timers.current.get(id);
     if (t) { clearTimeout(t); timers.current.delete(id); }
+  }, []);
+
+  useEffect(() => () => {
+    timers.current.forEach((timer) => clearTimeout(timer));
+    timers.current.clear();
   }, []);
 
   const dismiss = useCallback((id: string) => {


### PR DESCRIPTION
## Summary
- keep predictions optimistic until their chain transaction reaches a final state
- remove rejected predictions and restore the exact saved prediction slip
- expose an accessible persistent retry action that resubmits the preserved input
- clean up tracker timers on unmount and add rollback/retry regression coverage

## Verification
- `pnpm exec vitest run src/hooks/useOptimisticPrediction.test.tsx src/component/OptimisticPredictionIndicator.test.tsx` (2 tests passed)
- `pnpm exec tsc --noEmit` (repository baseline still reports four missing SVG imports in `coursenav.tsx`)
- `git diff --check`

Closes #1517