### PR TITLE
fix(contracts): cancel refund participant validation, prize claim idempotence, conditional depth limit, and resolution ordering

### DIFF
--- a/contracts/creator-event-manager/src/finalize.rs
+++ b/contracts/creator-event-manager/src/finalize.rs
@@ -301,12 +301,17 @@ pub fn claim_prize(env: &Env, winner: Address, event_id: u64) -> Result<i128, Ev
         return Err(EventError::AlreadyClaimed);
     }
 
+    if allocation.amount <= 0 {
+        return Err(EventError::NoAllocation);
+    }
+
+    // Mark as claimed in storage before external interaction (Checks-Effects-Interactions pattern)
+    allocation.claimed = true;
+    storage::set_prize_allocation(env, &allocation);
+
     let xlm_token = admin::get_xlm_token(env).unwrap_or_else(|| panic!("not_initialized"));
     TokenHelper::distribute_winnings(env, &xlm_token, &winner, allocation.amount)
         .map_err(|_| EventError::TransferFailed)?;
-
-    allocation.claimed = true;
-    storage::set_prize_allocation(env, &allocation);
 
     env.events().publish(
         (Symbol::new(env, "prize"), Symbol::new(env, "claimed")),

--- a/contracts/open-market/src/market.rs
+++ b/contracts/open-market/src/market.rs
@@ -863,11 +863,18 @@ pub fn resolve_market(
 
     let mut market = get_market(&env, market_id)?;
 
-    if let Some(parent_market_id) = env
+    let parent_id_opt = env
         .storage()
         .persistent()
         .get::<_, u64>(&DataKey::ConditionalParent(market_id))
-    {
+        .or_else(|| {
+            env.storage()
+                .persistent()
+                .get::<_, ConditionalMarket>(&DataKey::ConditionalMarket(market_id))
+                .map(|cm| cm.parent_market_id)
+        });
+
+    if let Some(parent_market_id) = parent_id_opt {
         let parent_market = get_market(&env, parent_market_id)?;
         if !parent_market.is_resolved {
             return Err(InsightArenaError::ParentNotResolved);
@@ -973,6 +980,9 @@ pub fn create_conditional_market(
     validate_conditional_params(env, parent_market_id, &required_outcome, &params)?;
 
     let parent_depth = calculate_conditional_depth(env, parent_market_id);
+    if parent_depth >= MAX_CONDITIONAL_DEPTH {
+        return Err(InsightArenaError::ConditionalDepthExceeded);
+    }
     let depth = parent_depth
         .checked_add(1)
         .ok_or(InsightArenaError::Overflow)?;
@@ -1057,6 +1067,12 @@ pub fn get_parent_market(env: &Env, market_id: u64) -> Result<Market, InsightAre
         .storage()
         .persistent()
         .get(&DataKey::ConditionalParent(market_id))
+        .or_else(|| {
+            env.storage()
+                .persistent()
+                .get::<_, ConditionalMarket>(&DataKey::ConditionalMarket(market_id))
+                .map(|cm| cm.parent_market_id)
+        })
         .ok_or(InsightArenaError::MarketNotFound)?;
 
     get_market(env, parent_market_id)
@@ -1090,6 +1106,12 @@ pub fn get_conditional_chain(
         .storage()
         .persistent()
         .get::<_, u64>(&DataKey::ConditionalParent(cursor))
+        .or_else(|| {
+            env.storage()
+                .persistent()
+                .get::<_, ConditionalMarket>(&DataKey::ConditionalMarket(cursor))
+                .map(|cm| cm.parent_market_id)
+        })
     {
         chain_ids.push_back(parent_id);
         cursor = parent_id;
@@ -1117,6 +1139,12 @@ pub fn calculate_conditional_depth(env: &Env, market_id: u64) -> u32 {
         .storage()
         .persistent()
         .get::<_, u64>(&DataKey::ConditionalParent(cursor))
+        .or_else(|| {
+            env.storage()
+                .persistent()
+                .get::<_, ConditionalMarket>(&DataKey::ConditionalMarket(cursor))
+                .map(|cm| cm.parent_market_id)
+        })
     {
         depth = depth.saturating_add(1);
         cursor = parent_id;
@@ -1142,7 +1170,13 @@ pub fn get_dependency_status(
     let parent_market_id = env
         .storage()
         .persistent()
-        .get::<_, u64>(&DataKey::ConditionalParent(market_id));
+        .get::<_, u64>(&DataKey::ConditionalParent(market_id))
+        .or_else(|| {
+            env.storage()
+                .persistent()
+                .get::<_, ConditionalMarket>(&DataKey::ConditionalMarket(market_id))
+                .map(|cm| cm.parent_market_id)
+        });
 
     let (is_conditional, parent_resolved) = match parent_market_id {
         Some(parent_id) => {
@@ -1210,6 +1244,12 @@ fn validate_no_circular_dependency(
             .storage()
             .persistent()
             .get::<_, u64>(&DataKey::ConditionalParent(current))
+            .or_else(|| {
+                env.storage()
+                    .persistent()
+                    .get::<_, ConditionalMarket>(&DataKey::ConditionalMarket(current))
+                    .map(|cm| cm.parent_market_id)
+            })
         {
             current = next_parent;
         } else {

--- a/contracts/open-market/src/prediction.rs
+++ b/contracts/open-market/src/prediction.rs
@@ -1554,6 +1554,14 @@ pub fn claim_cancel_refund(
         .get(&prediction_key)
         .ok_or(InsightArenaError::NotAParticipant)?;
 
+    if prediction.payout_claimed {
+        return Err(InsightArenaError::RefundAlreadyClaimed);
+    }
+
+    if prediction.stake_amount <= 0 {
+        return Err(InsightArenaError::NotAParticipant);
+    }
+
     let refund_amount = prediction.stake_amount;
 
     // ── Checks-Effects-Interactions: move record to temporary before transfer ─

--- a/contracts/open-market/tests/cancel_refund_tests.rs
+++ b/contracts/open-market/tests/cancel_refund_tests.rs
@@ -633,3 +633,31 @@ fn bonus_claim_payout_on_cancelled_market_is_rejected() {
         Err(Ok(InsightArenaError::MarketNotResolved))
     ));
 }
+
+/// A predictor who completely withdrew position has 0 stake and is rejected with `NotAParticipant`.
+#[test]
+fn cancel_refund_rejects_full_withdrawn_zero_stake_predictor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _oracle, xlm_token) = deploy(&env);
+
+    let creator = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let stake = 20_000_000_i128;
+
+    let market_id = client.create_market(&creator, &default_params(&env));
+    fund(&env, &xlm_token, &predictor, stake);
+    client.submit_prediction(&predictor, &market_id, &symbol_short!("yes"), &stake);
+
+    // Full withdrawal
+    client.withdraw_position(&predictor, &market_id, &stake);
+
+    client.cancel_market(&admin, &market_id);
+
+    let result = client.try_claim_cancel_refund(&predictor, &market_id);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::NotAParticipant))
+    ));
+}
+


### PR DESCRIPTION
## Summary

This PR addresses and resolves four smart contract validation and guard issues across `contracts/open-market` and `contracts/creator-event-manager`:

1. **Cancel-Refund Participant Validation (`contracts/open-market/src/prediction.rs`)**:
   - Rejects non-participants or callers with zero remaining stake with `NotAParticipant`.
   - Rejects repeat refund attempts with `RefundAlreadyClaimed`.
   - Validates that the market is cancelled (`MarketNotCancelled` otherwise).
   - Enforces Checks-Effects-Interactions (CEI) to persist the tombstone prior to escrow transfer.
   - Added test coverage in `cancel_refund_tests.rs`.

2. **Prize Claim Double-Claim Guard (`contracts/creator-event-manager/src/finalize.rs`)**:
   - Enforces Checks-Effects-Interactions (CEI) during `claim_prize` by marking `allocation.claimed = true` in storage before initiating token distribution.
   - Rejects non-winners (`NoAllocation`) and double claims (`AlreadyClaimed`).

3. **Conditional Market Depth Limit (`contracts/open-market/src/market.rs`)**:
   - Enforces `ConditionalDepthExceeded` when parent depth is at `MAX_CONDITIONAL_DEPTH` or the child depth would exceed the maximum depth limit.
   - Validates parent market existence.

4. **Parent-Resolution Ordering for Conditionals (`contracts/open-market/src/market.rs`)**:
   - Enforces `ParentNotResolved` guard during child market resolution until its parent settles.
   - Strengthens conditional parent resolution checks across `DataKey::ConditionalParent` and `DataKey::ConditionalMarket`.

## Testing
- `cargo test --package insightarena-contract` passed.
- `cargo test --package creator-event-manager` passed.

Closes #1687
Closes #1702
Closes #1688
Closes #1689