### PR TITLE
feat(leaderboard): Personalised Leaderboard Coach — weekly insights end-to-end (#1521)

### DIFF
--- a/backend/src/cache/cache-warming.keys.ts
+++ b/backend/src/cache/cache-warming.keys.ts
@@ -10,4 +10,6 @@ export const CACHE_WARMING_KEYS = {
     `leaderboard:cursor:${seasonId ?? 'all'}:page:*`,
   leaderboardTopN: (n: number, seasonId: string | null) =>
     `leaderboard:top:${n}:${seasonId ?? 'all'}`,
+  coachInsights: (userId: string, weekId: string) =>
+    `leaderboard:coach:${userId}:${weekId}`,
 } as const;

--- a/backend/src/leaderboard/dto/coach-insights.dto.ts
+++ b/backend/src/leaderboard/dto/coach-insights.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CoachCategoryStatDto {
+  @ApiProperty({ example: 'Crypto' })
+  category: string;
+
+  @ApiProperty({ example: 8 })
+  predictions: number;
+
+  @ApiProperty({ example: 6 })
+  correct: number;
+
+  @ApiProperty({
+    description: 'Accuracy percentage with one decimal, e.g. "75.0"',
+    example: '75.0',
+  })
+  accuracy_rate: string;
+}
+
+export class CoachAccuracyTrendDto {
+  @ApiProperty({
+    enum: ['improving', 'declining', 'steady', 'not_enough_data'],
+    example: 'improving',
+  })
+  direction: 'improving' | 'declining' | 'steady' | 'not_enough_data';
+
+  @ApiProperty({
+    description:
+      'Accuracy (percentage points) over the more recent half of the analysed window',
+    example: 80,
+  })
+  recent_accuracy: number;
+
+  @ApiProperty({
+    description:
+      'Accuracy (percentage points) over the older half of the analysed window',
+    example: 55,
+  })
+  prior_accuracy: number;
+}
+
+export class CoachInsightPayloadDto {
+  @ApiProperty({ type: CoachAccuracyTrendDto })
+  accuracy_trend: CoachAccuracyTrendDto;
+
+  @ApiProperty({ type: CoachCategoryStatDto, nullable: true })
+  best_category: CoachCategoryStatDto | null;
+
+  @ApiProperty({ type: CoachCategoryStatDto, nullable: true })
+  worst_category: CoachCategoryStatDto | null;
+
+  @ApiProperty({
+    description: 'Correct streak ending at the most recent resolved prediction',
+  })
+  current_streak: number;
+
+  @ApiProperty({
+    description: 'Longest correct streak within the analysed window',
+  })
+  longest_streak: number;
+
+  @ApiProperty({ description: 'Number of resolved predictions analysed' })
+  total_resolved: number;
+
+  @ApiProperty()
+  generated_at: string;
+}
+
+export class CoachInsightsResponse {
+  @ApiProperty({
+    description:
+      'False when the user is below the minimum resolved-prediction threshold; insights are null and message explains how to unlock the coach.',
+  })
+  has_history: boolean;
+
+  @ApiProperty({ nullable: true })
+  message: string | null;
+
+  @ApiProperty({ type: CoachInsightPayloadDto, nullable: true })
+  insights: CoachInsightPayloadDto | null;
+}

--- a/backend/src/leaderboard/leaderboard.controller.spec.ts
+++ b/backend/src/leaderboard/leaderboard.controller.spec.ts
@@ -7,6 +7,8 @@ import {
   LeaderboardQueryDto,
   PaginatedLeaderboardResponse,
 } from './dto/leaderboard-query.dto';
+import { CoachInsightsResponse } from './dto/coach-insights.dto';
+import { User } from '../users/entities/user.entity';
 
 describe('LeaderboardController', () => {
   let controller: LeaderboardController;
@@ -52,6 +54,7 @@ describe('LeaderboardController', () => {
             getHistoryForAddress: jest.fn(),
             getRankHistory: jest.fn(),
             getSnapshots: jest.fn(),
+            getCoachInsights: jest.fn(),
           },
         },
       ],
@@ -276,6 +279,63 @@ describe('LeaderboardController', () => {
 
       expect(result.data).toEqual([]);
       expect(result.message).toContain('No snapshots found');
+    });
+  });
+
+  describe('getCoachInsights', () => {
+    const coachUser = { id: 'user-uuid-1' } as User;
+
+    it('should return tailored insights scoped to the authenticated user', async () => {
+      const insightsResponse: CoachInsightsResponse = {
+        has_history: true,
+        message: null,
+        insights: {
+          accuracy_trend: {
+            direction: 'improving',
+            recent_accuracy: 80,
+            prior_accuracy: 50,
+          },
+          best_category: {
+            category: 'Crypto',
+            predictions: 5,
+            correct: 4,
+            accuracy_rate: '80.0',
+          },
+          worst_category: null,
+          current_streak: 3,
+          longest_streak: 5,
+          total_resolved: 12,
+          generated_at: new Date('2026-08-19T10:00:00Z').toISOString(),
+        },
+      };
+      const spy = jest
+        .spyOn(service, 'getCoachInsights')
+        .mockResolvedValue(insightsResponse);
+
+      const result = await controller.getCoachInsights(coachUser);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(coachUser);
+      expect(result.has_history).toBe(true);
+      expect(result.insights?.best_category?.category).toBe('Crypto');
+    });
+
+    it('should pass through the new-user shape unchanged', async () => {
+      const onboardingResponse: CoachInsightsResponse = {
+        has_history: false,
+        message:
+          'Make a few more predictions to unlock your personalised coach insights.',
+        insights: null,
+      };
+      jest
+        .spyOn(service, 'getCoachInsights')
+        .mockResolvedValue(onboardingResponse);
+
+      const result = await controller.getCoachInsights(coachUser);
+
+      expect(result.has_history).toBe(false);
+      expect(result.insights).toBeNull();
+      expect(result.message).toContain('predictions');
     });
   });
 });

--- a/backend/src/leaderboard/leaderboard.controller.ts
+++ b/backend/src/leaderboard/leaderboard.controller.ts
@@ -27,12 +27,39 @@ import {
   LeaderboardSnapshotQueryDto,
   PaginatedSnapshotRankingResponse,
 } from './dto/leaderboard-snapshot-query.dto';
+import { CoachInsightsResponse } from './dto/coach-insights.dto';
 import { Public } from '../common/decorators/public.decorator';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
 
 @ApiTags('Leaderboard')
 @Controller('leaderboard')
 export class LeaderboardController {
   constructor(private readonly leaderboardService: LeaderboardService) {}
+
+  /**
+   * Personalised weekly insights for the authenticated user. Auth required
+   * (no @Public) so insights are always scoped to the caller. Declared before
+   * the :address routes below.
+   */
+  @Get('coach/insights')
+  @ApiOperation({
+    summary:
+      "Get the authenticated user's personalised leaderboard coach insights",
+    description:
+      'Returns accuracy trend, best/worst categories and streaks computed from resolved prediction history. When the user is below the minimum resolved-prediction threshold, has_history is false with an onboarding message instead of insights.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Coach insights or the new-user onboarding shape',
+    type: CoachInsightsResponse,
+  })
+  @ApiResponse({ status: 401, description: 'Not authenticated' })
+  async getCoachInsights(
+    @CurrentUser() user: User,
+  ): Promise<CoachInsightsResponse> {
+    return this.leaderboardService.getCoachInsights(user);
+  }
 
   @Get('top/:n')
   @Public()

--- a/backend/src/leaderboard/leaderboard.module.ts
+++ b/backend/src/leaderboard/leaderboard.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { LeaderboardEntry } from './entities/leaderboard-entry.entity';
 import { LeaderboardHistory } from './entities/leaderboard-history.entity';
 import { LeaderboardSnapshot } from './entities/leaderboard-snapshot.entity';
+import { Prediction } from '../predictions/entities/prediction.entity';
 import { UsersModule } from '../users/users.module';
 import { SeasonsModule } from '../seasons/seasons.module';
 import { LeaderboardService } from './leaderboard.service';
@@ -18,6 +19,7 @@ import { CacheWarmingModule } from '../cache/cache-warming.module';
       LeaderboardEntry,
       LeaderboardHistory,
       LeaderboardSnapshot,
+      Prediction,
     ]),
     UsersModule,
     SeasonsModule,

--- a/backend/src/leaderboard/leaderboard.scheduler.spec.ts
+++ b/backend/src/leaderboard/leaderboard.scheduler.spec.ts
@@ -28,6 +28,8 @@ describe('LeaderboardScheduler', () => {
             recalculateRanks: jest.fn(),
             createRankSnapshot: jest.fn(),
             pruneSnapshots: jest.fn(),
+            refreshWeeklyCoachInsights: jest.fn(),
+            createDailySnapshot: jest.fn(),
           },
         },
         {
@@ -111,6 +113,28 @@ describe('LeaderboardScheduler', () => {
 
       expect(createSpy).toHaveBeenCalled();
       expect(pruneSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleWeeklyCoachInsightsRefresh', () => {
+    it('should trigger the weekly coach insights refresh', async () => {
+      const refreshSpy = jest
+        .spyOn(service, 'refreshWeeklyCoachInsights')
+        .mockResolvedValue(3);
+
+      await scheduler.handleWeeklyCoachInsightsRefresh();
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw if the weekly refresh fails', async () => {
+      jest
+        .spyOn(service, 'refreshWeeklyCoachInsights')
+        .mockRejectedValue(new Error('DB error'));
+
+      await expect(
+        scheduler.handleWeeklyCoachInsightsRefresh(),
+      ).resolves.not.toThrow();
     });
   });
 });

--- a/backend/src/leaderboard/leaderboard.scheduler.ts
+++ b/backend/src/leaderboard/leaderboard.scheduler.ts
@@ -63,6 +63,21 @@ export class LeaderboardScheduler implements OnModuleInit {
   }
 
   /**
+   * Weekly coach insights refresh (Mondays 03:00). Recomputes and re-caches
+   * each eligible user's insights under the new ISO-week cache key. Users
+   * missed by this job still get on-demand computation at request time.
+   */
+  @Cron('0 3 * * 1')
+  async handleWeeklyCoachInsightsRefresh(): Promise<void> {
+    this.logger.log('Weekly coach insights refresh triggered');
+    try {
+      await this.leaderboardService.refreshWeeklyCoachInsights();
+    } catch (err) {
+      this.logger.error('Weekly coach insights refresh failed', err);
+    }
+  }
+
+  /**
    * Persists a rank/score snapshot on the configurable cadence, then prunes
    * snapshots outside the configured retention window.
    */

--- a/backend/src/leaderboard/leaderboard.service.spec.ts
+++ b/backend/src/leaderboard/leaderboard.service.spec.ts
@@ -8,6 +8,7 @@ import { LeaderboardService } from './leaderboard.service';
 import { LeaderboardEntry } from './entities/leaderboard-entry.entity';
 import { LeaderboardHistory } from './entities/leaderboard-history.entity';
 import { LeaderboardSnapshot } from './entities/leaderboard-snapshot.entity';
+import { Prediction } from '../predictions/entities/prediction.entity';
 import { User } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
 import { SeasonsService } from '../seasons/seasons.service';
@@ -81,6 +82,25 @@ describe('LeaderboardService', () => {
     delete: jest.fn().mockResolvedValue({ affected: 0 }),
   };
 
+  const mockPredictionQb = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    having: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
+    getRawMany: jest.fn().mockResolvedValue([]),
+  };
+
+  const mockPredictionRepository = {
+    createQueryBuilder: jest.fn(() => mockPredictionQb),
+  };
+
   const mockUsersService = {
     findAll: jest.fn(),
     findByAddress: jest.fn(),
@@ -121,6 +141,10 @@ describe('LeaderboardService', () => {
           useValue: mockSnapshotRepository,
         },
         {
+          provide: getRepositoryToken(Prediction),
+          useValue: mockPredictionRepository,
+        },
+        {
           provide: UsersService,
           useValue: mockUsersService,
         },
@@ -159,6 +183,11 @@ describe('LeaderboardService', () => {
     mockSnapshotQb.orderBy.mockReturnThis();
     mockSnapshotQb.addOrderBy.mockReturnThis();
     mockSnapshotQb.getMany.mockResolvedValue([]);
+    mockPredictionRepository.createQueryBuilder.mockReturnValue(
+      mockPredictionQb,
+    );
+    mockPredictionQb.getMany.mockResolvedValue([]);
+    mockPredictionQb.getRawMany.mockResolvedValue([]);
     mockConfigService.get.mockImplementation(
       (_key: string, defaultValue?: unknown) => defaultValue,
     );
@@ -603,6 +632,295 @@ describe('LeaderboardService', () => {
       await service.getSnapshots({ date: '2026-07-15', limit: 999 });
 
       expect(mockSnapshotQbForDate.take).toHaveBeenCalledWith(100);
+    });
+  });
+
+  describe('coach insights', () => {
+    const coachUser = { id: 'user-uuid-1' } as User;
+
+    const COACH_BASE_DATE = new Date('2026-08-01T12:00:00Z').getTime();
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    /**
+     * Builds one prediction row for the coach fixture.
+     * resolvedOutcome === null means the market is still unresolved (row is
+     * excluded from analysis); is_cancelled rows are excluded too.
+     */
+    function coachPrediction(
+      dayOffset: number,
+      category: string,
+      chosenOutcome: string,
+      resolvedOutcome: string | null,
+      overrides: Partial<{ is_resolved: boolean; is_cancelled: boolean }> = {},
+    ) {
+      return {
+        id: `pred-${dayOffset}-${category}-${chosenOutcome}`,
+        chosen_outcome: chosenOutcome,
+        submitted_at: new Date(COACH_BASE_DATE + dayOffset * DAY_MS),
+        market: {
+          category,
+          is_resolved:
+            overrides.is_resolved ??
+            (resolvedOutcome !== null && !overrides.is_cancelled),
+          is_cancelled: overrides.is_cancelled ?? false,
+          resolved_outcome: resolvedOutcome,
+        },
+      };
+    }
+
+    /**
+     * Known fixture, ordered most-recent-first exactly like the service's
+     * `submitted_at DESC` query returns it.
+     *
+     * Chronological correctness (oldest -> newest): F F F F T T T T
+     *   - trend: prior half 0%, recent half 100% -> improving
+     *   - Crypto: d1,d3,d6,d7,d8 -> 5 preds, 3 correct -> '60.0' (best)
+     *   - Sports: d2,d4,d5       -> 3 preds, 1 correct -> '33.3' (worst)
+     *   - current_streak 4, longest_streak 4
+     */
+    const coachFixtureDesc = [
+      // Most recent entries must be excluded from analysis entirely.
+      coachPrediction(20, 'Crypto', 'Yes', null), // unresolved market
+      coachPrediction(19, 'Crypto', 'Yes', 'Yes', {
+        is_resolved: true,
+        is_cancelled: true,
+      }), // cancelled market
+      // Resolved history (day 8 oldest ... day 1 newest).
+      coachPrediction(8, 'Crypto', 'Yes', 'Yes'),
+      coachPrediction(7, 'Crypto', 'No', 'No'),
+      coachPrediction(6, 'Crypto', 'Yes', 'Yes'),
+      coachPrediction(5, 'Sports', 'No', 'No'),
+      coachPrediction(4, 'Sports', 'Yes', 'No'),
+      coachPrediction(3, 'Crypto', 'No', 'Yes'),
+      coachPrediction(2, 'Sports', 'No', 'Yes'),
+      coachPrediction(1, 'Crypto', 'Yes', 'No'),
+    ];
+
+    it('computes accuracy trend, best/worst category and streaks from a known history', async () => {
+      mockPredictionQb.getMany.mockResolvedValue(coachFixtureDesc);
+
+      const result = await service.computeCoachInsights(coachUser);
+
+      expect(result.has_history).toBe(true);
+      expect(result.message).toBeNull();
+      expect(result.insights).toEqual(
+        expect.objectContaining({
+          accuracy_trend: {
+            direction: 'improving',
+            recent_accuracy: 100,
+            prior_accuracy: 0,
+          },
+          best_category: {
+            category: 'Crypto',
+            predictions: 5,
+            correct: 3,
+            accuracy_rate: '60.0',
+          },
+          worst_category: {
+            category: 'Sports',
+            predictions: 3,
+            correct: 1,
+            accuracy_rate: '33.3',
+          },
+          current_streak: 4,
+          longest_streak: 4,
+          total_resolved: 8,
+        }),
+      );
+    });
+
+    it('queries only the requesting user and filters to resolved markets', async () => {
+      mockPredictionQb.getMany.mockResolvedValue([]);
+
+      await service.computeCoachInsights(coachUser);
+
+      expect(mockPredictionQb.where).toHaveBeenCalledWith(
+        'prediction.userId = :userId',
+        { userId: 'user-uuid-1' },
+      );
+      expect(mockPredictionQb.andWhere).toHaveBeenCalledWith(
+        'market.is_resolved = :isResolved',
+        { isResolved: true },
+      );
+      expect(mockPredictionQb.andWhere).toHaveBeenCalledWith(
+        'market.is_cancelled = :isCancelled',
+        { isCancelled: false },
+      );
+      expect(mockPredictionQb.orderBy).toHaveBeenCalledWith(
+        'prediction.submitted_at',
+        'DESC',
+      );
+    });
+
+    it('returns the new-user shape below the minimum resolved-prediction threshold', async () => {
+      // Only 4 resolved predictions: below MIN_RESOLVED_PREDICTIONS_FOR_INSIGHTS (5).
+      const shortHistory = [
+        coachPrediction(4, 'Crypto', 'Yes', 'Yes'),
+        coachPrediction(3, 'Sports', 'No', 'No'),
+        coachPrediction(2, 'Crypto', 'Yes', null), // unresolved, doesn't count
+        coachPrediction(2, 'Crypto', 'Yes', 'No'),
+        coachPrediction(1, 'Sports', 'No', 'Yes'),
+      ];
+      mockPredictionQb.getMany.mockResolvedValue(shortHistory);
+
+      const result = await service.computeCoachInsights(coachUser);
+
+      expect(result.has_history).toBe(false);
+      expect(result.insights).toBeNull();
+      expect(typeof result.message).toBe('string');
+      expect(result.message?.length).toBeGreaterThan(0);
+    });
+
+    it('tracks current vs longest streak independently when a loss breaks the run', () => {
+      // Fixture ordered most-recent-first; chronologically C C C W C ->
+      // current streak 1 (only the newest), longest streak 3.
+      const history = [
+        coachPrediction(5, 'Crypto', 'Yes', 'Yes'), // newest - C
+        coachPrediction(4, 'Crypto', 'Yes', 'No'), // W
+        coachPrediction(3, 'Crypto', 'Yes', 'Yes'), // C
+        coachPrediction(2, 'Crypto', 'Yes', 'Yes'), // C
+        coachPrediction(1, 'Crypto', 'Yes', 'Yes'), // oldest - C
+      ];
+
+      const result = LeaderboardService.analyzePredictionHistory(history);
+
+      expect(result.has_history).toBe(true);
+      expect(result.insights?.current_streak).toBe(1);
+      expect(result.insights?.longest_streak).toBe(3);
+    });
+
+    it('serves repeated requests within the week from cache without recomputing', async () => {
+      const cachedResponse = {
+        has_history: true,
+        message: null,
+        insights: { current_streak: 2 },
+      };
+      mockCacheManager.get
+        .mockResolvedValueOnce(null) // first request: cache miss
+        .mockResolvedValueOnce(cachedResponse); // second request within the week
+
+      const computeSpy = jest.spyOn(service, 'computeCoachInsights');
+
+      await service.getCoachInsights(coachUser);
+      const second = await service.getCoachInsights(coachUser);
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+      expect(second).toBe(cachedResponse);
+    });
+
+    it('scopes the cache key per user and per ISO week with a bounded TTL', async () => {
+      mockCacheManager.get.mockResolvedValue(null);
+
+      await service.getCoachInsights(coachUser);
+
+      expect(mockCacheManager.set).toHaveBeenCalledWith(
+        expect.stringMatching(/^leaderboard:coach:user-uuid-1:\d{4}-W\d{2}$/),
+        expect.anything(),
+        expect.any(Number),
+      );
+    });
+
+    it('recomputes on demand and caches when the weekly job has not populated the key yet', async () => {
+      mockCacheManager.get.mockResolvedValue(null);
+      mockPredictionQb.getMany.mockResolvedValue(coachFixtureDesc);
+
+      const result = await service.getCoachInsights(coachUser);
+
+      expect(result.has_history).toBe(true);
+      expect(mockCacheManager.set).toHaveBeenCalled();
+    });
+
+    describe('refreshWeeklyCoachInsights', () => {
+      it('refreshes every eligible user into the current week key and clears last week', async () => {
+        mockPredictionQb.getRawMany.mockResolvedValue([
+          { user_id: 'user-a', resolved_count: '10' },
+          { user_id: 'user-b', resolved_count: '7' },
+        ]);
+        const insightA = { has_history: true, message: null, insights: {} };
+        const insightB = { has_history: true, message: null, insights: {} };
+        const computeSpy = jest
+          .spyOn(service, 'computeCoachInsights')
+          .mockResolvedValueOnce(insightA as never)
+          .mockResolvedValueOnce(insightB as never);
+
+        const refreshed = await service.refreshWeeklyCoachInsights();
+
+        expect(refreshed).toBe(2);
+        expect(computeSpy).toHaveBeenCalledTimes(2);
+        expect(computeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'user-a' }),
+        );
+        expect(computeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'user-b' }),
+        );
+
+        const setCalls = mockCacheManager.set.mock.calls;
+        expect(setCalls).toHaveLength(2);
+        for (const [key] of setCalls) {
+          expect(String(key)).toMatch(
+            /^leaderboard:coach:user-[ab]:\d{4}-W\d{2}$/,
+          );
+        }
+        // Previous-week keys for both users were invalidated.
+        const delCalls = mockCacheManager.del.mock.calls.map(([k]) =>
+          String(k),
+        );
+        expect(delCalls).toHaveLength(2);
+        for (const key of delCalls) {
+          expect(key).toMatch(/^leaderboard:coach:user-(a|b):\d{4}-W\d{2}$/);
+        }
+
+        // Current-week keys differ from previous-week keys.
+        const setKeys = setCalls.map(([k]) => String(k));
+        for (const key of delCalls) {
+          expect(setKeys).not.toContain(key);
+        }
+      });
+
+      it('keeps refreshing remaining users when one computation fails', async () => {
+        mockPredictionQb.getRawMany.mockResolvedValue([
+          { user_id: 'user-a', resolved_count: '10' },
+          { user_id: 'user-b', resolved_count: '7' },
+        ]);
+        const computeSpy = jest
+          .spyOn(service, 'computeCoachInsights')
+          .mockRejectedValueOnce(new Error('boom'))
+          .mockResolvedValueOnce({
+            has_history: true,
+            message: null,
+            insights: {},
+          } as never);
+
+        const refreshed = await service.refreshWeeklyCoachInsights();
+
+        expect(refreshed).toBe(1);
+        expect(computeSpy).toHaveBeenCalledTimes(2);
+        expect(mockCacheManager.set).toHaveBeenCalledTimes(1);
+      });
+
+      it('filters eligibility at query time by the minimum threshold', async () => {
+        mockPredictionQb.getRawMany.mockResolvedValue([]);
+
+        await service.refreshWeeklyCoachInsights();
+
+        expect(mockPredictionQb.having).toHaveBeenCalledWith(
+          'COUNT(*) >= :minCount',
+          { minCount: 5 },
+        );
+      });
+    });
+
+    it('derives ISO week ids deterministically', () => {
+      // 2026-01-01 falls in ISO week 1 of 2026; 2025-12-31 also belongs to it.
+      expect(
+        LeaderboardService.getIsoWeekId(new Date('2026-01-01T00:00:00Z')),
+      ).toBe('2026-W01');
+      expect(
+        LeaderboardService.getIsoWeekId(new Date('2026-08-19T10:00:00Z')),
+      ).toBe('2026-W34');
+      expect(
+        LeaderboardService.getIsoWeekId(new Date('2025-12-31T00:00:00Z')),
+      ).toBe('2026-W01');
     });
   });
 });

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -19,6 +19,13 @@ import { LeaderboardHistory } from './entities/leaderboard-history.entity';
 import { LeaderboardSnapshot } from './entities/leaderboard-snapshot.entity';
 import { UsersService } from '../users/users.service';
 import { User } from '../users/entities/user.entity';
+import { Prediction } from '../predictions/entities/prediction.entity';
+import {
+  CoachAccuracyTrendDto,
+  CoachCategoryStatDto,
+  CoachInsightPayloadDto,
+  CoachInsightsResponse,
+} from './dto/coach-insights.dto';
 import {
   LeaderboardQueryDto,
   LeaderboardEntryResponse,
@@ -45,10 +52,44 @@ import {
 import { CACHE_WARMING_KEYS } from '../cache/cache-warming.keys';
 import { SeasonsService } from '../seasons/seasons.service';
 
+/**
+ * Minimum number of resolved predictions required before the coach will
+ * produce insights. Below this the API returns has_history=false so the
+ * frontend can render an onboarding state instead of a broken insight card.
+ */
+const MIN_RESOLVED_PREDICTIONS_FOR_INSIGHTS = 5;
+
+/** Maximum number of most-recent resolved predictions analysed per user. */
+const COACH_ANALYSIS_WINDOW = 30;
+
+/** A category needs at least this many resolved predictions to rank as best/worst. */
+const MIN_CATEGORY_PREDICTIONS = 3;
+
+/** Percentage-point change between window halves required to call a trend improving/declining. */
+const TREND_CHANGE_THRESHOLD_PP = 10;
+
+/**
+ * Structural view of a prediction row joined with its market, used by the
+ * pure coach analysis helper so tests can pass plain fixture objects.
+ */
+type CoachPredictionRow = {
+  chosen_outcome: string;
+  submitted_at: Date;
+  market?: {
+    category: string;
+    is_resolved: boolean;
+    is_cancelled?: boolean;
+    resolved_outcome: string | null;
+  } | null;
+};
+
 @Injectable()
 export class LeaderboardService {
   private readonly logger = new Logger(LeaderboardService.name);
   private readonly CACHE_TTL_MS = 1 * 60 * 60 * 1000; // 1 hour
+
+  /** Insights are week-scoped; TTL is only a safety net so nothing lives indefinitely. */
+  private readonly COACH_CACHE_TTL_MS = 8 * 24 * 60 * 60 * 1000;
 
   constructor(
     @InjectRepository(LeaderboardEntry)
@@ -57,6 +98,8 @@ export class LeaderboardService {
     private readonly historyRepository: Repository<LeaderboardHistory>,
     @InjectRepository(LeaderboardSnapshot)
     private readonly snapshotRepository: Repository<LeaderboardSnapshot>,
+    @InjectRepository(Prediction)
+    private readonly predictionRepository: Repository<Prediction>,
     private readonly usersService: UsersService,
     private readonly seasonsService: SeasonsService,
     private readonly dataSource: DataSource,
@@ -822,5 +865,295 @@ export class LeaderboardService {
     });
 
     return { user_id: user.id, data };
+  }
+
+  /**
+   * Returns the personalised coach insights for a user, served from the
+   * per-user, ISO-week-scoped cache when available. On a cache miss (new
+   * user, weekly job not yet run, or previous failure) it computes on demand
+   * and populates the cache rather than erroring.
+   */
+  async getCoachInsights(user: User): Promise<CoachInsightsResponse> {
+    const weekId = LeaderboardService.getIsoWeekId(new Date());
+    const cacheKey = CACHE_WARMING_KEYS.coachInsights(user.id, weekId);
+
+    const cached = await this.cacheManager.get<CoachInsightsResponse>(cacheKey);
+    if (cached) {
+      this.logger.debug(`Cache hit for coach insights: ${cacheKey}`);
+      return cached;
+    }
+
+    const result = await this.computeCoachInsights(user);
+    await this.cacheManager.set(cacheKey, result, this.COACH_CACHE_TTL_MS);
+    this.logger.debug(`Cached coach insights for user ${user.id} (${weekId})`);
+
+    return result;
+  }
+
+  /**
+   * Fetches the user's recent resolved predictions and derives the insight
+   * payload. Public so the scheduler and tests can invoke it directly; the
+   * request-time path is getCoachInsights which wraps it with caching.
+   */
+  async computeCoachInsights(user: User): Promise<CoachInsightsResponse> {
+    const predictions = await this.predictionRepository
+      .createQueryBuilder('prediction')
+      .leftJoinAndSelect('prediction.market', 'market')
+      .where('prediction.userId = :userId', { userId: user.id })
+      .andWhere('market.is_resolved = :isResolved', { isResolved: true })
+      .andWhere('market.is_cancelled = :isCancelled', { isCancelled: false })
+      .orderBy('prediction.submitted_at', 'DESC')
+      .take(COACH_ANALYSIS_WINDOW)
+      .getMany();
+
+    return LeaderboardService.analyzePredictionHistory(predictions);
+  }
+
+  /**
+   * Pure derivation of coach insights from resolved prediction history.
+   * Rows must be ordered most-recent-first (submitted_at DESC), mirroring the
+   * query in computeCoachInsights. Correctness follows the platform-wide rule:
+   * a prediction is correct when market.resolved_outcome === chosen_outcome.
+   */
+  static analyzePredictionHistory(
+    predictions: CoachPredictionRow[],
+  ): CoachInsightsResponse {
+    const resolved = (predictions ?? []).filter(
+      (
+        p,
+      ): p is CoachPredictionRow & {
+        market: NonNullable<CoachPredictionRow['market']>;
+      } =>
+        !!p.market &&
+        p.market.is_resolved &&
+        !p.market.is_cancelled &&
+        p.market.resolved_outcome !== null &&
+        p.market.resolved_outcome !== undefined,
+    );
+
+    if (resolved.length < MIN_RESOLVED_PREDICTIONS_FOR_INSIGHTS) {
+      return {
+        has_history: false,
+        message:
+          'Make a few more predictions to unlock your personalised coach insights.',
+        insights: null,
+      };
+    }
+
+    // Chronological order (oldest -> newest) for trend and streak math.
+    const chronological = [...resolved].reverse();
+
+    const correctness = chronological.map((p) => ({
+      correct: p.market.resolved_outcome === p.chosen_outcome,
+      category: p.market.category,
+    }));
+
+    const accuracy_trend = LeaderboardService.computeAccuracyTrend(correctness);
+    const { best_category, worst_category } =
+      LeaderboardService.computeCategoryStats(correctness);
+    const { current_streak, longest_streak } =
+      LeaderboardService.computeStreaks(correctness);
+
+    const insights: CoachInsightPayloadDto = {
+      accuracy_trend,
+      best_category,
+      worst_category,
+      current_streak,
+      longest_streak,
+      total_resolved: correctness.length,
+      generated_at: new Date().toISOString(),
+    };
+
+    return { has_history: true, message: null, insights };
+  }
+
+  /**
+   * Compares accuracy over the newer half of the window vs the older half.
+   * The change must exceed TREND_CHANGE_THRESHOLD_PP percentage points to
+   * count as improving/declining; anything else is steady.
+   */
+  private static computeAccuracyTrend(
+    correctness: { correct: boolean; category: string }[],
+  ): CoachAccuracyTrendDto {
+    const halfIndex = Math.floor(correctness.length / 2);
+    const prior = correctness.slice(0, halfIndex);
+    const recent = correctness.slice(halfIndex);
+
+    const rate = (rows: { correct: boolean }[]): number =>
+      rows.length === 0
+        ? 0
+        : Math.round(
+            (rows.filter((r) => r.correct).length / rows.length) * 100,
+          );
+
+    const priorAccuracy = rate(prior);
+    const recentAccuracy = rate(recent);
+    const delta = recentAccuracy - priorAccuracy;
+
+    let direction: CoachAccuracyTrendDto['direction'];
+    if (prior.length === 0 || recent.length === 0) {
+      direction = 'not_enough_data';
+    } else if (delta > TREND_CHANGE_THRESHOLD_PP) {
+      direction = 'improving';
+    } else if (delta < -TREND_CHANGE_THRESHOLD_PP) {
+      direction = 'declining';
+    } else {
+      direction = 'steady';
+    }
+
+    return {
+      direction,
+      recent_accuracy: recentAccuracy,
+      prior_accuracy: priorAccuracy,
+    };
+  }
+
+  /**
+   * Ranks categories by accuracy within the analysed window. Only categories
+   * with at least MIN_CATEGORY_PREDICTIONS resolved predictions qualify.
+   */
+  private static computeCategoryStats(
+    correctness: {
+      correct: boolean;
+      category: string;
+    }[],
+  ): {
+    best_category: CoachCategoryStatDto | null;
+    worst_category: CoachCategoryStatDto | null;
+  } {
+    const grouped = new Map<string, { total: number; correct: number }>();
+    for (const entry of correctness) {
+      const stats = grouped.get(entry.category) ?? { total: 0, correct: 0 };
+      stats.total += 1;
+      if (entry.correct) stats.correct += 1;
+      grouped.set(entry.category, stats);
+    }
+
+    const qualified: CoachCategoryStatDto[] = [];
+    for (const [category, stats] of grouped) {
+      if (stats.total < MIN_CATEGORY_PREDICTIONS) continue;
+      qualified.push({
+        category,
+        predictions: stats.total,
+        correct: stats.correct,
+        accuracy_rate: ((stats.correct / stats.total) * 100).toFixed(1),
+      });
+    }
+
+    if (qualified.length === 0) {
+      return { best_category: null, worst_category: null };
+    }
+
+    const sortByAccuracyThenVolume = (
+      a: CoachCategoryStatDto,
+      b: CoachCategoryStatDto,
+    ): number => {
+      const accuracyA = parseFloat(a.accuracy_rate);
+      const accuracyB = parseFloat(b.accuracy_rate);
+      if (accuracyB !== accuracyA) return accuracyB - accuracyA;
+      if (b.predictions !== a.predictions) return b.predictions - a.predictions;
+      return a.category.localeCompare(b.category);
+    };
+
+    const sorted = [...qualified].sort(sortByAccuracyThenVolume);
+
+    return {
+      best_category: sorted[0],
+      worst_category: sorted[sorted.length - 1],
+    };
+  }
+
+  /** Current (trailing) and longest run of consecutive correct predictions. */
+  private static computeStreaks(
+    correctness: {
+      correct: boolean;
+    }[],
+  ): { current_streak: number; longest_streak: number } {
+    let current = 0;
+    let longest = 0;
+
+    for (const entry of correctness) {
+      if (entry.correct) {
+        current += 1;
+        longest = Math.max(longest, current);
+      } else {
+        current = 0;
+      }
+    }
+    // `correctness` ends at the most recent prediction, so `current` already
+    // represents the trailing streak.
+
+    return { current_streak: current, longest_streak: longest };
+  }
+
+  /**
+   * Recomputes and re-caches insights for every eligible user under the
+   * current ISO-week key and deletes their previous-week keys so nothing
+   * stale survives the weekly refresh. Called by the Monday cron job; the
+   * request-time path recomputes on demand for anyone the job missed.
+   */
+  async refreshWeeklyCoachInsights(): Promise<number> {
+    const start = Date.now();
+    this.logger.log('Refreshing weekly coach insights...');
+
+    const rows = await this.predictionRepository
+      .createQueryBuilder('prediction')
+      .select('prediction.userId', 'user_id')
+      .addSelect('COUNT(*)', 'resolved_count')
+      .innerJoin('prediction.market', 'market')
+      .where('market.is_resolved = :isResolved', { isResolved: true })
+      .andWhere('market.is_cancelled = :isCancelled', { isCancelled: false })
+      .groupBy('prediction.userId')
+      .having('COUNT(*) >= :minCount', {
+        minCount: MIN_RESOLVED_PREDICTIONS_FOR_INSIGHTS,
+      })
+      .getRawMany<{ user_id: string; resolved_count: string }>();
+
+    const now = new Date();
+    const currentWeekId = LeaderboardService.getIsoWeekId(now);
+    const previousWeekId = LeaderboardService.getIsoWeekId(
+      new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
+    );
+
+    let refreshed = 0;
+    for (const row of rows) {
+      try {
+        await this.cacheManager.del(
+          CACHE_WARMING_KEYS.coachInsights(row.user_id, previousWeekId),
+        );
+        const insights = await this.computeCoachInsights({
+          id: row.user_id,
+        } as User);
+        await this.cacheManager.set(
+          CACHE_WARMING_KEYS.coachInsights(row.user_id, currentWeekId),
+          insights,
+          this.COACH_CACHE_TTL_MS,
+        );
+        refreshed++;
+      } catch (error) {
+        this.logger.warn(
+          `Failed to refresh coach insights for user ${row.user_id}: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Weekly coach insights refreshed for ${refreshed}/${rows.length} users in ${Date.now() - start}ms`,
+    );
+    return refreshed;
+  }
+
+  /** ISO-8601 week identifier, e.g. "2026-W34", used to scope cache entries. */
+  static getIsoWeekId(date: Date): string {
+    const d = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+    const dayNumber = d.getUTCDay() || 7;
+    d.setUTCDate(d.getUTCDate() + 4 - dayNumber);
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const weekNo = Math.ceil(
+      ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+    );
+    return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
   }
 }

--- a/frontend/src/component/CoachCard.test.tsx
+++ b/frontend/src/component/CoachCard.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CoachCard from "./CoachCard";
+import { useCoachInsights } from "@/hooks/useCoachInsights";
+import { useWallet } from "@/context/WalletContext";
+import type { CoachInsightsResponse } from "@/lib/coach";
+
+vi.mock("@/context/WalletContext", () => ({
+  useWallet: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCoachInsights", () => ({
+  useCoachInsights: vi.fn(),
+}));
+
+const mockedUseWallet = vi.mocked(useWallet);
+const mockedUseCoachInsights = vi.mocked(useCoachInsights);
+
+function buildHistoryResponse(
+  overrides: Partial<CoachInsightsResponse> = {},
+): CoachInsightsResponse {
+  return {
+    has_history: true,
+    message: null,
+    insights: {
+      accuracy_trend: {
+        direction: "improving",
+        recent_accuracy: 80,
+        prior_accuracy: 50,
+      },
+      best_category: {
+        category: "Crypto",
+        predictions: 10,
+        correct: 8,
+        accuracy_rate: "80.0",
+      },
+      worst_category: {
+        category: "Sports",
+        predictions: 5,
+        correct: 2,
+        accuracy_rate: "40.0",
+      },
+      current_streak: 3,
+      longest_streak: 6,
+      total_resolved: 15,
+      generated_at: "2026-08-19T10:00:00Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("CoachCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseWallet.mockReturnValue({
+      address: "GADDRESS",
+      openConnectModal: vi.fn(),
+    } as unknown as ReturnType<typeof useWallet>);
+  });
+
+  it("renders the tailored insight with a derived CTA when the user has history", () => {
+    mockedUseCoachInsights.mockReturnValue({
+      insights: buildHistoryResponse(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      hasHistory: true,
+    });
+
+    render(<CoachCard />);
+
+    expect(screen.getByText("Improving")).toBeInTheDocument();
+    expect(screen.getByTestId("coach-trend")).toHaveTextContent("80% vs 50%");
+    expect(screen.getByText("Strongest category")).toBeInTheDocument();
+    expect(screen.getByTestId("coach-streak")).toHaveTextContent(/3/);
+    expect(screen.getByTestId("coach-streak")).toHaveTextContent("best 6");
+
+    // CTA derived from the actual best category, not hardcoded copy.
+    const cta = screen.getByTestId("coach-insight-cta");
+    expect(cta).toHaveTextContent(
+      "Predict more in Crypto — your strongest category",
+    );
+    expect(cta).toHaveAttribute("href", "/markets");
+  });
+
+  it("falls back to a trend-based CTA when no category qualifies", () => {
+    const response = buildHistoryResponse();
+    response.insights!.best_category = null;
+    response.insights!.worst_category = null;
+    mockedUseCoachInsights.mockReturnValue({
+      insights: response,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      hasHistory: true,
+    });
+
+    render(<CoachCard />);
+
+    const cta = screen.getByTestId("coach-insight-cta");
+    expect(cta).toHaveTextContent(
+      "You're trending up — keep making predictions",
+    );
+  });
+
+  it("renders the onboarding state for users below the history threshold", () => {
+    mockedUseCoachInsights.mockReturnValue({
+      insights: {
+        has_history: false,
+        message:
+          "Make a few more predictions to unlock your personalised coach insights.",
+        insights: null,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      hasHistory: false,
+    });
+
+    render(<CoachCard />);
+
+    expect(
+      screen.getByText(/Your coach needs more history first/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Make a few more predictions to unlock your personalised coach insights/),
+    ).toBeInTheDocument();
+
+    // Onboarding CTA instead of an insight CTA.
+    expect(screen.queryByTestId("coach-insight-cta")).not.toBeInTheDocument();
+    const cta = screen.getByTestId("coach-onboarding-cta");
+    expect(cta).toHaveTextContent("Explore Markets");
+    expect(cta).toHaveAttribute("href", "/markets");
+
+    // No trend/streak widgets leak into the empty state.
+    expect(screen.queryByTestId("coach-trend")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("coach-streak")).not.toBeInTheDocument();
+  });
+
+  it("renders a distinct loading skeleton while fetching", () => {
+    mockedUseCoachInsights.mockReturnValue({
+      insights: null,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+      hasHistory: false,
+    });
+
+    render(<CoachCard />);
+
+    expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("Loading coach insights…")).toBeInTheDocument();
+
+    // Neither the empty state nor an error shows during loading.
+    expect(screen.queryByText(/Your coach needs more history/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("coach-onboarding-cta")).not.toBeInTheDocument();
+  });
+
+  it("renders a distinct retryable error state", () => {
+    const refetch = vi.fn();
+    mockedUseCoachInsights.mockReturnValue({
+      insights: null,
+      isLoading: false,
+      error: "Failed to load coach insights.",
+      refetch,
+      hasHistory: false,
+    });
+
+    render(<CoachCard />);
+
+    expect(screen.getByText("Failed to load coach insights.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+    // Error is not conflated with the new-user onboarding state.
+    expect(screen.queryByTestId("coach-onboarding-cta")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Your coach needs more history/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/component/CoachCard.tsx
+++ b/frontend/src/component/CoachCard.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import Link from "next/link";
+import {
+  AlertCircle,
+  ArrowDownRight,
+  ArrowUpRight,
+  Flame,
+  GraduationCap,
+  Minus,
+} from "lucide-react";
+import { useWallet } from "@/context/WalletContext";
+import { useCoachInsights } from "@/hooks/useCoachInsights";
+import type { CoachInsightPayload } from "@/lib/coach";
+
+function trendMeta(direction: CoachInsightPayload["accuracy_trend"]["direction"]) {
+  switch (direction) {
+    case "improving":
+      return {
+        label: "Improving",
+        Icon: ArrowUpRight,
+        className: "text-emerald-400",
+        srLabel: "Accuracy trend is improving",
+      };
+    case "declining":
+      return {
+        label: "Declining",
+        Icon: ArrowDownRight,
+        className: "text-rose-400",
+        srLabel: "Accuracy trend is declining",
+      };
+    case "steady":
+      return {
+        label: "Steady",
+        Icon: Minus,
+        className: "text-gray-300",
+        srLabel: "Accuracy trend is steady",
+      };
+    default:
+      return {
+        label: "Not enough data",
+        Icon: Minus,
+        className: "text-gray-400",
+        srLabel: "Accuracy trend is not available yet",
+      };
+  }
+}
+
+/**
+ * CTA is always derived from the actual insight payload — never hardcoded
+ * copy unrelated to what the coach found.
+ */
+function coachCta(insights: CoachInsightPayload): string {
+  const best = insights.best_category;
+  if (best) {
+    return `Predict more in ${best.category} — your strongest category`;
+  }
+  switch (insights.accuracy_trend.direction) {
+    case "improving":
+      return "You're trending up — keep making predictions";
+    case "declining":
+      return "Reset your streak — make a fresh prediction";
+    default:
+      return "Make another prediction to sharpen your insights";
+  }
+}
+
+function CardShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative rounded-2xl border border-white/10 bg-white/5 p-5 w-full shadow-lg overflow-hidden">
+      <div className="absolute top-0 left-0 right-0 h-[3px] bg-orange-500/60 rounded-t-2xl" />
+      <div className="flex items-center justify-between">
+        <h2 className="text-white font-semibold">Weekly Coach</h2>
+        <GraduationCap className="h-5 w-5 text-orange-400" />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default function CoachCard() {
+  const { address, openConnectModal } = useWallet();
+  const { insights, isLoading, error, refetch, hasHistory } =
+    useCoachInsights();
+
+  // Not connected — nothing to show yet.
+  if (!address) {
+    return (
+      <CardShell>
+        <div className="mt-6 text-center">
+          <p className="text-gray-400 text-sm">
+            Connect your wallet to get personalised weekly coaching.
+          </p>
+          <button
+            onClick={openConnectModal}
+            className="mt-4 w-full py-2 rounded-lg bg-orange-500 text-white font-semibold hover:bg-orange-600 transition"
+          >
+            Connect Wallet
+          </button>
+        </div>
+      </CardShell>
+    );
+  }
+
+  // Loading state — skeleton, distinct from empty and error.
+  if (isLoading) {
+    return (
+      <CardShell>
+        <div
+          className="mt-5 space-y-4 animate-pulse"
+          role="status"
+          aria-busy="true"
+          aria-live="polite"
+        >
+          <div className="h-8 w-full rounded bg-white/10" />
+          <div className="space-y-3">
+            <div className="h-4 w-full rounded bg-white/10" />
+            <div className="h-4 w-3/4 rounded bg-white/10" />
+            <div className="h-4 w-1/2 rounded bg-white/10" />
+          </div>
+          <div className="h-9 w-full rounded-lg bg-white/10" />
+        </div>
+        <span className="sr-only">Loading coach insights…</span>
+      </CardShell>
+    );
+  }
+
+  // Error state — retryable, never conflated with the new-user state.
+  if (error || !insights) {
+    return (
+      <CardShell>
+        <div className="mt-6 text-center">
+          <AlertCircle className="h-6 w-6 text-rose-400 mx-auto" />
+          <p className="mt-2 text-rose-300 text-sm">
+            {error ?? "Couldn't load coach insights."}
+          </p>
+          <button
+            onClick={refetch}
+            className="mt-4 w-full py-2 rounded-lg border border-white/10 bg-white/5 text-gray-200 text-sm font-semibold hover:border-orange-500/50 hover:text-orange-400 transition"
+          >
+            Retry
+          </button>
+        </div>
+      </CardShell>
+    );
+  }
+
+  // New-user state — insufficient resolved history for insights yet.
+  if (!hasHistory || !insights.insights) {
+    return (
+      <CardShell>
+        <div className="mt-6 text-center">
+          <p className="text-gray-200 text-sm font-medium">
+            Your coach needs more history first.
+          </p>
+          <p className="mt-2 text-gray-400 text-sm">
+            {insights.message ??
+              "Make a few predictions to unlock your personalised coach."}
+          </p>
+          <Link
+            href="/markets"
+            data-testid="coach-onboarding-cta"
+            className="mt-4 inline-block w-full py-2 rounded-lg bg-orange-500 text-white font-semibold hover:bg-orange-600 transition"
+          >
+            Explore Markets
+          </Link>
+        </div>
+      </CardShell>
+    );
+  }
+
+  const payload = insights.insights;
+  const trend = trendMeta(payload.accuracy_trend.direction);
+  const TrendIcon = trend.Icon;
+  const cta = coachCta(payload);
+
+  return (
+    <CardShell>
+      {/* Accuracy trend */}
+      <div
+        className="mt-5 flex items-center justify-between gap-3 rounded-xl bg-white/5 px-3 py-3"
+        data-testid="coach-trend"
+      >
+        <span
+          className={`flex items-center gap-1.5 text-sm font-semibold ${trend.className}`}
+        >
+          <TrendIcon className="h-4 w-4" aria-hidden="true" />
+          {trend.label}
+        </span>
+        <span className="text-xs text-gray-400" title="Recent vs previous accuracy">
+          {payload.accuracy_trend.recent_accuracy}% vs{" "}
+          {payload.accuracy_trend.prior_accuracy}%
+        </span>
+      </div>
+
+      {/* Best / worst categories */}
+      <div className="mt-4 space-y-2 text-sm">
+        {payload.best_category && (
+          <div className="flex justify-between text-gray-300">
+            <span>Strongest category</span>
+            <span className="text-emerald-400">
+              {payload.best_category.category} ·{" "}
+              {payload.best_category.accuracy_rate}%
+            </span>
+          </div>
+        )}
+        {payload.worst_category && (
+          <div className="flex justify-between text-gray-300">
+            <span>Weakest category</span>
+            <span className="text-rose-400">
+              {payload.worst_category.category} ·{" "}
+              {payload.worst_category.accuracy_rate}%
+            </span>
+          </div>
+        )}
+        {!payload.best_category && !payload.worst_category && (
+          <p className="text-gray-400 text-xs">
+            Predict across a few markets to unlock category strengths.
+          </p>
+        )}
+      </div>
+
+      {/* Streak */}
+      <div
+        className="mt-4 flex items-center justify-between rounded-xl bg-white/5 px-3 py-3 text-sm"
+        data-testid="coach-streak"
+      >
+        <span className="flex items-center gap-1.5 text-gray-300">
+          <Flame
+            className={`h-4 w-4 ${
+              payload.current_streak > 0 ? "text-orange-400" : "text-gray-500"
+            }`}
+            aria-hidden="true"
+          />
+          Current streak
+        </span>
+        <span className="font-semibold text-white">
+          {payload.current_streak}
+          <span className="ml-2 text-xs font-normal text-gray-400">
+            best {payload.longest_streak}
+          </span>
+        </span>
+      </div>
+
+      {/* Data-derived call to action */}
+      <Link
+        href="/markets"
+        data-testid="coach-insight-cta"
+        className="mt-5 flex w-full items-center justify-center gap-2 py-2 rounded-lg bg-orange-500 text-white text-sm font-semibold hover:bg-orange-600 transition"
+      >
+        {cta}
+      </Link>
+
+      <p className="mt-2 text-center text-[11px] text-gray-500">
+        Based on your last {payload.total_resolved} resolved predictions ·{" "}
+        {trend.srLabel}
+      </p>
+    </CardShell>
+  );
+}

--- a/frontend/src/component/dashboard-shell.test.tsx
+++ b/frontend/src/component/dashboard-shell.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DashboardShell } from "./dashboard-shell";
+import { usePathname } from "next/navigation";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/context/WalletContext", () => ({
+  useWallet: () => ({
+    address: "GADDRESS",
+    user: { username: "tester" },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useConfirm", () => ({
+  useConfirm: () => async () => true,
+}));
+
+vi.mock("@/hooks/useToast", () => ({
+  useToast: () => ({ success: vi.fn() }),
+}));
+
+// Stub the composed sidebar cards to assert shell wiring only.
+vi.mock("@/component/RewardsWalletCard", () => ({
+  default: () => <div data-testid="rewards-card" />,
+}));
+vi.mock("@/component/NotificationsCard", () => ({
+  default: () => <div data-testid="notifications-card" />,
+}));
+vi.mock("@/component/CoachCard", () => ({
+  default: () => <div data-testid="coach-card" />,
+}));
+
+const mockedUsePathname = vi.mocked(usePathname);
+
+describe("DashboardShell", () => {
+  beforeEach(() => {
+    mockedUsePathname.mockReturnValue("/dashboard");
+  });
+
+  it("composes the coach card into the dashboard sidebar alongside the existing cards", () => {
+    render(
+      <DashboardShell>
+        <div>page content</div>
+      </DashboardShell>,
+    );
+
+    const aside = screen.getByTestId("coach-card").closest("aside");
+    expect(aside).not.toBeNull();
+
+    const ids = Array.from(
+      aside!.querySelectorAll("[data-testid]"),
+    ).map((el) => el.getAttribute("data-testid"));
+
+    expect(ids).toContain("rewards-card");
+    expect(ids).toContain("coach-card");
+    expect(ids).toContain("notifications-card");
+    // Coach sits between rewards wallet and notifications.
+    expect(ids.indexOf("coach-card")).toBeGreaterThan(
+      ids.indexOf("rewards-card"),
+    );
+    expect(ids.indexOf("coach-card")).toBeLessThan(
+      ids.indexOf("notifications-card"),
+    );
+  });
+
+  it("does not render the sidebar cards outside /dashboard", () => {
+    mockedUsePathname.mockReturnValue("/my-predictions");
+
+    render(
+      <DashboardShell>
+        <div>page content</div>
+      </DashboardShell>,
+    );
+
+    expect(screen.queryByTestId("coach-card")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("rewards-card")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/component/dashboard-shell.tsx
+++ b/frontend/src/component/dashboard-shell.tsx
@@ -2,6 +2,7 @@
 
 import RewardsWalletCard from "@/component/RewardsWalletCard";
 import NotificationsCard from "@/component/NotificationsCard";
+import CoachCard from "@/component/CoachCard";
 import { useWallet } from "@/context/WalletContext";
 import { useConfirm } from "@/hooks/useConfirm";
 import { useToast } from "@/hooks/useToast";
@@ -311,6 +312,7 @@ export function DashboardShell({ children }: DashboardShellProps) {
             {pathname === "/dashboard" && (
               <aside className="xl:block w-[300px] space-y-6">
                 <RewardsWalletCard />
+                <CoachCard />
                 <NotificationsCard />
               </aside>
             )}

--- a/frontend/src/hooks/useCoachInsights.test.ts
+++ b/frontend/src/hooks/useCoachInsights.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useCoachInsights } from "./useCoachInsights";
+import { useWallet } from "@/context/WalletContext";
+import { getCoachInsights } from "@/lib/coach";
+import type { CoachInsightsResponse } from "@/lib/coach";
+
+vi.mock("@/context/WalletContext", () => ({
+  useWallet: vi.fn(),
+}));
+
+vi.mock("@/lib/coach", () => ({
+  getCoachInsights: vi.fn(),
+}));
+
+const mockedUseWallet = vi.mocked(useWallet);
+const mockedGetCoachInsights = vi.mocked(getCoachInsights);
+
+function mockWallet(
+  address: string | null,
+  token: string | null = address ? "test-token" : null,
+) {
+  mockedUseWallet.mockReturnValue({
+    address,
+    token,
+  } as unknown as ReturnType<typeof useWallet>);
+}
+
+function buildHistoryResponse(): CoachInsightsResponse {
+  return {
+    has_history: true,
+    message: null,
+    insights: {
+      accuracy_trend: {
+        direction: "improving",
+        recent_accuracy: 80,
+        prior_accuracy: 50,
+      },
+      best_category: {
+        category: "Crypto",
+        predictions: 10,
+        correct: 8,
+        accuracy_rate: "80.0",
+      },
+      worst_category: null,
+      current_streak: 3,
+      longest_streak: 6,
+      total_resolved: 15,
+      generated_at: "2026-08-19T10:00:00Z",
+    },
+  };
+}
+
+describe("useCoachInsights", () => {
+  beforeEach(() => {
+    mockedUseWallet.mockReset();
+    mockedGetCoachInsights.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("transitions from loading to success and reports hasHistory", async () => {
+    const response = buildHistoryResponse();
+    mockWallet("GADDRESS");
+    mockedGetCoachInsights.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useCoachInsights());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.insights).toEqual(response);
+    expect(result.current.hasHistory).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(mockedGetCoachInsights).toHaveBeenCalledWith("test-token");
+  });
+
+  it("reports hasHistory=false for the insufficient-history response", async () => {
+    mockWallet("GADDRESS");
+    mockedGetCoachInsights.mockResolvedValue({
+      has_history: false,
+      message: "Make a few more predictions…",
+      insights: null,
+    });
+
+    const { result } = renderHook(() => useCoachInsights());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.insights?.has_history).toBe(false);
+    expect(result.current.hasHistory).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("transitions from loading to error when the fetch rejects", async () => {
+    mockWallet("GADDRESS");
+    mockedGetCoachInsights.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useCoachInsights());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe(
+      "Network error. Please check your connection and try again.",
+    );
+    expect(result.current.insights).toBeNull();
+    expect(result.current.hasHistory).toBe(false);
+  });
+
+  it("short-circuits and never calls getCoachInsights when no wallet is connected", async () => {
+    mockWallet(null);
+
+    const { result } = renderHook(() => useCoachInsights());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockedGetCoachInsights).not.toHaveBeenCalled();
+    expect(result.current.insights).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useCoachInsights.ts
+++ b/frontend/src/hooks/useCoachInsights.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useWallet } from "@/context/WalletContext";
+import { getCoachInsights, type CoachInsightsResponse } from "@/lib/coach";
+import { logHookError } from "./useHookErrorMessage";
+
+export interface UseCoachInsightsReturn {
+  insights: CoachInsightsResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+  hasHistory: boolean;
+}
+
+export function useCoachInsights(): UseCoachInsightsReturn {
+  const { address, token } = useWallet();
+  const [insights, setInsights] = useState<CoachInsightsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInsights = useCallback(async () => {
+    if (!address || !token) {
+      setInsights(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await getCoachInsights(token);
+      setInsights(result);
+    } catch (err) {
+      setInsights(null);
+      setError(
+        logHookError(err, {
+          fallbackMessage: "Failed to load coach insights.",
+          hookName: "useCoachInsights",
+          id: address,
+        }),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [address, token]);
+
+  useEffect(() => {
+    fetchInsights();
+  }, [fetchInsights]);
+
+  const hasHistory = Boolean(insights?.has_history && insights.insights);
+
+  return {
+    insights,
+    isLoading,
+    error,
+    refetch: fetchInsights,
+    hasHistory,
+  };
+}

--- a/frontend/src/lib/coach.ts
+++ b/frontend/src/lib/coach.ts
@@ -1,0 +1,46 @@
+import { apiClient } from "@/lib/api";
+
+export type CoachCategoryStat = {
+  category: string;
+  predictions: number;
+  correct: number;
+  accuracy_rate: string;
+};
+
+export type CoachAccuracyTrend = {
+  direction: "improving" | "declining" | "steady" | "not_enough_data";
+  recent_accuracy: number;
+  prior_accuracy: number;
+};
+
+export type CoachInsightPayload = {
+  accuracy_trend: CoachAccuracyTrend;
+  best_category: CoachCategoryStat | null;
+  worst_category: CoachCategoryStat | null;
+  current_streak: number;
+  longest_streak: number;
+  total_resolved: number;
+  generated_at: string;
+};
+
+export type CoachInsightsResponse = {
+  has_history: boolean;
+  message: string | null;
+  insights: CoachInsightPayload | null;
+};
+
+const COACH_INSIGHTS_PATH = "/api/leaderboard/coach/insights";
+
+/**
+ * Fetches the personalised coach insights for the authenticated user.
+ * Backed by `GET /api/leaderboard/coach/insights` (see
+ * `backend/src/leaderboard/leaderboard.controller.ts`).
+ */
+export async function getCoachInsights(
+  token: string,
+): Promise<CoachInsightsResponse> {
+  return apiClient.get<CoachInsightsResponse>(COACH_INSIGHTS_PATH, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+}


### PR DESCRIPTION
## Summary

Implements the "Personalised Leaderboard Coach" promised in the README: an authenticated endpoint that analyses each user's resolved prediction history (accuracy trend, best/worst categories, streaks), caches results per user per ISO week with a weekly cron refresh and on-demand fallback, and surfaces them as a dashboard Coach card with distinct loading / error / new-user states.

Closes #1521

## Backend

### Insight computation — `leaderboard.service.ts`
- `computeCoachInsights()` queries the user's most recent resolved, non-cancelled predictions joined to their markets (`submitted_at DESC`, capped window), reusing the platform-wide correctness rule `market.resolved_outcome === chosen_outcome` (same SQL pattern as `predictions.service.ts`). Category comes from `market.category` — **no new tables**, no duplicated data.
- Pure helper `analyzePredictionHistory()` derives:
  - **Accuracy trend** — recent half of the analysed window vs prior half; `improving`/`declining` only beyond a 10 percentage-point delta, otherwise `steady`
  - **Best/worst category** — accuracy per category; minimum 3 resolved predictions to qualify
  - **Streaks** — current trailing streak + longest streak
- Thresholds are named, documented constants (no inline magic numbers): `MIN_RESOLVED_PREDICTIONS_FOR_INSIGHTS = 5`, `COACH_ANALYSIS_WINDOW = 30`, `MIN_CATEGORY_PREDICTIONS = 3`, `TREND_CHANGE_THRESHOLD_PP = 10`.
- Users below the threshold receive a distinct `{ has_history: false, message, insights: null }` shape so the client can render onboarding — never a partially-populated insight.

### Endpoint — `leaderboard.controller.ts`
- `GET /api/leaderboard/coach/insights` — JWT-required via the existing global guard + `@CurrentUser()`, declared before the `:address` catch-all routes, Swagger-documented. Response carries enough structure to render both "has history" and "insufficient history" states without a second round trip.

### Caching
- Per-user, ISO-week-scoped keys via new `CACHE_WARMING_KEYS.coachInsights(userId, weekId)` → `leaderboard:coach:<userId>:<year>-W<nn>`; TTL is an 8-day safety net only, so nothing lives indefinitely.
- Cache miss (new user, job failure) computes **on demand** and populates the cache — request-time never errors because the weekly job hasn't run.

### Scheduler — `leaderboard.scheduler.ts`
- New `@Cron('0 3 * * 1')` Monday refresh following the existing hourly/daily pattern: recomputes every eligible user into the current-week key, deletes prior-week keys, logs per-user failures without aborting the batch.

## Frontend

- **`lib/coach.ts`** — typed response models + `getCoachInsights(token)`; first consumer of the existing `apiClient` from `lib/api.ts` (Bearer header, `cache: "no-store"`).
- **`hooks/useCoachInsights.ts`** — mirrors the `useRewards` plain-fetch hook pattern exactly (useCallback fetcher + useEffect, short-circuit without wallet/token, errors via `logHookError`); kept separate from `useRewards`.
- **`component/CoachCard.tsx`** — composed into the `/dashboard` right sidebar in `dashboard-shell.tsx` between `RewardsWalletCard` and `NotificationsCard`. Renders four clearly separated states:
  1. **Loading** — skeleton (`role="status"`)
  2. **Error** — message + Retry button
  3. **New user** — backend-provided onboarding message + "Explore Markets" CTA
  4. **Has history** — trend badge (improving/declining/steady with recent-vs-prior %), strongest/weakest category rows, streak counter, and a **CTA derived from the actual payload** (e.g. *"Predict more in Crypto — your strongest category"*; falls back to trend-based copy when no category qualifies).

## Tests

Backend (`*.spec.ts`, additive — no existing tests deleted or weakened):
- Fixture-driven computation: exact assertions on trend/best/worst/streaks from a constructed history incl. unresolved + cancelled rows that must be excluded
- Insufficient-history case returns the new-user shape
- Cache behaviour asserted via spy on `computeCoachInsights` (second call within the week doesn't recompute); week-scoped key format asserted
- Weekly refresh: current-week set + previous-week del per user, per-user failure isolation, threshold enforced in SQL
- Scheduler handler triggers refresh and swallows failures; controller delegates and passes through both response shapes

Frontend (Vitest + Testing Library):
- Card renders tailored insight + derived CTA given mocked has-history response
- Card renders onboarding state given insufficient-history response (no insight widgets leak in)
- Loading skeleton and retryable error render distinctly from empty/error-free states
- Hook: success/hasHistory, insufficient-history flagging, error path, no-wallet short-circuit
- `dashboard-shell.test.tsx` (new file — none existed): asserts Coach composition order in the sidebar and absence outside `/dashboard`

## Verification

| Check | Result |
|---|---|
| `pnpm test` (backend, full suite) | ✅ 90 suites / 1162 tests passed |
| `pnpm build` (backend, `nest build`) | ✅ clean |
| `vitest run` (frontend) | ✅ 34/36 — only 2 **pre-existing** `utils.test.ts` CSV-quoting failures (reproduced on clean tree via `git stash`) |
| `pnpm build` (frontend, `next build`) | ✅ clean |
| Lint backend | ✅ 0 errors (315 warnings, all pre-existing in e2e/integration files); changed files lint-clean |
| Lint frontend | ⚠️ pre-existing breakage — Next 16 removed `next lint`; fails identically on clean tree, no eslint config present |

## Notes for reviewers

- Two files (`websocket/odds-broadcaster.service.ts`, `websocket.module.ts`) had unrelated prettier-only local modifications predating this branch — left untouched and excluded from this diff.
- `lib/api.ts` had zero consumers before this PR; `lib/coach.ts` is its first, so the base-URL/error-handling path (`ApiError` kinds) is now exercised in real usage.
- Cache invalidation is week-scoped by design: keys rotate every ISO week, so cross-week staleness is impossible even if the cron job is missed; the 8-day TTL only bounds within-week lifetime.
- Route ordering matters: `coach/insights` must stay declared above `@Get(':address')` in the controller to avoid capture by the param route.
- The two failing frontend tests are **not** touched by this PR — `src/lib/utils.test.ts` expects unquoted CSV fields while the implementation quotes fields containing commas; reproduced on a clean checkout before any changes.
