### PR TITLE
Backend/1646 1647 1648 1649 competitions creator events

### DIFF
--- a/backend/src/competitions/competitions.controller.ts
+++ b/backend/src/competitions/competitions.controller.ts
@@ -238,6 +238,26 @@ export class CompetitionsController {
     return this.competitionsService.getBracket(id);
   }
 
+  @Post(':id/cancel')
+  @UseGuards(BanGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Cancel a competition (creator only)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Competition cancelled',
+    type: Competition,
+  })
+  @ApiResponse({ status: 403, description: 'Only the creator can cancel' })
+  @ApiResponse({ status: 404, description: 'Competition not found' })
+  @ApiResponse({ status: 409, description: 'Competition already cancelled' })
+  async cancelCompetition(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+  ): Promise<Competition> {
+    return this.competitionsService.cancel(id, user.id);
+  }
+
   @Delete(':id/leave')
   @UseGuards(BanGuard)
   @HttpCode(HttpStatus.OK)

--- a/backend/src/competitions/competitions.module.ts
+++ b/backend/src/competitions/competitions.module.ts
@@ -8,6 +8,7 @@ import { BracketMatchup } from './entities/bracket-matchup.entity';
 import { CompetitionsService } from './competitions.service';
 import { CompetitionsController } from './competitions.controller';
 import { UsersModule } from '../users/users.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { UsersModule } from '../users/users.module';
       BracketMatchup,
     ]),
     UsersModule,
+    NotificationsModule,
   ],
   controllers: [CompetitionsController],
   providers: [CompetitionsService],

--- a/backend/src/competitions/competitions.service.spec.ts
+++ b/backend/src/competitions/competitions.service.spec.ts
@@ -1,7 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CompetitionsService } from './competitions.service';
+import { NotificationsService } from '../notifications/notifications.service';
 import {
   Competition,
   CompetitionVisibility,
@@ -42,12 +48,15 @@ describe('CompetitionsService', () => {
     find: jest.fn(),
     findOne: jest.fn(),
     createQueryBuilder: jest.fn(),
+    increment: jest.fn(),
     manager: {
       transaction: jest.fn(),
     },
   };
 
   const mockParticipantsRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
     createQueryBuilder: jest.fn(),
     findOne: jest.fn(),
     find: jest.fn(),
@@ -70,6 +79,10 @@ describe('CompetitionsService', () => {
     create: jest.fn(),
     save: jest.fn(),
     find: jest.fn(),
+  };
+
+  const mockNotificationsService = {
+    create: jest.fn(),
   };
 
   const makeListQueryBuilder = (competitions: Partial<Competition>[]) => {
@@ -150,6 +163,10 @@ describe('CompetitionsService', () => {
         {
           provide: getRepositoryToken(BracketMatchup),
           useValue: mockMatchupRepo,
+        },
+        {
+          provide: NotificationsService,
+          useValue: mockNotificationsService,
         },
       ],
     }).compile();
@@ -511,6 +528,127 @@ describe('CompetitionsService', () => {
     });
   });
 
+  describe('joinCompetition', () => {
+    it('should throw BadRequestException when competition is cancelled', async () => {
+      mockRepository.findOne.mockResolvedValue({
+        ...mockCompetition,
+        end_time: new Date(Date.now() + 1000 * 60 * 60),
+        is_cancelled: true,
+      });
+
+      await expect(
+        service.joinCompetition('comp-uuid-1', mockUser as User),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockParticipantsRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should allow joining a non-cancelled, active competition', async () => {
+      mockRepository.findOne.mockResolvedValue({
+        ...mockCompetition,
+        id: 'comp-uuid-1',
+        end_time: new Date(Date.now() + 1000 * 60 * 60),
+        is_cancelled: false,
+        max_participants: 0,
+      });
+      mockParticipantsRepository.findOne.mockResolvedValue(null);
+      mockParticipantsRepository.create.mockImplementation((v) => v);
+      mockParticipantsRepository.save.mockImplementation((v) =>
+        Promise.resolve({ id: 'participant-1', ...v }),
+      );
+      mockRepository.increment.mockResolvedValue(undefined);
+
+      const result = await service.joinCompetition(
+        'comp-uuid-1',
+        mockUser as User,
+      );
+
+      expect(result.id).toBe('participant-1');
+      expect(mockRepository.increment).toHaveBeenCalledWith(
+        { id: 'comp-uuid-1' },
+        'participant_count',
+        1,
+      );
+    });
+  });
+
+  describe('cancel', () => {
+    const creatorCompetition = {
+      ...mockCompetition,
+      id: 'comp-uuid-1',
+      is_cancelled: false,
+      creator: { id: 'user-uuid-1' },
+    };
+
+    it('should throw NotFoundException if competition does not exist', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.cancel('missing-id', 'user-uuid-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException if not the creator', async () => {
+      mockRepository.findOne.mockResolvedValue(creatorCompetition);
+
+      await expect(
+        service.cancel('comp-uuid-1', 'someone-else'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ConflictException if already cancelled', async () => {
+      mockRepository.findOne.mockResolvedValue({
+        ...creatorCompetition,
+        is_cancelled: true,
+      });
+
+      await expect(
+        service.cancel('comp-uuid-1', 'user-uuid-1'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should mark competition cancelled and notify participants', async () => {
+      mockRepository.findOne.mockResolvedValue({ ...creatorCompetition });
+      mockRepository.save.mockImplementation((v) => Promise.resolve(v));
+      mockParticipantsRepository.find.mockResolvedValue([
+        {
+          user_id: 'user-uuid-2',
+          user: { stellar_address: 'GPARTICIPANT1' },
+        },
+        {
+          user_id: 'user-uuid-3',
+          user: { stellar_address: 'GPARTICIPANT2' },
+        },
+      ]);
+
+      const result = await service.cancel('comp-uuid-1', 'user-uuid-1');
+
+      expect(result.is_cancelled).toBe(true);
+      expect(mockNotificationsService.create).toHaveBeenCalledTimes(2);
+      expect(mockNotificationsService.create).toHaveBeenCalledWith(
+        'GPARTICIPANT1',
+        'event_cancelled',
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ competition_id: 'comp-uuid-1' }),
+        'user-uuid-2',
+      );
+    });
+
+    it('should not fail cancellation if a participant has no linked user address', async () => {
+      mockRepository.findOne.mockResolvedValue({ ...creatorCompetition });
+      mockRepository.save.mockImplementation((v) => Promise.resolve(v));
+      mockParticipantsRepository.find.mockResolvedValue([
+        { user_id: 'user-uuid-2', user: null },
+      ]);
+
+      const result = await service.cancel('comp-uuid-1', 'user-uuid-1');
+
+      expect(result.is_cancelled).toBe(true);
+      expect(mockNotificationsService.create).not.toHaveBeenCalled();
+    });
+  });
+
   describe('leave', () => {
     it('should remove participant and decrement count before competition starts', async () => {
       const futureDate = new Date();
@@ -662,6 +800,128 @@ describe('CompetitionsService', () => {
       await expect(service.getBracket('comp-1')).rejects.toThrow(
         'No bracket found',
       );
+    });
+  });
+
+  describe('generateBracket - structure correctness', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockBracketRepo.create.mockImplementation((v) => v);
+      mockBracketRepo.save.mockImplementation((v) =>
+        Promise.resolve({ id: 'bracket-1', ...v }),
+      );
+      mockRoundRepo.create.mockImplementation((v) => v);
+      mockRoundRepo.save.mockImplementation((v, i) =>
+        Promise.resolve({ id: `round-${v.round_number}`, ...v }),
+      );
+      let matchupCounter = 0;
+      mockMatchupRepo.create.mockImplementation((v) => v);
+      mockMatchupRepo.save.mockImplementation((v) =>
+        Promise.resolve({ id: `matchup-${matchupCounter++}`, ...v }),
+      );
+    });
+
+    const seedParticipants = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `p${i + 1}`,
+        score: count - i,
+        joined_at: new Date(2026, 0, i + 1),
+      }));
+
+    it('produces a full bracket with no byes for a power-of-two count (4)', async () => {
+      mockRepository.findOne.mockResolvedValue({
+        ...mockCompetition,
+        creator: { id: 'user-1' },
+      });
+      mockBracketRepo.findOne.mockResolvedValue(null);
+      mockParticipantsRepository.find.mockResolvedValue(seedParticipants(4));
+
+      const bracket = await service.generateBracket(
+        'comp-1',
+        { metric: SeedingMetric.Score },
+        'user-1',
+      );
+
+      expect(bracket.total_rounds).toBe(2);
+
+      const firstRoundMatchups = mockMatchupRepo.save.mock.calls
+        .map((call) => call[0])
+        .filter((m) => m.round_id === 'round-1');
+
+      expect(firstRoundMatchups).toHaveLength(2);
+      expect(firstRoundMatchups.every((m) => !m.is_bye)).toBe(true);
+      // Top seed (p1) faces the lowest remaining seed (p4); p2 faces p3.
+      expect(firstRoundMatchups[0]).toMatchObject({
+        participant_1_id: 'p1',
+        participant_2_id: 'p2',
+      });
+    });
+
+    it('assigns byes to top seeds for a non-power-of-two count (5)', async () => {
+      mockRepository.findOne.mockResolvedValue({
+        ...mockCompetition,
+        creator: { id: 'user-1' },
+      });
+      mockBracketRepo.findOne.mockResolvedValue(null);
+      mockParticipantsRepository.find.mockResolvedValue(seedParticipants(5));
+
+      const bracket = await service.generateBracket(
+        'comp-1',
+        { metric: SeedingMetric.Score },
+        'user-1',
+      );
+
+      // 5 participants -> bracket size 8 -> 3 rounds, 3 byes in round 1.
+      expect(bracket.total_rounds).toBe(3);
+
+      const firstRoundMatchups = mockMatchupRepo.save.mock.calls
+        .map((call) => call[0])
+        .filter((m) => m.round_id === 'round-1');
+
+      expect(firstRoundMatchups).toHaveLength(4);
+      const byes = firstRoundMatchups.filter((m) => m.is_bye);
+      expect(byes).toHaveLength(3);
+      // Byes go to the top 3 seeds and each auto-advances as the winner.
+      expect(byes.map((m) => m.participant_1_id)).toEqual(['p1', 'p2', 'p3']);
+      byes.forEach((m) => {
+        expect(m.participant_2_id).toBeNull();
+        expect(m.winner_id).toBe(m.participant_1_id);
+      });
+
+      const nonByeMatchups = firstRoundMatchups.filter((m) => !m.is_bye);
+      expect(nonByeMatchups).toHaveLength(1);
+      expect(nonByeMatchups[0]).toMatchObject({
+        participant_1_id: 'p4',
+        participant_2_id: 'p5',
+        winner_id: null,
+      });
+
+      // Subsequent rounds are created empty (no participants assigned yet).
+      const laterRoundMatchups = mockMatchupRepo.save.mock.calls
+        .map((call) => call[0])
+        .filter((m) => m.round_id !== 'round-1');
+      expect(laterRoundMatchups).toHaveLength(2 + 1); // round-2 (2) + round-3 (1)
+      laterRoundMatchups.forEach((m) => {
+        expect(m.participant_1_id).toBeNull();
+        expect(m.participant_2_id).toBeNull();
+        expect(m.is_bye).toBe(false);
+      });
+    });
+
+    it('throws ConflictException if a bracket already exists', async () => {
+      mockRepository.findOne.mockResolvedValue({
+        ...mockCompetition,
+        creator: { id: 'user-1' },
+      });
+      mockBracketRepo.findOne.mockResolvedValue({ id: 'existing-bracket' });
+
+      await expect(
+        service.generateBracket(
+          'comp-1',
+          { metric: SeedingMetric.Score },
+          'user-1',
+        ),
+      ).rejects.toThrow('Bracket already exists');
     });
   });
 });

--- a/backend/src/competitions/competitions.service.ts
+++ b/backend/src/competitions/competitions.service.ts
@@ -36,6 +36,8 @@ import {
   BracketRoundResponseDto,
   BracketMatchupResponseDto,
 } from './dto/bracket-response.dto';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 
 @Injectable()
 export class CompetitionsService {
@@ -56,6 +58,7 @@ export class CompetitionsService {
     private readonly roundsRepository: Repository<BracketRound>,
     @InjectRepository(BracketMatchup)
     private readonly matchupsRepository: Repository<BracketMatchup>,
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   async create(dto: CreateCompetitionDto, user: User): Promise<Competition> {
@@ -356,6 +359,10 @@ export class CompetitionsService {
       );
     }
 
+    if (competition.is_cancelled) {
+      throw new BadRequestException('Competition has been cancelled');
+    }
+
     // Check if competition is active
     const now = new Date();
     if (now >= competition.end_time) {
@@ -447,6 +454,60 @@ export class CompetitionsService {
         1,
       );
     });
+  }
+
+  async cancel(competitionId: string, userId: string): Promise<Competition> {
+    const competition = await this.competitionsRepository.findOne({
+      where: { id: competitionId },
+      relations: ['creator'],
+    });
+
+    if (!competition) {
+      throw new NotFoundException(
+        `Competition with ID "${competitionId}" not found`,
+      );
+    }
+
+    if (competition.creator?.id !== userId) {
+      throw new ForbiddenException(
+        'Only the creator can cancel this competition',
+      );
+    }
+
+    if (competition.is_cancelled) {
+      throw new ConflictException('Competition is already cancelled');
+    }
+
+    competition.is_cancelled = true;
+    const saved = await this.competitionsRepository.save(competition);
+
+    await this.notifyParticipantsOfCancellation(competition);
+
+    return saved;
+  }
+
+  private async notifyParticipantsOfCancellation(
+    competition: Competition,
+  ): Promise<void> {
+    const participants = await this.participantsRepository.find({
+      where: { competition_id: competition.id },
+      relations: ['user'],
+    });
+
+    await Promise.all(
+      participants
+        .filter((p) => p.user?.stellar_address)
+        .map((p) =>
+          this.notificationsService.create(
+            p.user.stellar_address,
+            NotificationType.EventCancelled,
+            'Competition cancelled',
+            `"${competition.title}" has been cancelled by the organizer.`,
+            { competition_id: competition.id },
+            p.user_id,
+          ),
+        ),
+    );
   }
 
   // -------------------------------------------------------------------------

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -24,6 +24,17 @@ import { NotificationGeneratorService } from '../notifications/notification-gene
 import { BroadcasterService } from '../websocket/broadcaster.service';
 import { ReconciliationService } from './reconciliation.service';
 
+const makeUpdateQueryBuilder = () => {
+  const qb: any = {
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({ affected: 1 }),
+  };
+  return qb;
+};
+
 describe('IndexerService', () => {
   let service: IndexerService;
   let contractEventRepository: jest.Mocked<
@@ -259,6 +270,15 @@ describe('IndexerService', () => {
   });
 
   describe('EventCreated campaign metadata', () => {
+    const makeOverlapQueryBuilder = (count: number) => {
+      const qb: any = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(count),
+      };
+      return qb;
+    };
+
     beforeEach(() => {
       creatorEventRepository.findOne.mockResolvedValue(null);
       (creatorEventRepository.create as jest.Mock).mockImplementation(
@@ -266,6 +286,9 @@ describe('IndexerService', () => {
       );
       (creatorEventRepository.save as jest.Mock).mockImplementation(
         async (event: unknown) => event as CreatorEvent,
+      );
+      creatorEventRepository.createQueryBuilder.mockReturnValue(
+        makeOverlapQueryBuilder(0),
       );
     });
 
@@ -540,6 +563,67 @@ describe('IndexerService', () => {
         }),
       );
     });
+
+    it('rejects a new campaign whose window overlaps an existing active campaign for the same creator', async () => {
+      creatorEventRepository.createQueryBuilder.mockReturnValue(
+        makeOverlapQueryBuilder(1),
+      );
+
+      await (service as any).handleEventCreated({
+        event_id: '50',
+        creator: 'GCREATOR',
+        title: 'Overlapping Campaign',
+        description: 'Should be rejected',
+        created_at: 1710000000,
+        start_time: 1710003600,
+        end_time: 1710086400,
+      });
+
+      expect(creatorEventRepository.create).not.toHaveBeenCalled();
+      expect(creatorEventRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('accepts a new campaign whose window does not overlap any active campaign for the same creator', async () => {
+      creatorEventRepository.createQueryBuilder.mockReturnValue(
+        makeOverlapQueryBuilder(0),
+      );
+
+      await (service as any).handleEventCreated({
+        event_id: '51',
+        creator: 'GCREATOR',
+        title: 'Non-overlapping Campaign',
+        description: 'Should be indexed',
+        created_at: 1710000000,
+        start_time: 1710003600,
+        end_time: 1710086400,
+      });
+
+      expect(creatorEventRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ on_chain_event_id: 51 }),
+      );
+      expect(creatorEventRepository.save).toHaveBeenCalled();
+    });
+
+    it('scopes the overlap query to the same creator and non-cancelled campaigns', async () => {
+      const qb = makeOverlapQueryBuilder(0);
+      creatorEventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await (service as any).handleEventCreated({
+        event_id: '52',
+        creator: 'GCREATOR',
+        title: 'Scoped Campaign',
+        description: 'Checks query scoping',
+        created_at: 1710000000,
+        start_time: 1710003600,
+        end_time: 1710086400,
+      });
+
+      expect(qb.where).toHaveBeenCalledWith(
+        'event.creator_address = :creatorAddress',
+        { creatorAddress: 'GCREATOR' },
+      );
+      expect(qb.andWhere).toHaveBeenCalledWith('event.is_cancelled = false');
+    });
   });
 
   describe('handleUserJoinedEvent', () => {
@@ -569,15 +653,10 @@ describe('IndexerService', () => {
       expect(data).toMatchObject({ entry_fee_paid: '0' });
     });
 
-    it('adds the entry fee paid to prize_pool and total_entry_fees_collected', async () => {
-      const event = {
-        on_chain_event_id: 7,
-        participant_count: 2,
-        prize_pool: '5000000000',
-        total_entry_fees_collected: '20000000',
-      } as CreatorEvent;
-      creatorEventRepository.findOne.mockResolvedValue(event);
-      creatorEventRepository.save.mockResolvedValue(event);
+    it('issues a single atomic SQL update instead of read-modify-write', async () => {
+      creatorEventRepository.count.mockResolvedValue(1);
+      const qb = makeUpdateQueryBuilder();
+      creatorEventRepository.createQueryBuilder.mockReturnValue(qb);
 
       await (service as any).handleUserJoinedEvent({
         user_address: 'GUSER',
@@ -586,32 +665,131 @@ describe('IndexerService', () => {
         entry_fee_paid: '10000000',
       });
 
-      expect(event.participant_count).toBe(3);
-      expect(event.prize_pool).toBe('5010000000');
-      expect(event.total_entry_fees_collected).toBe('30000000');
-      expect(creatorEventRepository.save).toHaveBeenCalledWith(event);
+      // No read-modify-write: findOne/save must not be used for the mutation.
+      expect(creatorEventRepository.findOne).not.toHaveBeenCalled();
+      expect(creatorEventRepository.save).not.toHaveBeenCalled();
+
+      expect(qb.update).toHaveBeenCalled();
+      expect(qb.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          participant_count: expect.any(Function),
+          prize_pool: expect.any(Function),
+          total_entry_fees_collected: expect.any(Function),
+        }),
+      );
+      expect(qb.where).toHaveBeenCalledWith(
+        'on_chain_event_id = :onChainEventId',
+        { onChainEventId: 7 },
+      );
+      expect(qb.setParameter).toHaveBeenCalledWith('entryFeePaid', '10000000');
+      expect(qb.execute).toHaveBeenCalled();
     });
 
-    it('leaves prize_pool and total_entry_fees_collected unchanged for free events', async () => {
-      const event = {
-        on_chain_event_id: 7,
-        participant_count: 0,
-        prize_pool: '5000000000',
-        total_entry_fees_collected: '0',
-      } as CreatorEvent;
-      creatorEventRepository.findOne.mockResolvedValue(event);
-      creatorEventRepository.save.mockResolvedValue(event);
+    it('runs concurrent joins as independent atomic updates without lost updates', async () => {
+      creatorEventRepository.count.mockResolvedValue(1);
+      const builders = [makeUpdateQueryBuilder(), makeUpdateQueryBuilder()];
+      creatorEventRepository.createQueryBuilder
+        .mockReturnValueOnce(builders[0])
+        .mockReturnValueOnce(builders[1]);
+
+      await Promise.all([
+        (service as any).handleUserJoinedEvent({
+          user_address: 'GUSER1',
+          event_id: '7',
+          joined_at: 1710000000,
+          entry_fee_paid: '10000000',
+        }),
+        (service as any).handleUserJoinedEvent({
+          user_address: 'GUSER2',
+          event_id: '7',
+          joined_at: 1710000001,
+          entry_fee_paid: '10000000',
+        }),
+      ]);
+
+      // Each concurrent join executes its own atomic UPDATE — the DB, not
+      // application code, performs the increment, so neither call can clobber
+      // the other's write.
+      expect(builders[0].execute).toHaveBeenCalled();
+      expect(builders[1].execute).toHaveBeenCalled();
+    });
+
+    it('skips the update when the event does not exist', async () => {
+      creatorEventRepository.count.mockResolvedValue(0);
 
       await (service as any).handleUserJoinedEvent({
         user_address: 'GUSER',
         event_id: '7',
         joined_at: 1710000000,
-        entry_fee_paid: '0',
+        entry_fee_paid: '10000000',
       });
 
-      expect(event.participant_count).toBe(1);
-      expect(event.prize_pool).toBe('5000000000');
-      expect(event.total_entry_fees_collected).toBe('0');
+      expect(creatorEventRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recomputeEntryFeeTotals', () => {
+    it('recomputes total_entry_fees_collected from entry_fee * participant_count', async () => {
+      const event = {
+        on_chain_event_id: 7,
+        entry_fee: '10000000',
+        participant_count: 5,
+        total_entry_fees_collected: '40000000', // drifted from actual
+      } as CreatorEvent;
+      creatorEventRepository.findOne.mockResolvedValue(event);
+      const qb = makeUpdateQueryBuilder();
+      creatorEventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.recomputeEntryFeeTotals(7);
+
+      expect(qb.set).toHaveBeenCalledWith({
+        total_entry_fees_collected: '50000000',
+      });
+      expect(qb.where).toHaveBeenCalledWith(
+        'on_chain_event_id = :onChainEventId',
+        { onChainEventId: 7 },
+      );
+      expect(qb.execute).toHaveBeenCalled();
+    });
+
+    it('does nothing when the event is not found', async () => {
+      creatorEventRepository.findOne.mockResolvedValue(null);
+
+      await service.recomputeEntryFeeTotals(999);
+
+      expect(creatorEventRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleEventFinalized - entry fee reconciliation', () => {
+    it('recomputes entry fee totals before processing payouts', async () => {
+      const event = {
+        on_chain_event_id: 7,
+        is_finalized: false,
+        entry_fee: '10000000',
+        participant_count: 3,
+        total_entry_fees_collected: '20000000',
+      } as CreatorEvent;
+
+      creatorEventRepository.findOne
+        .mockResolvedValueOnce(event) // initial lookup in handleEventFinalized
+        .mockResolvedValueOnce(event); // lookup inside recomputeEntryFeeTotals
+      creatorEventRepository.save.mockResolvedValue(event);
+      const qb = makeUpdateQueryBuilder();
+      creatorEventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const payoutRepo = (service as any).creatorEventPayoutRepository;
+      payoutRepo.count.mockResolvedValue(0);
+
+      await (service as any).handleEventFinalized({
+        event_id: '7',
+        leaderboard: [],
+      });
+
+      expect(qb.set).toHaveBeenCalledWith({
+        total_entry_fees_collected: '30000000',
+      });
+      expect(qb.execute).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -627,9 +627,22 @@ export class IndexerService implements OnModuleInit {
         ? parsedEndTime
         : new Date(startTime.getTime() + DEFAULT_EVENT_DURATION_SECONDS * 1000);
 
+    const creatorAddress = this.readStr(data, 'creator');
+    const hasOverlap = await this.hasOverlappingCampaign(
+      creatorAddress,
+      startTime,
+      endTime,
+    );
+    if (hasOverlap) {
+      this.logger.warn(
+        `EventCreated rejected: event ${onChainEventId} overlaps an existing active campaign for creator ${creatorAddress}`,
+      );
+      return;
+    }
+
     const creatorEvent = this.creatorEventRepository.create({
       on_chain_event_id: onChainEventId,
-      creator_address: this.readStr(data, 'creator'),
+      creator_address: creatorAddress,
       title: this.readStr(data, 'title') || `Event ${onChainEventId}`,
       description: this.readStr(data, 'description'),
       creation_fee_paid: this.readUnsignedBigInt(data, 'creation_fee_paid'),
@@ -659,6 +672,28 @@ export class IndexerService implements OnModuleInit {
     // Trigger notification
     await this.notificationGeneratorService.handleEventCreated(data);
     this.broadcasterService.broadcastEventCreated(data);
+  }
+
+  /**
+   * Two campaigns overlap for the same creator when their [start, end)
+   * windows intersect and the existing one is still active (not cancelled).
+   */
+  private async hasOverlappingCampaign(
+    creatorAddress: string,
+    startTime: Date,
+    endTime: Date,
+  ): Promise<boolean> {
+    if (!creatorAddress) return false;
+
+    const count = await this.creatorEventRepository
+      .createQueryBuilder('event')
+      .where('event.creator_address = :creatorAddress', { creatorAddress })
+      .andWhere('event.is_cancelled = false')
+      .andWhere('event.start_time < :endTime', { endTime })
+      .andWhere('event.end_time > :startTime', { startTime })
+      .getCount();
+
+    return count > 0;
   }
 
   private async handleMatchAdded(data: Record<string, unknown>): Promise<void> {
@@ -732,33 +767,70 @@ export class IndexerService implements OnModuleInit {
       return;
     }
 
-    const event = await this.creatorEventRepository.findOne({
+    const exists = await this.creatorEventRepository.count({
       where: { on_chain_event_id: onChainEventId },
     });
-    if (!event) {
+    if (!exists) {
       this.logger.warn(
         `UserJoinedEvent skipped: event ${onChainEventId} not found`,
       );
       return;
     }
 
-    event.participant_count += 1;
-
     const entryFeePaid = this.readUnsignedBigInt(data, 'entry_fee_paid');
-    if (BigInt(entryFeePaid) > 0n) {
-      event.prize_pool = (
-        BigInt(event.prize_pool ?? '0') + BigInt(entryFeePaid)
-      ).toString();
-      event.total_entry_fees_collected = (
-        BigInt(event.total_entry_fees_collected ?? '0') + BigInt(entryFeePaid)
-      ).toString();
-    }
 
-    await this.creatorEventRepository.save(event);
+    // Atomic SQL update: avoids the lost-update race that a read-modify-write
+    // (findOne -> mutate in JS -> save) would hit under concurrent joins.
+    await this.creatorEventRepository
+      .createQueryBuilder()
+      .update()
+      .set({
+        participant_count: () => '"participant_count" + 1',
+        prize_pool: () => `"prize_pool" + :entryFeePaid`,
+        total_entry_fees_collected: () =>
+          `"total_entry_fees_collected" + :entryFeePaid`,
+      })
+      .where('on_chain_event_id = :onChainEventId', { onChainEventId })
+      .setParameter('entryFeePaid', entryFeePaid)
+      .execute();
 
     // Trigger notification
     await this.notificationGeneratorService.handleUserJoinedEvent(data);
     this.broadcasterService.broadcastUserJoined(data);
+  }
+
+  /**
+   * Recomputes total_entry_fees_collected for a creator event from its
+   * current participant_count and flat entry_fee (the contract charges a
+   * single flat entry_fee per event, not a per-participant amount), so this
+   * is the correct reconciliation source rather than re-deriving from
+   * on-chain participant records.
+   */
+  async recomputeEntryFeeTotals(onChainEventId: number): Promise<void> {
+    const event = await this.creatorEventRepository.findOne({
+      where: { on_chain_event_id: onChainEventId },
+    });
+    if (!event) {
+      this.logger.warn(
+        `recomputeEntryFeeTotals skipped: event ${onChainEventId} not found`,
+      );
+      return;
+    }
+
+    const recomputedTotal = (
+      BigInt(event.entry_fee ?? '0') * BigInt(event.participant_count ?? 0)
+    ).toString();
+
+    await this.creatorEventRepository
+      .createQueryBuilder()
+      .update()
+      .set({ total_entry_fees_collected: recomputedTotal })
+      .where('on_chain_event_id = :onChainEventId', { onChainEventId })
+      .execute();
+
+    this.logger.log(
+      `Recomputed total_entry_fees_collected for event_id=${onChainEventId}: ${recomputedTotal}`,
+    );
   }
 
   private async handlePredictionSubmitted(
@@ -1027,6 +1099,11 @@ export class IndexerService implements OnModuleInit {
       event.is_finalized = true;
       await this.creatorEventRepository.save(event);
     }
+
+    // Reconcile total_entry_fees_collected against participant_count so any
+    // drift from missed/duplicated UserJoinedEvent processing is corrected
+    // before payouts are computed.
+    await this.recomputeEntryFeeTotals(onChainEventId);
 
     const leaderboard: unknown[] = Array.isArray(data.leaderboard)
       ? data.leaderboard


### PR DESCRIPTION
# Competitions & Creator-Events: cancellation, bracket verification, entry-fee accounting, campaign validation

## Summary
- **Competitions cancelled flag**: `joinCompetition` now rejects joins on a cancelled competition; added `CompetitionsService.cancel()` (creator-only) which flags the competition and notifies all participants via `NotificationsService`; added `POST /competitions/:id/cancel`.
- **Competition bracket generation**: existing `generateBracket`/`getBracket` logic was already correct — added tests verifying bracket size, bye assignment/seeding for non-power-of-two participant counts, and empty subsequent rounds. No production code change needed.
- **Creator-event entry-fee accounting**: replaced the `findOne` → mutate → `save` read-modify-write in `handleUserJoinedEvent` with a single atomic SQL `UPDATE`, removing the lost-update race under concurrent joins. Added `recomputeEntryFeeTotals()` (derives `total_entry_fees_collected` from `entry_fee * participant_count`) and wired it into `handleEventFinalized` for reconciliation before payouts.
- **Creator-event campaign validation**: `handleEventCreated` now rejects (skips indexing) a new campaign whose window overlaps an existing active, non-cancelled campaign from the same creator. Existing defaulting behavior for malformed windows/negative budgets is preserved as-is, since on-chain events must always produce a DB row.

## Testing
- `pnpm test` — 1292/1292 passing
- `pnpm run lint` — 0 errors
- `pnpm run migration:check-timestamps` — passed
- `nest build` — clean

Closes #1646
Closes #1647
Closes #1648
Closes #1649
