### PR TITLE
Backend/1668 1673 1661 1660 disputes contract markets flags

### DIFF
--- a/backend/src/disputes/disputes.controller.spec.ts
+++ b/backend/src/disputes/disputes.controller.spec.ts
@@ -94,51 +94,37 @@ describe('DisputesController', () => {
   });
 
   describe('findAll', () => {
-    it('should return paginated disputes', async () => {
+    it('should return disputes with pagination metadata', async () => {
       const mockResult = {
         disputes: [mockDispute],
-        total: 1,
-        page: 1,
+        next_cursor: null,
+        has_more: false,
         limit: 20,
+        counts_by_status: { pending: 1, resolved: 0 },
       };
       jest.spyOn(service, 'findAll').mockResolvedValue(mockResult);
 
-      const result = await controller.findAll('1', '20');
+      const query = { limit: 20 } as any;
+      const result = await controller.findAll(query);
 
       expect(result).toEqual(mockResult);
-      expect(service.findAll).toHaveBeenCalledWith(1, 20, undefined);
+      expect(service.findAll).toHaveBeenCalledWith(query);
     });
 
-    it('should parse query parameters correctly', async () => {
+    it('should pass status filter through to the service', async () => {
       const mockResult = {
         disputes: [mockDispute],
-        total: 1,
-        page: 2,
+        next_cursor: null,
+        has_more: false,
         limit: 10,
+        counts_by_status: { pending: 1, resolved: 0 },
       };
       jest.spyOn(service, 'findAll').mockResolvedValue(mockResult);
 
-      await controller.findAll('2', '10', DisputeStatus.PENDING);
+      const query = { status: DisputeStatus.PENDING, limit: 10 } as any;
+      await controller.findAll(query);
 
-      expect(service.findAll).toHaveBeenCalledWith(
-        2,
-        10,
-        DisputeStatus.PENDING,
-      );
-    });
-
-    it('should use default values for pagination', async () => {
-      const mockResult = {
-        disputes: [mockDispute],
-        total: 1,
-        page: 1,
-        limit: 20,
-      };
-      jest.spyOn(service, 'findAll').mockResolvedValue(mockResult);
-
-      await controller.findAll();
-
-      expect(service.findAll).toHaveBeenCalledWith(1, 20, undefined);
+      expect(service.findAll).toHaveBeenCalledWith(query);
     });
   });
 

--- a/backend/src/disputes/disputes.controller.ts
+++ b/backend/src/disputes/disputes.controller.ts
@@ -21,7 +21,11 @@ import { DisputesService } from './disputes.service';
 import { CreateDisputeDto } from './dto/create-dispute.dto';
 import { AttachEvidenceDto } from './dto/attach-evidence.dto';
 import { CastVoteDto } from './dto/cast-vote.dto';
-import { Dispute, DisputeStatus } from './entities/dispute.entity';
+import {
+  ListDisputesDto,
+  PaginatedDisputesResponse,
+} from './dto/list-disputes.dto';
+import { Dispute } from './entities/dispute.entity';
 import { DisputeEvidence } from './entities/dispute-evidence.entity';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { BanGuard } from '../common/guards/ban.guard';
@@ -109,43 +113,19 @@ export class DisputesController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all disputes with pagination' })
-  @ApiQuery({
-    name: 'page',
-    required: false,
-    type: Number,
-    description: 'Page number',
-  })
-  @ApiQuery({
-    name: 'limit',
-    required: false,
-    type: Number,
-    description: 'Items per page',
-  })
-  @ApiQuery({
-    name: 'status',
-    required: false,
-    enum: DisputeStatus,
-    description: 'Filter by dispute status',
+  @ApiOperation({
+    summary:
+      'List disputes with status/date filters and cursor pagination. ' +
+      'Response metadata includes counts by status.',
   })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Disputes retrieved successfully',
   })
   async findAll(
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
-    @Query('status') status?: DisputeStatus,
-  ): Promise<{
-    disputes: Dispute[];
-    total: number;
-    page: number;
-    limit: number;
-  }> {
-    const pageNum = page ? parseInt(page, 10) : 1;
-    const limitNum = limit ? parseInt(limit, 10) : 20;
-
-    return this.disputesService.findAll(pageNum, limitNum, status);
+    @Query() query: ListDisputesDto,
+  ): Promise<PaginatedDisputesResponse> {
+    return this.disputesService.findAll(query);
   }
 
   @Get('market/:marketId')

--- a/backend/src/disputes/disputes.service.spec.ts
+++ b/backend/src/disputes/disputes.service.spec.ts
@@ -419,8 +419,11 @@ describe('DisputesService', () => {
   });
 
   describe('findAll', () => {
-    const makeDispute = (id: string, createdAt: Date, status = DisputeStatus.PENDING): Dispute =>
-      ({ ...mockDispute, id, createdAt, status }) as Dispute;
+    const makeDispute = (
+      id: string,
+      createdAt: Date,
+      status = DisputeStatus.PENDING,
+    ): Dispute => ({ ...mockDispute, id, createdAt, status }) as Dispute;
 
     /** Builds a chainable queryBuilder mock; `getMany` resolves to `rows`. */
     const mockQueryBuilder = (
@@ -444,9 +447,10 @@ describe('DisputesService', () => {
 
     it('narrows results when filtering by status', async () => {
       const pending = makeDispute('d1', new Date('2024-01-02T00:00:00Z'));
-      const qb = mockQueryBuilder([pending], [
-        { status: DisputeStatus.PENDING, count: '1' },
-      ]);
+      const qb = mockQueryBuilder(
+        [pending],
+        [{ status: DisputeStatus.PENDING, count: '1' }],
+      );
       jest.spyOn(disputesRepository, 'createQueryBuilder').mockReturnValue(qb);
 
       const result = await service.findAll({
@@ -499,7 +503,10 @@ describe('DisputesService', () => {
 
     it('rejects a malformed cursor', async () => {
       await expect(
-        service.findAll({ cursor: 'not-valid-base64-cursor!!', limit: 20 } as any),
+        service.findAll({
+          cursor: 'not-valid-base64-cursor!!',
+          limit: 20,
+        } as any),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/backend/src/disputes/disputes.service.spec.ts
+++ b/backend/src/disputes/disputes.service.spec.ts
@@ -88,6 +88,7 @@ describe('DisputesService', () => {
             findAndCount: jest.fn(),
             find: jest.fn(),
             update: jest.fn(),
+            createQueryBuilder: jest.fn(),
           },
         },
         {
@@ -418,46 +419,88 @@ describe('DisputesService', () => {
   });
 
   describe('findAll', () => {
-    it('should return paginated disputes', async () => {
-      const disputes = [mockDispute];
-      const mockFindAndCount = [disputes, 1];
-      jest
-        .spyOn(disputesRepository, 'findAndCount')
-        .mockResolvedValue(mockFindAndCount);
+    const makeDispute = (id: string, createdAt: Date, status = DisputeStatus.PENDING): Dispute =>
+      ({ ...mockDispute, id, createdAt, status }) as Dispute;
 
-      const result = await service.findAll(1, 20);
+    /** Builds a chainable queryBuilder mock; `getMany` resolves to `rows`. */
+    const mockQueryBuilder = (
+      rows: Dispute[],
+      countRows: Array<{ status: DisputeStatus; count: string }> = [],
+    ) => {
+      const qb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(rows),
+        getRawMany: jest.fn().mockResolvedValue(countRows),
+      };
+      return qb;
+    };
 
-      expect(result).toEqual({
-        disputes,
-        total: 1,
-        page: 1,
+    it('narrows results when filtering by status', async () => {
+      const pending = makeDispute('d1', new Date('2024-01-02T00:00:00Z'));
+      const qb = mockQueryBuilder([pending], [
+        { status: DisputeStatus.PENDING, count: '1' },
+      ]);
+      jest.spyOn(disputesRepository, 'createQueryBuilder').mockReturnValue(qb);
+
+      const result = await service.findAll({
+        status: DisputeStatus.PENDING,
         limit: 20,
+      } as any);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('dispute.status = :status', {
+        status: DisputeStatus.PENDING,
       });
-      expect(disputesRepository.findAndCount).toHaveBeenCalledWith({
-        where: {},
-        relations: ['market', 'disputant', 'resolvedBy'],
-        order: { createdAt: 'DESC' },
-        skip: 0,
-        take: 20,
-      });
+      expect(result.disputes).toEqual([pending]);
+      expect(result.counts_by_status).toEqual({ pending: 1, resolved: 0 });
     });
 
-    it('should filter by status', async () => {
-      const disputes = [mockDispute];
-      const mockFindAndCount = [disputes, 1];
-      jest
-        .spyOn(disputesRepository, 'findAndCount')
-        .mockResolvedValue(mockFindAndCount);
+    it('paginates stably via cursor, requesting one extra row to detect more pages', async () => {
+      const rows = [
+        makeDispute('d3', new Date('2024-01-03T00:00:00Z')),
+        makeDispute('d2', new Date('2024-01-02T00:00:00Z')),
+        makeDispute('d1', new Date('2024-01-01T00:00:00Z')),
+      ];
+      const qb = mockQueryBuilder(rows);
+      jest.spyOn(disputesRepository, 'createQueryBuilder').mockReturnValue(qb);
 
-      await service.findAll(1, 20, DisputeStatus.PENDING);
+      const result = await service.findAll({ limit: 2 } as any);
 
-      expect(disputesRepository.findAndCount).toHaveBeenCalledWith({
-        where: { status: DisputeStatus.PENDING },
-        relations: ['market', 'disputant', 'resolvedBy'],
-        order: { createdAt: 'DESC' },
-        skip: 0,
-        take: 20,
-      });
+      expect(qb.take).toHaveBeenCalledWith(3);
+      expect(result.disputes).toHaveLength(2);
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBeTruthy();
+    });
+
+    it('applies the decoded cursor as a strict less-than filter on createdAt/id', async () => {
+      const rows = [makeDispute('d1', new Date('2024-01-01T00:00:00Z'))];
+      const qb = mockQueryBuilder(rows);
+      jest.spyOn(disputesRepository, 'createQueryBuilder').mockReturnValue(qb);
+
+      const cursor = Buffer.from(
+        '2024-01-02T00:00:00.000Z:d2',
+        'utf-8',
+      ).toString('base64');
+
+      const result = await service.findAll({ cursor, limit: 20 } as any);
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('dispute.createdAt < :cursorCreatedAt'),
+        expect.objectContaining({ cursorId: 'd2' }),
+      );
+      expect(result.disputes).toEqual(rows);
+    });
+
+    it('rejects a malformed cursor', async () => {
+      await expect(
+        service.findAll({ cursor: 'not-valid-base64-cursor!!', limit: 20 } as any),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/backend/src/disputes/disputes.service.ts
+++ b/backend/src/disputes/disputes.service.ts
@@ -22,6 +22,11 @@ import { CreateDisputeDto } from './dto/create-dispute.dto';
 import { ResolveDisputeDto } from './dto/resolve-dispute.dto';
 import { AttachEvidenceDto } from './dto/attach-evidence.dto';
 import { CastVoteDto } from './dto/cast-vote.dto';
+import {
+  ListDisputesDto,
+  DisputeStatusCounts,
+  PaginatedDisputesResponse,
+} from './dto/list-disputes.dto';
 import { Market } from '../markets/entities/market.entity';
 import { User } from '../users/entities/user.entity';
 import { Role } from '../common/enums/role.enum';
@@ -485,34 +490,113 @@ export class DisputesService {
   }
 
   /**
-   * Find all disputes with pagination
+   * List disputes with status/date-range filters and cursor pagination.
+   * The cursor encodes `createdAt:id` of the last row of the previous page
+   * (base64), so pages stay stable even as new disputes are created
+   * concurrently - unlike offset pagination, which can skip or repeat rows
+   * under concurrent inserts.
    */
-  async findAll(
-    page = 1,
-    limit = 20,
-    status?: DisputeStatus,
-  ): Promise<{
-    disputes: Dispute[];
-    total: number;
-    page: number;
-    limit: number;
-  }> {
-    const where = status ? { status } : {};
+  async findAll(query: ListDisputesDto): Promise<PaginatedDisputesResponse> {
+    const limit = query.limit ?? 20;
+    const decodedCursor = query.cursor
+      ? this.decodeDisputeCursor(query.cursor)
+      : null;
 
-    const [disputes, total] = await this.disputesRepository.findAndCount({
-      where,
-      relations: ['market', 'disputant', 'resolvedBy'],
-      order: { createdAt: 'DESC' },
-      skip: (page - 1) * limit,
-      take: limit,
-    });
+    const qb = this.disputesRepository
+      .createQueryBuilder('dispute')
+      .leftJoinAndSelect('dispute.market', 'market')
+      .leftJoinAndSelect('dispute.disputant', 'disputant')
+      .leftJoinAndSelect('dispute.resolvedBy', 'resolvedBy')
+      .orderBy('dispute.createdAt', 'DESC')
+      .addOrderBy('dispute.id', 'DESC')
+      .take(limit + 1);
+
+    if (query.status) {
+      qb.andWhere('dispute.status = :status', { status: query.status });
+    }
+    if (query.created_after) {
+      qb.andWhere('dispute.createdAt >= :createdAfter', {
+        createdAfter: new Date(query.created_after),
+      });
+    }
+    if (query.created_before) {
+      qb.andWhere('dispute.createdAt <= :createdBefore', {
+        createdBefore: new Date(query.created_before),
+      });
+    }
+
+    if (decodedCursor) {
+      qb.andWhere(
+        '(dispute.createdAt < :cursorCreatedAt OR (dispute.createdAt = :cursorCreatedAt AND dispute.id < :cursorId))',
+        {
+          cursorCreatedAt: decodedCursor.createdAt,
+          cursorId: decodedCursor.id,
+        },
+      );
+    }
+
+    const [rows, counts] = await Promise.all([
+      qb.getMany(),
+      this.countByStatus(),
+    ]);
+
+    const hasMore = rows.length > limit;
+    const disputes = hasMore ? rows.slice(0, limit) : rows;
+    const last = disputes[disputes.length - 1];
+    const nextCursor =
+      hasMore && last
+        ? this.encodeDisputeCursor(last.createdAt, last.id)
+        : null;
 
     return {
       disputes,
-      total,
-      page,
+      next_cursor: nextCursor,
+      has_more: hasMore,
       limit,
+      counts_by_status: counts,
     };
+  }
+
+  private encodeDisputeCursor(createdAt: Date, id: string): string {
+    return Buffer.from(`${createdAt.toISOString()}:${id}`, 'utf-8').toString(
+      'base64',
+    );
+  }
+
+  private decodeDisputeCursor(cursor: string): { createdAt: Date; id: string } {
+    try {
+      const decoded = Buffer.from(cursor, 'base64').toString('utf-8');
+      const separatorIndex = decoded.lastIndexOf(':');
+      const isoDate = decoded.slice(0, separatorIndex);
+      const id = decoded.slice(separatorIndex + 1);
+      const createdAt = new Date(isoDate);
+      if (!id || Number.isNaN(createdAt.getTime())) {
+        throw new Error('malformed cursor');
+      }
+      return { createdAt, id };
+    } catch {
+      throw new BadRequestException('Invalid pagination cursor');
+    }
+  }
+
+  /** Counts of disputes grouped by status, for list response metadata. */
+  private async countByStatus(): Promise<DisputeStatusCounts> {
+    const rows = await this.disputesRepository
+      .createQueryBuilder('dispute')
+      .select('dispute.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('dispute.status')
+      .getRawMany<{ status: DisputeStatus; count: string }>();
+
+    const counts: DisputeStatusCounts = { pending: 0, resolved: 0 };
+    for (const row of rows) {
+      if (row.status === DisputeStatus.PENDING) {
+        counts.pending = Number(row.count);
+      } else if (row.status === DisputeStatus.RESOLVED) {
+        counts.resolved = Number(row.count);
+      }
+    }
+    return counts;
   }
 
   /**

--- a/backend/src/disputes/dto/list-disputes.dto.ts
+++ b/backend/src/disputes/dto/list-disputes.dto.ts
@@ -1,4 +1,12 @@
-import { IsOptional, IsString, IsEnum, IsInt, Min, Max, IsDateString } from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsInt,
+  Min,
+  Max,
+  IsDateString,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { DisputeStatus } from '../entities/dispute.entity';
@@ -10,7 +18,7 @@ import { DisputeStatus } from '../entities/dispute.entity';
  */
 export class ListDisputesDto {
   @ApiPropertyOptional({
-    description: 'Opaque cursor from a previous page\'s next_cursor',
+    description: "Opaque cursor from a previous page's next_cursor",
   })
   @IsOptional()
   @IsString()

--- a/backend/src/disputes/dto/list-disputes.dto.ts
+++ b/backend/src/disputes/dto/list-disputes.dto.ts
@@ -1,0 +1,66 @@
+import { IsOptional, IsString, IsEnum, IsInt, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { DisputeStatus } from '../entities/dispute.entity';
+
+/**
+ * Query DTO for the GET /disputes list endpoint.
+ * Cursor pagination (opaque `ledger`-style cursor over id+created_at) with a
+ * hard cap on page size, plus status/date-range filters.
+ */
+export class ListDisputesDto {
+  @ApiPropertyOptional({
+    description: 'Opaque cursor from a previous page\'s next_cursor',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    description: 'Results per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'limit must be an integer' })
+  @Min(1, { message: 'limit must not be less than 1' })
+  @Max(100, { message: 'limit must not be greater than 100' })
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    description: 'Filter by dispute status',
+    enum: DisputeStatus,
+  })
+  @IsOptional()
+  @IsEnum(DisputeStatus)
+  status?: DisputeStatus;
+
+  @ApiPropertyOptional({
+    description: 'Only include disputes created on/after this ISO date',
+  })
+  @IsOptional()
+  @IsDateString()
+  created_after?: string;
+
+  @ApiPropertyOptional({
+    description: 'Only include disputes created on/before this ISO date',
+  })
+  @IsOptional()
+  @IsDateString()
+  created_before?: string;
+}
+
+export interface DisputeStatusCounts {
+  pending: number;
+  resolved: number;
+}
+
+export interface PaginatedDisputesResponse {
+  disputes: import('../entities/dispute.entity').Dispute[];
+  next_cursor: string | null;
+  has_more: boolean;
+  limit: number;
+  counts_by_status: DisputeStatusCounts;
+}

--- a/backend/src/flags/feature-flags.service.spec.ts
+++ b/backend/src/flags/feature-flags.service.spec.ts
@@ -2,11 +2,13 @@ import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AdminAuditLog } from '../admin/entities/admin-audit-log.entity';
-import { FeatureFlag } from './entities/feature-flag.entity';
+import { FeatureFlag, FlagTargetType } from './entities/feature-flag.entity';
 import {
   FeatureFlagsService,
   FEATURE_FLAG_AUDIT_ACTIONS,
 } from './feature-flags.service';
+import { FlagEvaluationCacheService } from './flag-evaluation-cache.service';
+import { User } from '../users/entities/user.entity';
 
 describe('FeatureFlagsService - audit trail', () => {
   let service: FeatureFlagsService;
@@ -65,10 +67,11 @@ describe('FeatureFlagsService - audit trail', () => {
           provide: getRepositoryToken(AdminAuditLog),
           useValue: auditRepository,
         },
+        FlagEvaluationCacheService,
       ],
     }).compile();
 
-    service = module.get<FeatureFlagsService>(FeatureFlagsService);
+    service = await module.resolve<FeatureFlagsService>(FeatureFlagsService);
   });
 
   describe('update', () => {
@@ -217,5 +220,130 @@ describe('FeatureFlagsService - audit trail', () => {
         flagId: 'flag-1',
       });
     });
+  });
+});
+
+describe('FeatureFlagsService - rollout evaluation and per-request caching', () => {
+  let service: FeatureFlagsService;
+  let featureFlagsRepository: { find: jest.Mock; findOne: jest.Mock };
+
+  const buildFlag = (overrides: Partial<FeatureFlag> = {}): FeatureFlag =>
+    ({
+      id: 'flag-1',
+      key: 'new_slip_ui',
+      name: 'New Slip UI',
+      description: null,
+      is_enabled: true,
+      targeting_type: null,
+      targeting_rules: null,
+      rollout_percentage: 0,
+      created_at: new Date('2026-01-01T00:00:00Z'),
+      updated_at: new Date('2026-01-01T00:00:00Z'),
+      ...overrides,
+    }) as FeatureFlag;
+
+  const buildUser = (id: string): User => ({ id }) as User;
+
+  beforeEach(async () => {
+    featureFlagsRepository = { find: jest.fn(), findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeatureFlagsService,
+        {
+          provide: getRepositoryToken(FeatureFlag),
+          useValue: featureFlagsRepository,
+        },
+        {
+          provide: getRepositoryToken(AdminAuditLog),
+          useValue: { create: jest.fn(), save: jest.fn() },
+        },
+        FlagEvaluationCacheService,
+      ],
+    }).compile();
+
+    service = await module.resolve<FeatureFlagsService>(FeatureFlagsService);
+  });
+
+  it('buckets the same user into the same percentage-rollout outcome across repeated calls', async () => {
+    const flag = buildFlag({
+      targeting_type: FlagTargetType.PERCENTAGE,
+      rollout_percentage: 50,
+    });
+    featureFlagsRepository.findOne.mockResolvedValue(flag);
+    const user = buildUser('user-stable-bucket');
+
+    const first = await service.resolveFlagForUser('new_slip_ui', user);
+    const second = await service.resolveFlagForUser('new_slip_ui', user);
+
+    expect(first?.is_enabled).toBe(second?.is_enabled);
+  });
+
+  it('splits two different users deterministically at a 0/100% extreme without relying on hash luck', async () => {
+    const alwaysOff = buildFlag({
+      targeting_type: FlagTargetType.PERCENTAGE,
+      rollout_percentage: 0,
+    });
+    const alwaysOn = buildFlag({
+      targeting_type: FlagTargetType.PERCENTAGE,
+      rollout_percentage: 100,
+    });
+
+    featureFlagsRepository.findOne.mockResolvedValueOnce(alwaysOff);
+    const off = await service.resolveFlagForUser(
+      'new_slip_ui',
+      buildUser('user-a'),
+    );
+    expect(off?.is_enabled).toBe(false);
+
+    featureFlagsRepository.findOne.mockResolvedValueOnce(alwaysOn);
+    const on = await service.resolveFlagForUser(
+      'new_slip_ui',
+      buildUser('user-b'),
+    );
+    expect(on?.is_enabled).toBe(true);
+  });
+
+  it('applies user-list targeting overrides regardless of rollout percentage', async () => {
+    const flag = buildFlag({
+      targeting_type: FlagTargetType.USER_LIST,
+      targeting_rules: { user_ids: ['user-vip'] },
+    });
+    featureFlagsRepository.findOne.mockResolvedValue(flag);
+
+    const included = await service.resolveFlagForUser(
+      'new_slip_ui',
+      buildUser('user-vip'),
+    );
+    const excluded = await service.resolveFlagForUser(
+      'new_slip_ui',
+      buildUser('user-other'),
+    );
+
+    expect(included?.is_enabled).toBe(true);
+    expect(excluded?.is_enabled).toBe(false);
+  });
+
+  it('caches the evaluation for a flag/user pair so a second lookup skips the repository', async () => {
+    const flag = buildFlag();
+    featureFlagsRepository.findOne.mockResolvedValue(flag);
+    const user = buildUser('user-cache-1');
+
+    await service.resolveFlagForUser('new_slip_ui', user);
+    await service.resolveFlagForUser('new_slip_ui', user);
+
+    expect(featureFlagsRepository.findOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolveFlagsForUser populates the same cache resolveFlagForUser reads from', async () => {
+    const flag = buildFlag();
+    featureFlagsRepository.find.mockResolvedValue([flag]);
+    featureFlagsRepository.findOne.mockResolvedValue(flag);
+    const user = buildUser('user-cache-2');
+
+    await service.resolveFlagsForUser(user);
+    await service.resolveFlagForUser('new_slip_ui', user);
+
+    expect(featureFlagsRepository.findOne).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/flags/feature-flags.service.ts
+++ b/backend/src/flags/feature-flags.service.ts
@@ -14,6 +14,7 @@ import {
   FlagAttributeOperator,
 } from './entities/feature-flag.entity';
 import { CreateFeatureFlagDto } from './dto/create-feature-flag.dto';
+import { FlagEvaluationCacheService } from './flag-evaluation-cache.service';
 import * as crypto from 'crypto';
 
 export interface ResolvedFlagDto {
@@ -51,6 +52,7 @@ export class FeatureFlagsService {
     private readonly featureFlagsRepository: Repository<FeatureFlag>,
     @InjectRepository(AdminAuditLog)
     private readonly auditRepository: Repository<AdminAuditLog>,
+    private readonly evaluationCache: FlagEvaluationCacheService,
   ) {}
 
   async create(
@@ -228,16 +230,7 @@ export class FeatureFlagsService {
   async resolveFlagsForUser(user: User): Promise<ResolvedFlagDto[]> {
     const flags = await this.featureFlagsRepository.find();
 
-    return flags.map((flag) => {
-      const resolved = this.evaluateFlagForUser(flag, user);
-      return {
-        key: flag.key,
-        name: flag.name,
-        is_enabled: resolved,
-        targeting_type: flag.targeting_type,
-        targeting_rules: flag.targeting_rules,
-      };
-    });
+    return flags.map((flag) => this.resolveAndCache(flag, user));
   }
 
   /**
@@ -247,19 +240,35 @@ export class FeatureFlagsService {
     flagKey: string,
     user: User,
   ): Promise<ResolvedFlagDto | null> {
+    const cached = this.evaluationCache.get(flagKey, user.id);
+    if (cached) return cached;
+
     const flag = await this.featureFlagsRepository.findOne({
       where: { key: flagKey },
     });
     if (!flag) return null;
 
-    const resolved = this.evaluateFlagForUser(flag, user);
-    return {
+    return this.resolveAndCache(flag, user);
+  }
+
+  /**
+   * Evaluate a flag for a user and cache the result for the rest of this
+   * request, so a second lookup of the same flag/user pair (e.g. from a
+   * guard and the controller it guards) skips re-evaluation.
+   */
+  private resolveAndCache(flag: FeatureFlag, user: User): ResolvedFlagDto {
+    const cached = this.evaluationCache.get(flag.key, user.id);
+    if (cached) return cached;
+
+    const resolved: ResolvedFlagDto = {
       key: flag.key,
       name: flag.name,
-      is_enabled: resolved,
+      is_enabled: this.evaluateFlagForUser(flag, user),
       targeting_type: flag.targeting_type,
       targeting_rules: flag.targeting_rules,
     };
+    this.evaluationCache.set(flag.key, user.id, resolved);
+    return resolved;
   }
 
   private evaluateFlagForUser(flag: FeatureFlag, user: User): boolean {

--- a/backend/src/flags/flag-evaluation-cache.service.ts
+++ b/backend/src/flags/flag-evaluation-cache.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { ResolvedFlagDto } from './feature-flags.service';
+
+/**
+ * Per-request cache of resolved feature-flag evaluations. Request-scoped so
+ * a fresh, empty cache is created for every incoming request and discarded
+ * afterwards - repeated flag lookups for the same user within one request
+ * (e.g. a guard and a controller both resolving the same key) reuse the
+ * first evaluation instead of re-querying and re-hashing on every call.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class FlagEvaluationCacheService {
+  private readonly cache = new Map<string, ResolvedFlagDto>();
+
+  private key(flagKey: string, userId: string): string {
+    return `${flagKey}:${userId}`;
+  }
+
+  get(flagKey: string, userId: string): ResolvedFlagDto | undefined {
+    return this.cache.get(this.key(flagKey, userId));
+  }
+
+  set(flagKey: string, userId: string, value: ResolvedFlagDto): void {
+    this.cache.set(this.key(flagKey, userId), value);
+  }
+}

--- a/backend/src/flags/flags.module.ts
+++ b/backend/src/flags/flags.module.ts
@@ -9,6 +9,7 @@ import { FlagsService } from './flags.service';
 import { FlagsController } from './flags.controller';
 import { FeatureFlagsService } from './feature-flags.service';
 import { FeatureFlagsController } from './feature-flags.controller';
+import { FlagEvaluationCacheService } from './flag-evaluation-cache.service';
 import { AnalyticsModule } from '../analytics/analytics.module';
 
 @Module({
@@ -17,7 +18,7 @@ import { AnalyticsModule } from '../analytics/analytics.module';
     AnalyticsModule,
   ],
   controllers: [FlagsController, FeatureFlagsController],
-  providers: [FlagsService, FeatureFlagsService],
+  providers: [FlagsService, FeatureFlagsService, FlagEvaluationCacheService],
   exports: [FlagsService, FeatureFlagsService],
 })
 export class FlagsModule {}

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -7,7 +7,7 @@ import {
   Repository,
   SelectQueryBuilder,
 } from 'typeorm';
-import { IndexerService } from './indexer.service';
+import { IndexerService, EVENT_DECODER_VERSION } from './indexer.service';
 import {
   ContractEvent,
   ContractEventStatus,
@@ -722,6 +722,86 @@ describe('IndexerService', () => {
 
       expect(contractEventRepository.delete).toHaveBeenCalled();
       expect(count).toBe(10);
+    });
+  });
+
+  describe('decoder robustness', () => {
+    it('stamps decoded events with the current decoder version', () => {
+      const parsed = (service as any).parseRawEvent(
+        {
+          ledger: 10,
+          log_index: 0,
+          topic: [{ symbol: 'event' }, { symbol: 'created' }],
+          value: { event_id: { u64: '1' } },
+        },
+        0,
+      );
+
+      expect(parsed).not.toBeNull();
+      expect(parsed.data._decoder_version).toBe(EVENT_DECODER_VERSION);
+    });
+
+    it('skips an unrecognized event shape without throwing', () => {
+      const parsed = (service as any).parseRawEvent(
+        { ledger: 10, log_index: 0, topic: [], value: {} },
+        0,
+      );
+
+      expect(parsed).toBeNull();
+    });
+
+    it('does not abort the whole batch when one raw event throws during parsing', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_RPC_URL') return 'https://rpc.example';
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        return undefined;
+      });
+
+      const goodEvent = {
+        ledger: 11,
+        log_index: 0,
+        topic: [{ symbol: 'event' }, { symbol: 'created' }],
+        value: { event_id: { u64: '1' } },
+      };
+
+      const originalParseRawEvent = (service as any).parseRawEvent.bind(
+        service,
+      );
+      jest
+        .spyOn(service as any, 'parseRawEvent')
+        .mockImplementationOnce(() => {
+          throw new Error('unexpected/new event shape');
+        })
+        .mockImplementationOnce(originalParseRawEvent);
+
+      const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          result: {
+            events: [{ malformed: true }, goodEvent],
+            latestLedger: 100,
+          },
+        }),
+      } as unknown as Response);
+
+      try {
+        const { events } = await (service as any).fetchEventsFromContract(1);
+        expect(events).toHaveLength(1);
+        expect(events[0].event_type).toBe('EventCreated');
+      } finally {
+        fetchMock.mockRestore();
+      }
+    });
+
+    it('unwrapIndexerValue does not overflow the stack on pathologically nested values', () => {
+      let nested: any = { symbol: 'leaf' };
+      for (let i = 0; i < 1000; i++) {
+        nested = { value: nested };
+      }
+
+      expect(() =>
+        (service as any).unwrapIndexerValue(nested),
+      ).not.toThrow();
     });
   });
 });

--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -799,9 +799,7 @@ describe('IndexerService', () => {
         nested = { value: nested };
       }
 
-      expect(() =>
-        (service as any).unwrapIndexerValue(nested),
-      ).not.toThrow();
+      expect(() => (service as any).unwrapIndexerValue(nested)).not.toThrow();
     });
   });
 });

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -28,6 +28,15 @@ const CHECKPOINT_LEDGER_KEY_LATEST = 'indexer:latest_contract_ledger';
 const MAX_RETRIES = 5;
 const DLQ_THRESHOLD = 5;
 const BATCH_SIZE = 100;
+/**
+ * Version of the event decoder's output shape. Bumped when a field is
+ * renamed or removed (never for a purely additive change - new fields are
+ * forward-compatible by construction since {@link extractEventData}'s
+ * default case passes unrecognized fields through as-is). Stamped onto
+ * every decoded event's `data` so downstream consumers can tell which
+ * decoding rules produced a given row.
+ */
+export const EVENT_DECODER_VERSION = 1;
 const BACKFILL_BATCH_SIZE = 50;
 const DEFAULT_CREATOR_EVENT_CATEGORY = 'general';
 // Matches MAX_EVENT_DURATION_SECONDS in contracts/creator-event-manager.
@@ -251,7 +260,16 @@ export class IndexerService implements OnModuleInit {
           : fromLedger;
 
       const parsed = rawEvents
-        .map((raw: unknown, index: number) => this.parseRawEvent(raw, index))
+        .map((raw: unknown, index: number) => {
+          try {
+            return this.parseRawEvent(raw, index);
+          } catch (err) {
+            this.logger.warn(
+              `Skipping unparseable event at index ${index}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+            );
+            return null;
+          }
+        })
         .filter((e) => e !== null);
 
       return { events: parsed, latestLedger };
@@ -299,7 +317,10 @@ export class IndexerService implements OnModuleInit {
           ? record.id
           : null;
 
-    const data = this.extractEventData(eventType, value);
+    const data = {
+      ...this.extractEventData(eventType, value),
+      _decoder_version: EVENT_DECODER_VERSION,
+    };
 
     return {
       id,
@@ -1683,13 +1704,26 @@ export class IndexerService implements OnModuleInit {
     return null;
   }
 
-  private unwrapIndexerValue(value: unknown): unknown {
+  /**
+   * Unwraps a Soroban XDR-JSON value (e.g. `{ symbol: "..." }`,
+   * `{ value: { u64: "..." } }`) down to its plain JS value. Depth is capped
+   * so a forward-incompatible or malformed nesting shape degrades to
+   * returning the wrapper as-is rather than blowing the call stack and
+   * aborting the whole event batch.
+   */
+  private unwrapIndexerValue(value: unknown, depth = 0): unknown {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return value;
+    }
+    if (depth >= 20) {
+      this.logger.warn('unwrapIndexerValue: max unwrap depth exceeded');
       return value;
     }
 
     const record = value as Record<string, unknown>;
-    if ('value' in record) return this.unwrapIndexerValue(record.value);
+    if ('value' in record) {
+      return this.unwrapIndexerValue(record.value, depth + 1);
+    }
 
     for (const key of [
       'symbol',
@@ -1706,7 +1740,9 @@ export class IndexerService implements OnModuleInit {
       'bool',
       'boolean',
     ]) {
-      if (key in record) return this.unwrapIndexerValue(record[key]);
+      if (key in record) {
+        return this.unwrapIndexerValue(record[key], depth + 1);
+      }
     }
 
     return value;

--- a/backend/src/markets/entities/market.entity.ts
+++ b/backend/src/markets/entities/market.entity.ts
@@ -36,6 +36,21 @@ export enum MarketSettlementState {
 @Index(['is_resolved'])
 @Index(['is_featured'])
 @Index(['settlement_state'])
+@Index('IDX_markets_status_sort', [
+  'is_resolved',
+  'is_cancelled',
+  'is_featured',
+  'featured_at',
+  'created_at',
+])
+@Index('IDX_markets_category_status_sort', [
+  'category',
+  'is_resolved',
+  'is_cancelled',
+  'is_featured',
+  'created_at',
+])
+@Index('IDX_markets_public_sort', ['is_public', 'is_featured', 'created_at'])
 export class Market {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/backend/src/markets/markets.service.spec.ts
+++ b/backend/src/markets/markets.service.spec.ts
@@ -14,6 +14,7 @@ import { User } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
 import { ChallengeResolutionDto } from './dto/challenge-resolution.dto';
 import { CreateMarketDto } from './dto/create-market.dto';
+import { MarketStatus } from './dto/list-markets.dto';
 import { ProposeResolutionDto } from './dto/propose-resolution.dto';
 import { ResolveChallengeDto } from './dto/resolve-challenge.dto';
 import { UpdateMarketDto } from './dto/update-market.dto';
@@ -539,6 +540,148 @@ describe('MarketsService.findFeaturedMarkets', () => {
 
     expect(mockQueryBuilder.skip).toHaveBeenCalledWith(10);
     expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+  });
+});
+
+describe('MarketsService.findAllFiltered', () => {
+  let service: MarketsService;
+  let marketsRepository: jest.Mocked<Repository<Market>>;
+
+  const makeMarket = (overrides: Partial<Market> = {}): Market =>
+    ({
+      id: `market-${Math.random()}`,
+      on_chain_market_id: `on-chain-${Math.random()}`,
+      title: 'Test Market',
+      category: 'Crypto',
+      is_resolved: false,
+      is_cancelled: false,
+      is_public: true,
+      is_featured: false,
+      created_at: new Date(),
+      ...overrides,
+    }) as Market;
+
+  const buildMockQueryBuilder = () => ({
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+  });
+
+  beforeEach(async () => {
+    marketsRepository = {
+      createQueryBuilder: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MarketsService,
+        { provide: getRepositoryToken(Market), useValue: marketsRepository },
+        { provide: getRepositoryToken(Comment), useValue: {} },
+        { provide: getRepositoryToken(MarketTemplate), useValue: {} },
+        { provide: getRepositoryToken(UserBookmark), useValue: {} },
+        { provide: getRepositoryToken(Prediction), useValue: {} },
+        {
+          provide: getRepositoryToken(MarketPriceSnapshot),
+          useValue: { create: jest.fn(), save: jest.fn(), createQueryBuilder: jest.fn() },
+        },
+        { provide: UsersService, useValue: {} },
+        { provide: SorobanService, useValue: {} },
+        { provide: DataSource, useValue: {} },
+        { provide: WebhookDispatcherService, useValue: { emit: jest.fn() } },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn(), reset: jest.fn() },
+        },
+        {
+          provide: MarketSettlementScheduler,
+          useValue: { getDeadLetterQueue: jest.fn(), retrySettlement: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MarketsService>(MarketsService);
+  });
+
+  it('filters on the indexed status columns for MarketStatus.Open', async () => {
+    const qb = buildMockQueryBuilder();
+    marketsRepository.createQueryBuilder.mockReturnValue(
+      qb as unknown as SelectQueryBuilder<Market>,
+    );
+    const openMarket = makeMarket();
+    qb.getManyAndCount.mockResolvedValue([[openMarket], 1]);
+
+    const result = await service.findAllFiltered({
+      status: MarketStatus.Open,
+      page: 1,
+      limit: 20,
+    } as any);
+
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'market.is_resolved = false AND market.is_cancelled = false',
+    );
+    expect(result.data).toEqual([openMarket]);
+    expect(result.total).toBe(1);
+  });
+
+  it('combines category and status filters (indexed together via IDX_markets_category_status_sort)', async () => {
+    const qb = buildMockQueryBuilder();
+    marketsRepository.createQueryBuilder.mockReturnValue(
+      qb as unknown as SelectQueryBuilder<Market>,
+    );
+    qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+    await service.findAllFiltered({
+      category: 'Crypto',
+      status: MarketStatus.Resolved,
+      page: 1,
+      limit: 20,
+    } as any);
+
+    expect(qb.andWhere).toHaveBeenCalledWith('market.category = :category', {
+      category: 'Crypto',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('market.is_resolved = true');
+  });
+
+  it('sorts by the indexed is_featured/featured_at/created_at columns', async () => {
+    const qb = buildMockQueryBuilder();
+    marketsRepository.createQueryBuilder.mockReturnValue(
+      qb as unknown as SelectQueryBuilder<Market>,
+    );
+    qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+    await service.findAllFiltered({ page: 1, limit: 20 } as any);
+
+    expect(qb.orderBy).toHaveBeenCalledWith('market.is_featured', 'DESC');
+    expect(qb.addOrderBy).toHaveBeenCalledWith('market.featured_at', 'DESC');
+    expect(qb.addOrderBy).toHaveBeenCalledWith('market.created_at', 'DESC');
+  });
+
+  it('paginates using page/limit consistently across pages', async () => {
+    const qb = buildMockQueryBuilder();
+    marketsRepository.createQueryBuilder.mockReturnValue(
+      qb as unknown as SelectQueryBuilder<Market>,
+    );
+    qb.getManyAndCount.mockResolvedValue([[], 30]);
+
+    const result = await service.findAllFiltered({
+      page: 2,
+      limit: 10,
+    } as any);
+
+    expect(qb.skip).toHaveBeenCalledWith(10);
+    expect(qb.take).toHaveBeenCalledWith(10);
+    expect(result).toEqual({
+      data: [],
+      total: 30,
+      page: 2,
+      limit: 10,
+      totalPages: 3,
+    });
   });
 });
 

--- a/backend/src/markets/markets.service.spec.ts
+++ b/backend/src/markets/markets.service.spec.ts
@@ -586,7 +586,11 @@ describe('MarketsService.findAllFiltered', () => {
         { provide: getRepositoryToken(Prediction), useValue: {} },
         {
           provide: getRepositoryToken(MarketPriceSnapshot),
-          useValue: { create: jest.fn(), save: jest.fn(), createQueryBuilder: jest.fn() },
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
         },
         { provide: UsersService, useValue: {} },
         { provide: SorobanService, useValue: {} },
@@ -594,11 +598,19 @@ describe('MarketsService.findAllFiltered', () => {
         { provide: WebhookDispatcherService, useValue: { emit: jest.fn() } },
         {
           provide: CACHE_MANAGER,
-          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn(), reset: jest.fn() },
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            reset: jest.fn(),
+          },
         },
         {
           provide: MarketSettlementScheduler,
-          useValue: { getDeadLetterQueue: jest.fn(), retrySettlement: jest.fn() },
+          useValue: {
+            getDeadLetterQueue: jest.fn(),
+            retrySettlement: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/backend/src/migrations/1787655600000-AddMarketsFilteringIndexes.ts
+++ b/backend/src/migrations/1787655600000-AddMarketsFilteringIndexes.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Covering indexes for the GET /markets filtered-list query builder
+ * (`MarketsService.findAllFiltered`), which filters on `category`,
+ * `is_resolved`/`is_cancelled` (status), and `is_public`, then always
+ * orders by `is_featured DESC, featured_at DESC, created_at DESC`. The
+ * existing single-column indexes on `category`/`is_resolved`/`is_featured`
+ * don't let Postgres satisfy a filtered+sorted query with a single index
+ * scan, so large tables fall back to a sequential scan or an inefficient
+ * bitmap-and-sort. These composite indexes put the common filter columns
+ * first and the sort columns after, so the planner can use them directly.
+ */
+export class AddMarketsFilteringIndexes1787655600000
+  implements MigrationInterface
+{
+  name = 'AddMarketsFilteringIndexes1787655600000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_markets_status_sort"
+      ON "markets" ("is_resolved", "is_cancelled", "is_featured", "featured_at", "created_at")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_markets_category_status_sort"
+      ON "markets" ("category", "is_resolved", "is_cancelled", "is_featured", "created_at")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_markets_public_sort"
+      ON "markets" ("is_public", "is_featured", "created_at")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_markets_public_sort"`);
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_markets_category_status_sort"`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_markets_status_sort"`);
+  }
+}

--- a/backend/src/migrations/1787655600000-AddMarketsFilteringIndexes.ts
+++ b/backend/src/migrations/1787655600000-AddMarketsFilteringIndexes.ts
@@ -11,9 +11,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * bitmap-and-sort. These composite indexes put the common filter columns
  * first and the sort columns after, so the planner can use them directly.
  */
-export class AddMarketsFilteringIndexes1787655600000
-  implements MigrationInterface
-{
+export class AddMarketsFilteringIndexes1787655600000 implements MigrationInterface {
   name = 'AddMarketsFilteringIndexes1787655600000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
# Disputes, indexer, markets, and feature-flag fixes

## Summary
- **Disputes** (`disputes.controller.ts`, `disputes.service.ts`, new `list-disputes.dto.ts`): `GET /disputes` now supports status/date-range filters and stable cursor pagination (capped at 100/page), with counts-by-status in the response metadata.
- **Contract event decoder** (`indexer.service.ts`): per-event parsing is now wrapped so one malformed/unexpected Soroban event no longer aborts the whole poll batch; added a recursion-depth guard on the XDR value unwrapper and a decoder version stamp on decoded events.
- **Markets filtering indexes** (new migration `AddMarketsFilteringIndexes`, `market.entity.ts`): added composite indexes matching `findAllFiltered`'s actual filter (category, status, is_public) and sort (is_featured, featured_at, created_at) columns.
- **Feature flags** (`feature-flags.service.ts`, new `flag-evaluation-cache.service.ts`): flag evaluations are now cached per request (request-scoped provider), so resolving the same flag/user pair twice in one request skips re-querying and re-hashing. Deterministic percentage-rollout bucketing and targeting overrides were already correct; added test coverage for both plus cache reuse.

## Testing
- `pnpm run migration:check-timestamps` ✅
- `pnpm run lint` ✅
- `pnpm run test` — 101 suites / 1289 tests ✅
- `pnpm run build` ✅

Closes #1668
Closes #1673
Closes #1661
Closes #1660
