### PR TITLE
fix(open-market): distinguish quorum failure from slippage failure vi…

### DIFF
--- a/contracts/open-market/src/errors.rs
+++ b/contracts/open-market/src/errors.rs
@@ -85,6 +85,9 @@ pub enum InsightArenaError {
     AlreadyPredicted = 21,
     /// The submitted stake is below the market's `min_stake` threshold.
     /// Raised during prediction submission to enforce the minimum entry amount.
+    /// REUSED for AMM swap slippage protection: also raised by
+    /// `liquidity::swap_outcome` when the computed `amount_out` falls below
+    /// the caller-supplied `min_amount_out` guard.
     StakeTooLow = 22,
     /// The submitted stake exceeds the market's `max_stake` ceiling.
     /// Raised during prediction submission to enforce the maximum entry amount.
@@ -158,6 +161,9 @@ pub enum InsightArenaError {
     Paused = 101,
     /// A supplied argument fails basic validation that is not covered by a more
     /// specific error code (e.g. empty strings, zero-length outcome lists).
+    /// REUSED by `governance::execute_proposal`: also raised when a proposal's
+    /// voting window closes with turnout below `Config::governance_quorum_bps`,
+    /// distinguishing a quorum failure from a majority failure (`Unauthorized`).
     InvalidInput = 102,
 
     // ── Conditional Markets ───────────────────────────────────────────────────

--- a/contracts/open-market/src/governance.rs
+++ b/contracts/open-market/src/governance.rs
@@ -224,6 +224,13 @@ pub fn vote(
 /// `ready_at` (including a queued proposal's own queuing check re-run) then
 /// returns `TimelockNotElapsed`. Once `ready_at` is reached, a further call
 /// actually applies the effect.
+///
+/// The queueing check on that first call distinguishes two ways voting can
+/// fail to pass: `InvalidInput` if turnout fell below the configured quorum
+/// (`Config::governance_quorum_bps`), or `Unauthorized` if quorum was met but
+/// `votes_for <= votes_against`. Reused rather than dedicated variants
+/// because `InsightArenaError` is already at the 50-case XDR cap (see
+/// `errors.rs`).
 pub fn execute_proposal(
     env: &Env,
     executor: Address,
@@ -270,7 +277,17 @@ pub fn execute_proposal(
             actual_votes_scaled >= required_votes
         };
 
-        if !quorum_met || proposal.votes_for <= proposal.votes_against {
+        // A quorum failure (turnout too low to judge the vote at all) and a
+        // majority failure (turnout was sufficient, but the vote itself
+        // didn't pass) are distinct outcomes, surfaced via different errors.
+        // They can't be distinguished via `Proposal` state instead: a
+        // contract call that returns `Err` reverts every write it made (see
+        // this function's doc comment above), so nothing set here on the
+        // failing path would ever persist.
+        if !quorum_met {
+            return Err(InsightArenaError::InvalidInput);
+        }
+        if proposal.votes_for <= proposal.votes_against {
             return Err(InsightArenaError::Unauthorized);
         }
 

--- a/contracts/open-market/src/liquidity.rs
+++ b/contracts/open-market/src/liquidity.rs
@@ -1008,8 +1008,11 @@ pub fn swap_outcome(
 
     let amount_out = calculate_swap_output(amount_in, from_reserve, to_reserve, effective_fee_bps)?;
 
+    // Slippage guard: reject if the computed output falls below the caller's
+    // minimum. See `InsightArenaError::StakeTooLow` for why this reuses that
+    // variant rather than adding a new one (the error enum is at its 50-case cap).
     if amount_out < min_amount_out {
-        return Err(InsightArenaError::InvalidInput);
+        return Err(InsightArenaError::StakeTooLow);
     }
 
     let fee_amount = amount_in

--- a/contracts/open-market/src/storage_types.rs
+++ b/contracts/open-market/src/storage_types.rs
@@ -123,6 +123,12 @@ pub enum DataKey {
 /// the current ledger time rather than persisted directly.
 ///
 /// `Voting -> Queued -> Executable -> (Executed | Vetoed | Cancelled)`
+///
+/// Note: there is no terminal state for "voting closed without passing" —
+/// a Soroban contract call that returns `Err` reverts every write it made
+/// (see `governance::execute_proposal`), so a failed quorum/majority check
+/// can never persist a state transition. That distinction is instead made
+/// via the returned error: see `governance::execute_proposal`'s doc comment.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProposalState {

--- a/contracts/open-market/tests/governance_tests.rs
+++ b/contracts/open-market/tests/governance_tests.rs
@@ -511,7 +511,7 @@ fn test_set_guardian_requires_admin() {
 // ── AC1: Proposals below quorum cannot pass ───────────────────────────────────
 
 #[test]
-fn test_quorum_failure_returns_unauthorized() {
+fn test_quorum_failure_returns_invalid_input() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, _admin) = deploy(&env);
@@ -531,9 +531,12 @@ fn test_quorum_failure_returns_unauthorized() {
 
     let executor = Address::generate(&env);
     let result = client.try_execute_proposal(&executor, &id);
+    // Issue #1678: a quorum failure is distinguished from a majority failure
+    // via a distinct error code (InvalidInput vs. Unauthorized) rather than
+    // proposal state, since a call returning Err reverts every write it made.
     assert!(
-        matches!(result, Err(Ok(InsightArenaError::Unauthorized))),
-        "expected Unauthorized when votes < quorum, got {:?}",
+        matches!(result, Err(Ok(InsightArenaError::InvalidInput))),
+        "expected InvalidInput when votes < quorum, got {:?}",
         result
     );
 }
@@ -556,8 +559,8 @@ fn test_zero_votes_with_registered_users_fails_quorum() {
     let executor = Address::generate(&env);
     let result = client.try_execute_proposal(&executor, &id);
     assert!(
-        matches!(result, Err(Ok(InsightArenaError::Unauthorized))),
-        "expected Unauthorized when no votes cast, got {:?}",
+        matches!(result, Err(Ok(InsightArenaError::InvalidInput))),
+        "expected InvalidInput when no votes cast, got {:?}",
         result
     );
 }
@@ -585,8 +588,11 @@ fn test_majority_without_quorum_fails() {
 
     let executor = Address::generate(&env);
     let result = client.try_execute_proposal(&executor, &id);
+    // Turnout (5%) is below the 10% quorum, so this fails as a quorum
+    // failure (InvalidInput), not a majority failure — the majority-yes
+    // vote never gets evaluated because quorum is checked first.
     assert!(
-        matches!(result, Err(Ok(InsightArenaError::Unauthorized))),
+        matches!(result, Err(Ok(InsightArenaError::InvalidInput))),
         "majority alone (without quorum) must not pass"
     );
 }
@@ -722,7 +728,7 @@ fn test_higher_quorum_bps_rejects_borderline_participation() {
     let executor = Address::generate(&env);
     let result = client.try_execute_proposal(&executor, &id);
     assert!(
-        matches!(result, Err(Ok(InsightArenaError::Unauthorized))),
+        matches!(result, Err(Ok(InsightArenaError::InvalidInput))),
         "40% participation should fail a 50% quorum requirement"
     );
 }
@@ -911,5 +917,86 @@ fn test_full_governance_lifecycle_quorum_timelock_execute() {
         client.get_config().protocol_fee_bps,
         350,
         "fee must be updated after execution"
+    );
+}
+
+// ── Issue #1678: Distinguish quorum-fail from vote-fail ───────────────────────
+//
+// `execute_proposal` cannot record which failure occurred in `Proposal` state:
+// a Soroban call that returns `Err` reverts every write it made, so nothing
+// persisted on the failing path would survive. The distinction is therefore
+// made via the returned error instead (see `governance::execute_proposal`'s
+// doc comment): `InvalidInput` for a quorum failure, `Unauthorized` for a
+// majority failure once quorum is met.
+
+#[test]
+fn test_majority_failure_returns_unauthorized_when_quorum_met() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = deploy(&env);
+
+    // Quorum set to 0 so only the majority check can fail.
+    client.set_governance_quorum_bps(&admin, &0_u32);
+
+    let duration = 3_600_u64;
+    let proposer = Address::generate(&env);
+    let id = client.create_proposal(&proposer, &ProposalType::UpdateProtocolFee(400), &duration);
+
+    let voter_for = Address::generate(&env);
+    let voter_against = Address::generate(&env);
+    client.vote(&voter_for, &id, &true);
+    client.vote(&voter_against, &id, &false);
+    // Tie: votes_for (1) <= votes_against (1) fails majority, though quorum
+    // (0 bps) is trivially met.
+
+    env.ledger().with_mut(|l| l.timestamp += duration + 1);
+
+    let executor = Address::generate(&env);
+    let result = client.try_execute_proposal(&executor, &id);
+    assert!(
+        matches!(result, Err(Ok(InsightArenaError::Unauthorized))),
+        "a majority failure with quorum met must return Unauthorized, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_quorum_fail_and_majority_fail_return_different_errors() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let duration = 3_600_u64;
+
+    // Below-quorum proposal: 1 vote cast against 20 registered users (10%
+    // quorum requires 2).
+    let (client_a, _admin_a) = deploy(&env);
+    register_users(&env, &client_a, 20);
+    let proposer_a = Address::generate(&env);
+    let id_a =
+        client_a.create_proposal(&proposer_a, &ProposalType::UpdateProtocolFee(400), &duration);
+    let lone_voter = Address::generate(&env);
+    client_a.vote(&lone_voter, &id_a, &true);
+    env.ledger().with_mut(|l| l.timestamp += duration + 1);
+    let executor_a = Address::generate(&env);
+    let result_a = client_a.try_execute_proposal(&executor_a, &id_a);
+
+    // Quorum met (0 bps), but the vote itself is a tie.
+    let (client_b, admin_b) = deploy(&env);
+    client_b.set_governance_quorum_bps(&admin_b, &0_u32);
+    let proposer_b = Address::generate(&env);
+    let id_b =
+        client_b.create_proposal(&proposer_b, &ProposalType::UpdateProtocolFee(400), &duration);
+    let voter_for = Address::generate(&env);
+    let voter_against = Address::generate(&env);
+    client_b.vote(&voter_for, &id_b, &true);
+    client_b.vote(&voter_against, &id_b, &false);
+    env.ledger().with_mut(|l| l.timestamp += duration + 1);
+    let executor_b = Address::generate(&env);
+    let result_b = client_b.try_execute_proposal(&executor_b, &id_b);
+
+    assert!(matches!(result_a, Err(Ok(InsightArenaError::InvalidInput))));
+    assert!(matches!(result_b, Err(Ok(InsightArenaError::Unauthorized))));
+    assert_ne!(
+        result_a, result_b,
+        "quorum failure and majority failure must be distinguishable errors"
     );
 }

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -1110,7 +1110,43 @@ fn test_swap_outcome_fails_below_min_amount_out() {
         &swap_amount,
         &1_000_000_000_i128,
     );
-    assert!(matches!(result, Err(Ok(InsightArenaError::InvalidInput))));
+    assert!(matches!(result, Err(Ok(InsightArenaError::StakeTooLow))));
+}
+
+#[test]
+fn test_swap_outcome_at_exact_min_amount_out_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+    let trader = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 100_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    // Reserves are 500_000 / 500_000 (liquidity split across 2 outcomes) at the
+    // default volume-tier fee of 30 bps.
+    let expected_out = calculate_swap_output(swap_amount, 500_000, 500_000, 30).unwrap();
+
+    let result = client.try_swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &expected_out,
+    );
+    assert_eq!(result, Ok(Ok(expected_out)));
 }
 
 #[test]


### PR DESCRIPTION
…a distinct errors

[Contracts] — open-market: Swap Slippage / Min-Output Guard Fixes #1676

[Contracts] — open-market: Governance Proposal Quorum Enforcement Fixes #1678

[Contracts] — open-market: Timelock Cancellation Path Fixes #1679

[Contracts] — open-market: Invite Code Single-Use Race Guard Fixes #1680