### PR TITLE
feat: Timeout and Bounded Retry Wrapper for Soroban RPC Calls

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,18 @@ SERVER_SECRET_KEY=your-stellar-secret-key-here
 # Server Configuration
 PORT=3000
 
+# Soroban RPC Resilience Configuration
+# Per-call timeout (ms) applied to every outbound Soroban RPC call — reads
+# (getHealth/getAccount/simulateTransaction/getTransaction/getEvents) and
+# transaction submission. No RPC call is allowed to hang past this.
+SOROBAN_RPC_TIMEOUT_MS=10000
+# Number of retry attempts (in addition to the first) for idempotent read
+# calls after a timeout or connection error, with short exponential backoff.
+# Transaction submission never blind-retries on this budget: on an ambiguous
+# failure (timeout/network error) it checks the transaction status by hash
+# first and only resends if nothing landed, up to this many attempts.
+SOROBAN_RPC_MAX_RETRIES=2
+
 # Reconciliation Configuration
 RECONCILE_ENABLED=true
 RECONCILE_INTERVAL_MS=60000

--- a/backend/src/common/retry.util.ts
+++ b/backend/src/common/retry.util.ts
@@ -58,3 +58,48 @@ export async function withRetry<T>(
   }
   throw lastError;
 }
+
+/**
+ * Thrown by {@link withTimeout} when `fn` doesn't settle within `timeoutMs`.
+ * `name` is set to `AbortError` so it lines up with the native fetch/DOM
+ * abort convention — callers that already classify errors by `name`
+ * (e.g. Soroban's transient-error detection) pick it up for free.
+ */
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AbortError';
+  }
+}
+
+/**
+ * Races `fn` against a `timeoutMs` clock. If the clock wins, rejects with a
+ * {@link TimeoutError} labelled with `label`; the still-pending `fn` call is
+ * left to settle on its own (its result/rejection is swallowed) since most
+ * RPC clients don't expose a way to actually abort an in-flight call.
+ */
+export async function withTimeout<T>(
+  fn: () => Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  const inner = fn();
+  inner.catch(() => {
+    // Swallow — the timeout may have already "won" the race below, and an
+    // unobserved rejection on `inner` would otherwise surface as an
+    // unhandled rejection.
+  });
+
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new TimeoutError(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([inner, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -73,6 +73,18 @@ class EnvironmentVariables {
   @IsUrl({ require_tld: false })
   SOROBAN_RPC_URL?: string;
 
+  /** Default: 10000 */
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  SOROBAN_RPC_TIMEOUT_MS?: number;
+
+  /** Default: 2 */
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  SOROBAN_RPC_MAX_RETRIES?: number;
+
   /** Default: true */
   @IsOptional()
   @IsBooleanString()

--- a/backend/src/soroban/soroban.service.spec.ts
+++ b/backend/src/soroban/soroban.service.spec.ts
@@ -6,7 +6,7 @@ import {
   StrKey,
   SorobanDataBuilder,
 } from '@stellar/stellar-sdk';
-import { SorobanService } from './soroban.service';
+import { SorobanService, SorobanUnavailableError } from './soroban.service';
 
 describe('SorobanService', () => {
   let service: SorobanService;
@@ -20,18 +20,38 @@ describe('SorobanService', () => {
   // Generate a valid Soroban contract ID (starts with 'C')
   const validContractId = StrKey.encodeContract(Buffer.alloc(32));
 
-  beforeEach(async () => {
-    mockConfigService = {
+  function buildConfigService(
+    overrides: Record<string, string | number> = {},
+  ): jest.Mocked<ConfigService> {
+    return {
       get: jest.fn((key: string) => {
-        const values: Record<string, string> = {
+        const values: Record<string, string | number> = {
           SOROBAN_CONTRACT_ID: validContractId,
           STELLAR_NETWORK: 'testnet',
           SERVER_SECRET_KEY: testServerKeypair.secret(),
           SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
+          ...overrides,
         };
         return values[key];
       }),
     } as unknown as jest.Mocked<ConfigService>;
+  }
+
+  async function buildService(
+    overrides: Record<string, string | number> = {},
+  ): Promise<SorobanService> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SorobanService,
+        { provide: ConfigService, useValue: buildConfigService(overrides) },
+      ],
+    }).compile();
+
+    return module.get<SorobanService>(SorobanService);
+  }
+
+  beforeEach(async () => {
+    mockConfigService = buildConfigService();
 
     jest
       .spyOn(SorobanRpc.Server.prototype, 'getHealth')
@@ -199,7 +219,7 @@ describe('SorobanService', () => {
     });
   });
 
-  describe('sendTransaction retry behavior', () => {
+  describe('sendTransaction ambiguous-failure handling', () => {
     const mockTxHash = 'b'.repeat(64);
 
     beforeEach(() => {
@@ -218,47 +238,19 @@ describe('SorobanService', () => {
           minResourceFee: '100',
           _parsed: true,
         } as never);
-
-      jest
-        .spyOn(SorobanRpc.Server.prototype, 'getTransaction')
-        .mockResolvedValue({
-          status: 'SUCCESS',
-          hash: mockTxHash,
-        } as never);
-
-      // Retry backoff sleeps use setTimeout; keep tests fast.
-      jest.spyOn(global, 'setTimeout').mockImplementation(((fn: () => void) => {
-        fn();
-        return 0 as unknown as NodeJS.Timeout;
-      }) as unknown as typeof setTimeout);
     });
 
-    it('retries a transient network error on sendTransaction and eventually succeeds', async () => {
-      const sendTransactionSpy = jest
-        .spyOn(SorobanRpc.Server.prototype, 'sendTransaction')
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockResolvedValueOnce({
-          status: 'PENDING',
-          hash: mockTxHash,
-        } as never);
-
-      const result = await service.refundCompetitionParticipant(
-        testKeypair.publicKey(),
-        'comp_123',
-        '1000000',
-      );
-
-      expect(result.tx_hash).toBe(mockTxHash);
-      expect(sendTransactionSpy).toHaveBeenCalledTimes(2);
-    });
-
-    it('does not retry a definitive rejection (permanent error) on sendTransaction', async () => {
+    it('does not retry a definitive rejection (permanent error), and never checks tx status', async () => {
       const sendTransactionSpy = jest
         .spyOn(SorobanRpc.Server.prototype, 'sendTransaction')
         .mockResolvedValue({
           status: 'ERROR',
           errorResult: { message: 'txBadAuth' },
         } as never);
+      const getTransactionSpy = jest.spyOn(
+        SorobanRpc.Server.prototype,
+        'getTransaction',
+      );
 
       await expect(
         service.refundCompetitionParticipant(
@@ -269,12 +261,65 @@ describe('SorobanService', () => {
       ).rejects.toThrow(/Transaction submission failed/);
 
       expect(sendTransactionSpy).toHaveBeenCalledTimes(1);
+      expect(getTransactionSpy).not.toHaveBeenCalled();
     });
 
-    it('surfaces the final error after exhausting retries on persistent transient failures', async () => {
+    it('on an ambiguous failure, checks tx status by hash before ever resending, and skips resend if already submitted', async () => {
       const sendTransactionSpy = jest
         .spyOn(SorobanRpc.Server.prototype, 'sendTransaction')
         .mockRejectedValue(new TypeError('fetch failed'));
+
+      const getTransactionSpy = jest
+        .spyOn(SorobanRpc.Server.prototype, 'getTransaction')
+        .mockResolvedValue({ status: 'SUCCESS', hash: mockTxHash } as never);
+
+      const result = await service.refundCompetitionParticipant(
+        testKeypair.publicKey(),
+        'comp_123',
+        '1000000',
+      );
+
+      // The original submission attempt is the only sendTransaction call —
+      // the status check found it already landed, so no resend happened.
+      expect(sendTransactionSpy).toHaveBeenCalledTimes(1);
+      expect(getTransactionSpy).toHaveBeenCalled();
+      expect(result.tx_hash).toBeDefined();
+    });
+
+    it('resends only after confirming no existing submission (status NOT_FOUND), then succeeds', async () => {
+      const sendTransactionSpy = jest
+        .spyOn(SorobanRpc.Server.prototype, 'sendTransaction')
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce({
+          status: 'PENDING',
+          hash: mockTxHash,
+        } as never);
+
+      jest
+        .spyOn(SorobanRpc.Server.prototype, 'getTransaction')
+        // First call: the ambiguity check after the failed send — nothing landed.
+        .mockResolvedValueOnce({ status: 'NOT_FOUND' } as never)
+        // Subsequent calls: the confirmation poll after the resend succeeds.
+        .mockResolvedValue({ status: 'SUCCESS', hash: mockTxHash } as never);
+
+      const result = await service.refundCompetitionParticipant(
+        testKeypair.publicKey(),
+        'comp_123',
+        '1000000',
+      );
+
+      expect(sendTransactionSpy).toHaveBeenCalledTimes(2);
+      expect(result.tx_hash).toBe(mockTxHash);
+    });
+
+    it('surfaces a typed SorobanUnavailableError after exhausting attempts with no existing submission ever found', async () => {
+      const sendTransactionSpy = jest
+        .spyOn(SorobanRpc.Server.prototype, 'sendTransaction')
+        .mockRejectedValue(new TypeError('fetch failed'));
+
+      jest
+        .spyOn(SorobanRpc.Server.prototype, 'getTransaction')
+        .mockResolvedValue({ status: 'NOT_FOUND' } as never);
 
       await expect(
         service.refundCompetitionParticipant(
@@ -282,9 +327,68 @@ describe('SorobanService', () => {
           'comp_123',
           '1000000',
         ),
-      ).rejects.toThrow('fetch failed');
+      ).rejects.toThrow(SorobanUnavailableError);
 
+      // default SOROBAN_RPC_MAX_RETRIES = 2 -> 3 total attempts
       expect(sendTransactionSpy).toHaveBeenCalledTimes(3);
+    }, 10_000);
+  });
+
+  describe('RPC timeout & retry (idempotent reads)', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('retries a read call that times out and eventually succeeds', async () => {
+      const svc = await buildService({
+        SOROBAN_RPC_TIMEOUT_MS: 30,
+        SOROBAN_RPC_MAX_RETRIES: 2,
+      });
+
+      const getHealthSpy = jest
+        .spyOn(SorobanRpc.Server.prototype, 'getHealth')
+        .mockImplementationOnce(() => new Promise(() => {})) // hangs past the timeout
+        .mockResolvedValueOnce({ status: 'healthy' } as never);
+
+      await expect(svc.testConnection()).resolves.toBe(true);
+      expect(getHealthSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a read call on a connection error and eventually succeeds', async () => {
+      const svc = await buildService({ SOROBAN_RPC_MAX_RETRIES: 2 });
+
+      const getHealthSpy = jest
+        .spyOn(SorobanRpc.Server.prototype, 'getHealth')
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce({ status: 'healthy' } as never);
+
+      await expect(svc.testConnection()).resolves.toBe(true);
+      expect(getHealthSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('surfaces a typed SorobanUnavailableError after exhausting retries on a persistent timeout', async () => {
+      const svc = await buildService({
+        SOROBAN_RPC_TIMEOUT_MS: 30,
+        SOROBAN_RPC_MAX_RETRIES: 1,
+      });
+
+      const getHealthSpy = jest
+        .spyOn(SorobanRpc.Server.prototype, 'getHealth')
+        .mockImplementation(() => new Promise(() => {}));
+
+      await expect(svc.testConnection()).rejects.toThrow(
+        SorobanUnavailableError,
+      );
+      expect(getHealthSpy).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+    });
+
+    it('does not retry a non-transient read failure', async () => {
+      const svc = await buildService();
+
+      const getHealthSpy = jest
+        .spyOn(SorobanRpc.Server.prototype, 'getHealth')
+        .mockRejectedValue(new Error('Account not found: GABC123'));
+
+      await expect(svc.testConnection()).rejects.toThrow('Account not found');
+      expect(getHealthSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/backend/src/soroban/soroban.service.ts
+++ b/backend/src/soroban/soroban.service.ts
@@ -10,7 +10,11 @@ import {
   Networks,
   Transaction,
 } from '@stellar/stellar-sdk';
-import { withRetry } from '../common/retry.util';
+import {
+  computeBackoffDelay,
+  withRetry,
+  withTimeout,
+} from '../common/retry.util';
 
 /**
  * Errors we classify as "definitive rejections" — the network/contract has
@@ -82,6 +86,25 @@ export class SorobanPermanentError extends Error {
   }
 }
 
+/**
+ * Thrown when the Soroban RPC node itself is unreachable/unresponsive —
+ * every retry attempt timed out or failed at the network layer. Distinct
+ * from {@link SorobanPermanentError}, which means the RPC node responded
+ * but definitively rejected the request (a contract-level failure).
+ * Callers (e.g. cron jobs) can catch this specifically to distinguish an
+ * RPC outage from an application-level error.
+ */
+export class SorobanUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'SorobanUnavailableError';
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export interface SorobanPredictionResult {
   tx_hash: string;
   payout_amount_stroops?: string;
@@ -124,6 +147,24 @@ export interface SorobanFinalizeEventResult {
   tx_hash: string;
 }
 
+const DEFAULT_RPC_TIMEOUT_MS = 10_000;
+const DEFAULT_RPC_MAX_RETRIES = 2;
+/** Base delay for read-retry and post-ambiguity resend backoff — short by design (see #1). */
+const RPC_RETRY_BASE_DELAY_MS = 250;
+
+function readNonNegativeIntConfig(
+  configService: ConfigService,
+  key: string,
+  defaultValue: number,
+): number {
+  const raw = configService.get<string | number>(key);
+  if (raw === undefined || raw === null || raw === '') {
+    return defaultValue;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : defaultValue;
+}
+
 @Injectable()
 export class SorobanService {
   private readonly logger = new Logger(SorobanService.name);
@@ -132,6 +173,8 @@ export class SorobanService {
   private readonly serverSecretKey: string;
   private readonly rpcUrl: string;
   private readonly rpcServer: SorobanRpc.Server;
+  private readonly rpcTimeoutMs: number;
+  private readonly rpcMaxRetries: number;
 
   constructor(private readonly configService: ConfigService) {
     this.contractId =
@@ -142,6 +185,16 @@ export class SorobanService {
     this.rpcUrl =
       this.configService.get<string>('SOROBAN_RPC_URL') ??
       'https://soroban-testnet.stellar.org';
+    this.rpcTimeoutMs = readNonNegativeIntConfig(
+      this.configService,
+      'SOROBAN_RPC_TIMEOUT_MS',
+      DEFAULT_RPC_TIMEOUT_MS,
+    );
+    this.rpcMaxRetries = readNonNegativeIntConfig(
+      this.configService,
+      'SOROBAN_RPC_MAX_RETRIES',
+      DEFAULT_RPC_MAX_RETRIES,
+    );
 
     this.rpcServer = new SorobanRpc.Server(this.rpcUrl, {
       allowHttp: this.rpcUrl.startsWith('http://'),
@@ -166,7 +219,7 @@ export class SorobanService {
 
   async testConnection(): Promise<boolean> {
     return this.withSorobanErrorHandling('testConnection', async () => {
-      await this.rpcServer.getHealth();
+      await this.callRpc('testConnection', () => this.rpcServer.getHealth());
       return true;
     });
   }
@@ -288,8 +341,9 @@ export class SorobanService {
         );
 
         const serverKeypair = Keypair.fromSecret(this.serverSecretKey);
-        const serverAccount = await this.rpcServer.getAccount(
-          serverKeypair.publicKey(),
+        const serverAccount = await this.callRpc(
+          `refundCompetitionParticipant[${cid}]:getAccount`,
+          () => this.rpcServer.getAccount(serverKeypair.publicKey()),
         );
 
         const contract = new Contract(this.contractId);
@@ -311,7 +365,10 @@ export class SorobanService {
           .build();
 
         // Simulate
-        const simulation = await this.rpcServer.simulateTransaction(tx);
+        const simulation = await this.callRpc(
+          `refundCompetitionParticipant[${cid}]:simulateTransaction`,
+          () => this.rpcServer.simulateTransaction(tx),
+        );
         if (SorobanRpc.Api.isSimulationError(simulation)) {
           if (simulation.error.includes('EscrowEmpty')) {
             throw new Error('EscrowEmpty');
@@ -339,7 +396,12 @@ export class SorobanService {
         this.logger.log(`[${cid}] Refund submitted. tx_hash=${response.hash}`);
 
         // Wait for completion
-        let statusResponse = await this.rpcServer.getTransaction(response.hash);
+        const getTxStatus = () =>
+          this.callRpc(
+            `refundCompetitionParticipant[${cid}]:getTransaction`,
+            () => this.rpcServer.getTransaction(response.hash),
+          );
+        let statusResponse = await getTxStatus();
         let attempts = 0;
         while (
           statusResponse.status ===
@@ -347,7 +409,7 @@ export class SorobanService {
           attempts < 10
         ) {
           await new Promise((resolve) => setTimeout(resolve, 2000));
-          statusResponse = await this.rpcServer.getTransaction(response.hash);
+          statusResponse = await getTxStatus();
           attempts++;
         }
 
@@ -563,8 +625,8 @@ export class SorobanService {
       );
 
       // Get server account for transaction
-      const serverAccount = await this.rpcServer.getAccount(
-        serverKeypair.publicKey(),
+      const serverAccount = await this.callRpc('finalizeEvent:getAccount', () =>
+        this.rpcServer.getAccount(serverKeypair.publicKey()),
       );
 
       const contract = new Contract(this.contractId);
@@ -585,7 +647,10 @@ export class SorobanService {
         .build();
 
       // Simulate
-      const simulation = await this.rpcServer.simulateTransaction(tx);
+      const simulation = await this.callRpc(
+        'finalizeEvent:simulateTransaction',
+        () => this.rpcServer.simulateTransaction(tx),
+      );
       if (SorobanRpc.Api.isSimulationError(simulation)) {
         throw new Error(`Simulation failed: ${simulation.error}`);
       }
@@ -607,7 +672,11 @@ export class SorobanService {
       this.logger.log(`finalizeEvent submitted: tx_hash=${response.hash}`);
 
       // Wait for completion
-      let statusResponse = await this.rpcServer.getTransaction(response.hash);
+      const getTxStatus = () =>
+        this.callRpc('finalizeEvent:getTransaction', () =>
+          this.rpcServer.getTransaction(response.hash),
+        );
+      let statusResponse = await getTxStatus();
       let attempts = 0;
       while (
         statusResponse.status ===
@@ -615,7 +684,7 @@ export class SorobanService {
         attempts < 10
       ) {
         await new Promise((resolve) => setTimeout(resolve, 2000));
-        statusResponse = await this.rpcServer.getTransaction(response.hash);
+        statusResponse = await getTxStatus();
         attempts++;
       }
 
@@ -681,33 +750,9 @@ export class SorobanService {
         return { events: [], latestLedger: fromLedger };
       }
 
-      const response = await fetch(this.rpcUrl, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 'insightarena-events',
-          method: 'getEvents',
-          params: {
-            startLedger: fromLedger,
-            filters: [{ type: 'contract', contractIds: [this.contractId] }],
-            limit: 200,
-          },
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`Soroban RPC error: HTTP ${response.status}`);
-      }
-
-      const body = (await response.json()) as {
-        error?: { message?: string };
-        result?: { events?: unknown[]; latestLedger?: number };
-      };
-
-      if (body.error) {
-        throw new Error(body.error.message ?? 'Unknown Soroban RPC error');
-      }
+      const body = await this.withReadRetry('getEvents', () =>
+        this.fetchEventsOnce(fromLedger),
+      );
 
       const rawEvents = body.result?.events ?? [];
       const latestLedger =
@@ -724,19 +769,77 @@ export class SorobanService {
   }
 
   /**
-   * Submits an already-assembled and signed transaction, retrying on
-   * transient RPC errors (network blips, timeouts, 5xx/429) with backoff.
-   * Definitive rejections (bad auth, malformed tx, insufficient balance,
-   * simulation failure) are surfaced immediately without retrying, since
-   * retrying those would just fail again — or double-submit.
+   * Single attempt at the raw `getEvents` JSON-RPC call, bounded by
+   * `rpcTimeoutMs` via a real `AbortController` (unlike the stellar-sdk
+   * client calls, `fetch` lets us actually cancel the in-flight request).
+   */
+  private async fetchEventsOnce(fromLedger: number): Promise<{
+    error?: { message?: string };
+    result?: { events?: unknown[]; latestLedger?: number };
+  }> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.rpcTimeoutMs);
+    try {
+      const response = await fetch(this.rpcUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'insightarena-events',
+          method: 'getEvents',
+          params: {
+            startLedger: fromLedger,
+            filters: [{ type: 'contract', contractIds: [this.contractId] }],
+            limit: 200,
+          },
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Soroban RPC error: HTTP ${response.status}`);
+      }
+
+      const body = (await response.json()) as {
+        error?: { message?: string };
+        result?: { events?: unknown[]; latestLedger?: number };
+      };
+
+      if (body.error) {
+        throw new Error(body.error.message ?? 'Unknown Soroban RPC error');
+      }
+
+      return body;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Submits an already-assembled and signed transaction. Never blind-retries:
+   * a definitive rejection (bad auth, malformed tx, insufficient balance,
+   * simulation failure) surfaces immediately. An *ambiguous* failure — the
+   * `sendTransaction` call itself timed out or hit a network error, so we
+   * don't know whether the RPC node actually received it — is resolved by
+   * looking up the transaction's own hash before ever considering a resend,
+   * so we never fire the same submission twice into an unknown state.
+   * Exhausting all attempts without a definitive outcome surfaces a typed
+   * {@link SorobanUnavailableError}.
    */
   private async sendTransactionWithRetry(
     tx: Transaction,
     operation: string,
   ): Promise<SorobanRpc.Api.SendTransactionResponse> {
-    return withRetry(
-      async () => {
-        const response = await this.rpcServer.sendTransaction(tx);
+    const txHash = tx.hash().toString('hex');
+    const maxAttempts = this.rpcMaxRetries + 1;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const response = await this.withTimeoutRpc(
+          `${operation}:sendTransaction`,
+          () => this.rpcServer.sendTransaction(tx),
+        );
         if (response.status === 'ERROR') {
           const message = `Transaction submission failed: ${JSON.stringify(response.errorResult)}`;
           throw isTransientSorobanError(new Error(message))
@@ -744,19 +847,136 @@ export class SorobanService {
             : new SorobanPermanentError(message);
         }
         return response;
-      },
-      {
-        maxAttempts: 3,
-        baseDelayMs: 1000,
+      } catch (error) {
+        lastError = error;
+
+        // Definitive rejection: the RPC node conclusively refused the tx.
+        // Resending would just fail again — surface immediately.
+        if (error instanceof SorobanPermanentError) {
+          throw error;
+        }
+
+        // Anything else that isn't transient is unexpected — don't retry
+        // or resend on a failure mode we can't classify as ambiguous.
+        const ambiguous =
+          error instanceof SorobanTransientError ||
+          isTransientSorobanError(error);
+        if (!ambiguous) {
+          throw error;
+        }
+
+        this.logger.warn(
+          `${operation}: sendTransaction attempt ${attempt + 1} ambiguous (${errorMessage(error)}); checking tx_hash=${txHash} before considering a resend`,
+        );
+
+        const existing = await this.findSubmittedTransaction(txHash, operation);
+        if (existing) {
+          this.logger.log(
+            `${operation}: found existing submission for tx_hash=${txHash}; skipping resend`,
+          );
+          return existing;
+        }
+
+        if (attempt === maxAttempts - 1) {
+          break;
+        }
+
+        const delayMs = computeBackoffDelay(RPC_RETRY_BASE_DELAY_MS, attempt);
+        this.logger.warn(
+          `${operation}: no existing submission found for tx_hash=${txHash}; resending in ${delayMs}ms (attempt ${attempt + 2}/${maxAttempts})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+
+    throw new SorobanUnavailableError(
+      `${operation}: sendTransaction unavailable after ${maxAttempts} attempt(s): ${errorMessage(lastError)}`,
+      { cause: lastError },
+    );
+  }
+
+  /**
+   * Looks up a submitted transaction by hash to resolve an ambiguous
+   * `sendTransaction` outcome. Returns a synthetic "found" response if the
+   * RPC node already knows about it (any status other than NOT_FOUND);
+   * returns `null` — meaning "safe to resend" — both when it's genuinely
+   * not found and when the status check itself fails, since we can't
+   * confirm either way and withholding a resend indefinitely isn't better.
+   */
+  private async findSubmittedTransaction(
+    txHash: string,
+    operation: string,
+  ): Promise<SorobanRpc.Api.SendTransactionResponse | null> {
+    try {
+      const status = await this.callRpc(
+        `${operation}:getTransaction(${txHash})`,
+        () => this.rpcServer.getTransaction(txHash),
+      );
+      if (status.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+        return null;
+      }
+      return {
+        status: 'PENDING',
+        hash: txHash,
+      } as SorobanRpc.Api.SendTransactionResponse;
+    } catch (error) {
+      this.logger.warn(
+        `${operation}: status check for tx_hash=${txHash} failed (${errorMessage(error)}); treating as not found`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Runs a single RPC call under the configured per-call timeout, without
+   * retrying. Used for transaction submission, where retries must go
+   * through the ambiguous-failure/status-check path above rather than being
+   * blindly repeated.
+   */
+  private withTimeoutRpc<T>(
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    return withTimeout(fn, this.rpcTimeoutMs, operation);
+  }
+
+  /**
+   * Runs an idempotent read RPC call under the configured per-call timeout,
+   * retrying on timeout/connection errors up to `rpcMaxRetries` additional
+   * times with short backoff. Wraps an exhausted transient failure in a
+   * typed {@link SorobanUnavailableError} so callers can distinguish an RPC
+   * outage from an application-level error (e.g. "account not found").
+   */
+  private async withReadRetry<T>(
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await withRetry(fn, {
+        maxAttempts: this.rpcMaxRetries + 1,
+        baseDelayMs: RPC_RETRY_BASE_DELAY_MS,
         isTransient: isTransientSorobanError,
         onRetry: (error, attempt, delayMs) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
           this.logger.warn(
-            `${operation}: sendTransaction attempt ${attempt + 1} failed transiently (${message}), retrying in ${delayMs}ms`,
+            `${operation}: read attempt ${attempt + 1} failed transiently (${errorMessage(error)}), retrying in ${delayMs}ms`,
           );
         },
-      },
+      });
+    } catch (error) {
+      if (isTransientSorobanError(error)) {
+        throw new SorobanUnavailableError(
+          `${operation} unavailable after retrying: ${errorMessage(error)}`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  }
+
+  /** Combines {@link withReadRetry} and {@link withTimeoutRpc} for a single RPC call. */
+  private callRpc<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+    return this.withReadRetry(operation, () =>
+      this.withTimeoutRpc(operation, fn),
     );
   }
 


### PR DESCRIPTION




### Problem

`SorobanService` called Stellar RPC for contract reads and transaction submission with no timeout. A hung RPC node could hold a request — or a cron job like the market-settlement scheduler — open indefinitely, exhausting the worker pool. On top of that, transient RPC failures during `sendTransaction` were blindly retried, which risked double-submitting a transaction whose outcome was actually unknown (not lost).

### What changed

**Timeout on every outbound RPC call**

- Added a configurable per-call timeout (`SOROBAN_RPC_TIMEOUT_MS`, default `10000`) enforced on all `SorobanService` → Stellar RPC calls: `getHealth`, `getAccount`, `simulateTransaction`, `getTransaction`, `getEvents`, and `sendTransaction`.
- `getEvents` uses a real `AbortController` since it's a plain `fetch`. The stellar-sdk RPC client doesn't expose an abort signal, so those calls are bounded with a generic `Promise.race`-based `withTimeout` helper (added to `common/retry.util.ts`) instead — the in-flight call is abandoned from the caller's perspective if it doesn't settle in time.

**Bounded retries for idempotent reads**

- Reads (`getHealth`, `getAccount`, `simulateTransaction`, `getTransaction`, `getEvents`) retry up to `SOROBAN_RPC_MAX_RETRIES` (default `2`) additional attempts on timeout/connection errors, with short exponential backoff (reusing the existing `computeBackoffDelay` jittered backoff).
- Non-transient errors (e.g. "Account not found") are never retried — only network-layer/timeout failures are.

**Transaction submission never blind-retries**

- `sendTransactionWithRetry` no longer resubmits a signed transaction on faith. On an _ambiguous_ failure (the `sendTransaction` call itself timed out or hit a network error, so we don't know if the RPC node received it), it now looks up the transaction by its own hash (`tx.hash()`) via `getTransaction` **before** ever considering a resend. It only resends if that lookup confirms nothing landed.
- A _definitive_ rejection (bad auth, malformed tx, insufficient balance — classified via the existing `isTransientSorobanError`) still surfaces immediately, with no status check and no retry, since resending it would just fail again.

**Typed error for RPC outage**

- Added `SorobanUnavailableError`, thrown when retries/attempts are exhausted due to a transient/timeout condition. This is distinct from `SorobanPermanentError` (the RPC node responded with a definitive, contract-level rejection), so callers (e.g. the settlement scheduler) can tell "the network is down" apart from "the contract said no."

**Config**

- New env vars documented in `.env.example`:
  - `SOROBAN_RPC_TIMEOUT_MS` (default `10000`)
  - `SOROBAN_RPC_MAX_RETRIES` (default `2`)
- Added corresponding optional, validated fields to `src/config/env.validation.ts`.

### Files changed

| File                                          | Change                                                                                                                                     |
| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
| `backend/src/common/retry.util.ts`            | New generic `withTimeout()` + `TimeoutError` helper                                                                                        |
| `backend/src/soroban/soroban.service.ts`      | Timeout + bounded retry wiring for all RPC calls; safe ambiguous-failure resend logic for `sendTransaction`; new `SorobanUnavailableError` |
| `backend/src/config/env.validation.ts`        | `SOROBAN_RPC_TIMEOUT_MS` / `SOROBAN_RPC_MAX_RETRIES` validation                                                                            |
| `backend/.env.example`                        | Documented the two new env vars                                                                                                            |
| `backend/src/soroban/soroban.service.spec.ts` | Replaced blind-retry tests with coverage for timeout retries, ambiguous-failure status checks, safe resend, and the typed error            |

### Testing

- `npx jest src/soroban` — 21/21 passing, including 8 new tests:
  - definitive rejection never checks tx status / never retries
  - ambiguous failure checks tx status before resend, skips resend if already submitted
  - resends only after confirming no existing submission, then succeeds
  - `SorobanUnavailableError` after exhausting submission attempts with nothing found
  - read call retries on timeout and succeeds
  - read call retries on connection error and succeeds
  - `SorobanUnavailableError` after exhausting retries on a persistent timeout
  - non-transient read failure is not retried
- Full suite: `npx jest` — 1203/1203 passing, no regressions.
- `npx tsc --noEmit` — no new type errors introduced.
- `npx eslint` — clean on all changed files.

### Acceptance criteria

- [x] No RPC call can hang past its configured timeout.
- [x] Idempotent reads are retried on timeout/connection errors; transaction submission is never blind-retried.
- [x] Ambiguous submission failures are resolved by checking tx status by hash before any resend.
- [x] Callers get a typed, distinguishable error (`SorobanUnavailableError`) for RPC outage vs. contract-level failure (`SorobanPermanentError`).
- [x] Timeout/retry count are env-configurable and documented in `.env.example`.
- [x] Unit tests cover: timeout triggers retry on reads, submission never auto-retries, typed error propagates.



closes #1497 