### PR TITLE
Active-Market TTL Bump Coverage

### DIFF
--- a/contracts/open-market/src/dispute.rs
+++ b/contracts/open-market/src/dispute.rs
@@ -8,7 +8,11 @@ use crate::reputation;
 use crate::storage_types::{ArbiterAssignment, ArbiterTally, DataKey, Dispute, OracleSubmission, UserProfile};
 
 fn bump_dispute(env: &Env, market_id: u64) {
-    config::extend_market_ttl(env, market_id);
+    // A disputed market is still active (its escrow pool and price
+    // accumulator, if any, remain live for stakers), so every dispute write
+    // must bump the full hot-key set, not just the market record. See
+    // Issue #1516.
+    config::extend_active_market_ttl(env, market_id);
     env.storage().persistent().extend_ttl(
         &DataKey::Dispute(market_id),
         config::PERSISTENT_THRESHOLD,
@@ -164,7 +168,7 @@ pub fn resolve_dispute(
         env.storage()
             .persistent()
             .set(&DataKey::Market(market_id), &market);
-        config::extend_market_ttl(&env, market_id);
+        config::extend_active_market_ttl(&env, market_id);
     } else {
         // Slash bond: route the configured insurance-pool share to the
         // reserve, with the remainder to treasury (accounting balances only,
@@ -324,7 +328,7 @@ pub fn resolve_appeal(
         env.storage()
             .persistent()
             .set(&DataKey::Market(market_id), &market);
-        config::extend_market_ttl(&env, market_id);
+        config::extend_active_market_ttl(&env, market_id);
     } else {
         escrow::slash_funds(&env, dispute.appeal_bond)?;
     }
@@ -784,7 +788,7 @@ pub fn finalize_arbiter_vote(
         env.storage()
             .persistent()
             .set(&DataKey::Market(market_id), &market);
-        config::extend_market_ttl(&env, market_id);
+        config::extend_active_market_ttl(&env, market_id);
     } else {
         escrow::slash_funds(&env, dispute.bond)?;
     }

--- a/contracts/open-market/src/invite.rs
+++ b/contracts/open-market/src/invite.rs
@@ -136,7 +136,10 @@ pub fn redeem_invite_code(
         .ok_or(InsightArenaError::Overflow)?;
     env.storage().persistent().set(&invite_key, &invite);
     config::extend_invite_ttl(&env, &code);
-    config::extend_market_ttl(&env, invite.market_id);
+    // Redemption is about to let the invitee join an active market, so keep
+    // its full hot-key set (market + escrow + accumulator) alive too, not
+    // just the market record. See Issue #1516.
+    config::extend_active_market_ttl(&env, invite.market_id);
 
     env.events().publish(
         (symbol_short!("invite"), symbol_short!("redeemd")),

--- a/contracts/open-market/tests/ttl_tests.rs
+++ b/contracts/open-market/tests/ttl_tests.rs
@@ -428,3 +428,61 @@ fn market_ttl_decays_toward_archival_without_bump() {
     assert_eq!(ttl_after, ttl_before - elapsed);
     assert!(ttl_after < ttl_before);
 }
+
+/// While a dispute's arbiter panel is deliberating, the underlying market is
+/// still active — its escrow pool and price accumulator remain live for
+/// stakers — but nothing else touches the `Market` record during that
+/// window: `cast_arbiter_vote` only reads/writes the `Dispute` record via
+/// `bump_dispute`. If `bump_dispute` only extended the market key (as it did
+/// before Issue #1516's fix), the escrow and accumulator TTLs would keep
+/// decaying, unbumped, for the whole voting period and could be archived out
+/// from under stakers even while the market is actively being adjudicated.
+#[test]
+fn cast_arbiter_vote_bumps_market_escrow_and_accumulator_together() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = deploy(&env);
+
+    let market_id = market_with_pool_and_swap(&env, &client);
+    let admin = client.get_config().admin;
+    let oracle = client.get_config().oracle_address;
+    let token = client.get_config().xlm_token;
+
+    // Resolve the market and raise a dispute against it.
+    let market = client.get_market(&market_id);
+    env.ledger()
+        .set_timestamp(market.resolution_time.max(env.ledger().timestamp()) + 1);
+    client.resolve_market(&oracle, &market_id, &symbol_short!("yes"));
+
+    let disputer = Address::generate(&env);
+    let bond = 10_000_000_i128;
+    fund(&env, &token, &disputer, bond);
+    TokenClient::new(&env, &token).approve(&disputer, &client.address, &bond, &9999);
+    client.raise_dispute(&disputer, &market_id, &bond);
+
+    // Stake and assign a single arbiter to the panel.
+    let arbiter = Address::generate(&env);
+    let stake = 20_000_000_i128;
+    fund(&env, &token, &arbiter, stake);
+    TokenClient::new(&env, &token).approve(&arbiter, &client.address, &stake, &9999);
+    client.stake_as_arbiter(&arbiter, &stake);
+    client.assign_arbiters(&admin, &market_id, &vec![&env, arbiter.clone()]);
+
+    // Let all three hot keys' TTLs decay for a while before the arbiter
+    // votes, so the assertions below prove the vote itself performed a fresh
+    // bump rather than merely observing an already-high starting TTL. Only
+    // the sequence number advances (not the timestamp), so the vote stays
+    // within `voting_deadline`.
+    let start_seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(start_seq + 150_000);
+
+    client.cast_arbiter_vote(&arbiter, &market_id, &true);
+
+    let market_ttl = persistent_ttl(&env, &client, DataKey::Market(market_id));
+    let escrow_ttl = persistent_ttl(&env, &client, DataKey::LiquidityPool(market_id));
+    let accumulator_ttl = persistent_ttl(&env, &client, DataKey::VolatilityState(market_id));
+
+    assert!(market_ttl >= LEDGER_BUMP_MARKET - 14_400);
+    assert!(escrow_ttl >= LEDGER_BUMP_ESCROW - 14_400);
+    assert!(accumulator_ttl >= LEDGER_BUMP_ACCUMULATOR - 14_400);
+}


### PR DESCRIPTION
Summary

The core extend_active_market_ttl mechanism (in config.rs) already existed and correctly bumps market + escrow + accumulator together — it was added in a prior PR (#1516). Auditing every caller found the actual gap: the dispute/arbiter lifecycle wasn't using it consistently.

- dispute.rs: bump_dispute (called by raise_dispute, appeal_dispute, assign_arbiters, cast_arbiter_vote) only bumped the Market key via extend_market_ttl, never touching escrow/accumulator. During arbiter voting or a long dispute, if no swap/liquidity activity happens elsewhere, those keys decay unattended for the whole window. I proved this with a test (cast_arbiter_vote_bumps_market_escrow_and_accumulator_together) that fails on the old code (escrow/accumulator TTL falls to 368,400, below the 417,600 threshold) and passes once bump_dispute calls extend_active_market_ttl. Also hardened the three market-reactivation sites (resolve_dispute, resolve_appeal, finalize_arbiter_vote's uphold branches) to call extend_active_market_ttl directly instead of relying implicitly on the preceding get_market read to do it.
- invite.rs: invite redemption (which admits a new participant into an active market) also only bumped the market record; switched to extend_active_market_ttl.

All 4 dispute call sites and the invite call site now bump the full hot-key set. Verified the new test is discriminating (fails without the fix, passes with it) and ran the full workspace test suite — all suites pass (0 failures).


closes #1695
closes #1696