### PR TITLE
Backend/1656 1657 1658 1659 health ws cache versioning

### DIFF
--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -9,6 +9,7 @@ import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
 import { ActivityLog } from './entities/activity-log.entity';
 import { MarketHistory } from './entities/market-history.entity';
+import { CacheServiceModule } from '../cache/cache.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { MarketHistory } from './entities/market-history.entity';
       MarketHistory,
     ]),
     CacheModule.register(),
+    CacheServiceModule,
   ],
   controllers: [AnalyticsController],
   providers: [AnalyticsService],

--- a/backend/src/analytics/analytics.service.history.spec.ts
+++ b/backend/src/analytics/analytics.service.history.spec.ts
@@ -8,6 +8,7 @@ import { User } from '../users/entities/user.entity';
 import { Prediction } from '../predictions/entities/prediction.entity';
 import { LeaderboardEntry } from '../leaderboard/entities/leaderboard-entry.entity';
 import { ActivityLog } from './entities/activity-log.entity';
+import { CacheService } from '../cache/cache.service';
 
 describe('AnalyticsService - Market History', () => {
   let service: AnalyticsService;
@@ -72,6 +73,13 @@ describe('AnalyticsService - Market History', () => {
         {
           provide: getRepositoryToken(MarketHistory),
           useValue: marketHistoryRepository,
+        },
+        {
+          provide: CacheService,
+          useValue: {
+            getOrSet: (_ns: string, _key: string, loader: () => unknown) =>
+              loader(),
+          },
         },
       ],
     }).compile();

--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -12,6 +12,8 @@ import { LeaderboardEntry } from '../leaderboard/entities/leaderboard-entry.enti
 import { Market } from '../markets/entities/market.entity';
 import { ActivityLog } from './entities/activity-log.entity';
 import { MarketHistory } from './entities/market-history.entity';
+import { CacheService } from '../cache/cache.service';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 describe('predictorTierFromReputation', () => {
   it('maps 0 to Bronze Predictor', () => {
@@ -71,6 +73,13 @@ describe('AnalyticsService', () => {
   let marketHistoryRepository: jest.Mocked<
     Pick<Repository<MarketHistory>, 'createQueryBuilder'>
   >;
+  let marketsRepository: {
+    find: jest.Mock;
+    findOne: jest.Mock;
+    count: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let cacheService: CacheService;
 
   const baseUser: User = {
     id: 'user-id-1',
@@ -97,10 +106,33 @@ describe('AnalyticsService', () => {
     leaderboardRepository = { createQueryBuilder: jest.fn() };
     predictionsRepository = { createQueryBuilder: jest.fn() };
     marketHistoryRepository = { createQueryBuilder: jest.fn() };
+    marketsRepository = {
+      find: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn(),
+      count: jest.fn().mockResolvedValue(0),
+      createQueryBuilder: jest.fn(),
+    };
+
+    // Minimal in-memory cache-manager fake so CacheService's TTL/single-flight
+    // logic runs for real against these tests, rather than being stubbed out.
+    const store = new Map<string, unknown>();
+    const fakeCacheManager = {
+      get: jest.fn((key: string) => Promise.resolve(store.get(key))),
+      set: jest.fn((key: string, value: unknown) => {
+        store.set(key, value);
+        return Promise.resolve();
+      }),
+      del: jest.fn((key: string) => {
+        store.delete(key);
+        return Promise.resolve();
+      }),
+    };
 
     module = await Test.createTestingModule({
       providers: [
         AnalyticsService,
+        CacheService,
+        { provide: CACHE_MANAGER, useValue: fakeCacheManager },
         { provide: getRepositoryToken(User), useValue: usersRepository },
         {
           provide: getRepositoryToken(Prediction),
@@ -112,7 +144,7 @@ describe('AnalyticsService', () => {
         },
         {
           provide: getRepositoryToken(Market),
-          useValue: { findOne: jest.fn(), find: jest.fn() },
+          useValue: marketsRepository,
         },
         {
           provide: getRepositoryToken(ActivityLog),
@@ -130,6 +162,7 @@ describe('AnalyticsService', () => {
     }).compile();
 
     service = module.get(AnalyticsService);
+    cacheService = module.get(CacheService);
   });
 
   function mockQb(terminal: { getCount?: number; getMany?: Prediction[] }) {
@@ -384,6 +417,39 @@ describe('AnalyticsService', () => {
 
       service.removeActiveSession('user2');
       expect(service.getActiveUsersCount()).toBe(0);
+    });
+  });
+
+  describe('getCategoryAnalytics caching (stampede protection)', () => {
+    it('recomputes once for concurrent calls on a cold cache', async () => {
+      marketsRepository.find.mockResolvedValue([]);
+
+      await Promise.all([
+        service.getCategoryAnalytics(),
+        service.getCategoryAnalytics(),
+        service.getCategoryAnalytics(),
+      ]);
+
+      expect(marketsRepository.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves from cache without recomputing on a subsequent call', async () => {
+      marketsRepository.find.mockResolvedValue([]);
+
+      await service.getCategoryAnalytics();
+      await service.getCategoryAnalytics();
+
+      expect(marketsRepository.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('recomputes again once the cached entry is invalidated', async () => {
+      marketsRepository.find.mockResolvedValue([]);
+
+      await service.getCategoryAnalytics();
+      await cacheService.invalidate('analytics:category', 'all');
+      await service.getCategoryAnalytics();
+
+      expect(marketsRepository.find).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -24,6 +24,7 @@ import {
 } from './dto/category-analytics.dto';
 import { CohortDataDto, RetentionResponseDto } from './dto/retention.dto';
 import { PlatformStatsDto } from './dto/platform-stats.dto';
+import { CacheService } from '../cache/cache.service';
 
 /** Tier thresholds: Bronze < 200, Silver < 500, Gold < 1000, Platinum ≥ 1000 */
 export function predictorTierFromReputation(reputationScore: number): string {
@@ -55,6 +56,7 @@ export class AnalyticsService {
     private readonly activityLogsRepository: Repository<ActivityLog>,
     @InjectRepository(MarketHistory)
     private readonly marketHistoryRepository: Repository<MarketHistory>,
+    private readonly cacheService: CacheService,
   ) {}
   private readonly activeSessions = new Map<string, number>();
   private readonly IDLE_WINDOW_MS = parseInt(
@@ -460,9 +462,16 @@ export class AnalyticsService {
   }
 
   /**
-   * Get category analytics with trending calculation
+   * Get category analytics with trending calculation.
+   * Cached (with stampede protection) since this scans every market row.
    */
   async getCategoryAnalytics(): Promise<CategoryAnalyticsResponseDto> {
+    return this.cacheService.getOrSet('analytics:category', 'all', () =>
+      this.computeCategoryAnalytics(),
+    );
+  }
+
+  private async computeCategoryAnalytics(): Promise<CategoryAnalyticsResponseDto> {
     const markets = await this.marketsRepository.find();
 
     const categoryMap = new Map<
@@ -538,7 +547,23 @@ export class AnalyticsService {
   /**
    * Get retention analysis by cohort
    */
+  /**
+   * Get retention analysis by cohort.
+   * Cached (with stampede protection) since this loads all users,
+   * predictions, and activity logs into memory to compute cohorts.
+   */
   async getRetention(
+    period: 'day' | 'week' | 'month' = 'week',
+    periods: number = 8,
+  ): Promise<RetentionResponseDto> {
+    return this.cacheService.getOrSet(
+      'analytics:retention',
+      `${period}:${periods}`,
+      () => this.computeRetention(period, periods),
+    );
+  }
+
+  private async computeRetention(
     period: 'day' | 'week' | 'month' = 'week',
     periods: number = 8,
   ): Promise<RetentionResponseDto> {
@@ -699,7 +724,14 @@ export class AnalyticsService {
     }
     return d;
   }
+  /** Cached (with stampede protection) — aggregates several count/sum queries. */
   async getPlatformStats(): Promise<PlatformStatsDto> {
+    return this.cacheService.getOrSet('analytics:platform-stats', 'all', () =>
+      this.computePlatformStats(),
+    );
+  }
+
+  private async computePlatformStats(): Promise<PlatformStatsDto> {
     const [total_markets, total_predictions, active_markets, active_users] =
       await Promise.all([
         this.marketsRepository.count(),

--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -1,0 +1,10 @@
+import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
+import { Module } from '@nestjs/common';
+import { CacheService } from './cache.service';
+
+@Module({
+  imports: [NestCacheModule.register()],
+  providers: [CacheService],
+  exports: [CacheService],
+})
+export class CacheServiceModule {}

--- a/backend/src/cache/cache.policy.ts
+++ b/backend/src/cache/cache.policy.ts
@@ -1,0 +1,12 @@
+/**
+ * Per-namespace TTL policy for CacheService.getOrSet. Add an entry here
+ * when a new namespace needs a TTL other than DEFAULT_TTL_MS — keeps TTL
+ * tuning in one place instead of scattered magic numbers per service.
+ */
+export const CACHE_NAMESPACE_TTL_MS: Record<string, number> = {
+  'analytics:category': 5 * 60 * 1000, // 5 minutes
+  'analytics:retention': 15 * 60 * 1000, // 15 minutes — expensive full-table scan
+  'analytics:platform-stats': 5 * 60 * 1000, // 5 minutes
+};
+
+export const DEFAULT_TTL_MS = 60 * 1000; // 1 minute

--- a/backend/src/cache/cache.service.spec.ts
+++ b/backend/src/cache/cache.service.spec.ts
@@ -1,0 +1,131 @@
+import { CacheService } from './cache.service';
+import { CACHE_NAMESPACE_TTL_MS, DEFAULT_TTL_MS } from './cache.policy';
+
+describe('CacheService', () => {
+  let service: CacheService;
+  let store: Map<string, unknown>;
+  let cacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
+
+  beforeEach(() => {
+    store = new Map();
+    cacheManager = {
+      get: jest.fn((key: string) => Promise.resolve(store.get(key))),
+      set: jest.fn((key: string, value: unknown) => {
+        store.set(key, value);
+        return Promise.resolve();
+      }),
+      del: jest.fn((key: string) => {
+        store.delete(key);
+        return Promise.resolve();
+      }),
+    };
+    service = new CacheService(cacheManager as never);
+  });
+
+  it('computes and caches on a cold key', async () => {
+    const loader = jest.fn().mockResolvedValue('value-1');
+
+    const result = await service.getOrSet('ns', 'key', loader);
+
+    expect(result).toBe('value-1');
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(cacheManager.set).toHaveBeenCalledWith(
+      'ns:key',
+      'value-1',
+      expect.any(Number),
+    );
+  });
+
+  it('serves from cache without invoking the loader on a warm key', async () => {
+    const loader = jest.fn().mockResolvedValue('value-1');
+
+    await service.getOrSet('ns', 'key', loader);
+    const second = await service.getOrSet('ns', 'key', loader);
+
+    expect(second).toBe('value-1');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('single-flight: concurrent misses for the same key recompute exactly once', async () => {
+    let resolveLoader: (value: string) => void;
+    const loader = jest.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveLoader = resolve;
+        }),
+    );
+
+    const call1 = service.getOrSet('ns', 'key', loader);
+    const call2 = service.getOrSet('ns', 'key', loader);
+    const call3 = service.getOrSet('ns', 'key', loader);
+
+    // Let the microtask queue drain so all three calls reach the
+    // single-flight check before the loader resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // All three calls started before the loader resolved.
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    resolveLoader!('computed-once');
+    const [r1, r2, r3] = await Promise.all([call1, call2, call3]);
+
+    expect(r1).toBe('computed-once');
+    expect(r2).toBe('computed-once');
+    expect(r3).toBe('computed-once');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a fresh recompute after the in-flight computation settles and the entry is invalidated', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+
+    await service.getOrSet('ns', 'key', loader);
+    await service.invalidate('ns', 'key');
+    const result = await service.getOrSet('ns', 'key', loader);
+
+    expect(result).toBe('second');
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the configured namespace TTL when calling cacheManager.set', async () => {
+    const loader = jest.fn().mockResolvedValue('v');
+
+    await service.getOrSet('analytics:category', 'all', loader);
+
+    expect(cacheManager.set).toHaveBeenCalledWith(
+      'analytics:category:all',
+      'v',
+      CACHE_NAMESPACE_TTL_MS['analytics:category'],
+    );
+  });
+
+  it('falls back to the default TTL for an unconfigured namespace', async () => {
+    const loader = jest.fn().mockResolvedValue('v');
+
+    await service.getOrSet('some:unlisted:namespace', 'key', loader);
+
+    expect(cacheManager.set).toHaveBeenCalledWith(
+      'some:unlisted:namespace:key',
+      'v',
+      DEFAULT_TTL_MS,
+    );
+  });
+
+  it('invalidate removes the cached entry so the next call recomputes', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValueOnce('a')
+      .mockResolvedValueOnce('b');
+
+    await service.getOrSet('ns', 'key', loader);
+    await service.invalidate('ns', 'key');
+    const result = await service.getOrSet('ns', 'key', loader);
+
+    expect(result).toBe('b');
+    expect(cacheManager.del).toHaveBeenCalledWith('ns:key');
+  });
+});

--- a/backend/src/cache/cache.service.ts
+++ b/backend/src/cache/cache.service.ts
@@ -1,0 +1,73 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import type { Cache } from 'cache-manager';
+import { CACHE_NAMESPACE_TTL_MS, DEFAULT_TTL_MS } from './cache.policy';
+
+/**
+ * Thin wrapper around cache-manager's Cache that adds:
+ *
+ * 1. Per-namespace TTL policy (see cache.policy.ts) so callers don't need
+ *    to invent and track their own TTL constants per feature.
+ * 2. Single-flight stampede protection: concurrent `getOrSet` calls for the
+ *    same key, while the value is cold, share one in-flight computation
+ *    instead of each triggering its own recompute.
+ *
+ * Single-flight is in-process only (a plain `Map<string, Promise>`) — it
+ * protects a single Node instance from a thundering herd on a cold key. It
+ * does not coordinate across horizontally-scaled replicas, since the
+ * underlying store here is cache-manager's in-memory backend, not Redis.
+ */
+@Injectable()
+export class CacheService {
+  private readonly logger = new Logger(CacheService.name);
+  private readonly inFlight = new Map<string, Promise<unknown>>();
+
+  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+
+  /**
+   * Returns the cached value for `key` if present; otherwise computes it
+   * via `loader`, caches the result under `namespace`'s TTL policy, and
+   * returns it. Concurrent calls for the same key while the value is cold
+   * share a single `loader` invocation.
+   */
+  async getOrSet<T>(
+    namespace: string,
+    key: string,
+    loader: () => Promise<T>,
+  ): Promise<T> {
+    const cacheKey = `${namespace}:${key}`;
+
+    const cached = await this.cacheManager.get<T>(cacheKey);
+    if (cached !== undefined && cached !== null) {
+      return cached;
+    }
+
+    const pending = this.inFlight.get(cacheKey);
+    if (pending) {
+      return pending as Promise<T>;
+    }
+
+    const ttlMs = this.resolveTtl(namespace);
+    const computation = (async () => {
+      try {
+        const value = await loader();
+        await this.cacheManager.set(cacheKey, value, ttlMs);
+        return value;
+      } finally {
+        this.inFlight.delete(cacheKey);
+      }
+    })();
+
+    this.inFlight.set(cacheKey, computation);
+    return computation;
+  }
+
+  /** Invalidates a single cached key within a namespace. */
+  async invalidate(namespace: string, key: string): Promise<void> {
+    await this.cacheManager.del(`${namespace}:${key}`);
+  }
+
+  private resolveTtl(namespace: string): number {
+    return CACHE_NAMESPACE_TTL_MS[namespace] ?? DEFAULT_TTL_MS;
+  }
+}

--- a/backend/src/common/decorators/deprecated.decorator.ts
+++ b/backend/src/common/decorators/deprecated.decorator.ts
@@ -1,0 +1,19 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const DEPRECATED_METADATA_KEY = 'apiDeprecated';
+
+export interface DeprecatedOptions {
+  /** ISO 8601 date (or HTTP-date) the route will stop being served, sent as the Sunset header. */
+  sunset: string;
+  /** Optional link to migration docs, sent as a Link header with rel="deprecation". */
+  link?: string;
+}
+
+/**
+ * Marks a route (or every route on a controller) as deprecated. Read by
+ * DeprecationInterceptor to emit the `Deprecation` and `Sunset` response
+ * headers defined by draft-ietf-httpapi-deprecation-header, signalling
+ * clients to migrate before `sunset`.
+ */
+export const Deprecated = (options: DeprecatedOptions) =>
+  SetMetadata(DEPRECATED_METADATA_KEY, options);

--- a/backend/src/common/interceptors/deprecation.interceptor.spec.ts
+++ b/backend/src/common/interceptors/deprecation.interceptor.spec.ts
@@ -1,0 +1,80 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { of } from 'rxjs';
+import { DeprecationInterceptor } from './deprecation.interceptor';
+import { DEPRECATED_METADATA_KEY } from '../decorators/deprecated.decorator';
+
+describe('DeprecationInterceptor', () => {
+  let reflector: jest.Mocked<Pick<Reflector, 'getAllAndOverride'>>;
+  let interceptor: DeprecationInterceptor;
+  let setHeader: jest.Mock;
+
+  const makeContext = (): ExecutionContext => {
+    const response = { setHeader };
+    return {
+      switchToHttp: () => ({ getResponse: () => response }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+  };
+
+  const nextHandler = { handle: () => of({ ok: true }) };
+
+  beforeEach(() => {
+    setHeader = jest.fn();
+    reflector = { getAllAndOverride: jest.fn() };
+    interceptor = new DeprecationInterceptor(reflector as unknown as Reflector);
+  });
+
+  it('does not set any headers when the route has no @Deprecated metadata', (done) => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    interceptor.intercept(makeContext(), nextHandler).subscribe(() => {
+      expect(setHeader).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('sets Deprecation and Sunset headers when the route carries @Deprecated metadata', (done) => {
+    reflector.getAllAndOverride.mockReturnValue({
+      sunset: 'Wed, 31 Dec 2026 23:59:59 GMT',
+    });
+
+    interceptor.intercept(makeContext(), nextHandler).subscribe(() => {
+      expect(setHeader).toHaveBeenCalledWith('Deprecation', 'true');
+      expect(setHeader).toHaveBeenCalledWith(
+        'Sunset',
+        'Wed, 31 Dec 2026 23:59:59 GMT',
+      );
+      done();
+    });
+  });
+
+  it('sets a Link header with rel="deprecation" when a link is configured', (done) => {
+    reflector.getAllAndOverride.mockReturnValue({
+      sunset: 'Wed, 31 Dec 2026 23:59:59 GMT',
+      link: '/docs/migration',
+    });
+
+    interceptor.intercept(makeContext(), nextHandler).subscribe(() => {
+      expect(setHeader).toHaveBeenCalledWith(
+        'Link',
+        '</docs/migration>; rel="deprecation"',
+      );
+      done();
+    });
+  });
+
+  it('reads metadata from both the handler and the class (getAllAndOverride)', (done) => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+    const context = makeContext();
+
+    interceptor.intercept(context, nextHandler).subscribe(() => {
+      expect(reflector.getAllAndOverride).toHaveBeenCalledWith(
+        DEPRECATED_METADATA_KEY,
+        [context.getHandler(), context.getClass()],
+      );
+      done();
+    });
+  });
+});

--- a/backend/src/common/interceptors/deprecation.interceptor.ts
+++ b/backend/src/common/interceptors/deprecation.interceptor.ts
@@ -1,0 +1,43 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import type { Response } from 'express';
+import {
+  DEPRECATED_METADATA_KEY,
+  DeprecatedOptions,
+} from '../decorators/deprecated.decorator';
+
+/**
+ * Emits `Deprecation` and `Sunset` response headers (per
+ * draft-ietf-httpapi-deprecation-header) on any route marked with
+ * `@Deprecated(...)`, so clients get a machine-readable migration signal
+ * instead of silently continuing to call a route that will be removed.
+ *
+ * Routes without the decorator are untouched — no headers are added.
+ */
+@Injectable()
+export class DeprecationInterceptor implements NestInterceptor {
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const options = this.reflector.getAllAndOverride<
+      DeprecatedOptions | undefined
+    >(DEPRECATED_METADATA_KEY, [context.getHandler(), context.getClass()]);
+
+    if (options) {
+      const response = context.switchToHttp().getResponse<Response>();
+      response.setHeader('Deprecation', 'true');
+      response.setHeader('Sunset', options.sunset);
+      if (options.link) {
+        response.setHeader('Link', `<${options.link}>; rel="deprecation"`);
+      }
+    }
+
+    return next.handle();
+  }
+}

--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -2,6 +2,7 @@ jest.mock('./health.service', () => ({
   HealthService: class HealthService {},
 }));
 
+import { ServiceUnavailableException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
@@ -12,6 +13,8 @@ describe('HealthController', () => {
     checkHealth: jest.Mock;
     checkPing: jest.Mock;
     checkDetailed: jest.Mock;
+    checkLiveness: jest.Mock;
+    checkReadiness: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -23,6 +26,8 @@ describe('HealthController', () => {
         timestamp: new Date().toISOString(),
       }),
       checkDetailed: jest.fn(),
+      checkLiveness: jest.fn(),
+      checkReadiness: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -145,6 +150,48 @@ describe('HealthController', () => {
       await controller.checkDetailed('yes');
 
       expect(healthService.checkDetailed).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('checkLive', () => {
+    it('delegates to HealthService.checkLiveness without probing dependencies', () => {
+      healthService.checkLiveness.mockReturnValue({
+        status: 'ok',
+        uptime_seconds: 10,
+      });
+
+      const result = controller.checkLive();
+
+      expect(healthService.checkLiveness).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ status: 'ok', uptime_seconds: 10 });
+    });
+  });
+
+  describe('checkReady', () => {
+    it('delegates to HealthService.checkReadiness and returns dependency detail', async () => {
+      const readyBody = {
+        status: 'healthy',
+        database: { status: 'up', latency_ms: 2 },
+        soroban: { status: 'up', latency_ms: 50 },
+        cache: { status: 'up', latency_ms: 1 },
+        uptime_seconds: 10,
+      };
+      healthService.checkReadiness.mockResolvedValue(readyBody);
+
+      const result = await controller.checkReady();
+
+      expect(healthService.checkReadiness).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(readyBody);
+    });
+
+    it('propagates a not-ready (503) rejection from the service', async () => {
+      healthService.checkReadiness.mockRejectedValue(
+        new ServiceUnavailableException({ status: 'down' }),
+      );
+
+      await expect(controller.checkReady()).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
     });
   });
 

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -36,6 +36,38 @@ export class HealthController {
     return this.healthService.checkPing();
   }
 
+  @Get('live')
+  @Public()
+  @ApiOperation({
+    summary: 'Liveness probe — is the process itself responsive?',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Process is alive. Does not check dependencies.',
+  })
+  checkLive() {
+    return this.healthService.checkLiveness();
+  }
+
+  @Get('ready')
+  @Public()
+  @ApiOperation({
+    summary: 'Readiness probe — can this instance serve traffic?',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Database, Soroban RPC, and cache are all reachable',
+    type: DetailedHealthDto,
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'At least one critical dependency is unreachable',
+    type: DetailedHealthDto,
+  })
+  checkReady(): Promise<DetailedHealthDto> {
+    return this.healthService.checkReadiness();
+  }
+
   @Get('detailed')
   @Public()
   @ApiOperation({ summary: 'Detailed health status for monitoring' })

--- a/backend/src/health/health.service.spec.ts
+++ b/backend/src/health/health.service.spec.ts
@@ -1,3 +1,4 @@
+import { ServiceUnavailableException } from '@nestjs/common';
 import { HealthService } from './health.service';
 
 describe('HealthService - checkDetailed', () => {
@@ -111,5 +112,106 @@ describe('HealthService - checkDetailed', () => {
       status: 'up',
       latency_ms: expect.any(Number),
     });
+  });
+});
+
+describe('HealthService - checkLiveness', () => {
+  let service: HealthService;
+
+  beforeEach(() => {
+    service = new HealthService(
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+    );
+  });
+
+  it('reports ok without checking any dependency', () => {
+    const result = service.checkLiveness();
+
+    expect(result.status).toBe('ok');
+    expect(result.uptime_seconds).toEqual(expect.any(Number));
+  });
+});
+
+describe('HealthService - checkReadiness', () => {
+  let dataSource: { query: jest.Mock };
+  let cacheManager: { set: jest.Mock; get: jest.Mock };
+  let service: HealthService;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    dataSource = { query: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+    cacheManager = {
+      set: jest.fn().mockResolvedValue(undefined),
+      get: jest.fn().mockResolvedValue('ok'),
+    };
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    service = new HealthService(
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      dataSource as never,
+      cacheManager as never,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves with ready status when all dependencies are up', async () => {
+    const result = await service.checkReadiness();
+
+    expect(result.status).toBe('healthy');
+    expect(result.database.status).toBe('up');
+    expect(result.soroban.status).toBe('up');
+    expect(result.cache.status).toBe('up');
+  });
+
+  it('throws ServiceUnavailableException (not-ready) when the database is down', async () => {
+    dataSource.query.mockRejectedValue(new Error('connection refused'));
+
+    await expect(service.checkReadiness()).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('throws ServiceUnavailableException (not-ready) when Soroban RPC is down', async () => {
+    fetchMock.mockRejectedValue(new Error('timeout'));
+
+    await expect(service.checkReadiness()).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('throws ServiceUnavailableException (not-ready) when the cache is unreachable', async () => {
+    cacheManager.get.mockResolvedValue(undefined);
+
+    await expect(service.checkReadiness()).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('includes per-dependency detail in the not-ready exception response', async () => {
+    dataSource.query.mockRejectedValue(new Error('connection refused'));
+
+    try {
+      await service.checkReadiness();
+      fail('expected checkReadiness to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ServiceUnavailableException);
+      const response = (error as ServiceUnavailableException).getResponse();
+      expect(response).toMatchObject({
+        status: 'down',
+        database: { status: 'down' },
+      });
+    }
   });
 });

--- a/backend/src/health/health.service.ts
+++ b/backend/src/health/health.service.ts
@@ -1,5 +1,9 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import {
   DiskHealthIndicator,
   HealthCheck,
@@ -111,6 +115,51 @@ export class HealthService {
       cache: cacheResult,
       uptime_seconds,
     };
+  }
+
+  /**
+   * Liveness: is the process itself up and able to respond? No dependency
+   * checks — a dependency outage must not cause an orchestrator to restart
+   * an otherwise-healthy process.
+   */
+  checkLiveness(): { status: 'ok'; uptime_seconds: number } {
+    return {
+      status: 'ok',
+      uptime_seconds: Math.floor((Date.now() - START_TIME) / 1000),
+    };
+  }
+
+  /**
+   * Readiness: can this instance actually serve traffic right now? Probes
+   * DB, Soroban RPC, and cache; any dependency being down flips readiness
+   * to not-ready (503), signalling the orchestrator to stop routing traffic
+   * here until dependencies recover.
+   */
+  async checkReadiness(): Promise<DetailedHealthDto> {
+    const [dbResult, sorobanResult, cacheResult] = await Promise.all([
+      this.checkDatabase(),
+      this.checkSoroban(),
+      this.checkCache(),
+    ]);
+
+    const ready =
+      dbResult.status === 'up' &&
+      sorobanResult.status === 'up' &&
+      cacheResult.status === 'up';
+
+    const body: DetailedHealthDto = {
+      status: ready ? 'healthy' : 'down',
+      database: dbResult,
+      soroban: sorobanResult,
+      cache: cacheResult,
+      uptime_seconds: Math.floor((Date.now() - START_TIME) / 1000),
+    };
+
+    if (!ready) {
+      throw new ServiceUnavailableException(body);
+    }
+
+    return body;
   }
 
   private computeOverallStatus(

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,9 @@
 import { VersioningType } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
+import { DeprecationInterceptor } from './common/interceptors/deprecation.interceptor';
 
 import { Logger } from 'nestjs-pino';
 
@@ -22,7 +23,12 @@ async function bootstrap() {
   });
   app.useLogger(app.get(Logger));
 
-  // Enable URI-based versioning
+  // Enable URI-based versioning.
+  //
+  // Supported versions: v1 (current, default).
+  // Deprecated versions: none yet. When a version is deprecated, mark its
+  // routes with @Deprecated({ sunset, link }) (src/common/decorators)
+  // so DeprecationInterceptor emits Deprecation/Sunset response headers.
   app.enableVersioning({
     type: VersioningType.URI,
     defaultVersion: '1',
@@ -72,7 +78,10 @@ async function bootstrap() {
     process.exit(0);
   }
 
-  app.useGlobalInterceptors(new ResponseInterceptor());
+  app.useGlobalInterceptors(
+    new DeprecationInterceptor(app.get(Reflector)),
+    new ResponseInterceptor(),
+  );
   app.useGlobalFilters(new HttpExceptionFilter());
   await app.listen(env.PORT ?? 3000);
 }

--- a/backend/src/websocket/broadcast-queue.service.spec.ts
+++ b/backend/src/websocket/broadcast-queue.service.spec.ts
@@ -1,0 +1,157 @@
+import { BroadcastQueueService } from './broadcast-queue.service';
+
+/** Minimal fake of the socket.io Server surface BroadcastQueueService touches. */
+const makeFakeServer = () => {
+  const sockets = new Map<string, { emit: jest.Mock }>();
+  return {
+    sockets: { sockets },
+    _addSocket: (id: string) => {
+      const socket = { emit: jest.fn() };
+      sockets.set(id, socket);
+      return socket;
+    },
+  };
+};
+
+describe('BroadcastQueueService', () => {
+  let service: BroadcastQueueService;
+
+  beforeEach(() => {
+    service = new BroadcastQueueService({
+      get: (key: string) => {
+        const values: Record<string, number> = {
+          BROADCAST_QUEUE_MAX_SIZE: 3,
+          BROADCAST_QUEUE_FLUSH_MS: 50,
+        };
+        return values[key];
+      },
+    } as never);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
+  it('coalesces messages sharing the same key, keeping only the latest payload', () => {
+    const server = makeFakeServer();
+    server._addSocket('socket-1');
+
+    service.enqueue(
+      server as never,
+      'socket-1',
+      'odds:market-1',
+      'odds:update',
+      {
+        v: 1,
+      },
+    );
+    service.enqueue(
+      server as never,
+      'socket-1',
+      'odds:market-1',
+      'odds:update',
+      {
+        v: 2,
+      },
+    );
+    service.enqueue(
+      server as never,
+      'socket-1',
+      'odds:market-1',
+      'odds:update',
+      {
+        v: 3,
+      },
+    );
+
+    expect(service.getQueueDepth('socket-1')).toBe(1);
+    expect(service.getMetrics().coalesced).toBe(2);
+  });
+
+  it('drops the oldest non-coalescable message once the queue is at capacity', () => {
+    const server = makeFakeServer();
+    server._addSocket('socket-1');
+
+    // maxQueueSize = 3; four distinct keys → one must be dropped.
+    service.enqueue(server as never, 'socket-1', 'k1', 'ev', { v: 1 });
+    service.enqueue(server as never, 'socket-1', 'k2', 'ev', { v: 2 });
+    service.enqueue(server as never, 'socket-1', 'k3', 'ev', { v: 3 });
+    service.enqueue(server as never, 'socket-1', 'k4', 'ev', { v: 4 });
+
+    expect(service.getQueueDepth('socket-1')).toBe(3);
+    expect(service.getMetrics().dropped).toBe(1);
+  });
+
+  it('flushes queued messages to the socket on the flush interval', () => {
+    jest.useFakeTimers();
+    const server = makeFakeServer();
+    const socket = server._addSocket('socket-1');
+
+    service.enqueue(server as never, 'socket-1', 'k1', 'odds:update', {
+      v: 1,
+    });
+    expect(socket.emit).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(60);
+
+    expect(socket.emit).toHaveBeenCalledWith('odds:update', { v: 1 });
+    expect(service.getQueueDepth('socket-1')).toBe(0);
+    expect(service.getMetrics().sent).toBe(1);
+
+    jest.useRealTimers();
+  });
+
+  it('a slow socket whose emit throws does not block delivery to other sockets', () => {
+    jest.useFakeTimers();
+    const server = makeFakeServer();
+    const fastSocket = server._addSocket('fast');
+    const slowSocket = server._addSocket('slow');
+
+    // "Slow" socket: emit throws synchronously, simulating a stalled write
+    // (e.g. the underlying transport rejecting a write). Each socket has
+    // its own independent flush timer/queue — if broadcasting were still
+    // done via a single synchronous loop over all room members, one
+    // throwing socket would abort delivery to the rest in that same tick.
+    slowSocket.emit.mockImplementation(() => {
+      throw new Error('write buffer full');
+    });
+
+    service.enqueue(server as never, 'fast', 'k', 'ev', { v: 'fast' });
+    service.enqueue(server as never, 'slow', 'k', 'ev', { v: 'slow' });
+
+    jest.advanceTimersByTime(60);
+
+    // fast's independent flush timer delivered its message even though
+    // slow's flush (also fired this tick) threw.
+    expect(fastSocket.emit).toHaveBeenCalledWith('ev', { v: 'fast' });
+
+    jest.useRealTimers();
+  });
+
+  it('removeSocket clears the queue and stops its flush timer', () => {
+    jest.useFakeTimers();
+    const server = makeFakeServer();
+    const socket = server._addSocket('socket-1');
+
+    service.enqueue(server as never, 'socket-1', 'k1', 'ev', { v: 1 });
+    service.removeSocket('socket-1');
+
+    jest.advanceTimersByTime(200);
+
+    expect(socket.emit).not.toHaveBeenCalled();
+    expect(service.getQueueDepth('socket-1')).toBe(0);
+
+    jest.useRealTimers();
+  });
+
+  it('enforces the configured buffer bound across many rapid enqueues', () => {
+    const server = makeFakeServer();
+    server._addSocket('socket-1');
+
+    for (let i = 0; i < 50; i++) {
+      service.enqueue(server as never, 'socket-1', `k${i}`, 'ev', { v: i });
+    }
+
+    expect(service.getQueueDepth('socket-1')).toBeLessThanOrEqual(3);
+  });
+});

--- a/backend/src/websocket/broadcast-queue.service.ts
+++ b/backend/src/websocket/broadcast-queue.service.ts
@@ -1,0 +1,166 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Optional } from '@nestjs/common';
+import type { Server } from 'socket.io';
+
+interface QueuedMessage {
+  /** Coalesce key: a later message with the same key replaces the earlier one in-queue. */
+  key: string;
+  event: string;
+  payload: unknown;
+}
+
+interface SocketQueue {
+  messages: QueuedMessage[];
+  flushTimer: NodeJS.Timeout;
+}
+
+export interface BroadcastQueueMetrics {
+  /** Messages dropped because a socket's queue was at capacity and the message wasn't coalescable. */
+  dropped: number;
+  /** Messages that replaced an already-queued message sharing the same coalesce key. */
+  coalesced: number;
+  /** Messages successfully flushed to a socket. */
+  sent: number;
+}
+
+/**
+ * Per-connection bounded outbound queue for high-frequency broadcasts
+ * (e.g. live odds updates).
+ *
+ * Problem: emitting directly to a room (`server.to(room).emit(...)`) hands
+ * the payload to every socket's write buffer synchronously in a single
+ * server tick. A slow/backgrounded client whose transport can't drain fast
+ * enough causes its write buffer to grow — and because all sockets in the
+ * room are iterated in the same call, a pathological client can add
+ * latency to that broadcast for everyone else sharing the tick.
+ *
+ * Fix: queue per-socket instead of emitting directly. Each socket gets a
+ * small bounded buffer (`maxQueueSize` messages). Messages carry a
+ * coalesce key (e.g. `market:<id>`); a new message for a key already
+ * queued replaces it in place — only the latest odds snapshot matters, so
+ * this is safe and keeps memory bounded even under sustained updates.
+ * When the queue is full and the incoming message can't coalesce with
+ * anything already queued, the oldest message is dropped to make room.
+ * A per-socket flush timer drains the queue on a short interval, so one
+ * slow socket's flush never blocks another's.
+ */
+@Injectable()
+export class BroadcastQueueService implements OnModuleDestroy {
+  private readonly logger = new Logger(BroadcastQueueService.name);
+  private readonly queues = new Map<string, SocketQueue>();
+
+  private readonly maxQueueSize: number;
+  private readonly flushIntervalMs: number;
+
+  private readonly metrics: BroadcastQueueMetrics = {
+    dropped: 0,
+    coalesced: 0,
+    sent: 0,
+  };
+
+  constructor(@Optional() private readonly configService?: ConfigService) {
+    this.maxQueueSize =
+      this.configService?.get<number>('BROADCAST_QUEUE_MAX_SIZE') ?? 20;
+    this.flushIntervalMs =
+      this.configService?.get<number>('BROADCAST_QUEUE_FLUSH_MS') ?? 100;
+  }
+
+  /**
+   * Enqueue a message for delivery to a single socket. Messages sharing
+   * `key` for the same socket coalesce (latest wins). Call this instead of
+   * `socket.emit(...)` directly for high-frequency broadcast payloads.
+   */
+  enqueue(
+    server: Server,
+    socketId: string,
+    key: string,
+    event: string,
+    payload: unknown,
+  ): void {
+    let queue = this.queues.get(socketId);
+    if (!queue) {
+      queue = {
+        messages: [],
+        flushTimer: this.startFlushTimer(server, socketId),
+      };
+      this.queues.set(socketId, queue);
+    }
+
+    const existingIndex = queue.messages.findIndex((m) => m.key === key);
+    if (existingIndex !== -1) {
+      queue.messages[existingIndex] = { key, event, payload };
+      this.metrics.coalesced++;
+      return;
+    }
+
+    if (queue.messages.length >= this.maxQueueSize) {
+      queue.messages.shift();
+      this.metrics.dropped++;
+      this.logger.warn(
+        `[backpressure] dropped oldest queued message for socket ${socketId} (queue at capacity: ${this.maxQueueSize})`,
+      );
+    }
+
+    queue.messages.push({ key, event, payload });
+  }
+
+  /** Removes a socket's queue and stops its flush timer (call on disconnect). */
+  removeSocket(socketId: string): void {
+    const queue = this.queues.get(socketId);
+    if (!queue) return;
+    clearInterval(queue.flushTimer);
+    this.queues.delete(socketId);
+  }
+
+  /** Snapshot of dropped/coalesced/sent counters, for metrics/health reporting. */
+  getMetrics(): BroadcastQueueMetrics {
+    return { ...this.metrics };
+  }
+
+  /** Number of messages currently queued for a socket (test/inspection helper). */
+  getQueueDepth(socketId: string): number {
+    return this.queues.get(socketId)?.messages.length ?? 0;
+  }
+
+  private startFlushTimer(server: Server, socketId: string): NodeJS.Timeout {
+    const timer = setInterval(() => {
+      this.flush(server, socketId);
+    }, this.flushIntervalMs);
+    timer.unref?.();
+    return timer;
+  }
+
+  private flush(server: Server, socketId: string): void {
+    const queue = this.queues.get(socketId);
+    if (!queue || queue.messages.length === 0) return;
+
+    const socket = server.sockets.sockets.get(socketId);
+    if (!socket) {
+      // Socket already disconnected; stop queueing for it.
+      this.removeSocket(socketId);
+      return;
+    }
+
+    const pending = queue.messages;
+    queue.messages = [];
+
+    for (const message of pending) {
+      try {
+        socket.emit(message.event, message.payload);
+        this.metrics.sent++;
+      } catch (error) {
+        this.logger.warn(
+          `[backpressure] failed to emit to socket ${socketId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  onModuleDestroy(): void {
+    for (const queue of this.queues.values()) {
+      clearInterval(queue.flushTimer);
+    }
+    this.queues.clear();
+  }
+}

--- a/backend/src/websocket/events.gateway.ts
+++ b/backend/src/websocket/events.gateway.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { OddsBroadcasterService } from './odds-broadcaster.service';
+import { BroadcastQueueService } from './broadcast-queue.service';
 
 interface AuthenticatedSocket extends Socket {
   userAddress?: string;
@@ -73,6 +74,7 @@ export class EventsGateway
     @Inject(forwardRef(() => AnalyticsService))
     private readonly analyticsService: AnalyticsService,
     @Optional() private readonly oddsBroadcaster?: OddsBroadcasterService,
+    @Optional() private readonly broadcastQueue?: BroadcastQueueService,
   ) {}
 
   async handleConnection(client: AuthenticatedSocket): Promise<void> {
@@ -213,6 +215,7 @@ export class EventsGateway
     this.rateLimits.delete(client.id);
     this.analyticsService.removeActiveSession(client.id);
     this.broadcastActiveUsers();
+    this.broadcastQueue?.removeSocket(client.id);
 
     const userAddress = this.connections.get(client.id);
     this.connections.delete(client.id);

--- a/backend/src/websocket/odds-broadcaster.service.spec.ts
+++ b/backend/src/websocket/odds-broadcaster.service.spec.ts
@@ -1,0 +1,68 @@
+import { OddsBroadcasterService } from './odds-broadcaster.service';
+import { BroadcastQueueService } from './broadcast-queue.service';
+
+describe('OddsBroadcasterService', () => {
+  let service: OddsBroadcasterService;
+  let broadcastQueue: jest.Mocked<Pick<BroadcastQueueService, 'enqueue'>>;
+  let gateway: { server: unknown };
+
+  const marketId = 'market-1';
+  const room = `market:${marketId}`;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    const roomMembers = new Set(['socket-a', 'socket-b']);
+    gateway = {
+      server: {
+        sockets: { adapter: { rooms: new Map([[room, roomMembers]]) } },
+      },
+    };
+
+    broadcastQueue = { enqueue: jest.fn() };
+
+    service = new OddsBroadcasterService(
+      gateway as never,
+      broadcastQueue as never,
+      { get: () => 500 } as never,
+    );
+
+    service.onSubscribe(marketId);
+    service.onSubscribe(marketId);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    jest.useRealTimers();
+  });
+
+  it('enqueues the update on every subscribed socket individually instead of a room-wide emit', () => {
+    service.broadcastOddsUpdate(marketId, [
+      { outcome: 'Yes', count: 3, total_staked_stroops: '100' },
+    ]);
+
+    expect(broadcastQueue.enqueue).toHaveBeenCalledTimes(2);
+    expect(broadcastQueue.enqueue).toHaveBeenCalledWith(
+      gateway.server,
+      'socket-a',
+      `odds:${marketId}`,
+      'odds:update',
+      expect.objectContaining({ market_id: marketId }),
+    );
+    expect(broadcastQueue.enqueue).toHaveBeenCalledWith(
+      gateway.server,
+      'socket-b',
+      `odds:${marketId}`,
+      'odds:update',
+      expect.objectContaining({ market_id: marketId }),
+    );
+  });
+
+  it('does not enqueue anything when the market has no subscribers', () => {
+    service.broadcastOddsUpdate('no-subscribers-market', [
+      { outcome: 'Yes', count: 1, total_staked_stroops: '10' },
+    ]);
+
+    expect(broadcastQueue.enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/websocket/odds-broadcaster.service.ts
+++ b/backend/src/websocket/odds-broadcaster.service.ts
@@ -1,11 +1,7 @@
-import {
-  Injectable,
-  Logger,
-  OnModuleDestroy,
-  Optional,
-} from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventsGateway } from './events.gateway';
+import { BroadcastQueueService } from './broadcast-queue.service';
 import { PredictionStatsDto } from '../markets/dto/prediction-stats.dto';
 
 export interface OddsUpdatePayload {
@@ -52,6 +48,7 @@ export class OddsBroadcasterService implements OnModuleDestroy {
 
   constructor(
     private readonly gateway: EventsGateway,
+    private readonly broadcastQueue: BroadcastQueueService,
     @Optional() private readonly configService?: ConfigService,
   ) {
     this.throttleMs =
@@ -124,10 +121,7 @@ export class OddsBroadcasterService implements OnModuleDestroy {
    *
    * No-ops when there are no subscribers, avoiding unnecessary allocations.
    */
-  broadcastOddsUpdate(
-    marketId: string,
-    odds: PredictionStatsDto[],
-  ): void {
+  broadcastOddsUpdate(marketId: string, odds: PredictionStatsDto[]): void {
     // Skip entirely when nobody is listening.
     if (!this.hasSubscribers(marketId)) {
       return;
@@ -195,10 +189,30 @@ export class OddsBroadcasterService implements OnModuleDestroy {
   // Private helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * Enqueues the update on each subscribed socket's own bounded outbound
+   * queue instead of a direct room-wide `emit`, so one slow client can't
+   * add latency to delivery for the rest of the room (see
+   * BroadcastQueueService for the backpressure policy).
+   */
   private emit(marketId: string, payload: OddsUpdatePayload): void {
-    this.gateway.server.to(`market:${marketId}`).emit('odds:update', payload);
+    const room = `market:${marketId}`;
+    const socketIds = this.gateway.server.sockets.adapter.rooms.get(room);
+
+    if (socketIds) {
+      for (const socketId of socketIds) {
+        this.broadcastQueue.enqueue(
+          this.gateway.server,
+          socketId,
+          `odds:${marketId}`,
+          'odds:update',
+          payload,
+        );
+      }
+    }
+
     this.logger.debug(
-      `[odds] emitted odds:update → market:${marketId} (${payload.odds.length} outcomes)`,
+      `[odds] queued odds:update → market:${marketId} (${payload.odds.length} outcomes, ${socketIds?.size ?? 0} subscriber(s))`,
     );
   }
 }

--- a/backend/src/websocket/websocket.module.ts
+++ b/backend/src/websocket/websocket.module.ts
@@ -6,6 +6,7 @@ import { EventsGateway } from './events.gateway';
 import { BroadcasterService } from './broadcaster.service';
 import { NotificationBroadcasterService } from './notification-broadcaster.service';
 import { OddsBroadcasterService } from './odds-broadcaster.service';
+import { BroadcastQueueService } from './broadcast-queue.service';
 
 @Module({
   imports: [
@@ -23,7 +24,13 @@ import { OddsBroadcasterService } from './odds-broadcaster.service';
     BroadcasterService,
     NotificationBroadcasterService,
     OddsBroadcasterService,
+    BroadcastQueueService,
   ],
-  exports: [BroadcasterService, NotificationBroadcasterService, OddsBroadcasterService],
+  exports: [
+    BroadcasterService,
+    NotificationBroadcasterService,
+    OddsBroadcasterService,
+    BroadcastQueueService,
+  ],
 })
 export class WebsocketModule {}

--- a/backend/test/api-versioning.e2e-spec.ts
+++ b/backend/test/api-versioning.e2e-spec.ts
@@ -1,58 +1,92 @@
+import {
+  Controller,
+  Get,
+  INestApplication,
+  VersioningType,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import request from 'supertest';
+import { Deprecated } from '../src/common/decorators/deprecated.decorator';
+import { DeprecationInterceptor } from '../src/common/interceptors/deprecation.interceptor';
+
 /**
- * API Versioning Configuration Test
- *
- * This file documents the API versioning configuration:
- * - VersioningType.URI is enabled in src/main.ts
- * - Global prefix is set to 'api'
- * - Default version is set to '1'
- * - All endpoints are automatically prefixed with /api/v1/
- *
- * Example endpoints:
- * - GET /api/v1/markets
- * - GET /api/v1/seasons
- * - GET /api/v1/health
- * - POST /api/v1/seasons/:id/finalize
- *
- * Old paths without versioning (e.g., /markets) will return 404.
+ * Throwaway controller exercising both a current and a deprecated route,
+ * versioned the same way production controllers are (URI versioning,
+ * default version '1' — see src/main.ts).
  */
+@Controller({ path: 'widgets', version: '1' })
+class WidgetsController {
+  @Get('current')
+  current() {
+    return { ok: true };
+  }
 
-describe('API Versioning Configuration', () => {
-  it('Versioning is enabled with VersioningType.URI', () => {
-    // Configuration is verified by successful build and compilation
-    // See src/main.ts for the implementation:
-    // app.enableVersioning({
-    //   type: VersioningType.URI,
-    //   defaultVersion: '1',
-    // });
-    expect(true).toBe(true);
+  @Get('legacy')
+  @Deprecated({
+    sunset: 'Wed, 31 Dec 2026 23:59:59 GMT',
+    link: '/docs/migration',
+  })
+  legacy() {
+    return { ok: true };
+  }
+}
+
+describe('API Versioning & Deprecation (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [WidgetsController],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.enableVersioning({
+      type: VersioningType.URI,
+      defaultVersion: '1',
+    });
+    app.setGlobalPrefix('api');
+    app.useGlobalInterceptors(new DeprecationInterceptor(app.get(Reflector)));
+    await app.init();
   });
 
-  it('Global API prefix is set to /api', () => {
-    // Configuration is verified by successful build and compilation
-    // See src/main.ts for the implementation:
-    // app.setGlobalPrefix('api');
-    expect(true).toBe(true);
+  afterEach(async () => {
+    await app.close();
   });
 
-  it('All endpoints should be prefixed with /api/v1/', () => {
-    // With VersioningType.URI and defaultVersion '1', all endpoints
-    // that don't explicitly specify a version will use v1.
-    // This means:
-    // - @Controller('markets') becomes GET /api/v1/markets
-    // - @Controller('seasons') becomes GET /api/v1/seasons
-    // - etc.
-    expect(true).toBe(true);
+  it('serves versioned routes under /api/v1/', () => {
+    return request(app.getHttpServer())
+      .get('/api/v1/widgets/current')
+      .expect(200);
   });
 
-  it('Swagger UI is available at /api/v1/docs', () => {
-    // See src/main.ts:
-    // SwaggerModule.setup('api/v1/docs', app, document);
-    expect(true).toBe(true);
+  it('returns 404 for unversioned/unprefixed paths', () => {
+    return request(app.getHttpServer()).get('/widgets/current').expect(404);
   });
 
-  it('Old paths without version prefix return 404', () => {
-    // Requests to /markets (without /api/v1 prefix) will return 404
-    // This prevents accidental access to unversioned endpoints
-    expect(true).toBe(true);
+  it('does not include Deprecation/Sunset headers on a current route', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/widgets/current')
+      .expect(200);
+
+    expect(res.headers.deprecation).toBeUndefined();
+    expect(res.headers.sunset).toBeUndefined();
+  });
+
+  it('includes Deprecation and Sunset headers on a route marked @Deprecated', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/widgets/legacy')
+      .expect(200);
+
+    expect(res.headers.deprecation).toBe('true');
+    expect(res.headers.sunset).toBe('Wed, 31 Dec 2026 23:59:59 GMT');
+  });
+
+  it('includes a Link header pointing to migration docs when configured', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/widgets/legacy')
+      .expect(200);
+
+    expect(res.headers.link).toBe('</docs/migration>; rel="deprecation"');
   });
 });


### PR DESCRIPTION
# Backend: health probes, WS backpressure, cache stampede protection, deprecation headers

## Summary
- **Health**: added `GET /health/live` (process-only liveness) and `GET /health/ready` (DB + Soroban RPC + cache, 503 when any is down), reusing the existing per-dependency probes. The prior `/health` (terminus) and `/health/detailed` endpoints are unchanged.
- **WebSocket backpressure**: `OddsBroadcasterService` now enqueues odds updates per-socket via a new `BroadcastQueueService` instead of a direct room-wide emit — bounded buffer, same-key coalescing (latest snapshot wins), oldest-message drop under pressure, independent per-socket flush timers, and dropped/coalesced/sent counters.
- **Cache**: new `CacheService.getOrSet(namespace, key, loader)` with per-namespace TTL policy and in-process single-flight dedup (concurrent misses for the same key share one computation). Wired into `AnalyticsService`'s expensive full-scan aggregates (`getCategoryAnalytics`, `getRetention`, `getPlatformStats`). Single-flight is in-process only — no Redis in this stack, so it protects one instance, not a fleet.
- **API deprecation headers**: new `@Deprecated({ sunset, link })` decorator + global `DeprecationInterceptor` emitting `Deprecation`/`Sunset`/`Link` headers on marked routes. No route is deprecated yet (only v1 exists) — this lands the mechanism. Replaced the placeholder `api-versioning.e2e-spec.ts` (all `expect(true).toBe(true)`) with real supertest assertions.

## Testing
- `pnpm run lint` — 0 errors (pre-existing warnings only, unrelated to this change).
- `pnpm run test` — full backend unit suite passes, including new coverage for readiness/liveness, single-flight/TTL caching, bounded broadcast queue (slow client doesn't block others, buffer bound enforced), and deprecation headers.
- `pnpm run test:e2e` — new `api-versioning.e2e-spec.ts` passes standalone (5/5); pre-existing e2e suites that require a live DB/`.env` fail the same way on `main` (not introduced by this change) — CI's `test` job doesn't run `test:e2e`.
- `pnpm run build` — clean.

Closes #1656
Closes #1657
Closes #1658
Closes #1659
