### PR TITLE
feat(coursenav): persist lesson progress

### DIFF
--- a/frontend/src/component/CourseCard.tsx
+++ b/frontend/src/component/CourseCard.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import {
+  CourseLesson,
+  getResumeLesson,
+  getViewedLessonIds,
+  markLessonViewed,
+} from '../lib/utils';
 
 interface CourseCardProps {
   title: string;
@@ -8,6 +15,8 @@ interface CourseCardProps {
   duration: number;
   level: string;
   tags?: string[] | null;
+  courseId?: string;
+  lessons?: CourseLesson[];
 }
 
 const CourseCard: React.FC<CourseCardProps> = ({
@@ -17,7 +26,18 @@ const CourseCard: React.FC<CourseCardProps> = ({
   duration,
   level,
   tags,
+  courseId = title.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+  lessons = [],
 }) => {
+  const [viewedLessonIds, setViewedLessonIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    setViewedLessonIds(getViewedLessonIds(courseId));
+  }, [courseId]);
+
+  const resumeLesson = getResumeLesson(courseId, lessons);
+  const viewedLessonSet = new Set(viewedLessonIds);
+
   return (
     <div className="bg-black border border-gray-800 rounded-2xl p-6 flex flex-col shadow-md hover:shadow-purple-800/20 transition-shadow">
       {/* Header Row: Title + Tags */}
@@ -55,16 +75,37 @@ const CourseCard: React.FC<CourseCardProps> = ({
         </div>
       </div>
 
+      {lessons.length > 0 && (
+        <div className="mb-4" aria-label="Course lesson progress">
+          <p className="text-xs text-gray-400 mb-2">
+            {viewedLessonIds.filter((id) => lessons.some((lesson) => lesson.id === id)).length}/{lessons.length} lessons viewed
+          </p>
+          <div className="flex gap-1" role="list" aria-label="Viewed lessons">
+            {lessons.map((lesson) => (
+              <span
+                key={lesson.id}
+                role="listitem"
+                aria-label={`${lesson.title}: ${viewedLessonSet.has(lesson.id) ? 'viewed' : 'not viewed'}`}
+                className={`h-1.5 flex-1 rounded-full ${viewedLessonSet.has(lesson.id) ? 'bg-purple-400' : 'bg-gray-700'}`}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Footer Row */}
       <div className="flex items-center justify-between mt-auto pt-4 border-t border-gray-800">
         <span className="text-xs bg-purple-700 text-white px-2 py-1 rounded-full">
           {level}
         </span>
         <Link
-          href="/courses/crypto-101"
+          href={resumeLesson?.href ?? "/courses/crypto-101"}
+          onClick={() => {
+            if (resumeLesson) setViewedLessonIds(markLessonViewed(courseId, resumeLesson.id));
+          }}
           className="text-sm font-semibold text-purple-400 hover:underline"
         >
-          Start Learning →
+          {resumeLesson && viewedLessonIds.length > 0 ? "Resume where you left off" : "Start Learning"} →
         </Link>
       </div>
     </div>

--- a/frontend/src/component/coursenav.tsx
+++ b/frontend/src/component/coursenav.tsx
@@ -14,15 +14,28 @@ import tradingicon from "../../public/assets/tradingIcon.svg";
 import airdropicon from "../../public/assets/airdropIcon.svg";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-const Navbar = () => {
+import { CourseLesson, getResumeLesson, getViewedLessonIds, markLessonViewed } from "../lib/utils";
+
+interface NavbarProps {
+  courseId?: string;
+  lessons?: CourseLesson[];
+}
+
+const Navbar = ({ courseId = "crypto-101", lessons = [] }: NavbarProps) => {
   const router = useRouter();
+  const [viewedLessonIds, setViewedLessonIds] = useState<string[]>([]);
   const [isCoursesOpen, setIsCoursesOpen] = useState(false);
   const [isResourcesOpen, setIsResourcesOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const resumeLesson = getResumeLesson(courseId, lessons);
+
+  React.useEffect(() => {
+    setViewedLessonIds(getViewedLessonIds(courseId));
+  }, [courseId]);
 
   return (
     <nav
-      className="bg-black border-1 rounded-lg border-white text-white px-6 py-4 flex justify-between w-full items-center m-auto mt-4 "
+      className="bg-black border rounded-lg border-white text-white px-6 py-4 flex justify-between w-full items-center m-auto mt-4 "
       aria-label="Courses navigation"
     >
       <Link href="/" className="text-[2rem] font-bold">Stark Academy</Link>
@@ -55,6 +68,16 @@ const Navbar = () => {
               open={isCoursesOpen}
               onClose={() => setIsCoursesOpen(false)}
             />
+          )}
+          {resumeLesson && (
+            <Link
+              href={resumeLesson.href}
+              onClick={() => setViewedLessonIds(markLessonViewed(courseId, resumeLesson.id))}
+              className="mt-3 block border-t border-gray-800 pt-3 text-sm text-purple-300 hover:text-white"
+            >
+              Resume where you left off
+              <span className="ml-2 text-gray-400">{viewedLessonIds.length}/{lessons.length}</span>
+            </Link>
           )}
         </div>
 

--- a/frontend/src/lib/course-progress.test.tsx
+++ b/frontend/src/lib/course-progress.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  COURSE_PROGRESS_STORAGE_KEY,
+  getResumeLesson,
+  getViewedLessonIds,
+  markLessonViewed,
+  type CourseLesson,
+} from "./utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CourseCard from "../component/CourseCard";
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+const lessons: CourseLesson[] = [
+  { id: "intro", title: "Introduction", href: "/courses/crypto-101/intro" },
+  { id: "wallets", title: "Wallets", href: "/courses/crypto-101/wallets" },
+  { id: "markets", title: "Markets", href: "/courses/crypto-101/markets" },
+];
+
+describe("course progress", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("persists viewed lesson ids in local storage", () => {
+    markLessonViewed("crypto-101", "intro");
+    markLessonViewed("crypto-101", "wallets");
+
+    expect(getViewedLessonIds("crypto-101")).toEqual(["intro", "wallets"]);
+    expect(JSON.parse(localStorage.getItem(COURSE_PROGRESS_STORAGE_KEY)!)).toEqual({
+      "crypto-101": ["intro", "wallets"],
+    });
+  });
+
+  it("returns the first unviewed lesson as the resume target", () => {
+    markLessonViewed("crypto-101", "intro");
+
+    expect(getResumeLesson("crypto-101", lessons)).toEqual(lessons[1]);
+  });
+
+  it("renders persisted viewed state and the resume action", () => {
+    markLessonViewed("crypto-101", "intro");
+
+    render(
+      <CourseCard
+        title="Crypto 101"
+        description="Learn the basics."
+        lessonCount={lessons.length}
+        duration={30}
+        level="Beginner"
+        courseId="crypto-101"
+        lessons={lessons}
+      />,
+    );
+
+    expect(screen.getByText("1/3 lessons viewed")).toBeInTheDocument();
+    expect(screen.getByLabelText("Introduction: viewed")).toBeInTheDocument();
+    expect(screen.getByLabelText("Wallets: not viewed")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /resume where you left off/i })).toHaveAttribute(
+      "href",
+      "/courses/crypto-101/wallets",
+    );
+  });
+});

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,63 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export interface CourseLesson {
+  id: string;
+  title: string;
+  href: string;
+}
+
+export const COURSE_PROGRESS_STORAGE_KEY = "insightarena.course-progress.v1";
+
+function readCourseProgress(): Record<string, string[]> {
+  if (typeof window === "undefined") return {};
+
+  try {
+    const stored = window.localStorage.getItem(COURSE_PROGRESS_STORAGE_KEY);
+    const parsed: unknown = stored ? JSON.parse(stored) : {};
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        ([, lessonIds]) =>
+          Array.isArray(lessonIds) && lessonIds.every((lessonId) => typeof lessonId === "string"),
+      ),
+    ) as Record<string, string[]>;
+  } catch {
+    return {};
+  }
+}
+
+export function getViewedLessonIds(courseId: string): string[] {
+  return readCourseProgress()[courseId] ?? [];
+}
+
+export function markLessonViewed(courseId: string, lessonId: string): string[] {
+  const progress = readCourseProgress();
+  const viewedLessonIds = Array.from(new Set([...(progress[courseId] ?? []), lessonId]));
+
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(
+        COURSE_PROGRESS_STORAGE_KEY,
+        JSON.stringify({ ...progress, [courseId]: viewedLessonIds }),
+      );
+    } catch {
+      // Storage can be unavailable in private browsing or restricted embeds.
+    }
+  }
+
+  return viewedLessonIds;
+}
+
+export function getResumeLesson(
+  courseId: string,
+  lessons: CourseLesson[],
+): CourseLesson | undefined {
+  const viewedLessonIds = new Set(getViewedLessonIds(courseId));
+  return lessons.find((lesson) => !viewedLessonIds.has(lesson.id)) ?? lessons.at(-1);
+}
+
 const STROOPS_PER_XLM = 10_000_000;
 
 /**


### PR DESCRIPTION
Persist lesson viewed state in course navigation, render progress markers correctly, and support resuming from the last viewed lesson. Added coverage to verify progress persistence across visits.

closes #1590 