### PR TITLE
fix(markets): advisory-lock settlement scheduler, add crash recovery

### DIFF
--- a/backend/src/markets/entities/market.entity.ts
+++ b/backend/src/markets/entities/market.entity.ts
@@ -19,12 +19,18 @@ import { User } from '../../users/entities/user.entity';
 /**
  * Grace-period settlement state machine, independent of the legacy
  * `is_resolved` flag used by the immediate admin-override resolution path.
- * PENDING -> PROPOSED -> SETTLED, with PROPOSED -> CHALLENGED -> SETTLED
- * when a challenge is raised during the grace window.
+ * PENDING -> PROPOSED -> SETTLING -> SETTLED, with PROPOSED -> CHALLENGED ->
+ * SETTLED when a challenge is raised during the grace window. SETTLING is a
+ * short-lived, crash-visible marker: MarketSettlementScheduler moves a
+ * market here once it has claimed it (advisory lock + settlement-attempt
+ * row) and before the on-chain call resolves, so a crash between those two
+ * steps leaves a durable trace instead of silently losing the market
+ * between PROPOSED and SETTLED.
  */
 export enum MarketSettlementState {
   PENDING = 'pending',
   PROPOSED = 'proposed',
+  SETTLING = 'settling',
   CHALLENGED = 'challenged',
   SETTLED = 'settled',
 }

--- a/backend/src/markets/entities/settlement-attempt.entity.ts
+++ b/backend/src/markets/entities/settlement-attempt.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { Market } from './market.entity';
+
+/**
+ * Status transitions for a single settlement attempt on a market.
+ * RESOLVING -> RESOLVED on a successful on-chain call, RESOLVING -> FAILED
+ * on a rejected/errored call. A market stuck at RESOLVING past the stale
+ * threshold (see MarketSettlementScheduler) is presumed crashed and is
+ * picked back up by a fresh attempt.
+ */
+export enum SettlementAttemptStatus {
+  RESOLVING = 'resolving',
+  RESOLVED = 'resolved',
+  FAILED = 'failed',
+}
+
+@Entity('settlement_attempts')
+@Index(['market'])
+@Index(['status'])
+@Index(['market', 'created_at'])
+export class SettlementAttempt {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Market, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'market_id' })
+  market: Market;
+
+  @Column({ type: 'uuid' })
+  market_id: string;
+
+  @Column({
+    type: 'varchar',
+    enum: SettlementAttemptStatus,
+    default: SettlementAttemptStatus.RESOLVING,
+  })
+  status: SettlementAttemptStatus;
+
+  @Column({ type: 'varchar', nullable: true })
+  proposed_outcome: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  error_message: string | null;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  completed_at: Date | null;
+}

--- a/backend/src/markets/market-settlement.scheduler.spec.ts
+++ b/backend/src/markets/market-settlement.scheduler.spec.ts
@@ -1,20 +1,34 @@
-import { Test, TestingModule } from '@nestjs/testing';
+﻿import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository, UpdateResult } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { MarketSettlementScheduler } from './market-settlement.scheduler';
 import { Market, MarketSettlementState } from './entities/market.entity';
+import {
+  SettlementAttempt,
+  SettlementAttemptStatus,
+} from './entities/settlement-attempt.entity';
 import { SorobanService } from '../soroban/soroban.service';
 import { WebhookDispatcherService } from '../webhooks/services/webhook-dispatcher.service';
 
-type MockRepo = jest.Mocked<Pick<Repository<Market>, 'find' | 'update'>>;
+type MockMarketRepo = jest.Mocked<Pick<Repository<Market>, 'find' | 'findOne'>>;
+type MockAttemptRepo = jest.Mocked<
+  Pick<Repository<SettlementAttempt>, 'findOne' | 'update'>
+>;
 
 describe('MarketSettlementScheduler', () => {
   let scheduler: MarketSettlementScheduler;
-  let marketsRepository: MockRepo;
+  let marketsRepository: MockMarketRepo;
+  let settlementAttemptRepository: MockAttemptRepo;
   let sorobanService: jest.Mocked<Pick<SorobanService, 'resolveMarket'>>;
   let webhookDispatcher: { emit: jest.Mock };
+  let dataSource: jest.Mocked<DataSource>;
 
   const currentNow = new Date('2026-06-15T12:00:00.000Z');
+
+  // Queue of advisory-lock results consumed in call order across every
+  // queryRunner created during a test — lets a test simulate "another
+  // instance already holds the lock" for a specific claim attempt.
+  let lockResultsQueue: boolean[];
 
   const makeMarket = (overrides: Partial<Market> = {}): Market =>
     ({
@@ -29,20 +43,57 @@ describe('MarketSettlementScheduler', () => {
       ...overrides,
     }) as Market;
 
+  const makeQueryRunner = () => {
+    const manager = {
+      findOne: jest.fn(),
+      create: jest.fn((_entity, plain) => plain),
+      save: jest.fn((entity) =>
+        Promise.resolve({ id: 'attempt-1', ...entity }),
+      ),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      connect: jest.fn().mockResolvedValue(undefined),
+      startTransaction: jest.fn().mockResolvedValue(undefined),
+      commitTransaction: jest.fn().mockResolvedValue(undefined),
+      rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
+      query: jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve([{ locked: lockResultsQueue.shift() ?? true }]),
+        ),
+      manager,
+    };
+  };
+
   beforeEach(async () => {
     jest.useFakeTimers();
     jest.setSystemTime(currentNow);
+    lockResultsQueue = [];
 
     marketsRepository = {
-      find: jest.fn(),
-      update: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn(),
+    };
+    settlementAttemptRepository = {
+      findOne: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue(undefined),
     };
     sorobanService = { resolveMarket: jest.fn().mockResolvedValue(undefined) };
+    dataSource = {
+      createQueryRunner: jest.fn(() => makeQueryRunner()),
+    } as unknown as jest.Mocked<DataSource>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MarketSettlementScheduler,
         { provide: getRepositoryToken(Market), useValue: marketsRepository },
+        {
+          provide: getRepositoryToken(SettlementAttempt),
+          useValue: settlementAttemptRepository,
+        },
+        { provide: DataSource, useValue: dataSource },
         { provide: SorobanService, useValue: sorobanService },
         { provide: WebhookDispatcherService, useValue: { emit: jest.fn() } },
       ],
@@ -58,38 +109,70 @@ describe('MarketSettlementScheduler', () => {
     jest.useRealTimers();
   });
 
+  const mockProposedCandidates = (markets: Market[]) => {
+    marketsRepository.find.mockImplementation(
+      ({ where }: { where: { settlement_state: MarketSettlementState } }) => {
+        if (where.settlement_state === MarketSettlementState.PROPOSED) {
+          return Promise.resolve(markets);
+        }
+        return Promise.resolve([]);
+      },
+    );
+  };
+
   it('does not settle a market whose grace period has not elapsed', async () => {
     const market = makeMarket({
       resolution_proposed_at: new Date(currentNow.getTime() - 1000), // 1s ago, grace is 86400s
     });
-    marketsRepository.find.mockResolvedValue([market]);
+    mockProposedCandidates([market]);
 
     const settled = await scheduler.settleEligibleMarkets();
 
     expect(settled).toBe(0);
-    expect(marketsRepository.update).not.toHaveBeenCalled();
+    expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
     expect(sorobanService.resolveMarket).not.toHaveBeenCalled();
   });
 
   it('settles a market once its grace period has elapsed', async () => {
     const market = makeMarket();
-    marketsRepository.find.mockResolvedValue([market]);
-    marketsRepository.update.mockResolvedValue({ affected: 1 } as UpdateResult);
+    mockProposedCandidates([market]);
+    lockResultsQueue = [true, true]; // claim, then finalize
+
+    const queryRunners: ReturnType<typeof makeQueryRunner>[] = [];
+    dataSource.createQueryRunner = jest.fn(() => {
+      const qr = makeQueryRunner();
+      qr.manager.findOne.mockResolvedValue(market);
+      queryRunners.push(qr);
+      return qr;
+    }) as unknown as jest.Mocked<DataSource>['createQueryRunner'];
 
     const settled = await scheduler.settleEligibleMarkets();
 
     expect(settled).toBe(1);
-    expect(marketsRepository.update).toHaveBeenCalledWith(
-      { id: 'market-1', settlement_state: MarketSettlementState.PROPOSED },
+    expect(sorobanService.resolveMarket).toHaveBeenCalledWith(
+      'on-chain-1',
+      'YES',
+    );
+    // Claim transaction: attempt logged RESOLVING, market moved to SETTLING.
+    expect(queryRunners[0].manager.update).toHaveBeenCalledWith(
+      Market,
+      { id: 'market-1' },
+      { settlement_state: MarketSettlementState.SETTLING },
+    );
+    // Finalize transaction: market SETTLED, attempt RESOLVED.
+    expect(queryRunners[1].manager.update).toHaveBeenCalledWith(
+      Market,
+      { id: 'market-1' },
       expect.objectContaining({
         settlement_state: MarketSettlementState.SETTLED,
         is_resolved: true,
         resolved_outcome: 'YES',
       }),
     );
-    expect(sorobanService.resolveMarket).toHaveBeenCalledWith(
-      'on-chain-1',
-      'YES',
+    expect(queryRunners[1].manager.update).toHaveBeenCalledWith(
+      SettlementAttempt,
+      { id: 'attempt-1' },
+      expect.objectContaining({ status: SettlementAttemptStatus.RESOLVED }),
     );
     expect(webhookDispatcher.emit).toHaveBeenCalledWith(
       'market.settled',
@@ -100,47 +183,169 @@ describe('MarketSettlementScheduler', () => {
   it('skips markets that are frozen by a challenge', async () => {
     // A challenged market is never returned by the PROPOSED-state query,
     // so the repository mock simply returns nothing eligible.
-    marketsRepository.find.mockResolvedValue([]);
+    mockProposedCandidates([]);
 
     const settled = await scheduler.settleEligibleMarkets();
 
     expect(settled).toBe(0);
-    expect(marketsRepository.update).not.toHaveBeenCalled();
+    expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
   });
 
-  it('settles each eligible market exactly once even when run twice back-to-back (double-run)', async () => {
+  it('settles each eligible market exactly once under concurrent schedulers (advisory lock)', async () => {
     const market = makeMarket();
-    marketsRepository.find.mockResolvedValue([market]);
-    // First call claims the row; second call's conditional WHERE no longer
-    // matches (settlement_state moved to SETTLED), so affected === 0.
-    marketsRepository.update
-      .mockResolvedValueOnce({ affected: 1 } as UpdateResult)
-      .mockResolvedValueOnce({ affected: 0 } as UpdateResult);
+    mockProposedCandidates([market]);
 
-    const firstRun = await scheduler.settleEligibleMarkets();
-    const secondRun = await scheduler.settleEligibleMarkets();
+    const queryRunners: ReturnType<typeof makeQueryRunner>[] = [];
+    dataSource.createQueryRunner = jest.fn(() => {
+      const qr = makeQueryRunner();
+      qr.manager.findOne.mockResolvedValue(market);
+      queryRunners.push(qr);
+      return qr;
+    }) as unknown as jest.Mocked<DataSource>['createQueryRunner'];
 
-    expect(firstRun).toBe(1);
-    expect(secondRun).toBe(0);
-    expect(marketsRepository.update).toHaveBeenCalledTimes(2);
+    // First "instance" claims the lock; a second, overlapping tick's claim
+    // attempt fails to acquire it. Finalize (third queryRunner) succeeds.
+    lockResultsQueue = [true, false, true];
+
+    const [firstRun, secondRun] = await Promise.all([
+      scheduler.settleEligibleMarkets(),
+      scheduler.settleEligibleMarkets(),
+    ]);
+
+    expect(firstRun + secondRun).toBe(1);
     expect(sorobanService.resolveMarket).toHaveBeenCalledTimes(1);
     expect(webhookDispatcher.emit).toHaveBeenCalledTimes(1);
+    // The losing claim rolled back rather than committing any market write.
+    const rolledBack = queryRunners.filter(
+      (qr) => qr.rollbackTransaction.mock.calls.length > 0,
+    );
+    expect(rolledBack.length).toBeGreaterThan(0);
   });
 
-  it('queues for retry without throwing when Soroban settlement fails', async () => {
+  it('does not re-settle a market another instance already resolved', async () => {
     const market = makeMarket();
-    marketsRepository.find.mockResolvedValue([market]);
-    marketsRepository.update.mockResolvedValue({ affected: 1 } as UpdateResult);
-    sorobanService.resolveMarket.mockRejectedValue(new Error('RPC down'));
+    mockProposedCandidates([market]);
+    lockResultsQueue = [true];
+
+    dataSource.createQueryRunner = jest.fn(() => {
+      const qr = makeQueryRunner();
+      // Lock is granted, but by the time we re-read the row it's already
+      // SETTLED — another instance finished first.
+      qr.manager.findOne.mockResolvedValue({
+        ...market,
+        settlement_state: MarketSettlementState.SETTLED,
+      });
+      return qr;
+    }) as unknown as jest.Mocked<DataSource>['createQueryRunner'];
 
     const settled = await scheduler.settleEligibleMarkets();
 
-    // A failed on-chain settlement is not counted as settled; it is instead
-    // added to the retry queue and no `market.settled` event is emitted.
     expect(settled).toBe(0);
-    expect(webhookDispatcher.emit).not.toHaveBeenCalledWith(
+    expect(sorobanService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('resumes a market abandoned mid-settlement by a crashed instance', async () => {
+    const settlingMarket = makeMarket({
+      settlement_state: MarketSettlementState.SETTLING,
+    });
+    marketsRepository.find.mockImplementation(
+      ({ where }: { where: { settlement_state: MarketSettlementState } }) => {
+        if (where.settlement_state === MarketSettlementState.SETTLING) {
+          return Promise.resolve([settlingMarket]);
+        }
+        return Promise.resolve([]);
+      },
+    );
+    settlementAttemptRepository.findOne.mockResolvedValue({
+      id: 'stale-attempt',
+      market_id: 'market-1',
+      status: SettlementAttemptStatus.RESOLVING,
+      created_at: new Date(currentNow.getTime() - 10 * 60 * 1000), // 10 min ago
+    } as SettlementAttempt);
+
+    lockResultsQueue = [true, true];
+    dataSource.createQueryRunner = jest.fn(() => {
+      const qr = makeQueryRunner();
+      qr.manager.findOne.mockResolvedValue(settlingMarket);
+      return qr;
+    }) as unknown as jest.Mocked<DataSource>['createQueryRunner'];
+
+    const settled = await scheduler.settleEligibleMarkets();
+
+    expect(settled).toBe(1);
+    expect(sorobanService.resolveMarket).toHaveBeenCalledWith(
+      'on-chain-1',
+      'YES',
+    );
+  });
+
+  it('does not resume a SETTLING market whose attempt is still fresh (in flight elsewhere)', async () => {
+    const settlingMarket = makeMarket({
+      settlement_state: MarketSettlementState.SETTLING,
+    });
+    marketsRepository.find.mockImplementation(
+      ({ where }: { where: { settlement_state: MarketSettlementState } }) => {
+        if (where.settlement_state === MarketSettlementState.SETTLING) {
+          return Promise.resolve([settlingMarket]);
+        }
+        return Promise.resolve([]);
+      },
+    );
+    settlementAttemptRepository.findOne.mockResolvedValue({
+      id: 'fresh-attempt',
+      market_id: 'market-1',
+      status: SettlementAttemptStatus.RESOLVING,
+      created_at: new Date(currentNow.getTime() - 30 * 1000), // 30s ago
+    } as SettlementAttempt);
+
+    const settled = await scheduler.settleEligibleMarkets();
+
+    expect(settled).toBe(0);
+    expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+    expect(sorobanService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('skip-and-logs a market whose on-chain resolution fails, without blocking the batch', async () => {
+    const failingMarket = makeMarket({
+      id: 'market-1',
+      on_chain_market_id: 'on-chain-1',
+    });
+    const healthyMarket = makeMarket({
+      id: 'market-2',
+      on_chain_market_id: 'on-chain-2',
+    });
+    mockProposedCandidates([failingMarket, healthyMarket]);
+    lockResultsQueue = [true, true, true]; // failing claim, healthy claim, healthy finalize
+
+    dataSource.createQueryRunner = jest.fn(() => {
+      const qr = makeQueryRunner();
+      qr.manager.findOne.mockImplementation(
+        (_entity: unknown, options: { where: { id: string } }) =>
+          Promise.resolve(
+            options.where.id === 'market-1' ? failingMarket : healthyMarket,
+          ),
+      );
+      return qr;
+    }) as unknown as jest.Mocked<DataSource>['createQueryRunner'];
+
+    sorobanService.resolveMarket.mockImplementation((onChainId: string) => {
+      if (onChainId === 'on-chain-1') {
+        return Promise.reject(new Error('RPC down'));
+      }
+      return Promise.resolve();
+    });
+
+    const settled = await scheduler.settleEligibleMarkets();
+
+    expect(settled).toBe(1); // only the healthy market
+    expect(settlementAttemptRepository.update).toHaveBeenCalledWith(
+      'attempt-1',
+      expect.objectContaining({ status: SettlementAttemptStatus.FAILED }),
+    );
+    expect(webhookDispatcher.emit).toHaveBeenCalledTimes(1);
+    expect(webhookDispatcher.emit).toHaveBeenCalledWith(
       'market.settled',
-      expect.any(Object),
+      expect.objectContaining({ id: 'market-2' }),
     );
     expect(scheduler.getDeadLetterQueue()).toHaveLength(1);
   });

--- a/backend/src/markets/market-settlement.scheduler.ts
+++ b/backend/src/markets/market-settlement.scheduler.ts
@@ -1,8 +1,12 @@
-import { Injectable, Logger } from '@nestjs/common';
+﻿import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { Market, MarketSettlementState } from './entities/market.entity';
+import {
+  SettlementAttempt,
+  SettlementAttemptStatus,
+} from './entities/settlement-attempt.entity';
 import { SorobanService } from '../soroban/soroban.service';
 import { WebhookDispatcherService } from '../webhooks/services/webhook-dispatcher.service';
 
@@ -19,12 +23,19 @@ export class MarketSettlementScheduler {
   private readonly MAX_SETTLEMENTS_PER_TICK = 50;
   private readonly MAX_RETRY_ATTEMPTS = 5;
   private readonly INITIAL_BACKOFF_MS = 60000; // 1 minute
+  // A market stuck in SETTLING with its latest attempt still RESOLVING past
+  // this age is presumed abandoned by a crashed/killed instance and is
+  // eligible to be picked back up.
+  private readonly STALE_SETTLING_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
   private readonly deadLetterQueue: Map<string, SettlementRetryInfo> =
     new Map();
 
   constructor(
     @InjectRepository(Market)
     private readonly marketsRepository: Repository<Market>,
+    @InjectRepository(SettlementAttempt)
+    private readonly settlementAttemptRepository: Repository<SettlementAttempt>,
+    private readonly dataSource: DataSource,
     private readonly sorobanService: SorobanService,
     private readonly webhookDispatcher: WebhookDispatcherService,
   ) {}
@@ -91,19 +102,22 @@ export class MarketSettlementScheduler {
   }
 
   /**
-   * Finds PROPOSED markets whose grace period has elapsed and settles them.
-   * Each market is claimed via a conditional UPDATE guarded on its current
-   * settlement_state, so calling this concurrently or twice for the same
-   * tick settles each eligible market exactly once.
+   * Finds PROPOSED markets whose grace period has elapsed, plus SETTLING
+   * markets abandoned by a crashed run, and settles them. Each market is
+   * claimed under a Postgres advisory lock scoped to the claim transaction,
+   * so calling this concurrently (multiple instances, or an overlapping
+   * tick) settles each eligible market exactly once. A per-market try/catch
+   * means one market's unexpected failure never blocks the rest of the
+   * batch.
    */
   async settleEligibleMarkets(): Promise<number> {
-    const candidates = await this.marketsRepository.find({
+    const proposedCandidates = await this.marketsRepository.find({
       where: { settlement_state: MarketSettlementState.PROPOSED },
       take: this.MAX_SETTLEMENTS_PER_TICK,
     });
 
     const now = Date.now();
-    const due = candidates.filter((market) => {
+    const due = proposedCandidates.filter((market) => {
       if (!market.resolution_proposed_at) {
         return false;
       }
@@ -113,11 +127,22 @@ export class MarketSettlementScheduler {
       return deadline <= now;
     });
 
+    const staleSettling = await this.findStaleSettlingMarkets();
+
     let settledCount = 0;
-    for (const market of due) {
-      const settled = await this.settleMarket(market);
-      if (settled) {
-        settledCount++;
+    for (const market of [...due, ...staleSettling]) {
+      try {
+        const settled = await this.settleMarket(market);
+        if (settled) {
+          settledCount++;
+        }
+      } catch (err) {
+        // Skip-and-log: an unexpected failure on one market must not stop
+        // the rest of the batch from being processed.
+        this.logger.error(
+          `Unexpected error settling market ${market.id}, skipping`,
+          err,
+        );
       }
     }
 
@@ -128,51 +153,213 @@ export class MarketSettlementScheduler {
     return settledCount;
   }
 
-  private async settleMarket(market: Market): Promise<boolean> {
-    const { affected } = await this.marketsRepository.update(
-      { id: market.id, settlement_state: MarketSettlementState.PROPOSED },
-      {
-        settlement_state: MarketSettlementState.SETTLED,
-        is_resolved: true,
-        resolved_outcome: market.proposed_outcome as string,
-        resolved_at: new Date(),
-      },
-    );
-
-    if (!affected) {
-      this.logger.debug(
-        `Market ${market.id} was already settled by another run, skipping`,
-      );
-      return false;
+  /**
+   * Markets left in SETTLING whose most recent attempt is still RESOLVING
+   * but old enough to be presumed lost to a crash. These are re-claimed
+   * exactly like fresh PROPOSED markets.
+   */
+  private async findStaleSettlingMarkets(): Promise<Market[]> {
+    const settlingMarkets = await this.marketsRepository.find({
+      where: { settlement_state: MarketSettlementState.SETTLING },
+      take: this.MAX_SETTLEMENTS_PER_TICK,
+    });
+    if (settlingMarkets.length === 0) {
+      return [];
     }
 
+    const staleBefore = new Date(Date.now() - this.STALE_SETTLING_THRESHOLD_MS);
+    const stale: Market[] = [];
+    for (const market of settlingMarkets) {
+      const latestAttempt = await this.settlementAttemptRepository.findOne({
+        where: { market_id: market.id },
+        order: { created_at: 'DESC' },
+      });
+      if (
+        latestAttempt &&
+        latestAttempt.status === SettlementAttemptStatus.RESOLVING &&
+        latestAttempt.created_at <= staleBefore
+      ) {
+        stale.push(market);
+      }
+    }
+    return stale;
+  }
+
+  /**
+   * Acquire a transaction-scoped advisory lock for a market. Scoped with
+   * `pg_try_advisory_xact_lock` rather than session-scoped so it is
+   * released automatically on commit, rollback, *or* a dropped connection —
+   * a crashed instance can never hold the lock forever.
+   */
+  private async acquireAdvisoryLock(
+    queryRunner: QueryRunner,
+    marketId: string,
+  ): Promise<boolean> {
+    const result: Array<{ locked: boolean }> = await queryRunner.query(
+      'SELECT pg_try_advisory_xact_lock(hashtext($1)) AS locked',
+      [marketId],
+    );
+    return result?.[0]?.locked === true;
+  }
+
+  /**
+   * Claim a market for settlement: acquire the advisory lock, re-verify
+   * eligibility under the lock (guards against re-settling a market another
+   * instance already resolved), write a settlement-attempt row, and mark
+   * the market SETTLING — all in one short transaction. Returns the claimed
+   * outcome/attempt id, or null if the market could not be claimed.
+   */
+  private async claimMarketForSettlement(
+    market: Market,
+  ): Promise<{ outcome: string; attemptId: string } | null> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
     try {
-      await this.sorobanService.resolveMarket(
-        market.on_chain_market_id,
-        market.proposed_outcome as string,
-      );
+      const gotLock = await this.acquireAdvisoryLock(queryRunner, market.id);
+      if (!gotLock) {
+        await queryRunner.rollbackTransaction();
+        this.logger.debug(
+          `Market ${market.id} is locked by another instance, skipping`,
+        );
+        return null;
+      }
+
+      const fresh = await queryRunner.manager.findOne(Market, {
+        where: { id: market.id },
+      });
+      const stillEligible =
+        fresh &&
+        (fresh.settlement_state === MarketSettlementState.PROPOSED ||
+          fresh.settlement_state === MarketSettlementState.SETTLING) &&
+        !!fresh.proposed_outcome;
+
+      if (!stillEligible) {
+        await queryRunner.rollbackTransaction();
+        this.logger.debug(
+          `Market ${market.id} no longer eligible (state=${fresh?.settlement_state}), skipping`,
+        );
+        return null;
+      }
+
+      const attempt = queryRunner.manager.create(SettlementAttempt, {
+        market_id: fresh.id,
+        status: SettlementAttemptStatus.RESOLVING,
+        proposed_outcome: fresh.proposed_outcome,
+      });
+      const savedAttempt = await queryRunner.manager.save(attempt);
+
+      if (fresh.settlement_state !== MarketSettlementState.SETTLING) {
+        await queryRunner.manager.update(
+          Market,
+          { id: fresh.id },
+          { settlement_state: MarketSettlementState.SETTLING },
+        );
+      }
+
+      await queryRunner.commitTransaction();
+      return {
+        outcome: fresh.proposed_outcome as string,
+        attemptId: savedAttempt.id,
+      };
     } catch (err) {
-      this.logger.error(
-        `Soroban settlement call failed for market ${market.id}`,
-        err,
+      await queryRunner.rollbackTransaction();
+      this.logger.error(`Failed to claim market ${market.id}`, err);
+      return null;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /**
+   * Record the outcome of an attempt and, on success, flip the market to
+   * SETTLED. Reacquires the advisory lock for this short write so a
+   * concurrent stale-recovery pass can't interleave with it.
+   */
+  private async finalizeSettlement(
+    market: Market,
+    outcome: string,
+    attemptId: string,
+  ): Promise<void> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      await this.acquireAdvisoryLock(queryRunner, market.id);
+      await queryRunner.manager.update(
+        Market,
+        { id: market.id },
+        {
+          settlement_state: MarketSettlementState.SETTLED,
+          is_resolved: true,
+          resolved_outcome: outcome,
+          resolved_at: new Date(),
+        },
       );
-      // Add to retry queue with exponential backoff
-      await this.addToRetryQueue(
-        market,
-        err instanceof Error ? err.message : 'Unknown error',
+      await queryRunner.manager.update(
+        SettlementAttempt,
+        { id: attemptId },
+        { status: SettlementAttemptStatus.RESOLVED, completed_at: new Date() },
       );
-      return false;
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
     }
 
     await this.webhookDispatcher.emit('market.settled', {
       id: market.id,
       on_chain_market_id: market.on_chain_market_id,
-      resolved_outcome: market.proposed_outcome,
+      resolved_outcome: outcome,
       settled_at: new Date(),
     });
 
     this.logger.log(`Market ${market.id} settled after grace period elapsed`);
+  }
 
+  private async recordAttemptFailure(
+    attemptId: string,
+    errorMessage: string,
+  ): Promise<void> {
+    await this.settlementAttemptRepository.update(attemptId, {
+      status: SettlementAttemptStatus.FAILED,
+      error_message: errorMessage,
+      completed_at: new Date(),
+    });
+  }
+
+  private async settleMarket(market: Market): Promise<boolean> {
+    const claim = await this.claimMarketForSettlement(market);
+    if (!claim) {
+      return false;
+    }
+    const { outcome, attemptId } = claim;
+
+    // The on-chain call runs outside the claim transaction/lock so a slow
+    // or hanging RPC call never holds a DB connection or an advisory lock.
+    // The market stays SETTLING (and the attempt row stays RESOLVING) for
+    // the duration; if this process dies here, the next sweep's staleness
+    // check resumes it instead of losing it silently between states.
+    try {
+      await this.sorobanService.resolveMarket(
+        market.on_chain_market_id,
+        outcome,
+      );
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+      this.logger.error(
+        `Soroban settlement call failed for market ${market.id}`,
+        err,
+      );
+      await this.recordAttemptFailure(attemptId, errorMsg);
+      await this.addToRetryQueue(market, errorMsg);
+      return false;
+    }
+
+    await this.finalizeSettlement(market, outcome, attemptId);
     return true;
   }
 

--- a/backend/src/markets/markets.module.ts
+++ b/backend/src/markets/markets.module.ts
@@ -19,6 +19,7 @@ import { ApiKeyGuard } from '../common/guards/api-key.guard';
 import { PublicMarketsController } from './public-markets.controller';
 
 import { MarketPriceSnapshot } from './entities/market-price-snapshot.entity';
+import { SettlementAttempt } from './entities/settlement-attempt.entity';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { MarketPriceSnapshot } from './entities/market-price-snapshot.entity';
       UserBookmark,
       Prediction,
       MarketPriceSnapshot,
+      SettlementAttempt,
     ]),
     UsersModule,
     AnalyticsModule,

--- a/backend/src/migrations/1777900000000-CreateSettlementAttempts.ts
+++ b/backend/src/migrations/1777900000000-CreateSettlementAttempts.ts
@@ -1,0 +1,105 @@
+﻿import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateSettlementAttempts1777900000000 implements MigrationInterface {
+  name = 'CreateSettlementAttempts1777900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // New intermediate settlement state: claimed-but-not-yet-confirmed.
+    await queryRunner.query(
+      `ALTER TYPE "public"."market_settlement_state" ADD VALUE IF NOT EXISTS 'settling' AFTER 'proposed'`,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'settlement_attempts',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'market_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'varchar',
+            default: `'resolving'`,
+            isNullable: false,
+          },
+          {
+            name: 'proposed_outcome',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'error_message',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'completed_at',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createForeignKey(
+      'settlement_attempts',
+      new TableForeignKey({
+        name: 'FK_settlement_attempts_market',
+        columnNames: ['market_id'],
+        referencedTableName: 'markets',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'settlement_attempts',
+      new TableIndex({
+        name: 'IDX_settlement_attempts_market_created',
+        columnNames: ['market_id', 'created_at'],
+      }),
+    );
+    await queryRunner.createIndex(
+      'settlement_attempts',
+      new TableIndex({
+        name: 'IDX_settlement_attempts_status',
+        columnNames: ['status'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('settlement_attempts');
+    // Postgres cannot drop a single enum value; 'settling' is left in the
+    // type on down-migration (harmless — no row will reference it once the
+    // scheduler code is reverted alongside this migration).
+  }
+}


### PR DESCRIPTION
Closes #1506

Summary

MarketSettlementScheduler could double-settle a market under concurrency and left markets in a partial state if the process crashed between marking a market settled in the DB and confirming the settlement on-chain.

Changes
Advisory locking: pg_try_advisory_xact_lock (transaction-scoped) wraps each market's claim step, so concurrent scheduler instances — or an overlapping cron tick — settle a given market exactly once. The lock releases automatically on commit, rollback, or a dropped connection, so a crashed instance can never hold it indefinitely.
Crash-safe intermediate state: added a SETTLING value to MarketSettlementState. A market moves here once claimed but before the on-chain call resolves, so a crash mid-settlement leaves a durable, recoverable trace instead of silently stranding the market between PROPOSED and SETTLED.
Settlement attempt log: new SettlementAttempt entity/table records status transitions (resolving → resolved/failed) per attempt.
Crash recovery: markets stuck in SETTLING with their latest attempt still resolving past a 5-minute threshold are picked back up on the next sweep, guarded by the same advisory lock.
Batch resilience: per-market try/catch in the sweep loop, so one market's unexpected failure (or on-chain rejection) is skipped and logged rather than blocking the rest of the batch.
Files
backend/src/markets/market-settlement.scheduler.ts — core fix
backend/src/markets/entities/market.entity.ts — new SETTLING state
backend/src/markets/entities/settlement-attempt.entity.ts — new entity
backend/src/markets/markets.module.ts — registers new entity
backend/src/migrations/1777900000000-CreateSettlementAttempts.ts — new migration
backend/src/markets/market-settlement.scheduler.spec.ts — 9 new tests
Tests
New scheduler suite: 9/9 passing (concurrent-instance locking, no re-settling an already-resolved market, crash-recovery resume, fresh-in-flight markets not double-picked, skip-and-log on failure)
Full markets module suite: 105/105 passing
eslint: 0 errors
tsc --noEmit: no new errors (confirmed the 51 pre-existing repo-wide errors are unrelated to this change, none in touched files)
Migration timestamp check: passed