### PR TITLE
feat(frontend): add per-item claimable/vesting actions to RewardsWall…

### DIFF
--- a/frontend/src/component/RewardsWalletCard.tsx
+++ b/frontend/src/component/RewardsWalletCard.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { AlertCircle, Loader2, Wallet } from "lucide-react";
+import { AlertCircle, Clock, Loader2, Wallet } from "lucide-react";
 import { useWallet } from "@/context/WalletContext";
-import { useRewards } from "@/hooks/useRewards";
-import RewardStatusBadge from "@/component/rewards/RewardStatusBadge";
+import { useRewards, type WalletRewardItem } from "@/hooks/useRewards";
 
 function formatXlm(amount: number): string {
   return `${amount.toLocaleString(undefined, {
@@ -29,6 +28,56 @@ function CardShell({ children }: { children: React.ReactNode }) {
   );
 }
 
+interface ClaimableRewardRowProps {
+  item: WalletRewardItem;
+  onClaim: (itemId: string) => void;
+  disabled: boolean;
+}
+
+function ClaimableRewardRow({ item, onClaim, disabled }: ClaimableRewardRowProps) {
+  const isPending = item.claimStatus === "pending";
+
+  return (
+    <li className="rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm text-gray-200">{item.marketTitle}</p>
+          <p className="text-xs text-orange-400 font-medium">
+            {formatXlm(item.amountXlm)}
+          </p>
+        </div>
+
+        <button
+          onClick={() => onClaim(item.id)}
+          disabled={disabled || isPending}
+          className="flex-shrink-0 flex items-center gap-1.5 rounded-md bg-orange-500 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-orange-500"
+        >
+          {isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+          {isPending ? "Claiming…" : "Claim"}
+        </button>
+      </div>
+
+      {item.claimStatus === "error" && item.claimError && (
+        <p className="mt-1.5 text-xs text-rose-300">{item.claimError}</p>
+      )}
+    </li>
+  );
+}
+
+function VestingRewardRow({ item }: { item: WalletRewardItem }) {
+  return (
+    <li className="rounded-lg border border-white/5 bg-white/[0.02] px-3 py-2.5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="truncate text-sm text-gray-300">{item.marketTitle}</p>
+        <div className="flex-shrink-0 flex items-center gap-1.5 text-xs text-gray-400">
+          <Clock className="h-3 w-3" />
+          <span>{formatXlm(item.amountXlm)}</span>
+        </div>
+      </div>
+    </li>
+  );
+}
+
 export default function RewardsWalletCard() {
   const { address, openConnectModal } = useWallet();
   const {
@@ -36,9 +85,11 @@ export default function RewardsWalletCard() {
     isLoading,
     error,
     refetch,
-    claim,
-    claimStatus,
-    claimError,
+    claimableItems,
+    vestingItems,
+    claimItem,
+    claimAllItems,
+    isClaimingAll,
     hasClaimableRewards,
     isEmpty,
   } = useRewards();
@@ -119,8 +170,6 @@ export default function RewardsWalletCard() {
     );
   }
 
-  const isPending = claimStatus === "pending";
-
   return (
     <CardShell>
       {/* Total Earned */}
@@ -134,59 +183,58 @@ export default function RewardsWalletCard() {
         </div>
       </div>
 
-      {/* Line Items */}
-      <div className="mt-5 space-y-3 text-sm">
-        <div className="flex justify-between text-gray-300">
-          <span>Claimable Rewards</span>
-          <span className="text-orange-400">
-            {formatXlm(summary.claimableXlm)}
-          </span>
+      {/* Claimable Rewards */}
+      <div className="mt-5">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            Claimable ({claimableItems.length})
+          </h3>
+          {claimableItems.length > 0 && (
+            <button
+              onClick={claimAllItems}
+              disabled={!hasClaimableRewards || isClaimingAll}
+              className="flex items-center gap-1.5 rounded-md bg-orange-500/15 border border-orange-500/30 px-2.5 py-1 text-xs font-semibold text-orange-400 transition hover:bg-orange-500/25 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isClaimingAll && <Loader2 className="h-3 w-3 animate-spin" />}
+              {isClaimingAll ? "Claiming All…" : "Claim All"}
+            </button>
+          )}
         </div>
 
-        <div className="flex justify-between text-gray-300">
-          <span>Vesting Rewards</span>
-          <span>{formatXlm(summary.vestingXlm)}</span>
-        </div>
+        {claimableItems.length === 0 ? (
+          <p className="mt-2 text-xs text-gray-500">
+            Nothing claimable right now.
+          </p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {claimableItems.map((item) => (
+              <ClaimableRewardRow
+                key={item.id}
+                item={item}
+                onClaim={claimItem}
+                disabled={isClaimingAll}
+              />
+            ))}
+          </ul>
+        )}
       </div>
 
-      {/* Transaction status */}
-      {claimStatus !== "idle" && (
-        <div className="mt-4 flex justify-center">
-          <RewardStatusBadge
-            status={
-              claimStatus === "pending"
-                ? "processing"
-                : claimStatus === "success"
-                  ? "claimed"
-                  : "failed"
-            }
-          />
-        </div>
-      )}
+      {/* Vesting Rewards */}
+      <div className="mt-5">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+          Vesting ({vestingItems.length})
+        </h3>
 
-      {claimStatus === "error" && claimError && (
-        <p className="mt-2 text-center text-xs text-rose-300">{claimError}</p>
-      )}
-
-      {claimStatus === "success" && (
-        <p className="mt-2 text-center text-xs text-emerald-300">
-          Rewards claimed successfully.
-        </p>
-      )}
-
-      {/* Button */}
-      <button
-        onClick={claim}
-        disabled={!hasClaimableRewards || isPending}
-        className="mt-6 w-full py-2 rounded-lg bg-orange-500 text-white font-semibold hover:bg-orange-600 transition disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-orange-500 flex items-center justify-center gap-2"
-      >
-        {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-        {isPending
-          ? "Claiming…"
-          : hasClaimableRewards
-            ? "Claim Rewards"
-            : "Nothing to Claim"}
-      </button>
+        {vestingItems.length === 0 ? (
+          <p className="mt-2 text-xs text-gray-500">No rewards vesting.</p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {vestingItems.map((item) => (
+              <VestingRewardRow key={item.id} item={item} />
+            ))}
+          </ul>
+        )}
+      </div>
     </CardShell>
   );
 }

--- a/frontend/src/hooks/useRewards.test.ts
+++ b/frontend/src/hooks/useRewards.test.ts
@@ -2,8 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { useRewards } from "./useRewards";
 import { useWallet } from "@/context/WalletContext";
-import { claimRewards, getRewardsSummary } from "@/lib/rewards";
-import type { RewardsSummary } from "@/lib/rewards";
+import {
+  claimRewardItem,
+  claimRewards,
+  getRewardItems,
+  getRewardsSummary,
+} from "@/lib/rewards";
+import type { RewardItem, RewardsSummary } from "@/lib/rewards";
 
 vi.mock("@/context/WalletContext", () => ({
   useWallet: vi.fn(),
@@ -12,11 +17,15 @@ vi.mock("@/context/WalletContext", () => ({
 vi.mock("@/lib/rewards", () => ({
   getRewardsSummary: vi.fn(),
   claimRewards: vi.fn(),
+  getRewardItems: vi.fn(),
+  claimRewardItem: vi.fn(),
 }));
 
 const mockedUseWallet = vi.mocked(useWallet);
 const mockedGetRewardsSummary = vi.mocked(getRewardsSummary);
 const mockedClaimRewards = vi.mocked(claimRewards);
+const mockedGetRewardItems = vi.mocked(getRewardItems);
+const mockedClaimRewardItem = vi.mocked(claimRewardItem);
 
 function mockWallet(address: string | null, token: string | null = address ? "test-token" : null) {
   mockedUseWallet.mockReturnValue({
@@ -34,11 +43,25 @@ function buildSummary(overrides: Partial<RewardsSummary> = {}): RewardsSummary {
   };
 }
 
+function buildItem(overrides: Partial<RewardItem> = {}): RewardItem {
+  return {
+    id: "pred-1",
+    marketId: "market-1",
+    marketTitle: "Will BTC close above $100k?",
+    amountXlm: 50,
+    status: "claimable",
+    ...overrides,
+  };
+}
+
 describe("useRewards", () => {
   beforeEach(() => {
     mockedUseWallet.mockReset();
     mockedGetRewardsSummary.mockReset();
     mockedClaimRewards.mockReset();
+    mockedGetRewardItems.mockReset();
+    mockedClaimRewardItem.mockReset();
+    mockedGetRewardItems.mockResolvedValue([]);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
@@ -158,5 +181,194 @@ describe("useRewards", () => {
 
     expect(mockedClaimRewards).not.toHaveBeenCalled();
     expect(result.current.claimStatus).toBe("idle");
+  });
+
+  describe("claimable/vesting item split", () => {
+    it("splits fetched reward items into claimable and vesting buckets", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([
+        buildItem({ id: "pred-1", status: "claimable", amountXlm: 50 }),
+        buildItem({ id: "pred-2", status: "claimable", amountXlm: 100 }),
+        buildItem({ id: "pred-3", status: "vesting", amountXlm: 95 }),
+      ]);
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(3);
+      expect(result.current.claimableItems.map((i) => i.id)).toEqual([
+        "pred-1",
+        "pred-2",
+      ]);
+      expect(result.current.vestingItems.map((i) => i.id)).toEqual([
+        "pred-3",
+      ]);
+      expect(
+        result.current.items.every((item) => item.claimStatus === "idle"),
+      ).toBe(true);
+    });
+
+    it("returns empty claimable/vesting buckets when there are no items", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.claimableItems).toEqual([]);
+      expect(result.current.vestingItems).toEqual([]);
+    });
+  });
+
+  describe("claimItem", () => {
+    it("marks the item pending, then removes it and updates the summary on success", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([
+        buildItem({ id: "pred-1", status: "claimable", amountXlm: 50 }),
+      ]);
+      mockedClaimRewardItem.mockResolvedValue({
+        id: "pred-1",
+        claimedXlm: 48,
+        transactionHash: "tx_item_1",
+      });
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.claimItem("pred-1");
+      });
+
+      expect(mockedClaimRewardItem).toHaveBeenCalledWith(
+        "test-token",
+        "pred-1",
+      );
+      expect(result.current.items).toHaveLength(0);
+      expect(result.current.summary?.claimableXlm).toBe(100);
+      expect(result.current.summary?.totalEarnedXlm).toBe(1288);
+    });
+
+    it("records a per-item error and leaves the item in the list on failure", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([
+        buildItem({ id: "pred-1", status: "claimable" }),
+      ]);
+      mockedClaimRewardItem.mockRejectedValue(new Error("Claim rejected"));
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.claimItem("pred-1").catch(() => undefined);
+      });
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].claimStatus).toBe("error");
+      expect(result.current.items[0].claimError).toBe("Claim rejected");
+    });
+
+    it("does not call claimRewardItem for a vesting item", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([
+        buildItem({ id: "pred-1", status: "vesting" }),
+      ]);
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.claimItem("pred-1");
+      });
+
+      expect(mockedClaimRewardItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("claimAllItems", () => {
+    it("triggers one per-item claim for every claimable item and leaves vesting items untouched", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([
+        buildItem({ id: "pred-1", status: "claimable", amountXlm: 50 }),
+        buildItem({ id: "pred-2", status: "claimable", amountXlm: 100 }),
+        buildItem({ id: "pred-3", status: "vesting", amountXlm: 95 }),
+      ]);
+      mockedClaimRewardItem.mockImplementation(async (_token, itemId) => ({
+        id: itemId,
+        claimedXlm: itemId === "pred-1" ? 48 : 97,
+        transactionHash: `tx_${itemId}`,
+      }));
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.claimAllItems();
+      });
+
+      expect(mockedClaimRewardItem).toHaveBeenCalledTimes(2);
+      expect(mockedClaimRewardItem).toHaveBeenNthCalledWith(
+        1,
+        "test-token",
+        "pred-1",
+      );
+      expect(mockedClaimRewardItem).toHaveBeenNthCalledWith(
+        2,
+        "test-token",
+        "pred-2",
+      );
+      expect(result.current.claimableItems).toHaveLength(0);
+      expect(result.current.vestingItems).toHaveLength(1);
+      expect(result.current.isClaimingAll).toBe(false);
+    });
+
+    it("continues claiming remaining items when one item fails", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([
+        buildItem({ id: "pred-1", status: "claimable" }),
+        buildItem({ id: "pred-2", status: "claimable" }),
+      ]);
+      mockedClaimRewardItem.mockImplementation(async (_token, itemId) => {
+        if (itemId === "pred-1") {
+          throw new Error("Claim rejected");
+        }
+        return { id: itemId, claimedXlm: 10, transactionHash: "tx_pred-2" };
+      });
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.claimAllItems();
+      });
+
+      expect(mockedClaimRewardItem).toHaveBeenCalledTimes(2);
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].id).toBe("pred-1");
+      expect(result.current.items[0].claimStatus).toBe("error");
+    });
+
+    it("does nothing when there are no claimable items", async () => {
+      mockWallet("GADDRESS");
+      mockedGetRewardsSummary.mockResolvedValue(buildSummary());
+      mockedGetRewardItems.mockResolvedValue([
+        buildItem({ id: "pred-1", status: "vesting" }),
+      ]);
+
+      const { result } = renderHook(() => useRewards());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.claimAllItems();
+      });
+
+      expect(mockedClaimRewardItem).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/hooks/useRewards.ts
+++ b/frontend/src/hooks/useRewards.ts
@@ -3,13 +3,23 @@
 import { useCallback, useEffect, useState } from "react";
 import { useWallet } from "@/context/WalletContext";
 import {
+  claimRewardItem,
   claimRewards,
+  getRewardItems,
   getRewardsSummary,
+  type RewardItem,
   type RewardsSummary,
 } from "@/lib/rewards";
 import { logHookError } from "./useHookErrorMessage";
 
 export type ClaimStatus = "idle" | "pending" | "success" | "error";
+export type ItemClaimStatus = "idle" | "pending" | "success" | "error";
+
+/** A reward item decorated with its own, independently-tracked claim state. */
+export interface WalletRewardItem extends RewardItem {
+  claimStatus: ItemClaimStatus;
+  claimError: string | null;
+}
 
 export interface UseRewardsReturn {
   summary: RewardsSummary | null;
@@ -17,14 +27,27 @@ export interface UseRewardsReturn {
   error: string | null;
   refetch: () => void;
 
+  // Whole-summary claim (claims everything in one backend call).
   claim: () => Promise<void>;
   claimStatus: ClaimStatus;
   claimError: string | null;
   lastClaimedXlm: number | null;
   lastTransactionHash: string | null;
 
+  // Per-item claimable/vesting rewards.
+  items: WalletRewardItem[];
+  claimableItems: WalletRewardItem[];
+  vestingItems: WalletRewardItem[];
+  claimItem: (itemId: string) => Promise<void>;
+  claimAllItems: () => Promise<void>;
+  isClaimingAll: boolean;
+
   hasClaimableRewards: boolean;
   isEmpty: boolean;
+}
+
+function decorateItem(item: RewardItem): WalletRewardItem {
+  return { ...item, claimStatus: "idle", claimError: null };
 }
 
 export function useRewards(): UseRewardsReturn {
@@ -40,9 +63,13 @@ export function useRewards(): UseRewardsReturn {
     string | null
   >(null);
 
+  const [items, setItems] = useState<WalletRewardItem[]>([]);
+  const [isClaimingAll, setIsClaimingAll] = useState(false);
+
   const fetchSummary = useCallback(async () => {
     if (!address || !token) {
       setSummary(null);
+      setItems([]);
       setError(null);
       setIsLoading(false);
       return;
@@ -51,10 +78,15 @@ export function useRewards(): UseRewardsReturn {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await getRewardsSummary(token);
-      setSummary(result);
+      const [summaryResult, itemsResult] = await Promise.all([
+        getRewardsSummary(token),
+        getRewardItems(token),
+      ]);
+      setSummary(summaryResult);
+      setItems(itemsResult.map(decorateItem));
     } catch (err) {
       setSummary(null);
+      setItems([]);
       setError(
         logHookError(err, {
           fallbackMessage: "Failed to load rewards.",
@@ -77,6 +109,7 @@ export function useRewards(): UseRewardsReturn {
     setClaimError(null);
     setLastClaimedXlm(null);
     setLastTransactionHash(null);
+    setIsClaimingAll(false);
   }, [address]);
 
   const claim = useCallback(async () => {
@@ -109,6 +142,89 @@ export function useRewards(): UseRewardsReturn {
     }
   }, [address, token, summary]);
 
+  const claimItem = useCallback(
+    async (itemId: string) => {
+      if (!address || !token) return;
+
+      const target = items.find((item) => item.id === itemId);
+      if (
+        !target ||
+        target.status !== "claimable" ||
+        target.claimStatus === "pending"
+      ) {
+        return;
+      }
+
+      setItems((current) =>
+        current.map((item) =>
+          item.id === itemId
+            ? { ...item, claimStatus: "pending", claimError: null }
+            : item,
+        ),
+      );
+
+      try {
+        const result = await claimRewardItem(token, itemId);
+        setItems((current) => current.filter((item) => item.id !== itemId));
+        setSummary((current) =>
+          current
+            ? {
+                ...current,
+                claimableXlm: Math.max(
+                  0,
+                  current.claimableXlm - target.amountXlm,
+                ),
+                totalEarnedXlm: current.totalEarnedXlm + result.claimedXlm,
+              }
+            : current,
+        );
+      } catch (err) {
+        const message = logHookError(err, {
+          fallbackMessage: "Failed to claim this reward. Please try again.",
+          hookName: "useRewards.claimItem",
+          id: itemId,
+        });
+        setItems((current) =>
+          current.map((item) =>
+            item.id === itemId
+              ? { ...item, claimStatus: "error", claimError: message }
+              : item,
+          ),
+        );
+        throw err;
+      }
+    },
+    [address, token, items],
+  );
+
+  const claimAllItems = useCallback(async () => {
+    if (!address || !token || isClaimingAll) return;
+
+    const claimableIds = items
+      .filter(
+        (item) => item.status === "claimable" && item.claimStatus !== "pending",
+      )
+      .map((item) => item.id);
+
+    if (claimableIds.length === 0) return;
+
+    setIsClaimingAll(true);
+    try {
+      for (const itemId of claimableIds) {
+        try {
+          await claimItem(itemId);
+        } catch {
+          // Per-item error is already recorded on the item; keep claiming the rest.
+        }
+      }
+    } finally {
+      setIsClaimingAll(false);
+    }
+  }, [address, token, items, claimItem, isClaimingAll]);
+
+  const claimableItems = items.filter((item) => item.status === "claimable");
+  const vestingItems = items.filter((item) => item.status === "vesting");
+
   const hasClaimableRewards = Boolean(summary && summary.claimableXlm > 0);
   const isEmpty = Boolean(
     summary &&
@@ -127,6 +243,12 @@ export function useRewards(): UseRewardsReturn {
     claimError,
     lastClaimedXlm,
     lastTransactionHash,
+    items,
+    claimableItems,
+    vestingItems,
+    claimItem,
+    claimAllItems,
+    isClaimingAll,
     hasClaimableRewards,
     isEmpty,
   };

--- a/frontend/src/lib/rewards.ts
+++ b/frontend/src/lib/rewards.ts
@@ -11,6 +11,23 @@ export type ClaimRewardsResult = {
   summary: RewardsSummary;
 };
 
+/** A single reward tied to one prediction — either claimable now or still vesting. */
+export type RewardItemStatus = "claimable" | "vesting";
+
+export type RewardItem = {
+  id: string;
+  marketId: string;
+  marketTitle: string;
+  amountXlm: number;
+  status: RewardItemStatus;
+};
+
+export type ClaimRewardItemResult = {
+  id: string;
+  claimedXlm: number;
+  transactionHash: string;
+};
+
 type RewardsSummaryResponse = {
   total_earned_xlm: number;
   claimable_xlm: number;
@@ -24,13 +41,54 @@ type ClaimAllRewardsResponse = {
   summary: RewardsSummaryResponse;
 };
 
+type PredictionWithStatusResponse = {
+  id: string;
+  stake_amount_stroops: string;
+  payout_claimed: boolean;
+  market: {
+    id: string;
+    title: string;
+  };
+};
+
+type PaginatedPredictionsResponse = {
+  data: PredictionWithStatusResponse[];
+};
+
+type ClaimPredictionResponse = {
+  id: string;
+  payout_amount_stroops: string;
+  tx_hash: string | null;
+};
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+const STROOPS_PER_XLM = 10_000_000;
+
+/** Max predictions to pull per claimable/vesting bucket for the wallet card's item list. */
+const REWARD_ITEMS_PAGE_LIMIT = 50;
 
 function toRewardsSummary(response: RewardsSummaryResponse): RewardsSummary {
   return {
     totalEarnedXlm: response.total_earned_xlm,
     claimableXlm: response.claimable_xlm,
     vestingXlm: response.vesting_xlm,
+  };
+}
+
+function stroopsToXlm(stroops: string | number): number {
+  return Number(stroops) / STROOPS_PER_XLM;
+}
+
+function toRewardItem(
+  prediction: PredictionWithStatusResponse,
+  status: RewardItemStatus,
+): RewardItem {
+  return {
+    id: prediction.id,
+    marketId: prediction.market.id,
+    marketTitle: prediction.market.title,
+    amountXlm: stroopsToXlm(prediction.stake_amount_stroops),
+    status,
   };
 }
 
@@ -82,5 +140,63 @@ export async function claimRewards(token: string): Promise<ClaimRewardsResult> {
     claimedCount: data.claimed_count,
     transactionHash: data.transaction_hash,
     summary: toRewardsSummary(data.summary),
+  };
+}
+
+/**
+ * Fetches the authenticated user's individual claimable and vesting reward
+ * items (one per prediction), so the wallet UI can offer a per-item claim
+ * action alongside the aggregate totals from `getRewardsSummary`. Backed by
+ * `GET /api/predictions/me` (see `predictions.controller.ts::getMyPredictions`).
+ */
+export async function getRewardItems(token: string): Promise<RewardItem[]> {
+  const params = `limit=${REWARD_ITEMS_PAGE_LIMIT}`;
+  const [wonResponse, activeResponse] = await Promise.all([
+    fetch(`${API_BASE_URL}/api/predictions/me?status=won&${params}`, {
+      headers: authHeaders(token),
+      cache: "no-store",
+    }),
+    fetch(`${API_BASE_URL}/api/predictions/me?status=active&${params}`, {
+      headers: authHeaders(token),
+      cache: "no-store",
+    }),
+  ]);
+
+  const [won, active] = await Promise.all([
+    parseJsonResponse<PaginatedPredictionsResponse>(wonResponse),
+    parseJsonResponse<PaginatedPredictionsResponse>(activeResponse),
+  ]);
+
+  const claimable = won.data
+    .filter((prediction) => !prediction.payout_claimed)
+    .map((prediction) => toRewardItem(prediction, "claimable"));
+  const vesting = active.data.map((prediction) =>
+    toRewardItem(prediction, "vesting"),
+  );
+
+  return [...claimable, ...vesting];
+}
+
+/**
+ * Claims the payout for a single winning prediction. Backed by
+ * `POST /api/predictions/:id/claim` (see `predictions.controller.ts::claimPayout`).
+ */
+export async function claimRewardItem(
+  token: string,
+  itemId: string,
+): Promise<ClaimRewardItemResult> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/predictions/${itemId}/claim`,
+    {
+      method: "POST",
+      headers: { ...authHeaders(token), "Content-Type": "application/json" },
+    },
+  );
+
+  const data = await parseJsonResponse<ClaimPredictionResponse>(response);
+  return {
+    id: data.id,
+    claimedXlm: stroopsToXlm(data.payout_amount_stroops),
+    transactionHash: data.tx_hash ?? "",
   };
 }


### PR DESCRIPTION
closes #1585

Splits the wallet card's rewards into individually claimable and vesting items (backed by the existing GET /predictions/me and POST /predictions/:id/claim endpoints), each with its own claim button and pending/error state, plus a "Claim All" action that claims every claimable item one at a time.