### PR TITLE
Contracts/1705 1706 1707 1708 vault and verification

### DIFF
--- a/contracts/creator-event-manager/Cargo.lock
+++ b/contracts/creator-event-manager/Cargo.lock
@@ -280,6 +280,8 @@ dependencies = [
 name = "creator-event-manager"
 version = "0.1.0"
 dependencies = [
+ "ed25519-dalek",
+ "rand",
  "soroban-sdk",
 ]
 

--- a/contracts/creator-event-manager/Cargo.toml
+++ b/contracts/creator-event-manager/Cargo.toml
@@ -12,6 +12,8 @@ soroban-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+ed25519-dalek = "2.1"
+rand = "0.8"
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contracts/creator-event-manager/src/admin.rs
+++ b/contracts/creator-event-manager/src/admin.rs
@@ -3,7 +3,7 @@
 /// The `initialize` function is the single entry point that must be called
 /// exactly once after deployment.  It stores every piece of global config in
 /// persistent storage and sets the counters to zero.
-use soroban_sdk::{Address, Env, Symbol, Vec};
+use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
 
 use crate::storage::TTL_LEDGERS;
 use crate::storage_types::DataKey;
@@ -42,6 +42,9 @@ pub enum AdminError {
     NotNominee = 10,
     /// A nomination already exists; cancel it before nominating another (#1356).
     NominationPending = 11,
+    /// `set_verifier_public_key` was called for an address that is not in
+    /// the configured verifier signer set (#1705).
+    NotAVerifierSigner = 12,
 }
 
 // ---------------------------------------------------------------------------
@@ -530,6 +533,63 @@ pub fn get_verifier_threshold(env: &Env) -> u32 {
         .persistent()
         .get::<DataKey, u32>(&DataKey::VerifierThreshold)
         .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Verifier signature keys (#1705)
+// ---------------------------------------------------------------------------
+
+/// Bind a raw ed25519 public key to a configured verifier signer.
+///
+/// `verification::submit_verification` uses this key to check a detached
+/// signature over the submitted payload, rather than trusting
+/// `Address::require_auth` alone (which proves the caller controls the
+/// signer's account, not that a specific piece of off-chain data — e.g. an
+/// oracle attestation — was actually produced by that signer's key).
+///
+/// # Errors
+/// * [`AdminError::Unauthorized`] — caller is not the admin.
+/// * [`AdminError::NotAVerifierSigner`] — `signer` is not in the currently
+///   configured verifier signer set (see `set_verifier_config`).
+///
+/// # Events
+/// Emits `(Symbol("admin"), Symbol("verifier_key_set"))` with data `signer`.
+pub fn set_verifier_public_key(
+    env: &Env,
+    caller: Address,
+    signer: Address,
+    public_key: BytesN<32>,
+) -> Result<(), AdminError> {
+    require_is_admin(env, &caller)?;
+
+    if !get_verifier_signers(env).iter().any(|addr| addr == signer) {
+        return Err(AdminError::NotAVerifierSigner);
+    }
+
+    let key = DataKey::VerifierPublicKey(signer.clone());
+    env.storage().persistent().set(&key, &public_key);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+
+    env.events().publish(
+        (Symbol::new(env, "admin"), Symbol::new(env, "verifier_key_set")),
+        signer,
+    );
+
+    Ok(())
+}
+
+/// Return the ed25519 public key bound to a verifier signer, if any.
+pub fn get_verifier_public_key(env: &Env, signer: &Address) -> Option<BytesN<32>> {
+    let key = DataKey::VerifierPublicKey(signer.clone());
+    let public_key = env.storage().persistent().get::<DataKey, BytesN<32>>(&key);
+    if public_key.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+    }
+    public_key
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/creator-event-manager/src/lib.rs
+++ b/contracts/creator-event-manager/src/lib.rs
@@ -267,6 +267,35 @@ impl CreatorEventManagerContract {
         admin::get_verifier_threshold(&env)
     }
 
+    /// Bind a raw ed25519 public key to a configured verifier signer, used by
+    /// `submit_verification` to check a detached signature over the
+    /// submitted attestation payload.
+    ///
+    /// Only the admin may call this, and `signer` must already be in the
+    /// configured verifier signer set (see `set_verifier_config`).
+    ///
+    /// # Panics
+    /// * `"unauthorized"` — caller is not the admin.
+    /// * `"not_a_verifier_signer"` — `signer` is not in the configured set.
+    pub fn set_verifier_public_key(
+        env: Env,
+        caller: Address,
+        signer: Address,
+        public_key: soroban_sdk::BytesN<32>,
+    ) {
+        match admin::set_verifier_public_key(&env, caller, signer, public_key) {
+            Ok(()) => {}
+            Err(AdminError::Unauthorized) => panic!("unauthorized"),
+            Err(AdminError::NotAVerifierSigner) => panic!("not_a_verifier_signer"),
+            Err(_) => panic!("unexpected_error"),
+        }
+    }
+
+    /// Return the ed25519 public key bound to a verifier signer, if any.
+    pub fn get_verifier_public_key(env: Env, signer: Address) -> Option<soroban_sdk::BytesN<32>> {
+        admin::get_verifier_public_key(&env, &signer)
+    }
+
     // =========================================================================
     // Verification (#790–#793)
     // =========================================================================
@@ -337,21 +366,38 @@ impl CreatorEventManagerContract {
         verification::is_verified(&env, address)
     }
 
-    /// Submit a verifier signature for an event (M-of-N event verification).
+    /// Submit a signed verifier attestation for an event (M-of-N event
+    /// verification).
     ///
     /// `signer` must be one of the addresses configured via
-    /// `set_verifier_config`. Each signer may submit at most once per event.
-    /// Returns the number of distinct signers who have now submitted.
+    /// `set_verifier_config`, with an ed25519 public key bound via
+    /// `set_verifier_public_key`. `signature` must be a valid ed25519
+    /// signature by that key over `event_id (8 bytes, big-endian) || data`,
+    /// so a signature cannot be replayed against a different event. Each
+    /// signer may submit at most once per event. Returns the number of
+    /// distinct signers who have now submitted.
     ///
     /// # Panics
     /// * `"event_not_found"` — no event exists for `event_id`.
     /// * `"not_a_verifier_signer"` — `signer` is not a configured verifier.
+    /// * `"no_public_key_configured"` — `signer` has no bound public key.
     /// * `"duplicate_signer"` — `signer` already submitted for this event.
-    pub fn submit_verification(env: Env, event_id: u64, signer: Address) -> u32 {
-        match verification::submit_verification(&env, event_id, signer) {
+    /// * an ed25519 verification panic — `signature` does not verify against
+    ///   the signer's bound key and the event-bound payload.
+    pub fn submit_verification(
+        env: Env,
+        event_id: u64,
+        signer: Address,
+        data: soroban_sdk::Bytes,
+        signature: soroban_sdk::BytesN<64>,
+    ) -> u32 {
+        match verification::submit_verification(&env, event_id, signer, data, signature) {
             Ok(count) => count,
             Err(VerificationError::EventNotFound) => panic!("event_not_found"),
             Err(VerificationError::NotAVerifierSigner) => panic!("not_a_verifier_signer"),
+            Err(VerificationError::NoPublicKeyConfigured) => {
+                panic!("no_public_key_configured")
+            }
             Err(VerificationError::DuplicateSigner) => panic!("duplicate_signer"),
             Err(_) => panic!("unexpected_error"),
         }

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -298,6 +298,15 @@ pub enum DataKey {
     /// `verification::submit_verification`.
     EventVerificationSigners(u64),
 
+    // ── Verifier signature keys (#1705) ──────────────────────────────────────
+    /// The raw ed25519 public key (32 bytes) bound to a configured verifier
+    /// signer's `Address`  (signer). Written by `admin::set_verifier_config`.
+    /// `verification::submit_verification` verifies the caller's signature
+    /// against this key rather than trusting `require_auth` alone, since a
+    /// detached ed25519 signature can be checked against a payload bound to
+    /// the specific event being verified.
+    VerifierPublicKey(Address),
+
     // ── Multi-source oracle aggregation (#1347) ──────────────────────────────
     /// Vec<Address> of addresses authorized to submit numeric oracle values.
     /// Written by `oracle::configure_oracle_sources`.

--- a/contracts/creator-event-manager/src/verification.rs
+++ b/contracts/creator-event-manager/src/verification.rs
@@ -8,7 +8,7 @@
 /// and is independent of other contract state. Any address can be verified or
 /// unverified by the admin at any time, enabling flexible access control for
 /// features that require whitelisted participants.
-use soroban_sdk::{Address, Env, Symbol, Vec};
+use soroban_sdk::{Address, Bytes, BytesN, Env, Symbol, Vec};
 
 use crate::storage::TTL_LEDGERS;
 use crate::storage_types::DataKey;
@@ -39,6 +39,12 @@ pub enum VerificationError {
     DuplicateSigner = 7,
     /// No event exists for the given event_id.
     EventNotFound = 8,
+    /// No ed25519 public key has been bound to this signer via
+    /// `admin::set_verifier_public_key` (#1705).
+    NoPublicKeyConfigured = 9,
+    /// The supplied signature does not verify against the signer's bound
+    /// public key and the event-bound payload (#1705).
+    InvalidSignature = 10,
 }
 
 // ---------------------------------------------------------------------------
@@ -232,20 +238,44 @@ pub fn is_verified(env: &Env, address: Address) -> bool {
 // M-of-N event verification (#1358)
 // ---------------------------------------------------------------------------
 
-/// Submit a verifier signature for an event.
+/// Build the payload a verifier signs for [`submit_verification`]: the
+/// `event_id` as 8 big-endian bytes followed by the caller-supplied
+/// attestation `data`. Binding `event_id` into the signed bytes means a
+/// signature produced for one event cannot be replayed to verify a
+/// different one.
+fn verification_payload(env: &Env, event_id: u64, data: &Bytes) -> Bytes {
+    let mut payload = Bytes::from_array(env, &event_id.to_be_bytes());
+    payload.append(data);
+    payload
+}
+
+/// Submit a signed verifier attestation for an event.
 ///
 /// `signer` must be one of the addresses configured via
-/// `admin::set_verifier_config`. Each signer may submit at most once per
-/// event — a second submission from the same signer is rejected. Once `M`
-/// (the configured threshold) distinct signers have submitted, the event is
-/// considered verified; see [`is_event_verified`].
+/// `admin::set_verifier_config`, with an ed25519 public key bound via
+/// `admin::set_verifier_public_key`. `signature` must be a valid ed25519
+/// signature, by that bound key, over the payload
+/// `event_id (8 bytes, big-endian) || data` — see [`verification_payload`].
+/// Binding `event_id` into the signed payload means a signature cannot be
+/// replayed against a different event even if `data` happens to match.
+///
+/// Each signer may submit at most once per event — a second submission from
+/// the same signer is rejected. Once `M` (the configured threshold) distinct
+/// signers have submitted, the event is considered verified; see
+/// [`is_event_verified`].
 ///
 /// # Errors
 /// * [`VerificationError::EventNotFound`] — no event exists for `event_id`.
 /// * [`VerificationError::NotAVerifierSigner`] — `signer` is not in the
 ///   configured verifier signer set.
+/// * [`VerificationError::NoPublicKeyConfigured`] — `signer` has no ed25519
+///   public key bound via `admin::set_verifier_public_key`.
 /// * [`VerificationError::DuplicateSigner`] — `signer` already submitted
 ///   verification for this event.
+/// * Panics if `signature` does not verify against the signer's bound public
+///   key and the event-bound payload (an invalid ed25519 signature aborts
+///   the transaction rather than returning an error, per
+///   `env.crypto().ed25519_verify`).
 ///
 /// # Returns
 /// The number of distinct signers who have now submitted for this event.
@@ -257,6 +287,8 @@ pub fn submit_verification(
     env: &Env,
     event_id: u64,
     signer: Address,
+    data: Bytes,
+    signature: BytesN<64>,
 ) -> Result<u32, VerificationError> {
     signer.require_auth();
 
@@ -269,10 +301,18 @@ pub fn submit_verification(
         return Err(VerificationError::NotAVerifierSigner);
     }
 
+    let public_key = crate::admin::get_verifier_public_key(env, &signer)
+        .ok_or(VerificationError::NoPublicKeyConfigured)?;
+
     let mut submitted = crate::storage::get_event_verification_signers(env, event_id);
     if submitted.iter().any(|addr| addr == signer) {
         return Err(VerificationError::DuplicateSigner);
     }
+
+    // Reverts (panics) the whole call if the signature does not verify
+    // against `signer`'s bound key and the event-bound payload.
+    let payload = verification_payload(env, event_id, &data);
+    env.crypto().ed25519_verify(&public_key, &payload, &signature);
 
     crate::storage::add_event_verification_signer(env, event_id, &signer);
     submitted.push_back(signer.clone());

--- a/contracts/creator-event-manager/src/views.rs
+++ b/contracts/creator-event-manager/src/views.rs
@@ -14,11 +14,22 @@ use soroban_sdk::{contracttype, Address, Env, Vec};
 /// Returned by `get_event_statistics(event_id)` as a compact summary of the
 /// event's current on-chain state:
 /// * `event_id` — event being summarized.
-/// * `participant_count` — number of joined participants stored on the event.
-/// * `match_count` — number of matches stored on the event.
+/// * `participant_count` — number of entries in the `EventParticipants`
+///   source list (not the cached `Event.participant_count` counter).
+/// * `match_count` — number of entries in the `EventMatches` source list
+///   (not the cached `Event.match_count` counter).
 /// * `total_predictions` — total predictions linked to all event matches.
 /// * `all_matches_resolved` — `true` only when the event has at least one
 ///   match and every stored match has a submitted result.
+///
+/// # Consistency
+/// `participant_count`, `match_count`, and `total_predictions` are derived
+/// directly from the underlying storage lists on every call, so they always
+/// reflect current on-chain state — they cannot drift even if a cached
+/// counter elsewhere (e.g. `Event.participant_count`, used only for O(1)
+/// capacity checks on `join_event`) were ever out of sync. `all_matches_resolved`
+/// is a point-in-time read: a match resolved in the same ledger after this
+/// view is read will not retroactively change an already-returned value.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EventStatistics {
@@ -75,8 +86,13 @@ pub fn get_event_reward_distribution(env: &Env, event_id: u64) -> Result<Vec<u32
 /// then derives prediction totals from the event's match index and completion
 /// status from each stored match result.
 pub fn get_event_statistics(env: &Env, event_id: u64) -> Result<EventStatistics, EventError> {
-    let event = event::get_event(env, event_id)?;
+    // Validate the event exists; statistics themselves are derived entirely
+    // from source records below rather than from this record's cached
+    // counters, so a churned event never reports stale figures.
+    event::get_event(env, event_id)?;
     let match_ids = storage::get_event_matches(env, event_id);
+    let participant_count = storage::get_event_participants(env, event_id).len();
+    let match_count = match_ids.len();
 
     let mut total_predictions: u32 = 0;
     let mut resolved_matches: u32 = 0;
@@ -92,14 +108,12 @@ pub fn get_event_statistics(env: &Env, event_id: u64) -> Result<EventStatistics,
         }
     }
 
-    let all_matches_resolved = event.match_count > 0
-        && match_ids.len() == event.match_count
-        && resolved_matches == event.match_count;
+    let all_matches_resolved = match_count > 0 && resolved_matches == match_count;
 
     Ok(EventStatistics {
         event_id,
-        participant_count: event.participant_count,
-        match_count: event.match_count,
+        participant_count,
+        match_count,
         total_predictions,
         all_matches_resolved,
     })
@@ -196,6 +210,19 @@ pub struct PlatformStatistics {
 /// Aggregates data across all events to provide a comprehensive view of
 /// platform activity including total events, matches, predictions, unique
 /// participants, and fees collected.
+///
+/// # Consistency
+/// `total_events`, `total_matches`, and `total_predictions` read the
+/// monotonically-incrementing `EventCounter` / `MatchCounter` /
+/// `PredictionCounter` instance values. These counters are themselves the
+/// source of truth for ID assignment (every `next_*_id` call both allocates
+/// an ID and advances the counter in the same write), so unlike a
+/// denormalized cache they cannot drift from the records they describe —
+/// reconciling them against a full per-event scan would be strictly more
+/// expensive with no consistency benefit. `unique_participants` and
+/// `total_fees_collected` are computed by scanning every event's source
+/// `EventParticipants` list and `creation_fee_paid` field on each call, so
+/// they always reflect current state at read time.
 ///
 /// # Returns
 /// `PlatformStatistics` struct with aggregated platform data.

--- a/contracts/creator-event-manager/tests/verification_tests.rs
+++ b/contracts/creator-event-manager/tests/verification_tests.rs
@@ -3,9 +3,11 @@
 /// Covers: verify_address, batch_verify_addresses, unverify_address, is_verified,
 /// and the M-of-N event-verification signer threshold (#1358).
 use creator_event_manager::CreatorEventManagerContractClient;
+use ed25519_dalek::{Signer, SigningKey};
+use rand::rngs::OsRng;
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::token::StellarAssetClient;
-use soroban_sdk::{Address, Env, String, Vec};
+use soroban_sdk::{Address, Bytes, BytesN, Env, String, Vec};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -394,9 +396,42 @@ fn test_is_verified_requires_no_auth() {
 
 // ===========================================================================
 // #1358 — M-of-N event verification (submit_verification / is_event_verified)
+// #1705 — Verification signature check
 // ===========================================================================
 
 const FEE: i128 = 1_000_000;
+
+/// A test signer's ed25519 keypair alongside the Soroban `Address` used as
+/// its identity in the verifier signer set / `require_auth`.
+struct VerifierKey {
+    address: Address,
+    signing_key: SigningKey,
+}
+
+fn generate_verifier_key(env: &Env) -> VerifierKey {
+    let signing_key = SigningKey::generate(&mut OsRng);
+    VerifierKey {
+        address: Address::generate(env),
+        signing_key,
+    }
+}
+
+fn public_key_bytes(env: &Env, key: &VerifierKey) -> BytesN<32> {
+    BytesN::from_array(env, key.signing_key.verifying_key().as_bytes())
+}
+
+/// Sign the same `event_id || data` payload that `submit_verification`
+/// verifies against.
+fn sign_verification(env: &Env, key: &VerifierKey, event_id: u64, data: &Bytes) -> BytesN<64> {
+    let mut payload = event_id.to_be_bytes().to_vec();
+    payload.extend(data.iter());
+    let signature = key.signing_key.sign(&payload);
+    BytesN::from_array(env, &signature.to_bytes())
+}
+
+fn sample_data(env: &Env) -> Bytes {
+    Bytes::from_array(env, &[1u8, 2, 3, 4])
+}
 
 fn fund(env: &Env, token: &Address, user: &Address, amount: i128) {
     StellarAssetClient::new(env, token).mint(user, &amount);
@@ -456,16 +491,19 @@ fn setup_with_event() -> (
 fn test_submit_verification_by_configured_signer_succeeds() {
     let (env, client, _contract_id, admin, event_id) = setup_with_event();
 
-    let signer1 = Address::generate(&env);
-    let signer2 = Address::generate(&env);
-    let signer3 = Address::generate(&env);
+    let signer1 = generate_verifier_key(&env);
+    let signer2 = generate_verifier_key(&env);
+    let signer3 = generate_verifier_key(&env);
     let mut signers = Vec::new(&env);
-    signers.push_back(signer1.clone());
-    signers.push_back(signer2.clone());
-    signers.push_back(signer3.clone());
+    signers.push_back(signer1.address.clone());
+    signers.push_back(signer2.address.clone());
+    signers.push_back(signer3.address.clone());
     client.set_verifier_config(&admin, &signers, &2u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
 
-    let count = client.submit_verification(&event_id, &signer1);
+    let data = sample_data(&env);
+    let signature = sign_verification(&env, &signer1, event_id, &data);
+    let count = client.submit_verification(&event_id, &signer1.address, &data, &signature);
     assert_eq!(count, 1);
 }
 
@@ -474,13 +512,15 @@ fn test_submit_verification_by_configured_signer_succeeds() {
 fn test_submit_verification_by_non_signer_is_rejected() {
     let (env, client, _contract_id, admin, event_id) = setup_with_event();
 
-    let signer1 = Address::generate(&env);
+    let signer1 = generate_verifier_key(&env);
     let mut signers = Vec::new(&env);
-    signers.push_back(signer1);
+    signers.push_back(signer1.address.clone());
     client.set_verifier_config(&admin, &signers, &1u32);
 
-    let not_a_signer = Address::generate(&env);
-    client.submit_verification(&event_id, &not_a_signer);
+    let not_a_signer = generate_verifier_key(&env);
+    let data = sample_data(&env);
+    let signature = sign_verification(&env, &not_a_signer, event_id, &data);
+    client.submit_verification(&event_id, &not_a_signer.address, &data, &signature);
 }
 
 #[test]
@@ -488,12 +528,15 @@ fn test_submit_verification_by_non_signer_is_rejected() {
 fn test_submit_verification_unknown_event_is_rejected() {
     let (env, client, _contract_id, admin, _event_id) = setup_with_event();
 
-    let signer1 = Address::generate(&env);
+    let signer1 = generate_verifier_key(&env);
     let mut signers = Vec::new(&env);
-    signers.push_back(signer1.clone());
+    signers.push_back(signer1.address.clone());
     client.set_verifier_config(&admin, &signers, &1u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
 
-    client.submit_verification(&999_999_u64, &signer1);
+    let data = sample_data(&env);
+    let signature = sign_verification(&env, &signer1, 999_999_u64, &data);
+    client.submit_verification(&999_999_u64, &signer1.address, &data, &signature);
 }
 
 #[test]
@@ -501,38 +544,102 @@ fn test_submit_verification_unknown_event_is_rejected() {
 fn test_submit_verification_duplicate_signer_is_rejected() {
     let (env, client, _contract_id, admin, event_id) = setup_with_event();
 
-    let signer1 = Address::generate(&env);
-    let signer2 = Address::generate(&env);
+    let signer1 = generate_verifier_key(&env);
+    let signer2 = generate_verifier_key(&env);
     let mut signers = Vec::new(&env);
-    signers.push_back(signer1.clone());
-    signers.push_back(signer2);
+    signers.push_back(signer1.address.clone());
+    signers.push_back(signer2.address.clone());
     client.set_verifier_config(&admin, &signers, &2u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
 
-    client.submit_verification(&event_id, &signer1);
+    let data = sample_data(&env);
+    let signature = sign_verification(&env, &signer1, event_id, &data);
+    client.submit_verification(&event_id, &signer1.address, &data, &signature);
     // Same signer submitting again must be rejected, even though the
     // threshold has not been reached yet.
-    client.submit_verification(&event_id, &signer1);
+    client.submit_verification(&event_id, &signer1.address, &data, &signature);
+}
+
+#[test]
+#[should_panic(expected = "no_public_key_configured")]
+fn test_submit_verification_without_bound_public_key_is_rejected() {
+    let (env, client, _contract_id, admin, event_id) = setup_with_event();
+
+    let signer1 = generate_verifier_key(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.address.clone());
+    client.set_verifier_config(&admin, &signers, &1u32);
+    // Deliberately skip set_verifier_public_key.
+
+    let data = sample_data(&env);
+    let signature = sign_verification(&env, &signer1, event_id, &data);
+    client.submit_verification(&event_id, &signer1.address, &data, &signature);
+}
+
+/// #1705 — a signature that does not verify against the signer's bound key
+/// (here: signed by an unrelated key) must be rejected rather than accepted.
+#[test]
+#[should_panic]
+fn test_submit_verification_with_invalid_signature_is_rejected() {
+    let (env, client, _contract_id, admin, event_id) = setup_with_event();
+
+    let signer1 = generate_verifier_key(&env);
+    let attacker_key = generate_verifier_key(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.address.clone());
+    client.set_verifier_config(&admin, &signers, &1u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
+
+    let data = sample_data(&env);
+    // Signed with a key that was never bound to signer1.
+    let bogus_signature = sign_verification(&env, &attacker_key, event_id, &data);
+    client.submit_verification(&event_id, &signer1.address, &data, &bogus_signature);
+}
+
+/// #1705 — a signature produced for a different event must not verify here,
+/// even though it is a genuinely valid signature by the correct key: the
+/// payload binds `event_id` so it cannot be replayed cross-event.
+#[test]
+#[should_panic]
+fn test_submit_verification_signature_bound_to_wrong_event_is_rejected() {
+    let (env, client, _contract_id, admin, event_id) = setup_with_event();
+
+    let signer1 = generate_verifier_key(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(signer1.address.clone());
+    client.set_verifier_config(&admin, &signers, &1u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
+
+    let data = sample_data(&env);
+    // Valid signature, but bound to a different event_id.
+    let signature_for_other_event = sign_verification(&env, &signer1, event_id + 1, &data);
+    client.submit_verification(&event_id, &signer1.address, &data, &signature_for_other_event);
 }
 
 #[test]
 fn test_event_not_verified_below_threshold() {
     let (env, client, _contract_id, admin, event_id) = setup_with_event();
 
-    let signer1 = Address::generate(&env);
-    let signer2 = Address::generate(&env);
-    let signer3 = Address::generate(&env);
+    let signer1 = generate_verifier_key(&env);
+    let signer2 = generate_verifier_key(&env);
+    let signer3 = generate_verifier_key(&env);
     let mut signers = Vec::new(&env);
-    signers.push_back(signer1.clone());
-    signers.push_back(signer2.clone());
-    signers.push_back(signer3);
+    signers.push_back(signer1.address.clone());
+    signers.push_back(signer2.address.clone());
+    signers.push_back(signer3.address.clone());
     client.set_verifier_config(&admin, &signers, &3u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
+    client.set_verifier_public_key(&admin, &signer2.address, &public_key_bytes(&env, &signer2));
 
     assert!(!client.is_event_verified(&event_id));
 
-    client.submit_verification(&event_id, &signer1);
+    let data = sample_data(&env);
+    let sig1 = sign_verification(&env, &signer1, event_id, &data);
+    client.submit_verification(&event_id, &signer1.address, &data, &sig1);
     assert!(!client.is_event_verified(&event_id));
 
-    client.submit_verification(&event_id, &signer2);
+    let sig2 = sign_verification(&env, &signer2, event_id, &data);
+    client.submit_verification(&event_id, &signer2.address, &data, &sig2);
     // 2 of 3 distinct signers submitted; threshold is 3 — still unverified.
     assert!(!client.is_event_verified(&event_id));
     assert_eq!(client.get_event_verification_count(&event_id), 2);
@@ -542,19 +649,24 @@ fn test_event_not_verified_below_threshold() {
 fn test_event_verified_at_exact_threshold() {
     let (env, client, _contract_id, admin, event_id) = setup_with_event();
 
-    let signer1 = Address::generate(&env);
-    let signer2 = Address::generate(&env);
-    let signer3 = Address::generate(&env);
+    let signer1 = generate_verifier_key(&env);
+    let signer2 = generate_verifier_key(&env);
+    let signer3 = generate_verifier_key(&env);
     let mut signers = Vec::new(&env);
-    signers.push_back(signer1.clone());
-    signers.push_back(signer2.clone());
-    signers.push_back(signer3);
+    signers.push_back(signer1.address.clone());
+    signers.push_back(signer2.address.clone());
+    signers.push_back(signer3.address.clone());
     client.set_verifier_config(&admin, &signers, &2u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
+    client.set_verifier_public_key(&admin, &signer2.address, &public_key_bytes(&env, &signer2));
 
-    client.submit_verification(&event_id, &signer1);
+    let data = sample_data(&env);
+    let sig1 = sign_verification(&env, &signer1, event_id, &data);
+    client.submit_verification(&event_id, &signer1.address, &data, &sig1);
     assert!(!client.is_event_verified(&event_id));
 
-    client.submit_verification(&event_id, &signer2);
+    let sig2 = sign_verification(&env, &signer2, event_id, &data);
+    client.submit_verification(&event_id, &signer2.address, &data, &sig2);
     // 2 of 3 distinct signers submitted; threshold is 2 — now verified.
     assert!(client.is_event_verified(&event_id));
     assert_eq!(client.get_event_verification_count(&event_id), 2);
@@ -573,16 +685,22 @@ fn test_event_not_verified_without_any_config() {
 fn test_get_event_verification_count_reflects_distinct_signers_only() {
     let (env, client, _contract_id, admin, event_id) = setup_with_event();
 
-    let signer1 = Address::generate(&env);
-    let signer2 = Address::generate(&env);
+    let signer1 = generate_verifier_key(&env);
+    let signer2 = generate_verifier_key(&env);
     let mut signers = Vec::new(&env);
-    signers.push_back(signer1.clone());
-    signers.push_back(signer2.clone());
+    signers.push_back(signer1.address.clone());
+    signers.push_back(signer2.address.clone());
     client.set_verifier_config(&admin, &signers, &2u32);
+    client.set_verifier_public_key(&admin, &signer1.address, &public_key_bytes(&env, &signer1));
+    client.set_verifier_public_key(&admin, &signer2.address, &public_key_bytes(&env, &signer2));
+
+    let data = sample_data(&env);
 
     assert_eq!(client.get_event_verification_count(&event_id), 0);
-    client.submit_verification(&event_id, &signer1);
+    let sig1 = sign_verification(&env, &signer1, event_id, &data);
+    client.submit_verification(&event_id, &signer1.address, &data, &sig1);
     assert_eq!(client.get_event_verification_count(&event_id), 1);
-    client.submit_verification(&event_id, &signer2);
+    let sig2 = sign_verification(&env, &signer2, event_id, &data);
+    client.submit_verification(&event_id, &signer2.address, &data, &sig2);
     assert_eq!(client.get_event_verification_count(&event_id), 2);
 }

--- a/contracts/creator-event-manager/tests/views_tests.rs
+++ b/contracts/creator-event-manager/tests/views_tests.rs
@@ -293,6 +293,62 @@ fn test_event_statistics_completion_status() {
     assert!(completed_statistics.all_matches_resolved);
 }
 
+/// #1706 — `get_event_statistics` must read `EventParticipants` /
+/// `EventMatches` directly rather than trusting the cached
+/// `Event.participant_count` / `Event.match_count` counters, so a view stays
+/// correct even if those cached counters were ever to desync from the
+/// source lists (e.g. a future code path that mutates one without the
+/// other). This test forces exactly that desync directly in storage and
+/// asserts the view still reports the true, source-derived counts.
+#[test]
+fn test_event_statistics_match_source_records_after_counter_drift() {
+    let (env, client, contract_id, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let user_one = Address::generate(&env);
+    let user_two = Address::generate(&env);
+    let user_three = Address::generate(&env);
+    fund(&env, &xlm_token, &creator, FEE);
+
+    let start_time = get_future_time(&env, 3600);
+    let end_time = get_future_time(&env, 7200);
+    let (event_id, invite_code) = client.create_event(
+        &creator,
+        &title(&env),
+        &desc(&env),
+        &5u32,
+        &start_time,
+        &end_time,
+        &0i128,
+        &Vec::new(&env),
+        &0i128,
+    );
+
+    client.join_event(&user_one, &invite_code);
+    client.join_event(&user_two, &invite_code);
+    client.join_event(&user_three, &invite_code);
+
+    env.as_contract(&contract_id, || {
+        add_match(&env, event_id, false);
+        add_match(&env, event_id, false);
+        add_match(&env, event_id, false);
+
+        // Simulate the cached counters falling out of sync with the source
+        // lists (the drift scenario #1706 guards against) by rewriting them
+        // directly, without touching EventParticipants / EventMatches.
+        let mut event = storage::get_event(&env, event_id).expect("event exists");
+        event.participant_count = 1;
+        event.match_count = 1;
+        storage::set_event(&env, event_id, &event);
+    });
+
+    let statistics = client.get_event_statistics(&event_id);
+
+    // The view must reflect the real source records (3 participants, 3
+    // matches), not the desynced cached counters (1, 1).
+    assert_eq!(statistics.participant_count, 3);
+    assert_eq!(statistics.match_count, 3);
+}
+
 #[test]
 #[should_panic(expected = "event_not_found")]
 fn test_event_statistics_missing_event_panics() {

--- a/contracts/staking-vault/.gitignore
+++ b/contracts/staking-vault/.gitignore
@@ -1,0 +1,42 @@
+# Rust/Cargo
+/target/
+# Cargo.lock is committed to pin reproducible dependency versions for CI
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Soroban
+.soroban/
+
+# Test snapshots (generated, can be heavy)
+test_snapshots/
+
+# Build artifacts
+*.wasm
+*.wasm.gz
+
+# Logs
+*.log
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Temporary files
+*.tmp
+*.temp
+*~
+
+# Coverage reports
+tarpaulin-report.html
+lcov.info
+
+# Backup files
+*.bak
+*.backup

--- a/contracts/staking-vault/Cargo.lock
+++ b/contracts/staking-vault/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -125,7 +125,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -193,15 +193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -281,15 +272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,7 +289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -320,16 +302,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -349,27 +321,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "curve25519-dalek-derive",
- "digest 0.11.3",
- "fiat-crypto 0.3.0",
- "rand_core 0.10.1",
+ "digest",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -539,20 +494,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -574,10 +519,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -587,16 +532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
-dependencies = [
- "signature 3.0.0",
+ "signature",
 ]
 
 [[package]]
@@ -605,26 +541,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "rand_core 0.6.4",
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
  "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
-dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
- "rand_core 0.10.1",
- "sha2 0.11.0",
- "signature 3.0.0",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -643,11 +564,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -677,7 +598,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -686,12 +607,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -760,7 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -806,16 +721,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
-dependencies = [
- "typenum",
+ "digest",
 ]
 
 [[package]]
@@ -965,7 +871,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -974,7 +880,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1061,7 +967,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1161,7 +1067,7 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1171,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1182,12 +1088,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -1360,19 +1260,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1381,7 +1270,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -1397,17 +1286,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "rand_core 0.10.1",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1473,9 +1353,9 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "ecdsa",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
  "getrandom",
@@ -1489,7 +1369,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "sec1",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -1538,7 +1418,7 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "derive_arbitrary",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
@@ -1562,7 +1442,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "sha2 0.10.9",
+ "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
@@ -1591,7 +1471,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-spec",
  "stellar-xdr",
  "syn 2.0.119",

--- a/contracts/staking-vault/src/fees.rs
+++ b/contracts/staking-vault/src/fees.rs
@@ -1,22 +1,43 @@
 //! Fee intake: the `fee_source` contract (e.g. open-market) transfers protocol
 //! fees into the vault, which are then distributed to stakers via [`crate::pool`].
-//!
-//! Skeleton — fill in the token transfer-in and pool distribution.
 
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{token::Client as TokenClient, Address, Env};
 
 use crate::errors::StakingError;
+use crate::pool;
+use crate::storage_types::{Config, DataKey, PoolState};
 
 /// Pull `amount` of the staking token from `from` into the vault and fold it
 /// into the reward pool. Caller must be the configured `fee_source`.
-pub fn deposit_fees(
-    _env: &Env,
-    _from: Address,
-    _amount: i128,
-) -> Result<(), StakingError> {
-    // TODO:
-    //   1. require_auth(from) and assert from == config.fee_source
-    //   2. token.transfer(from, contract, amount)
-    //   3. pool::distribute(env, &mut pool, amount)
-    todo!()
+pub fn deposit_fees(env: &Env, from: Address, amount: i128) -> Result<(), StakingError> {
+    from.require_auth();
+
+    if amount <= 0 {
+        return Err(StakingError::InvalidAmount);
+    }
+
+    let config = env
+        .storage()
+        .instance()
+        .get::<DataKey, Config>(&DataKey::Config)
+        .ok_or(StakingError::NotInitialized)?;
+
+    if from != config.fee_source {
+        return Err(StakingError::Unauthorized);
+    }
+
+    let mut pool_state = env
+        .storage()
+        .instance()
+        .get::<DataKey, PoolState>(&DataKey::Pool)
+        .ok_or(StakingError::NotInitialized)?;
+
+    let token_client = TokenClient::new(env, &config.token);
+    token_client.transfer(&from, &env.current_contract_address(), &amount);
+
+    pool::distribute(env, &mut pool_state, amount)?;
+
+    env.storage().instance().set(&DataKey::Pool, &pool_state);
+
+    Ok(())
 }

--- a/contracts/staking-vault/src/lib.rs
+++ b/contracts/staking-vault/src/lib.rs
@@ -10,7 +10,9 @@ pub mod storage_types;
 pub use crate::errors::StakingError;
 pub use crate::storage_types::{Config, DataKey, LockTier, Position, PoolState};
 
-use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, token::Client as TokenClient, Address, Env, Vec};
+
+use crate::storage_types::{LEDGER_BUMP_PERMANENT, LEDGER_BUMP_POSITION};
 
 /// Staking & fee-sharing vault for InsightArena.
 ///
@@ -20,6 +22,62 @@ use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
 #[contract]
 pub struct StakingVault;
 
+fn get_config(env: &Env) -> Result<Config, StakingError> {
+    env.storage()
+        .instance()
+        .get::<DataKey, Config>(&DataKey::Config)
+        .ok_or(StakingError::NotInitialized)
+}
+
+fn get_pool_state(env: &Env) -> Result<PoolState, StakingError> {
+    env.storage()
+        .instance()
+        .get::<DataKey, PoolState>(&DataKey::Pool)
+        .ok_or(StakingError::NotInitialized)
+}
+
+fn set_pool_state(env: &Env, pool_state: &PoolState) {
+    env.storage().instance().set(&DataKey::Pool, pool_state);
+}
+
+fn get_lock_tiers(env: &Env) -> Vec<LockTier> {
+    env.storage()
+        .instance()
+        .get::<DataKey, Vec<LockTier>>(&DataKey::LockTiers)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn get_position_raw(env: &Env, staker: &Address) -> Option<Position> {
+    let key = DataKey::Position(staker.clone());
+    let position = env.storage().persistent().get::<DataKey, Position>(&key);
+    if position.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_BUMP_POSITION, LEDGER_BUMP_POSITION);
+    }
+    position
+}
+
+fn set_position(env: &Env, staker: &Address, position: &Position) {
+    let key = DataKey::Position(staker.clone());
+    env.storage().persistent().set(&key, position);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_BUMP_POSITION, LEDGER_BUMP_POSITION);
+}
+
+fn require_not_paused(env: &Env) -> Result<(), StakingError> {
+    let paused = env
+        .storage()
+        .instance()
+        .get::<DataKey, bool>(&DataKey::Paused)
+        .unwrap_or(false);
+    if paused {
+        return Err(StakingError::Paused);
+    }
+    Ok(())
+}
+
 #[contractimpl]
 impl StakingVault {
     // ── Initialisation ──────────────────────────────────────────────────────────
@@ -27,14 +85,45 @@ impl StakingVault {
     /// Configure the vault for first use. Reverts with `AlreadyInitialized`
     /// on any subsequent call.
     pub fn initialize(
-        _env: Env,
-        _admin: Address,
-        _token: Address,
-        _fee_source: Address,
-        _lock_tiers: Vec<LockTier>,
+        env: Env,
+        admin: Address,
+        token: Address,
+        fee_source: Address,
+        lock_tiers: Vec<LockTier>,
     ) -> Result<(), StakingError> {
-        // TODO: persist Config + LockTiers, init empty PoolState, guard re-init.
-        todo!()
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::Config)
+        {
+            return Err(StakingError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        let config = Config {
+            admin,
+            token,
+            fee_source,
+        };
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::LockTiers, &lock_tiers);
+        env.storage().instance().set(&DataKey::Paused, &false);
+
+        let pool_state = PoolState {
+            total_shares: 0,
+            acc_reward_per_share: 0,
+            pending_rewards: 0,
+        };
+        env.storage().instance().set(&DataKey::Pool, &pool_state);
+
+        env.storage()
+            .instance()
+            .extend_ttl(LEDGER_BUMP_PERMANENT, LEDGER_BUMP_PERMANENT);
+
+        Ok(())
     }
 
     // ── Staking ─────────────────────────────────────────────────────────────────
@@ -42,69 +131,195 @@ impl StakingVault {
     /// Stake `amount` of the token, locking it for `lock_duration` seconds in
     /// exchange for boosted reward shares. Transfers tokens into the vault.
     pub fn stake(
-        _env: Env,
-        _staker: Address,
-        _amount: i128,
-        _lock_duration: u64,
+        env: Env,
+        staker: Address,
+        amount: i128,
+        lock_duration: u64,
     ) -> Result<(), StakingError> {
-        // TODO: require_auth, settle pending rewards, transfer in, mint shares.
-        todo!()
+        staker.require_auth();
+        require_not_paused(&env)?;
+
+        if amount <= 0 {
+            return Err(StakingError::InvalidAmount);
+        }
+
+        let config = get_config(&env)?;
+        let tiers = get_lock_tiers(&env);
+        let tier = lock::tier_for(&tiers, lock_duration)?;
+        let new_shares = lock::boosted_shares(amount, tier.boost_bps)?;
+
+        let mut pool_state = get_pool_state(&env)?;
+
+        let mut position = get_position_raw(&env, &staker).unwrap_or(Position {
+            owner: staker.clone(),
+            amount: 0,
+            shares: 0,
+            unlock_at: 0,
+            reward_debt: 0,
+        });
+
+        // Settle any pending rewards on the existing position before changing
+        // its share balance, so the boost from this deposit does not
+        // retroactively apply to already-accrued rewards.
+        if position.shares > 0 {
+            let owed = pool::pending(&pool_state, &position)?;
+            if owed > 0 {
+                let token_client = TokenClient::new(&env, &config.token);
+                token_client.transfer(&env.current_contract_address(), &staker, &owed);
+            }
+        }
+
+        let token_client = TokenClient::new(&env, &config.token);
+        token_client.transfer(&staker, &env.current_contract_address(), &amount);
+
+        position.amount = position
+            .amount
+            .checked_add(amount)
+            .ok_or(StakingError::Overflow)?;
+        position.shares = position
+            .shares
+            .checked_add(new_shares)
+            .ok_or(StakingError::Overflow)?;
+        position.unlock_at = lock::unlock_at(&env, lock_duration);
+
+        pool_state.total_shares = pool_state
+            .total_shares
+            .checked_add(new_shares)
+            .ok_or(StakingError::Overflow)?;
+
+        pool::settle_debt(&pool_state, &mut position);
+
+        set_position(&env, &staker, &position);
+        set_pool_state(&env, &pool_state);
+
+        Ok(())
     }
 
     /// Withdraw `amount` of staked tokens once the lock has elapsed.
     /// Pending rewards are auto-claimed as part of unstaking.
-    pub fn unstake(
-        _env: Env,
-        _staker: Address,
-        _amount: i128,
-    ) -> Result<(), StakingError> {
-        // TODO: require_auth, check unlock_at, claim, burn shares, transfer out.
-        todo!()
+    pub fn unstake(env: Env, staker: Address, amount: i128) -> Result<(), StakingError> {
+        staker.require_auth();
+        require_not_paused(&env)?;
+
+        if amount <= 0 {
+            return Err(StakingError::InvalidAmount);
+        }
+
+        let config = get_config(&env)?;
+        let mut pool_state = get_pool_state(&env)?;
+        let mut position =
+            get_position_raw(&env, &staker).ok_or(StakingError::PositionNotFound)?;
+
+        if amount > position.amount {
+            return Err(StakingError::InsufficientStake);
+        }
+
+        if env.ledger().timestamp() < position.unlock_at {
+            return Err(StakingError::LockNotElapsed);
+        }
+
+        let owed = pool::pending(&pool_state, &position)?;
+
+        // Shares are proportional to the raw amount being withdrawn.
+        let shares_to_burn = if amount == position.amount {
+            position.shares
+        } else {
+            position
+                .shares
+                .checked_mul(amount)
+                .ok_or(StakingError::Overflow)?
+                .checked_div(position.amount)
+                .ok_or(StakingError::Overflow)?
+        };
+
+        position.amount = position
+            .amount
+            .checked_sub(amount)
+            .ok_or(StakingError::Overflow)?;
+        position.shares = position
+            .shares
+            .checked_sub(shares_to_burn)
+            .ok_or(StakingError::Overflow)?;
+
+        pool_state.total_shares = pool_state
+            .total_shares
+            .checked_sub(shares_to_burn)
+            .ok_or(StakingError::Overflow)?;
+
+        pool::settle_debt(&pool_state, &mut position);
+
+        set_position(&env, &staker, &position);
+        set_pool_state(&env, &pool_state);
+
+        let token_client = TokenClient::new(&env, &config.token);
+        let total_out = amount
+            .checked_add(owed)
+            .ok_or(StakingError::Overflow)?;
+        if total_out > 0 {
+            token_client.transfer(&env.current_contract_address(), &staker, &total_out);
+        }
+
+        Ok(())
     }
 
     // ── Rewards ─────────────────────────────────────────────────────────────────
 
     /// Claim accrued reward-share of protocol fees without unstaking.
-    pub fn claim_rewards(_env: Env, _staker: Address) -> Result<i128, StakingError> {
-        // TODO: require_auth, compute pending, reset debt, transfer out.
-        todo!()
+    pub fn claim_rewards(env: Env, staker: Address) -> Result<i128, StakingError> {
+        staker.require_auth();
+        require_not_paused(&env)?;
+
+        let config = get_config(&env)?;
+        let pool_state = get_pool_state(&env)?;
+        let mut position =
+            get_position_raw(&env, &staker).ok_or(StakingError::PositionNotFound)?;
+
+        let owed = pool::pending(&pool_state, &position)?;
+        if owed <= 0 {
+            return Err(StakingError::NothingToClaim);
+        }
+
+        pool::settle_debt(&pool_state, &mut position);
+        set_position(&env, &staker, &position);
+
+        let token_client = TokenClient::new(&env, &config.token);
+        token_client.transfer(&env.current_contract_address(), &staker, &owed);
+
+        Ok(owed)
     }
 
     /// Push protocol fees into the reward pool. Callable only by `fee_source`.
-    pub fn deposit_fees(
-        _env: Env,
-        _from: Address,
-        _amount: i128,
-    ) -> Result<(), StakingError> {
-        // TODO: delegate to fees::deposit_fees.
-        todo!()
+    pub fn deposit_fees(env: Env, from: Address, amount: i128) -> Result<(), StakingError> {
+        require_not_paused(&env)?;
+        fees::deposit_fees(&env, from, amount)
     }
 
     // ── Views ───────────────────────────────────────────────────────────────────
 
     /// Return a staker's current position, if any.
-    pub fn get_position(_env: Env, _staker: Address) -> Option<Position> {
-        // TODO: read DataKey::Position(staker).
-        todo!()
+    pub fn get_position(env: Env, staker: Address) -> Option<Position> {
+        get_position_raw(&env, &staker)
     }
 
     /// Return the rewards currently claimable by a staker.
-    pub fn pending_rewards(_env: Env, _staker: Address) -> Result<i128, StakingError> {
-        // TODO: pool::pending against stored position.
-        todo!()
+    pub fn pending_rewards(env: Env, staker: Address) -> Result<i128, StakingError> {
+        let pool_state = get_pool_state(&env)?;
+        let position = get_position_raw(&env, &staker).ok_or(StakingError::PositionNotFound)?;
+        pool::pending(&pool_state, &position)
     }
 
     /// Return global pool accounting.
-    pub fn get_pool(_env: Env) -> Result<PoolState, StakingError> {
-        // TODO: read DataKey::Pool.
-        todo!()
+    pub fn get_pool(env: Env) -> Result<PoolState, StakingError> {
+        get_pool_state(&env)
     }
 
     // ── Admin ───────────────────────────────────────────────────────────────────
 
     /// Pause / unpause sensitive operations. Admin-only.
-    pub fn set_paused(_env: Env, _paused: bool) -> Result<(), StakingError> {
-        // TODO: require admin auth, write DataKey::Paused.
-        todo!()
+    pub fn set_paused(env: Env, paused: bool) -> Result<(), StakingError> {
+        let config = get_config(&env)?;
+        config.admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        Ok(())
     }
 }

--- a/contracts/staking-vault/src/lock.rs
+++ b/contracts/staking-vault/src/lock.rs
@@ -1,6 +1,4 @@
 //! Lock-tier logic: longer lock durations grant a higher share boost.
-//!
-//! Skeleton — fill in tier lookup and boost application.
 
 use soroban_sdk::{Env, Vec};
 
@@ -11,19 +9,29 @@ use crate::storage_types::LockTier;
 pub const BPS_DENOMINATOR: u32 = 10_000;
 
 /// Look up the [`LockTier`] matching `duration`, or error if none is configured.
-pub fn tier_for(_tiers: &Vec<LockTier>, _duration: u64) -> Result<LockTier, StakingError> {
-    // TODO: find tier by exact duration match
-    todo!()
+pub fn tier_for(tiers: &Vec<LockTier>, duration: u64) -> Result<LockTier, StakingError> {
+    for tier in tiers.iter() {
+        if tier.duration == duration {
+            return Ok(tier);
+        }
+    }
+    Err(StakingError::InvalidLockPeriod)
 }
 
 /// Apply a tier's boost to a raw staked amount to produce effective shares.
-pub fn boosted_shares(_amount: i128, _boost_bps: u32) -> Result<i128, StakingError> {
-    // TODO: amount * boost_bps / BPS_DENOMINATOR with checked arithmetic
-    todo!()
+pub fn boosted_shares(amount: i128, boost_bps: u32) -> Result<i128, StakingError> {
+    if amount <= 0 {
+        return Err(StakingError::InvalidAmount);
+    }
+
+    amount
+        .checked_mul(boost_bps as i128)
+        .ok_or(StakingError::Overflow)?
+        .checked_div(BPS_DENOMINATOR as i128)
+        .ok_or(StakingError::Overflow)
 }
 
 /// Compute the unlock timestamp for a new position given the current ledger.
-pub fn unlock_at(_env: &Env, _duration: u64) -> u64 {
-    // TODO: env.ledger().timestamp() + duration
-    todo!()
+pub fn unlock_at(env: &Env, duration: u64) -> u64 {
+    env.ledger().timestamp() + duration
 }

--- a/contracts/staking-vault/src/pool.rs
+++ b/contracts/staking-vault/src/pool.rs
@@ -1,9 +1,8 @@
 //! Reward accounting for the staking pool (accumulator-per-share model).
 //!
-//! Skeleton — fill in the checked arithmetic. The invariant is that a staker's
-//! claimable rewards equal `shares * acc_reward_per_share / ACC_PRECISION -
-//! reward_debt`, and `reward_debt` is reset to the first term on every stake,
-//! unstake, or claim.
+//! The invariant is that a staker's claimable rewards equal `shares *
+//! acc_reward_per_share / ACC_PRECISION - reward_debt`, and `reward_debt` is
+//! reset to the first term on every stake, unstake, or claim.
 
 use soroban_sdk::Env;
 
@@ -15,19 +14,60 @@ pub const ACC_PRECISION: i128 = 1_000_000_000_000; // 1e12
 
 /// Fold a newly received reward amount into the pool accumulator.
 /// When `total_shares == 0`, park it in `pending_rewards` instead.
-pub fn distribute(_env: &Env, _pool: &mut PoolState, _amount: i128) -> Result<(), StakingError> {
-    // TODO: acc_reward_per_share += amount * ACC_PRECISION / total_shares
-    todo!()
+pub fn distribute(_env: &Env, pool: &mut PoolState, amount: i128) -> Result<(), StakingError> {
+    if amount <= 0 {
+        return Err(StakingError::InvalidAmount);
+    }
+
+    if pool.total_shares == 0 {
+        pool.pending_rewards = pool
+            .pending_rewards
+            .checked_add(amount)
+            .ok_or(StakingError::Overflow)?;
+        return Ok(());
+    }
+
+    // Fold in any rewards that were parked while total_shares was 0.
+    let total_amount = amount
+        .checked_add(pool.pending_rewards)
+        .ok_or(StakingError::Overflow)?;
+    pool.pending_rewards = 0;
+
+    let scaled = total_amount
+        .checked_mul(ACC_PRECISION)
+        .ok_or(StakingError::Overflow)?;
+    let increment = scaled
+        .checked_div(pool.total_shares)
+        .ok_or(StakingError::Overflow)?;
+
+    pool.acc_reward_per_share = pool
+        .acc_reward_per_share
+        .checked_add(increment)
+        .ok_or(StakingError::Overflow)?;
+
+    Ok(())
 }
 
 /// Compute the rewards currently claimable by a position.
-pub fn pending(_pool: &PoolState, _position: &Position) -> Result<i128, StakingError> {
-    // TODO: shares * acc_reward_per_share / ACC_PRECISION - reward_debt
-    todo!()
+pub fn pending(pool: &PoolState, position: &Position) -> Result<i128, StakingError> {
+    let accrued = position
+        .shares
+        .checked_mul(pool.acc_reward_per_share)
+        .ok_or(StakingError::Overflow)?
+        .checked_div(ACC_PRECISION)
+        .ok_or(StakingError::Overflow)?;
+
+    accrued
+        .checked_sub(position.reward_debt)
+        .ok_or(StakingError::Overflow)
 }
 
 /// Reset a position's `reward_debt` to the current accumulator checkpoint.
-pub fn settle_debt(_pool: &PoolState, _position: &mut Position) {
-    // TODO: position.reward_debt = shares * acc_reward_per_share / ACC_PRECISION
-    todo!()
+pub fn settle_debt(pool: &PoolState, position: &mut Position) {
+    // shares * acc_reward_per_share cannot realistically overflow i128 for
+    // token-scale amounts; guard with saturating arithmetic as a last resort.
+    position.reward_debt = position
+        .shares
+        .saturating_mul(pool.acc_reward_per_share)
+        / ACC_PRECISION;
 }

--- a/contracts/staking-vault/tests/staking_tests.rs
+++ b/contracts/staking-vault/tests/staking_tests.rs
@@ -1,29 +1,284 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
-use staking_vault::{LockTier, StakingVault, StakingVaultClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient},
+    Address, Env, Vec,
+};
+use staking_vault::{LockTier, StakingError, StakingVault, StakingVaultClient};
 
-fn setup(env: &Env) -> (StakingVaultClient, Address, Address) {
+fn setup_token(env: &Env) -> (Address, TokenClient<'static>, StellarAssetClient<'static>) {
+    let admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(admin);
+    let address = sac.address();
+    let token_client = TokenClient::new(env, &address);
+    let asset_client = StellarAssetClient::new(env, &address);
+    (address, token_client, asset_client)
+}
+
+fn tiers(env: &Env) -> Vec<LockTier> {
+    let mut tiers = Vec::new(env);
+    tiers.push_back(LockTier {
+        duration: 30 * 86_400,
+        boost_bps: 10_000, // 1.0x
+    });
+    tiers.push_back(LockTier {
+        duration: 90 * 86_400,
+        boost_bps: 15_000, // 1.5x
+    });
+    tiers.push_back(LockTier {
+        duration: 365 * 86_400,
+        boost_bps: 20_000, // 2.0x
+    });
+    tiers
+}
+
+fn setup(env: &Env) -> (StakingVaultClient<'static>, Address, Address, TokenClient<'static>, StellarAssetClient<'static>) {
     let contract_id = env.register(StakingVault, ());
     let client = StakingVaultClient::new(env, &contract_id);
     let admin = Address::generate(env);
-    let token = Address::generate(env);
-    (client, admin, token)
+    let (token_address, token_client, asset_client) = setup_token(env);
+    let fee_source = Address::generate(env);
+
+    client.initialize(&admin, &token_address, &fee_source, &tiers(env));
+
+    (client, admin, fee_source, token_client, asset_client)
+}
+
+// ---------------------------------------------------------------------------
+// #1707 — Reward Accumulator Math
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, _token, _asset) = setup(&env);
+
+    let pool = client.get_pool();
+    assert_eq!(pool.total_shares, 0);
+    assert_eq!(pool.acc_reward_per_share, 0);
+    assert_eq!(pool.pending_rewards, 0);
 }
 
 #[test]
-#[ignore = "skeleton: implement initialize first"]
-fn test_initialize() {
+fn test_double_initialize_reverts() {
     let env = Env::default();
-    let (client, admin, token) = setup(&env);
-    let fee_source = Address::generate(&env);
-    let tiers: Vec<LockTier> = Vec::new(&env);
+    env.mock_all_auths();
+    let (client, admin, fee_source, token, _asset) = setup(&env);
 
-    client.initialize(&admin, &token, &fee_source, &tiers);
-    // TODO: assert config stored, double-init reverts.
+    let result = client.try_initialize(&admin, &token.address, &fee_source, &tiers(&env));
+    assert_eq!(result, Err(Ok(StakingError::AlreadyInitialized)));
 }
 
-// TODO: test_stake_mints_boosted_shares
-// TODO: test_unstake_before_unlock_reverts
-// TODO: test_deposit_fees_distributes_pro_rata
-// TODO: test_claim_rewards
+#[test]
+fn test_two_stakers_accrue_rewards_pro_rata() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, fee_source, token, asset) = setup(&env);
+
+    let staker1 = Address::generate(&env);
+    let staker2 = Address::generate(&env);
+
+    asset.mint(&staker1, &1_000_000);
+    asset.mint(&staker2, &1_000_000);
+    asset.mint(&fee_source, &1_000_000);
+
+    // Both stake the same duration/tier so shares are proportional to amount.
+    client.stake(&staker1, &1_000, &(30 * 86_400));
+    client.stake(&staker2, &3_000, &(30 * 86_400));
+
+    // Push 1000 units of reward into the pool: staker1 (1/4 of shares) should
+    // get 250, staker2 (3/4 of shares) should get 750.
+    client.deposit_fees(&fee_source, &1_000);
+
+    let pending1 = client.pending_rewards(&staker1);
+    let pending2 = client.pending_rewards(&staker2);
+
+    assert_eq!(pending1, 250);
+    assert_eq!(pending2, 750);
+
+    let claimed1 = client.claim_rewards(&staker1);
+    assert_eq!(claimed1, 250);
+    assert_eq!(client.pending_rewards(&staker1), 0);
+
+    assert_eq!(token.balance(&staker1), 1_000_000 - 1_000 + 250);
+}
+
+#[test]
+fn test_late_staker_gets_no_back_pay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, fee_source, _token, asset) = setup(&env);
+
+    let early_staker = Address::generate(&env);
+    let late_staker = Address::generate(&env);
+
+    asset.mint(&early_staker, &1_000_000);
+    asset.mint(&late_staker, &1_000_000);
+    asset.mint(&fee_source, &1_000_000);
+
+    client.stake(&early_staker, &1_000, &(30 * 86_400));
+
+    // Rewards distributed before the late staker joins.
+    client.deposit_fees(&fee_source, &500);
+
+    client.stake(&late_staker, &1_000, &(30 * 86_400));
+
+    // The late staker should have accrued nothing from the earlier distribution.
+    assert_eq!(client.pending_rewards(&late_staker), 0);
+    assert_eq!(client.pending_rewards(&early_staker), 500);
+
+    // A subsequent distribution now splits evenly between the two.
+    client.deposit_fees(&fee_source, &1_000);
+    assert_eq!(client.pending_rewards(&early_staker), 500 + 500);
+    assert_eq!(client.pending_rewards(&late_staker), 500);
+}
+
+#[test]
+fn test_deposit_fees_with_zero_shares_parks_in_pending_rewards() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, fee_source, _token, asset) = setup(&env);
+
+    asset.mint(&fee_source, &1_000_000);
+
+    client.deposit_fees(&fee_source, &777);
+
+    let pool = client.get_pool();
+    assert_eq!(pool.pending_rewards, 777);
+    assert_eq!(pool.acc_reward_per_share, 0);
+
+    // Once a staker joins and a new distribution comes in, the parked amount
+    // plus the new amount are folded in together.
+    let staker = Address::generate(&env);
+    asset.mint(&staker, &1_000_000);
+    client.stake(&staker, &1_000, &(30 * 86_400));
+
+    client.deposit_fees(&fee_source, &223);
+
+    let pool = client.get_pool();
+    assert_eq!(pool.pending_rewards, 0);
+    assert_eq!(client.pending_rewards(&staker), 777 + 223);
+}
+
+#[test]
+fn test_deposit_fees_by_non_fee_source_reverts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, _token, asset) = setup(&env);
+
+    let not_fee_source = Address::generate(&env);
+    asset.mint(&not_fee_source, &1_000_000);
+
+    let result = client.try_deposit_fees(&not_fee_source, &100);
+    assert_eq!(result, Err(Ok(StakingError::Unauthorized)));
+}
+
+// ---------------------------------------------------------------------------
+// #1708 — Lock-Tier Boost and Unlock Enforcement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_stake_applies_tier_boost() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, _token, asset) = setup(&env);
+
+    let staker = Address::generate(&env);
+    asset.mint(&staker, &1_000_000);
+
+    // 90-day tier has a 1.5x boost.
+    client.stake(&staker, &1_000, &(90 * 86_400));
+
+    let position = client.get_position(&staker).unwrap();
+    assert_eq!(position.amount, 1_000);
+    assert_eq!(position.shares, 1_500);
+}
+
+#[test]
+fn test_stake_with_invalid_lock_period_reverts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, _token, asset) = setup(&env);
+
+    let staker = Address::generate(&env);
+    asset.mint(&staker, &1_000_000);
+
+    let result = client.try_stake(&staker, &1_000, &(42 * 86_400));
+    assert_eq!(result, Err(Ok(StakingError::InvalidLockPeriod)));
+}
+
+#[test]
+fn test_unstake_before_unlock_reverts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, _token, asset) = setup(&env);
+
+    let staker = Address::generate(&env);
+    asset.mint(&staker, &1_000_000);
+
+    client.stake(&staker, &1_000, &(30 * 86_400));
+
+    let result = client.try_unstake(&staker, &1_000);
+    assert_eq!(result, Err(Ok(StakingError::LockNotElapsed)));
+}
+
+#[test]
+fn test_unstake_at_and_after_unlock_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, token, asset) = setup(&env);
+
+    let staker = Address::generate(&env);
+    asset.mint(&staker, &1_000_000);
+
+    let lock_duration: u64 = 30 * 86_400;
+    client.stake(&staker, &1_000, &lock_duration);
+
+    let position = client.get_position(&staker).unwrap();
+
+    // Exactly at unlock_at succeeds.
+    env.ledger().with_mut(|l| l.timestamp = position.unlock_at);
+    client.unstake(&staker, &1_000);
+
+    assert_eq!(token.balance(&staker), 1_000_000);
+    let position_after = client.get_position(&staker).unwrap();
+    assert_eq!(position_after.amount, 0);
+    assert_eq!(position_after.shares, 0);
+}
+
+#[test]
+fn test_unstake_after_unlock_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, token, asset) = setup(&env);
+
+    let staker = Address::generate(&env);
+    asset.mint(&staker, &1_000_000);
+
+    let lock_duration: u64 = 30 * 86_400;
+    client.stake(&staker, &1_000, &lock_duration);
+
+    let position = client.get_position(&staker).unwrap();
+    env.ledger()
+        .with_mut(|l| l.timestamp = position.unlock_at + 1);
+
+    client.unstake(&staker, &1_000);
+    assert_eq!(token.balance(&staker), 1_000_000);
+}
+
+#[test]
+fn test_set_paused_blocks_stake() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _fee_source, _token, asset) = setup(&env);
+
+    client.set_paused(&true);
+
+    let staker = Address::generate(&env);
+    asset.mint(&staker, &1_000_000);
+
+    let result = client.try_stake(&staker, &1_000, &(30 * 86_400));
+    assert_eq!(result, Err(Ok(StakingError::Paused)));
+}


### PR DESCRIPTION
# Staking Vault reward/lock math + Creator Event Manager verification & views consistency

## Summary

- **staking-vault**: implemented the accumulator-per-share reward model (`pool.rs`), lock-tier boost/unlock logic (`lock.rs`), and wired both through the previously-stubbed contract entry points (`lib.rs`, `fees.rs`). Also fixed a broken `Cargo.lock` (conflicting `ed25519-dalek`/`rand_core` versions blocked `cargo test`) and added the missing `.gitignore`.
- **creator-event-manager**: `get_event_statistics` now derives `participant_count`/`match_count` from the source `EventParticipants`/`EventMatches` lists instead of cached counters, so views can't drift from on-chain state.
- **creator-event-manager**: `submit_verification` now requires and checks a real ed25519 signature (`env.crypto().ed25519_verify`) over a payload bound to `event_id`, via a new `admin::set_verifier_public_key`. Previously it only checked `require_auth` + signer whitelist membership, which doesn't prove a specific attestation was produced by that signer's key.

## Testing

- `cargo test` — all green in both `contracts/staking-vault` and `contracts/creator-event-manager`
- `cargo build --target wasm32-unknown-unknown --release` — succeeds for both contracts
- New tests: pro-rata reward accrual, late-staker no-back-pay, lock-tier boost, unlock enforcement (staking-vault); statistics-after-counter-drift (views); valid/invalid signature, cross-event replay rejection (verification)

## Note for maintainers

`staking-vault` has no CI job in `.github/workflows/contract-ci.yml` (only `open-market` and `creator-event-manager` are covered) — left as-is since it's outside these issues' scope, but worth adding.

Closes #1705
Closes #1706
Closes #1707
Closes #1708
