### PR TITLE
Feat/1703 1704 1651 1650 fee admin comments predictions

### DIFF
--- a/backend/src/common/comment-moderation.util.ts
+++ b/backend/src/common/comment-moderation.util.ts
@@ -1,0 +1,52 @@
+/**
+ * Basic automated moderation for user-submitted comments: a profanity
+ * word-list check and a link-spam heuristic (too many URLs for a short
+ * comment). Matches are soft-hidden (`is_flagged`) rather than rejected, so
+ * the author still sees their own comment while other users don't.
+ */
+
+const PROFANITY_WORDS = [
+  'fuck',
+  'shit',
+  'bitch',
+  'asshole',
+  'bastard',
+  'cunt',
+  'dick',
+  'faggot',
+  'nigger',
+  'whore',
+];
+
+const URL_PATTERN = /https?:\/\/\S+|www\.\S+/gi;
+
+/** Comments with more than this many links are treated as link spam. */
+const MAX_LINKS_ALLOWED = 2;
+
+export interface ModerationResult {
+  flagged: boolean;
+  reason: string | null;
+}
+
+function containsProfanity(content: string): boolean {
+  const normalized = content.toLowerCase();
+  return PROFANITY_WORDS.some((word) =>
+    new RegExp(`\\b${word}\\b`, 'i').test(normalized),
+  );
+}
+
+function isLinkSpam(content: string): boolean {
+  const matches = content.match(URL_PATTERN);
+  return (matches?.length ?? 0) > MAX_LINKS_ALLOWED;
+}
+
+/** Screen a comment's content, returning whether it should be soft-hidden. */
+export function moderateCommentContent(content: string): ModerationResult {
+  if (containsProfanity(content)) {
+    return { flagged: true, reason: 'profanity' };
+  }
+  if (isLinkSpam(content)) {
+    return { flagged: true, reason: 'link_spam' };
+  }
+  return { flagged: false, reason: null };
+}

--- a/backend/src/contract/contract.service.ts
+++ b/backend/src/contract/contract.service.ts
@@ -61,6 +61,8 @@ export interface ContractPrediction {
   claimed?: boolean;
   isCorrect?: boolean | null;
   is_correct?: boolean | null;
+  isWithdrawn?: boolean;
+  is_withdrawn?: boolean;
 }
 
 export interface ContractEventStatistics {

--- a/backend/src/creator-events/creator-events-predictions-stats.spec.ts
+++ b/backend/src/creator-events/creator-events-predictions-stats.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import {
   ContractPrediction,
   ContractService,
@@ -31,6 +32,7 @@ describe('CreatorEventsService predictions and stats', () => {
     createQueryBuilder: jest.Mock;
     findOne: jest.Mock;
   };
+  let cacheManager: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
 
   const mockEvent = {
     eventId: '1',
@@ -107,11 +109,19 @@ describe('CreatorEventsService predictions and stats', () => {
         },
         {
           provide: getRepositoryToken(User),
-          useValue: {},
+          useValue: { findOne: jest.fn().mockResolvedValue(null) },
         },
         {
           provide: getRepositoryToken(CreatorEventPayout),
           useValue: {},
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: (cacheManager = {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+          }),
         },
       ],
     }).compile();
@@ -165,6 +175,89 @@ describe('CreatorEventsService predictions and stats', () => {
       await expect(
         service.getUserPredictionsForEvent('999', 'GUSER'),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('excludes withdrawn predictions from the response and score (#1650)', async () => {
+      contractService.getUserPredictions.mockResolvedValue([
+        {
+          prediction_id: 1,
+          match_id: 10,
+          predicted_outcome: 'TEAM_A',
+          predicted_at: 1_040_000,
+          is_correct: true,
+        },
+        {
+          prediction_id: 2,
+          match_id: 11,
+          predicted_outcome: 'DRAW',
+          predicted_at: 1_050_000,
+          is_withdrawn: true,
+        },
+      ] as ContractPrediction[]);
+
+      const result = await service.getUserPredictionsForEvent('1', 'GUSER');
+
+      expect(result.predictions).toHaveLength(1);
+      expect(result.predictions[0].matchId).toBe('10');
+      expect(result.score).toEqual({
+        totalPredictions: 1,
+        correctPredictions: 1,
+        accuracyPercentage: 100,
+        // The withdrawn prediction's match is no longer counted as predicted.
+        matchesRemaining: 1,
+      });
+    });
+  });
+
+  describe('getUserScore', () => {
+    beforeEach(() => {
+      contractService.getEvent.mockResolvedValue(mockEvent);
+      contractService.getEventMatches.mockResolvedValue(mockMatches);
+      contractService.getEventParticipants.mockResolvedValue([]);
+    });
+
+    it('excludes withdrawn predictions from every count (#1650)', async () => {
+      contractService.getUserPredictions.mockResolvedValue([
+        {
+          prediction_id: 1,
+          match_id: 10,
+          predicted_outcome: 'TEAM_A',
+          is_correct: true,
+        },
+        {
+          prediction_id: 2,
+          match_id: 11,
+          predicted_outcome: 'DRAW',
+          is_withdrawn: true,
+        },
+      ] as ContractPrediction[]);
+
+      const result = await service.getUserScore('1', 'GUSER');
+
+      expect(result.totalPredictions).toBe(1);
+      expect(result.correctPredictions).toBe(1);
+      expect(result.incorrectPredictions).toBe(0);
+      expect(result.pendingPredictions).toBe(0);
+      // Counts must stay internally consistent once withdrawals exist.
+      expect(result.correctPredictions + result.incorrectPredictions).toBe(
+        result.totalPredictions - result.pendingPredictions,
+      );
+    });
+  });
+
+  describe('invalidatePredictionStatsCache', () => {
+    it('deletes the event stats cache key, and the user score key when an address is given', async () => {
+      await service.invalidatePredictionStatsCache('1');
+      expect(cacheManager.del).toHaveBeenCalledWith('/creator-events/1/stats');
+      expect(cacheManager.del).toHaveBeenCalledTimes(1);
+
+      cacheManager.del.mockClear();
+
+      await service.invalidatePredictionStatsCache('1', 'GUSER');
+      expect(cacheManager.del).toHaveBeenCalledWith('/creator-events/1/stats');
+      expect(cacheManager.del).toHaveBeenCalledWith(
+        '/creator-events/1/score/GUSER',
+      );
     });
   });
 

--- a/backend/src/creator-events/creator-events.service.spec.ts
+++ b/backend/src/creator-events/creator-events.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { ContractService } from '../contract/contract.service';
@@ -80,6 +81,10 @@ describe('CreatorEventsService searchEvents', () => {
         {
           provide: getRepositoryToken(CreatorEventPayout),
           useValue: {},
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
         },
       ],
     }).compile();
@@ -205,6 +210,10 @@ describe('CreatorEventsService getUpcomingMatches', () => {
           useValue: {},
         },
         { provide: getRepositoryToken(CreatorEventPayout), useValue: {} },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
       ],
     }).compile();
 

--- a/backend/src/creator-events/creator-events.service.ts
+++ b/backend/src/creator-events/creator-events.service.ts
@@ -1,5 +1,7 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { In, Repository } from 'typeorm';
 import {
   ContractService,
@@ -98,7 +100,27 @@ export class CreatorEventsService {
     private readonly leaderboardEntryRepository: Repository<CreatorEventLeaderboardEntry>,
     @InjectRepository(CreatorEventPayout)
     private readonly creatorEventPayoutRepository: Repository<CreatorEventPayout>,
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager: Cache,
   ) {}
+
+  /**
+   * Evict the cached prediction-stats responses for an event (and, when
+   * given, a specific user's score within it) so a stale count isn't served
+   * after a prediction is edited or withdrawn. `getEventStats`/`getUserScore`
+   * are cached by `CacheInterceptor` under the raw request URL (#1650) — the
+   * keys below must match those routes exactly.
+   */
+  async invalidatePredictionStatsCache(
+    eventId: string,
+    address?: string,
+  ): Promise<void> {
+    const keys = [`/creator-events/${eventId}/stats`];
+    if (address) {
+      keys.push(`/creator-events/${eventId}/score/${address}`);
+    }
+    await Promise.all(keys.map((key) => this.cacheManager.del(key)));
+  }
 
   async searchEvents(
     query: SearchEventsQueryDto,
@@ -354,6 +376,10 @@ export class CreatorEventsService {
     const predictions = rawPredictions
       .map((raw) => {
         const normalized = normalizeContractPrediction(raw);
+        if (normalized.isWithdrawn) {
+          return null;
+        }
+
         const match = matchMap.get(normalized.matchId);
         if (!match) {
           return null;
@@ -511,13 +537,20 @@ export class CreatorEventsService {
     let correctPredictions = 0;
     let incorrectPredictions = 0;
     let pendingPredictions = 0;
+    let totalPredictions = 0;
 
     for (const prediction of userPredictions) {
       const normalized = normalizeContractPrediction(prediction);
+      // Withdrawn predictions no longer represent the user's current state
+      // for this event and must not contribute to any of the counts below.
+      if (normalized.isWithdrawn) continue;
+
       const match = matches.find(
         (m) => String(m.matchId) === normalized.matchId,
       );
       if (!match) continue;
+
+      totalPredictions++;
 
       if (!match.resolved) {
         pendingPredictions++;
@@ -529,8 +562,6 @@ export class CreatorEventsService {
         incorrectPredictions++;
       }
     }
-
-    const totalPredictions = userPredictions.length;
     const resolvedPredictions = correctPredictions + incorrectPredictions;
     const accuracyPercentage =
       resolvedPredictions > 0

--- a/backend/src/creator-events/utils/prediction.util.spec.ts
+++ b/backend/src/creator-events/utils/prediction.util.spec.ts
@@ -21,6 +21,7 @@ describe('prediction.util', () => {
         predictedOutcome: 'TEAM_A',
         predictedAt: 1_700_000_000,
         isCorrect: true,
+        isWithdrawn: false,
       });
     });
 
@@ -34,6 +35,23 @@ describe('prediction.util', () => {
 
       expect(result.predictedOutcome).toBe('DRAW');
       expect(result.isCorrect).toBeNull();
+      expect(result.isWithdrawn).toBe(false);
+    });
+
+    it('normalizes a withdrawn prediction from either field casing', () => {
+      const snakeCase = normalizeContractPrediction({
+        prediction_id: 1,
+        match_id: 1,
+        is_withdrawn: true,
+      } as ContractPrediction);
+      const camelCase = normalizeContractPrediction({
+        predictionId: '1',
+        matchId: '1',
+        isWithdrawn: true,
+      });
+
+      expect(snakeCase.isWithdrawn).toBe(true);
+      expect(camelCase.isWithdrawn).toBe(true);
     });
   });
 

--- a/backend/src/creator-events/utils/prediction.util.ts
+++ b/backend/src/creator-events/utils/prediction.util.ts
@@ -6,6 +6,7 @@ export interface NormalizedPrediction {
   predictedOutcome: string;
   predictedAt: number;
   isCorrect: boolean | null;
+  isWithdrawn: boolean;
 }
 
 export function normalizeContractPrediction(
@@ -38,12 +39,15 @@ export function normalizeContractPrediction(
     isCorrect = isCorrectRaw;
   }
 
+  const isWithdrawn = (raw.isWithdrawn ?? raw.is_withdrawn) === true;
+
   return {
     predictionId,
     matchId,
     predictedOutcome,
     predictedAt,
     isCorrect,
+    isWithdrawn,
   };
 }
 

--- a/backend/src/markets/entities/comment.entity.ts
+++ b/backend/src/markets/entities/comment.entity.ts
@@ -43,6 +43,13 @@ export class Comment {
   @Column({ type: 'text', nullable: true })
   moderation_reason: string | null;
 
+  /** Soft-hidden automatically by the spam/profanity filter at creation time. */
+  @Column({ default: false })
+  is_flagged: boolean;
+
+  @Column({ type: 'text', nullable: true })
+  flagged_reason: string | null;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/backend/src/markets/markets.controller.ts
+++ b/backend/src/markets/markets.controller.ts
@@ -424,6 +424,7 @@ export class MarketsController {
 
   @Post(':id/comments')
   @UseGuards(BanGuard)
+  @ThrottleTier('write')
   @HttpCode(HttpStatus.CREATED)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Post a comment on a market' })

--- a/backend/src/markets/markets.service.comments.spec.ts
+++ b/backend/src/markets/markets.service.comments.spec.ts
@@ -27,7 +27,9 @@ describe('MarketsService - Comments moderation and rate limiting', () => {
   const mockUser = { id: 'user-1', stellar_address: 'GABC123' } as User;
   const mockMarket = { id: 'market-1' } as Market;
 
-  const makeDto = (content = 'A perfectly normal comment'): CreateCommentDto => ({
+  const makeDto = (
+    content = 'A perfectly normal comment',
+  ): CreateCommentDto => ({
     content,
   });
 
@@ -55,12 +57,24 @@ describe('MarketsService - Comments moderation and rate limiting', () => {
         { provide: getRepositoryToken(MarketTemplate), useValue: {} },
         {
           provide: getRepositoryToken(UserBookmark),
-          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn(), delete: jest.fn() },
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+          },
         },
-        { provide: getRepositoryToken(Prediction), useValue: { find: jest.fn() } },
+        {
+          provide: getRepositoryToken(Prediction),
+          useValue: { find: jest.fn() },
+        },
         {
           provide: getRepositoryToken(MarketPriceSnapshot),
-          useValue: { create: jest.fn(), save: jest.fn(), createQueryBuilder: jest.fn() },
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
         },
         { provide: UsersService, useValue: {} },
         { provide: SorobanService, useValue: {} },
@@ -68,11 +82,19 @@ describe('MarketsService - Comments moderation and rate limiting', () => {
         { provide: WebhookDispatcherService, useValue: { emit: jest.fn() } },
         {
           provide: CACHE_MANAGER,
-          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn(), reset: jest.fn() },
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            reset: jest.fn(),
+          },
         },
         {
           provide: MarketSettlementScheduler,
-          useValue: { getDeadLetterQueue: jest.fn(), retrySettlement: jest.fn() },
+          useValue: {
+            getDeadLetterQueue: jest.fn(),
+            retrySettlement: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/backend/src/markets/markets.service.comments.spec.ts
+++ b/backend/src/markets/markets.service.comments.spec.ts
@@ -1,0 +1,176 @@
+import { HttpException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { MarketsService } from './markets.service';
+import { MarketSettlementScheduler } from './market-settlement.scheduler';
+import { Market } from './entities/market.entity';
+import { Comment } from './entities/comment.entity';
+import { MarketTemplate } from './entities/market-template.entity';
+import { UserBookmark } from './entities/user-bookmark.entity';
+import { Prediction } from '../predictions/entities/prediction.entity';
+import { MarketPriceSnapshot } from './entities/market-price-snapshot.entity';
+import { SorobanService } from '../soroban/soroban.service';
+import { UsersService } from '../users/users.service';
+import { User } from '../users/entities/user.entity';
+import { WebhookDispatcherService } from '../webhooks/services/webhook-dispatcher.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+
+describe('MarketsService - Comments moderation and rate limiting', () => {
+  let service: MarketsService;
+  let marketsRepository: jest.Mocked<Pick<Repository<Market>, 'findOne'>>;
+  let commentsRepository: jest.Mocked<
+    Pick<Repository<Comment>, 'create' | 'save' | 'findOne' | 'findAndCount'>
+  >;
+
+  const mockUser = { id: 'user-1', stellar_address: 'GABC123' } as User;
+  const mockMarket = { id: 'market-1' } as Market;
+
+  const makeDto = (content = 'A perfectly normal comment'): CreateCommentDto => ({
+    content,
+  });
+
+  beforeEach(async () => {
+    marketsRepository = {
+      findOne: jest.fn().mockResolvedValue(mockMarket),
+    };
+
+    commentsRepository = {
+      create: jest.fn((data) => data),
+      save: jest.fn(async (data) => data),
+      findOne: jest.fn().mockResolvedValue(null), // no prior comment by default
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+    } as any;
+
+    const dataSource = {
+      createQueryRunner: jest.fn(),
+    } as unknown as DataSource;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MarketsService,
+        { provide: getRepositoryToken(Market), useValue: marketsRepository },
+        { provide: getRepositoryToken(Comment), useValue: commentsRepository },
+        { provide: getRepositoryToken(MarketTemplate), useValue: {} },
+        {
+          provide: getRepositoryToken(UserBookmark),
+          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn(), delete: jest.fn() },
+        },
+        { provide: getRepositoryToken(Prediction), useValue: { find: jest.fn() } },
+        {
+          provide: getRepositoryToken(MarketPriceSnapshot),
+          useValue: { create: jest.fn(), save: jest.fn(), createQueryBuilder: jest.fn() },
+        },
+        { provide: UsersService, useValue: {} },
+        { provide: SorobanService, useValue: {} },
+        { provide: DataSource, useValue: dataSource },
+        { provide: WebhookDispatcherService, useValue: { emit: jest.fn() } },
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn(), reset: jest.fn() },
+        },
+        {
+          provide: MarketSettlementScheduler,
+          useValue: { getDeadLetterQueue: jest.fn(), retrySettlement: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MarketsService>(MarketsService);
+  });
+
+  describe('rate limiting', () => {
+    it('allows a comment when the user has never posted before', async () => {
+      await expect(
+        service.createComment('market-1', makeDto(), mockUser),
+      ).resolves.toBeDefined();
+    });
+
+    it('allows a comment when the last one was posted long ago', async () => {
+      commentsRepository.findOne.mockResolvedValueOnce({
+        created_at: new Date(Date.now() - 60_000),
+      } as Comment);
+
+      await expect(
+        service.createComment('market-1', makeDto(), mockUser),
+      ).resolves.toBeDefined();
+    });
+
+    it('rejects a comment posted within the minimum interval of the last one', async () => {
+      commentsRepository.findOne.mockResolvedValueOnce({
+        created_at: new Date(),
+      } as Comment);
+
+      await expect(
+        service.createComment('market-1', makeDto(), mockUser),
+      ).rejects.toThrow(HttpException);
+      expect(commentsRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('moderation', () => {
+    it('does not flag ordinary content', async () => {
+      const comment = await service.createComment(
+        'market-1',
+        makeDto('Great prediction, looking forward to the result!'),
+        mockUser,
+      );
+
+      expect(comment.is_flagged).toBe(false);
+      expect(comment.flagged_reason).toBeNull();
+    });
+
+    it('soft-hides content containing profanity', async () => {
+      const comment = await service.createComment(
+        'market-1',
+        makeDto('This market is complete shit honestly'),
+        mockUser,
+      );
+
+      expect(comment.is_flagged).toBe(true);
+      expect(comment.flagged_reason).toBe('profanity');
+      // Soft-hidden, not rejected — the comment is still saved.
+      expect(commentsRepository.save).toHaveBeenCalled();
+    });
+
+    it('soft-hides link-spam content', async () => {
+      const comment = await service.createComment(
+        'market-1',
+        makeDto(
+          'Check these out http://a.example http://b.example http://c.example',
+        ),
+        mockUser,
+      );
+
+      expect(comment.is_flagged).toBe(true);
+      expect(comment.flagged_reason).toBe('link_spam');
+    });
+  });
+
+  describe('getComments', () => {
+    it('excludes flagged comments from the results', async () => {
+      await service.getComments('market-1');
+
+      expect(commentsRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ is_flagged: false }),
+        }),
+      );
+    });
+  });
+
+  it('rejects when the parent comment does not exist', async () => {
+    commentsRepository.findOne
+      .mockResolvedValueOnce(null) // rate-limit lookup: no prior comment
+      .mockResolvedValueOnce(null); // parent lookup: not found
+
+    await expect(
+      service.createComment(
+        'market-1',
+        { content: 'reply', parentId: 'missing-parent' },
+        mockUser,
+      ),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/backend/src/markets/markets.service.ts
+++ b/backend/src/markets/markets.service.ts
@@ -3,6 +3,8 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  HttpException,
+  HttpStatus,
   Inject,
   Injectable,
   Logger,
@@ -37,6 +39,7 @@ import {
   TrendingMarketsQueryDto,
 } from './dto/trending-markets.dto';
 import { Comment } from './entities/comment.entity';
+import { moderateCommentContent } from '../common/comment-moderation.util';
 import { MarketTemplate } from './entities/market-template.entity';
 import { Market, MarketSettlementState } from './entities/market.entity';
 import { UserBookmark } from './entities/user-bookmark.entity';
@@ -916,6 +919,9 @@ export class MarketsService {
     }
   }
 
+  /** Minimum time a user must wait between posting comments. */
+  private static readonly COMMENT_MIN_INTERVAL_MS = 10_000;
+
   /**
    * Create a comment for a market
    */
@@ -925,6 +931,20 @@ export class MarketsService {
     user: User,
   ): Promise<Comment> {
     const market = await this.findByIdOrOnChainId(marketId);
+
+    const lastComment = await this.commentsRepository.findOne({
+      where: { author: { id: user.id } },
+      order: { created_at: 'DESC' },
+    });
+    if (lastComment) {
+      const elapsedMs = Date.now() - lastComment.created_at.getTime();
+      if (elapsedMs < MarketsService.COMMENT_MIN_INTERVAL_MS) {
+        throw new HttpException(
+          'You are posting comments too quickly. Please wait before posting again.',
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+    }
 
     let parent: Comment | null = null;
     if (dto.parentId) {
@@ -938,11 +958,15 @@ export class MarketsService {
       }
     }
 
+    const { flagged, reason } = moderateCommentContent(dto.content);
+
     const comment = this.commentsRepository.create({
       content: dto.content,
       author: user,
       market,
       parent: parent || undefined,
+      is_flagged: flagged,
+      flagged_reason: reason,
     });
 
     return await this.commentsRepository.save(comment);
@@ -968,7 +992,7 @@ export class MarketsService {
     const skip = (page - 1) * take;
 
     const [data, total] = await this.commentsRepository.findAndCount({
-      where: { market: { id: market.id } },
+      where: { market: { id: market.id }, is_flagged: false },
       relations: ['author', 'parent'],
       order: { created_at: 'ASC' },
       skip,

--- a/backend/src/migrations/1787700000000-AddCommentModerationFlags.ts
+++ b/backend/src/migrations/1787700000000-AddCommentModerationFlags.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddCommentModerationFlags1787700000000
-  implements MigrationInterface
-{
+export class AddCommentModerationFlags1787700000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumns('comments', [
       new TableColumn({

--- a/backend/src/migrations/1787700000000-AddCommentModerationFlags.ts
+++ b/backend/src/migrations/1787700000000-AddCommentModerationFlags.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddCommentModerationFlags1787700000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('comments', [
+      new TableColumn({
+        name: 'is_flagged',
+        type: 'boolean',
+        default: false,
+      }),
+      new TableColumn({
+        name: 'flagged_reason',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('comments', 'flagged_reason');
+    await queryRunner.dropColumn('comments', 'is_flagged');
+  }
+}

--- a/contracts/creator-event-manager/src/admin.rs
+++ b/contracts/creator-event-manager/src/admin.rs
@@ -775,7 +775,12 @@ pub fn get_xlm_token(env: &Env) -> Option<Address> {
 /// Calls `caller.require_auth()` (Soroban signature check) then looks up
 /// `DataKey::Admin(caller)` in persistent storage. Returns
 /// [`AdminError::Unauthorized`] if the address is not found.
-fn require_is_admin(env: &Env, caller: &Address) -> Result<(), AdminError> {
+///
+/// This is the single centralized admin-role check (#1704) — other modules
+/// that gate a privileged action on the admin role (e.g.
+/// `oracle::configure_oracle_sources`) should call this rather than
+/// re-implementing the same storage lookup inline.
+pub(crate) fn require_is_admin(env: &Env, caller: &Address) -> Result<(), AdminError> {
     caller.require_auth();
     let is_admin = env
         .storage()

--- a/contracts/creator-event-manager/src/event.rs
+++ b/contracts/creator-event-manager/src/event.rs
@@ -85,6 +85,8 @@ pub enum EventError {
     InviteCodeExpired = 32,
     /// The invite code has already been redeemed `max_uses` times (#1699).
     InviteCodeUsesExceeded = 33,
+    /// A fee/share computation overflowed `i128` (#1703).
+    Overflow = 34,
 }
 
 impl From<InviteError> for EventError {

--- a/contracts/creator-event-manager/src/fee.rs
+++ b/contracts/creator-event-manager/src/fee.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{Address, Env, Symbol};
 
 use crate::admin;
 use crate::storage::{self, TTL_LEDGERS};
-use crate::storage_types::{CreatorVestingSchedule, DataKey};
+use crate::storage_types::{CreatorVestingSchedule, DataKey, MAX_FEE_BPS};
 use crate::token::TokenHelper;
 
 /// Errors for fee module operations.
@@ -25,6 +25,33 @@ pub enum FeeError {
     /// `claim_vested_revenue` called before any additional amount has
     /// unlocked since the last claim.
     NothingToClaim = 10,
+    /// A fee/share computation overflowed `i128` — guards against corrupt or
+    /// adversarial inputs on very large pools rather than panicking.
+    Overflow = 11,
+}
+
+/// Compute `amount * share_bps / MAX_FEE_BPS` using checked arithmetic.
+///
+/// This is the single bounded, overflow-safe fee/share calculation used
+/// throughout the contract (e.g. splitting a creator's leftover prize-pool
+/// revenue into an immediate payout and a vested portion). `share_bps` must
+/// already have been validated to be `<= MAX_FEE_BPS` by the caller (see
+/// [`set_creator_vesting_config`]) — this function additionally re-checks the
+/// bound defensively and rejects it with [`FeeError::InvalidConfig`].
+///
+/// # Errors
+/// * [`FeeError::InvalidConfig`] — `share_bps > MAX_FEE_BPS`.
+/// * [`FeeError::Overflow`] — the multiplication overflowed `i128` (only
+///   possible for pathologically large `amount` values).
+pub fn calculate_bounded_fee(amount: i128, share_bps: u32) -> Result<i128, FeeError> {
+    if share_bps > MAX_FEE_BPS {
+        return Err(FeeError::InvalidConfig);
+    }
+
+    amount
+        .checked_mul(share_bps as i128)
+        .and_then(|scaled| scaled.checked_div(MAX_FEE_BPS as i128))
+        .ok_or(FeeError::Overflow)
 }
 
 /// Return the XLM balance of the configured treasury address.
@@ -137,7 +164,7 @@ pub fn set_creator_vesting_config(
 ) -> Result<(), FeeError> {
     require_is_admin(env, &caller)?;
 
-    if vest_share_bps > 10_000 {
+    if vest_share_bps > MAX_FEE_BPS {
         return Err(FeeError::InvalidConfig);
     }
 
@@ -288,4 +315,58 @@ pub fn forfeit_creator_vesting(
     );
 
     Ok(remaining)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: calculate_bounded_fee (#1703)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod bounded_fee_tests {
+    use super::*;
+
+    #[test]
+    fn rejects_share_above_max_fee_bps() {
+        let result = calculate_bounded_fee(1_000_000, MAX_FEE_BPS + 1);
+        assert_eq!(result, Err(FeeError::InvalidConfig));
+    }
+
+    #[test]
+    fn accepts_share_at_max_fee_bps() {
+        // 100% share returns the full amount.
+        let result = calculate_bounded_fee(1_000_000, MAX_FEE_BPS);
+        assert_eq!(result, Ok(1_000_000));
+    }
+
+    #[test]
+    fn computes_partial_share_correctly() {
+        // 25% of 1,000,000 = 250,000.
+        let result = calculate_bounded_fee(1_000_000, 2_500);
+        assert_eq!(result, Ok(250_000));
+    }
+
+    #[test]
+    fn zero_share_yields_zero_fee() {
+        let result = calculate_bounded_fee(1_000_000, 0);
+        assert_eq!(result, Ok(0));
+    }
+
+    #[test]
+    fn large_pool_computes_without_overflow() {
+        // Near the top of i128's range — a naive `amount * bps` would
+        // overflow long before this, but the checked multiply catches it
+        // and only succeeds because share_bps is small enough that the
+        // scaled intermediate still fits.
+        let large_pool = i128::MAX / 20_000; // headroom for MAX_FEE_BPS multiply
+        let result = calculate_bounded_fee(large_pool, MAX_FEE_BPS);
+        assert_eq!(result, Ok(large_pool));
+    }
+
+    #[test]
+    fn overflow_is_rejected_not_panicking() {
+        // amount so large that amount * share_bps overflows i128 even
+        // though share_bps itself is within bounds.
+        let result = calculate_bounded_fee(i128::MAX, 2);
+        assert_eq!(result, Err(FeeError::Overflow));
+    }
 }

--- a/contracts/creator-event-manager/src/finalize.rs
+++ b/contracts/creator-event-manager/src/finalize.rs
@@ -199,8 +199,9 @@ pub fn finalize_event(
     // giving the creator an ongoing stake in the event's dispute outcome.
     let refund_to_creator = prize_pool - total_distributed;
     if refund_to_creator > 0 {
-        let vest_share_bps = fee::get_creator_vest_share_bps(env) as i128;
-        let vested_amount = refund_to_creator * vest_share_bps / 10_000;
+        let vest_share_bps = fee::get_creator_vest_share_bps(env);
+        let vested_amount = fee::calculate_bounded_fee(refund_to_creator, vest_share_bps)
+            .map_err(|_| EventError::Overflow)?;
         let immediate_amount = refund_to_creator - vested_amount;
 
         if immediate_amount > 0 {

--- a/contracts/creator-event-manager/src/oracle.rs
+++ b/contracts/creator-event-manager/src/oracle.rs
@@ -3,9 +3,7 @@ use soroban_sdk::{Address, Env, Symbol, Vec};
 use crate::admin;
 use crate::leaderboard;
 use crate::storage::{self, StorageError};
-use crate::storage_types::{
-    DataKey, Event, Match, MatchResult, MatchResultSubmission, OracleSubmission,
-};
+use crate::storage_types::{Event, Match, MatchResult, MatchResultSubmission, OracleSubmission};
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -328,16 +326,7 @@ pub fn configure_oracle_sources(
     sources: Vec<Address>,
     min_sources: u32,
 ) -> Result<(), OracleError> {
-    caller.require_auth();
-
-    let is_admin = env
-        .storage()
-        .persistent()
-        .get::<DataKey, Address>(&DataKey::Admin(caller.clone()))
-        .is_some();
-    if !is_admin {
-        return Err(OracleError::Unauthorized);
-    }
+    admin::require_is_admin(env, &caller).map_err(|_| OracleError::Unauthorized)?;
 
     let source_count = sources.len();
     if min_sources == 0 || min_sources > source_count {

--- a/contracts/creator-event-manager/src/storage_types.rs
+++ b/contracts/creator-event-manager/src/storage_types.rs
@@ -9,6 +9,12 @@ pub const MAX_REWARD_RANKS: u32 = 5;
 /// The reward distribution percentages must sum to exactly this value.
 pub const REWARD_PERCENT_TOTAL: u32 = 100;
 
+/// Upper bound (basis points, 0-10000) on any creator/platform fee share
+/// configured on this contract — e.g. `fee::set_creator_vesting_config`'s
+/// `vest_share_bps`. `10_000` bps = 100%, so this simply forbids configuring
+/// a share greater than the whole pool.
+pub const MAX_FEE_BPS: u32 = 10_000;
+
 /// Maximum length for event title (characters)
 pub const MAX_TITLE_LEN: u32 = 200;
 /// Maximum length for event description (characters)

--- a/contracts/creator-event-manager/src/verification.rs
+++ b/contracts/creator-event-manager/src/verification.rs
@@ -434,14 +434,5 @@ pub fn challenge_finalization(
 // ---------------------------------------------------------------------------
 
 fn require_is_admin(env: &Env, caller: &Address) -> Result<(), VerificationError> {
-    caller.require_auth();
-    let is_admin = env
-        .storage()
-        .persistent()
-        .get::<DataKey, Address>(&DataKey::Admin(caller.clone()))
-        .is_some();
-    if !is_admin {
-        return Err(VerificationError::Unauthorized);
-    }
-    Ok(())
+    crate::admin::require_is_admin(env, caller).map_err(|_| VerificationError::Unauthorized)
 }

--- a/contracts/creator-event-manager/tests/fee_views_tests.rs
+++ b/contracts/creator-event-manager/tests/fee_views_tests.rs
@@ -306,3 +306,52 @@ fn test_withdraw_zero_amount_rejected() {
     let recipient = Address::generate(&env);
     client.withdraw_fees(&admin, &recipient, &0);
 }
+
+#[test]
+#[should_panic(expected = "invalid_config")]
+fn test_set_creator_vesting_config_over_max_bps_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(creator_event_manager::CreatorEventManagerContract, ());
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> =
+        unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+
+    // MAX_FEE_BPS is 10_000; anything above that must be rejected.
+    client.set_creator_vesting_config(&admin, &10_001u32, &0u64);
+}
+
+#[test]
+fn test_set_creator_vesting_config_at_max_bps_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(creator_event_manager::CreatorEventManagerContract, ());
+    let client = CreatorEventManagerContractClient::new(&env, &contract_id);
+    let client: CreatorEventManagerContractClient<'static> =
+        unsafe { core::mem::transmute(client) };
+
+    let admin = Address::generate(&env);
+    let ai_agent = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let xlm_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &ai_agent, &treasury, &xlm_token, &FEE);
+
+    // Exactly MAX_FEE_BPS (100%) is a valid boundary value.
+    client.set_creator_vesting_config(&admin, &10_000u32, &0u64);
+}

--- a/contracts/creator-event-manager/tests/oracle_consensus_tests.rs
+++ b/contracts/creator-event-manager/tests/oracle_consensus_tests.rs
@@ -105,6 +105,23 @@ fn read_match(env: &Env, contract_id: &Address, match_id: u64) -> Match {
 }
 
 // ---------------------------------------------------------------------------
+// Role separation (#1704)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_configure_oracle_sources_non_admin_rejected() {
+    let (env, client, _contract_id, _admin, _xlm_token) = setup();
+
+    let non_admin = Address::generate(&env);
+    let source_a = Address::generate(&env);
+    let mut sources = Vec::new(&env);
+    sources.push_back(source_a);
+
+    client.configure_oracle_sources(&non_admin, &sources, &1u32);
+}
+
+// ---------------------------------------------------------------------------
 // Threshold reached finalizes
 // ---------------------------------------------------------------------------
 

--- a/contracts/creator-event-manager/tests/oracle_tests.rs
+++ b/contracts/creator-event-manager/tests/oracle_tests.rs
@@ -142,6 +142,36 @@ fn test_submit_match_result_ai_agent_can_submit() {
 }
 
 #[test]
+#[should_panic(expected = "unauthorized")]
+fn test_submit_match_result_wrong_role_rejected() {
+    // Neither the admin nor an arbitrary address is the configured AI agent
+    // (#1704) — only the address bound via `initialize`/`set_ai_agent` may
+    // submit match results.
+    let (env, client, contract_id, admin, _ai_agent, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let (_event_id, _invite_code, match_id) =
+        create_event_with_match(&env, &contract_id, &client, &creator, &xlm_token, 1000);
+
+    env.ledger().with_mut(|l| l.timestamp += 2000);
+
+    client.submit_match_result(&admin, &match_id, &2u32, &1u32);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_submit_match_result_random_address_rejected() {
+    let (env, client, contract_id, _admin, _ai_agent, xlm_token) = setup();
+    let creator = Address::generate(&env);
+    let (_event_id, _invite_code, match_id) =
+        create_event_with_match(&env, &contract_id, &client, &creator, &xlm_token, 1000);
+
+    env.ledger().with_mut(|l| l.timestamp += 2000);
+
+    let random = Address::generate(&env);
+    client.submit_match_result(&random, &match_id, &2u32, &1u32);
+}
+
+#[test]
 #[should_panic(expected = "result_already_submitted")]
 fn test_submit_match_result_duplicate_submission_rejected() {
     let (env, client, contract_id, _admin, ai_agent, xlm_token) = setup();


### PR DESCRIPTION
# Fee bounds, admin role separation, comment moderation, prediction stats accuracy

## Summary

- **Contracts — fee bounds (#1703):** Added `MAX_FEE_BPS` and a checked, bounds-enforcing `fee::calculate_bounded_fee` helper; `finalize.rs`'s creator revenue split now uses it instead of an unchecked `i128` multiply/divide. Added unit tests for over-max rejection and large-pool overflow-safety.
- **Contracts — admin role separation (#1704):** Centralized the duplicated admin-role storage check into `admin::require_is_admin`, used now by `oracle::configure_oracle_sources` and `verification`'s local check. Added wrong-role rejection tests for `submit_match_result` and `configure_oracle_sources`.
- **Backend — comment moderation & rate limiting (#1651):** Added a per-user minimum comment interval, a profanity/link-spam filter that soft-hides matches (`is_flagged`), and applied the existing `write` throttle tier to the comment endpoint. Flagged comments are excluded from the public list.
- **Backend — prediction stats accuracy (#1650):** `getUserPredictionsForEvent`/`getUserScore` now exclude withdrawn predictions (`isWithdrawn`) from every count, and `invalidatePredictionStatsCache` evicts the cached stats/score responses by their known cache keys.

## Testing

- `cargo test` (contracts/creator-event-manager): 342+ tests, all passing
- `cargo build --target wasm32-unknown-unknown --release`: passing
- `pnpm run lint`, `pnpm run build`, `pnpm run test` (backend): passing, 0 lint errors, 1321 tests passing

Closes #1703
Closes #1704
Closes #1651
Closes #1650
