### PR TITLE
feat(open-market): harden reputation decay application for #1681

### DIFF
--- a/contracts/open-market/src/reputation.rs
+++ b/contracts/open-market/src/reputation.rs
@@ -68,14 +68,17 @@ pub fn apply_reputation_decay(
         return score;
     }
     let half_life_seconds = half_life_seconds as u64;
-    match mode {
+    let decayed = match mode {
         ReputationDecayMode::Linear => {
             let full_life = half_life_seconds.saturating_mul(2);
-            if elapsed_seconds >= full_life {
+            if full_life == 0 || elapsed_seconds >= full_life {
                 0
             } else {
-                let remaining = full_life - elapsed_seconds;
-                ((score as u64 * remaining) / full_life) as u32
+                let remaining = full_life.saturating_sub(elapsed_seconds);
+                (score as u64)
+                    .checked_mul(remaining)
+                    .and_then(|v| v.checked_div(full_life))
+                    .unwrap_or(0) as u32
             }
         }
         ReputationDecayMode::Exponential => {
@@ -84,13 +87,17 @@ pub fn apply_reputation_decay(
             let mut decayed = score >> halvings;
             if remainder > 0 && decayed > 0 {
                 let next = decayed >> 1;
-                let diff = decayed - next;
-                let interpolated = ((diff as u64) * remainder / half_life_seconds) as u32;
+                let diff = decayed.saturating_sub(next);
+                let interpolated = (diff as u64)
+                    .checked_mul(remainder)
+                    .and_then(|v| v.checked_div(half_life_seconds))
+                    .unwrap_or(0) as u32;
                 decayed = decayed.saturating_sub(interpolated);
             }
             decayed
         }
-    }
+    };
+    decayed.min(score)
 }
 
 /// Recompute the live (undecayed) formula score, then decay it against the

--- a/contracts/open-market/tests/reputation_tests.rs
+++ b/contracts/open-market/tests/reputation_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use insightarena_contract::config::{self, ReputationDecayMode};
 use insightarena_contract::market::CreateMarketParams;
 use insightarena_contract::reputation::*;
 use insightarena_contract::storage_types::CreatorStats;
@@ -351,6 +352,122 @@ fn test_reputation_decay_over_time() {
         .set_timestamp(env.ledger().timestamp() + 86400 * 30);
     let stats_after_two_half_lives = client.get_creator_stats(&creator);
     assert_eq!(stats_after_two_half_lives.reputation_score, 150);
+}
+
+// ── Decay application (Issue #1681) ─────────────────────────────────────────
+
+#[test]
+fn apply_reputation_decay_no_op_when_zero_score_or_elapsed() {
+    assert_eq!(apply_reputation_decay(0, 1_000, 100, ReputationDecayMode::Linear), 0);
+    assert_eq!(apply_reputation_decay(500, 0, 100, ReputationDecayMode::Linear), 500);
+    assert_eq!(
+        apply_reputation_decay(500, 0, 100, ReputationDecayMode::Exponential),
+        500
+    );
+    assert_eq!(apply_reputation_decay(500, 1_000, 0, ReputationDecayMode::Linear), 500);
+}
+
+#[test]
+fn apply_reputation_decay_linear_scales_with_elapsed_time() {
+    let half = 1_000_u32;
+    assert_eq!(
+        apply_reputation_decay(1_000, 0, half, ReputationDecayMode::Linear),
+        1_000
+    );
+    assert_eq!(
+        apply_reputation_decay(1_000, 500, half, ReputationDecayMode::Linear),
+        750
+    );
+    assert_eq!(
+        apply_reputation_decay(1_000, 1_000, half, ReputationDecayMode::Linear),
+        500
+    );
+    assert_eq!(
+        apply_reputation_decay(1_000, 1_500, half, ReputationDecayMode::Linear),
+        250
+    );
+    assert_eq!(
+        apply_reputation_decay(1_000, 2_000, half, ReputationDecayMode::Linear),
+        0
+    );
+    assert_eq!(
+        apply_reputation_decay(1_000, 3_000, half, ReputationDecayMode::Linear),
+        0
+    );
+}
+
+#[test]
+fn apply_reputation_decay_exponential_halves_each_half_life() {
+    let half = 1_000_u32;
+    assert_eq!(
+        apply_reputation_decay(800, 1_000, half, ReputationDecayMode::Exponential),
+        400
+    );
+    assert_eq!(
+        apply_reputation_decay(800, 2_000, half, ReputationDecayMode::Exponential),
+        200
+    );
+}
+
+#[test]
+fn apply_reputation_decay_never_exceeds_input_score() {
+    let linear = apply_reputation_decay(600, 500, 1_000, ReputationDecayMode::Linear);
+    assert!(linear <= 600);
+    let exponential = apply_reputation_decay(600, 500, 1_000, ReputationDecayMode::Exponential);
+    assert!(exponential <= 600);
+}
+
+#[test]
+fn test_reputation_linear_decay_on_read() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, _) = deploy(&env);
+    let creator = Address::generate(&env);
+
+    env.as_contract(&client.address, || {
+        config::set_reputation_decay_config(
+            &env,
+            admin.clone(),
+            86_400_u32 * 30,
+            ReputationDecayMode::Linear,
+        )
+    })
+    .unwrap();
+
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 2000);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert_eq!(client.get_reputation_score(&creator), 600);
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 86_400 * 30);
+    assert_eq!(client.get_reputation_score(&creator), 300);
+
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 86_400 * 30);
+    assert_eq!(client.get_reputation_score(&creator), 0);
+}
+
+#[test]
+fn test_stale_high_score_decays_below_creation_gate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, _) = deploy(&env);
+    let creator = Address::generate(&env);
+
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(env.ledger().timestamp() + 2000);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert_eq!(client.get_reputation_score(&creator), 600);
+
+    client.set_min_creator_reputation(&admin, &400_u32);
+    assert!(client.try_create_market(&creator, &default_params(&env)).is_ok());
+
+    // Two half-lives of inactivity (default exponential) should drop 600 -> 150.
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 86_400 * 60);
+    assert_eq!(client.get_reputation_score(&creator), 150);
+    assert!(client.try_create_market(&creator, &default_params(&env)).is_err());
 }
 
 #[test]

--- a/contracts/open-market/tests/reputation_tests.rs
+++ b/contracts/open-market/tests/reputation_tests.rs
@@ -461,9 +461,11 @@ fn test_stale_high_score_decays_below_creation_gate() {
     assert_eq!(client.get_reputation_score(&creator), 600);
 
     client.set_min_creator_reputation(&admin, &400_u32);
-    assert!(client.try_create_market(&creator, &default_params(&env)).is_ok());
+    assert!(client.get_reputation_score(&creator) >= 400_u32);
 
     // Two half-lives of inactivity (default exponential) should drop 600 -> 150.
+    // Do not create another market here — that would reset last_updated and
+    // change the raw formula score (1 resolved / 2 created = 300).
     env.ledger()
         .set_timestamp(env.ledger().timestamp() + 86_400 * 60);
     assert_eq!(client.get_reputation_score(&creator), 150);


### PR DESCRIPTION
## Description

### Summary
Implements reputation decay, applied lazily on read rather than via a scheduled/background job, so scores reflect decay accurately at the moment they're accessed without requiring a separate cron/worker process.

### What Was Implemented
- **Lazy decay on read** — reputation decay is computed and applied when a score is read, not on a fixed schedule, keeping stored state simple and avoiding drift from missed scheduled runs.
- **`apply_reputation_decay`** — uses checked arithmetic throughout, preventing overflow/underflow when computing decayed values.
- **Test coverage** — six new tests covering:
  - Linear decay behavior
  - Exponential decay behavior
  - The stale-high-score gate (preventing an old high score from remaining artificially inflated indefinitely)

### Status
Two files modified, changes complete but not yet committed.

### Branch
feature/1681-reputation-decay-application

### Related Issue
Closes #1681