### PR TITLE
feat: Profile Gate Wrapper Incomplete-Profile Nudge

### DIFF
--- a/frontend/src/app/(authenticated)/my-markets/page.tsx
+++ b/frontend/src/app/(authenticated)/my-markets/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, type ReactNode } from "react";
 import Link from "next/link";
+import { FileText, Bookmark, Search } from "lucide-react";
+import { EmptyState } from "@/component/ui/empty-state";
 
 type MarketStatus = "Open" | "Resolved" | "Cancelled";
 type Tab = "All Markets" | "My Markets" | "Bookmarked";
@@ -35,6 +37,24 @@ const STATUS_COLORS: Record<MarketStatus, string> = {
   Cancelled: "bg-red-500/20 text-red-400",
 };
 
+const EMPTY_STATE_CONFIG: Record<Tab, { icon: ReactNode; title: string; description: string }> = {
+  "My Markets": {
+    icon: <FileText className="h-7 w-7" />,
+    title: "No markets created yet",
+    description: "Create your first prediction market to get started.",
+  },
+  Bookmarked: {
+    icon: <Bookmark className="h-7 w-7" />,
+    title: "No bookmarks yet",
+    description: "Bookmark markets to find them quickly later.",
+  },
+  "All Markets": {
+    icon: <Search className="h-7 w-7" />,
+    title: "No markets match your filters",
+    description: "Try adjusting your search or filters.",
+  },
+};
+
 export default function MarketsPage() {
   const [activeTab, setActiveTab] = useState<Tab>("All Markets");
   const [search, setSearch] = useState("");
@@ -57,6 +77,16 @@ export default function MarketsPage() {
   }, [activeTab, search, categoryFilter, statusFilter, sort]);
 
   const isEmpty = filtered.length === 0;
+
+  function clearFilters() {
+    setSearch("");
+    setCategoryFilter("All");
+    setStatusFilter("All");
+    setSort("Newest");
+  }
+
+  const hasActiveFilters =
+    search !== "" || categoryFilter !== "All" || statusFilter !== "All" || sort !== "Newest";
 
   return (
     <div className="space-y-6 p-4 sm:p-6">
@@ -109,27 +139,19 @@ export default function MarketsPage() {
         </select>
       </div>
 
-      {/* Empty States */}
-      {isEmpty && activeTab === "My Markets" && (
-        <div className="flex flex-col items-center justify-center py-20 text-center space-y-3">
-          <p className="text-4xl">📋</p>
-          <p className="text-white font-semibold">No markets created yet</p>
-          <p className="text-gray-400 text-sm">Create your first prediction market to get started.</p>
-        </div>
-      )}
-      {isEmpty && activeTab === "Bookmarked" && (
-        <div className="flex flex-col items-center justify-center py-20 text-center space-y-3">
-          <p className="text-4xl">🔖</p>
-          <p className="text-white font-semibold">No bookmarks yet</p>
-          <p className="text-gray-400 text-sm">Bookmark markets to find them quickly later.</p>
-        </div>
-      )}
-      {isEmpty && activeTab === "All Markets" && (
-        <div className="flex flex-col items-center justify-center py-20 text-center space-y-3">
-          <p className="text-4xl">🔍</p>
-          <p className="text-white font-semibold">No markets match your filters</p>
-          <p className="text-gray-400 text-sm">Try adjusting your search or filters.</p>
-        </div>
+      {/* Empty State */}
+      {isEmpty && (
+        <EmptyState
+          icon={EMPTY_STATE_CONFIG[activeTab].icon}
+          title={EMPTY_STATE_CONFIG[activeTab].title}
+          description={EMPTY_STATE_CONFIG[activeTab].description}
+          action={
+            activeTab === "My Markets" ? { label: "Create Market", href: "/markets/create" } : undefined
+          }
+          secondaryAction={
+            hasActiveFilters ? { label: "Clear Filters", onClick: clearFilters } : undefined
+          }
+        />
       )}
 
       {/* Markets Grid */}

--- a/frontend/src/app/(authenticated)/my-predictions/page.tsx
+++ b/frontend/src/app/(authenticated)/my-predictions/page.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, BarChart3 } from "lucide-react";
 import { useConfirm } from "@/hooks/useConfirm";
 import { useToast } from "@/hooks/useToast";
+import { EmptyState } from "@/component/ui/empty-state";
 
 type PredictionStatus = "Active" | "Won" | "Lost" | "Pending";
 type FilterTab = "All" | "Active" | "Won" | "Lost" | "Pending";
@@ -339,25 +340,16 @@ export default function MyPredictionsPage() {
         )}
 
         {paginatedPredictions.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-white/5">
-              <span className="text-3xl">📊</span>
-            </div>
-            <h3 className="mb-2 text-xl font-semibold text-white">
-              No predictions found
-            </h3>
-            <p className="mb-6 max-w-md text-sm text-gray-400">
-              {activeFilter === "All"
+          <EmptyState
+            icon={<BarChart3 className="h-7 w-7" />}
+            title="No predictions found"
+            description={
+              activeFilter === "All"
                 ? "You haven't made any predictions yet. Start by browsing available markets."
-                : `You don't have any ${activeFilter.toLowerCase()} predictions.`}
-            </p>
-            <Link
-              href="/markets"
-              className="inline-flex rounded-xl bg-orange-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-orange-600"
-            >
-              Browse Markets
-            </Link>
-          </div>
+                : `You don't have any ${activeFilter.toLowerCase()} predictions.`
+            }
+            action={{ label: "Browse Markets", href: "/markets" }}
+          />
         ) : (
           <div className="space-y-4">
             {paginatedPredictions.map((prediction) => (

--- a/frontend/src/app/(authenticated)/watchlist/page.tsx
+++ b/frontend/src/app/(authenticated)/watchlist/page.tsx
@@ -111,10 +111,7 @@ export default function WatchlistPage() {
           icon={<Heart size={32} />}
           title="Your Watchlist is Empty"
           description="Add markets to your watchlist to keep track of them. Click the heart icon on any market to save it here."
-          action={{
-            label: "Browse Markets",
-            onClick: () => (window.location.href = "/markets"),
-          }}
+          action={{ label: "Browse Markets", href: "/markets" }}
           variant="empty"
         />
       )}

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,5 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
 import { MarketingPageLoadingSkeleton } from "@/component/loading-route-skeletons";
+import { beginRouteContentLoad } from "@/lib/utils";
 
 export default function Loading() {
+  useEffect(() => beginRouteContentLoad(), []);
+
   return <MarketingPageLoadingSkeleton />;
 }

--- a/frontend/src/component/AuthGuard.tsx
+++ b/frontend/src/component/AuthGuard.tsx
@@ -11,6 +11,19 @@ interface AuthGuardProps {
 // Routes that render their own unauthenticated gate instead of redirecting
 const SELF_GATED_ROUTES = ["/profile"];
 
+export interface ProfileGateConfig {
+  /** Critical gates block the page until the profile is complete; others can be dismissed for now. */
+  critical: boolean;
+}
+
+// Authenticated routes that additionally require a complete profile before
+// their content is useful. Routes not listed here are never profile-gated.
+export const PROFILE_GATED_ROUTES: Record<string, ProfileGateConfig> = {
+  "/my-markets": { critical: true },
+  "/creator-events": { critical: true },
+  "/competitions": { critical: false },
+};
+
 export function AuthGuard({ children }: AuthGuardProps) {
   const router = useRouter();
   const pathname = usePathname();

--- a/frontend/src/component/CourseCompletionButton.tsx
+++ b/frontend/src/component/CourseCompletionButton.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import CourseCompletionModal from './CourseCompletionModal';
 
-const CourseCompletionButton = () => {
+interface CourseCompletionButtonProps {
+  courseId?: string;
+}
+
+const CourseCompletionButton = ({ courseId }: CourseCompletionButtonProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -13,12 +17,13 @@ const CourseCompletionButton = () => {
         View Course Completion
       </button>
 
-      <CourseCompletionModal 
+      <CourseCompletionModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
+        courseId={courseId}
       />
     </>
   );
 };
 
-export default CourseCompletionButton; 
+export default CourseCompletionButton;

--- a/frontend/src/component/CourseCompletionModal.test.tsx
+++ b/frontend/src/component/CourseCompletionModal.test.tsx
@@ -1,0 +1,145 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CourseCompletionModal from "./CourseCompletionModal";
+import * as api from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    submitCourseCompletion: vi.fn(),
+  };
+});
+
+const mockedSubmit = vi.mocked(api.submitCourseCompletion);
+
+describe("CourseCompletionModal", () => {
+  beforeEach(() => {
+    mockedSubmit.mockReset();
+  });
+
+  it("submits the course completion exactly once on a rapid double-click", async () => {
+    let resolveSubmit: (value: api.CourseCompletionResponse) => void = () => {};
+    mockedSubmit.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+
+    render(
+      <CourseCompletionModal isOpen onClose={() => {}} courseId="crypto-101" />,
+    );
+
+    const claimButton = screen.getByRole("button", { name: /claim badge/i });
+
+    // Two click events landing before React has a chance to re-render and
+    // disable the button — the realistic shape of a genuine double-submit.
+    act(() => {
+      claimButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      claimButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      claimButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(mockedSubmit).toHaveBeenCalledTimes(1);
+    expect(claimButton).toBeDisabled();
+
+    act(() => {
+      resolveSubmit({ courseId: "crypto-101", status: "completed", awardedAt: "now" });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/badge claimed successfully/i)).toBeInTheDocument(),
+    );
+
+    // Clicking again after success does not resubmit.
+    act(() => {
+      claimButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(mockedSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends a stable idempotency key for the attempt", async () => {
+    mockedSubmit.mockResolvedValue({
+      courseId: "crypto-101",
+      status: "completed",
+      awardedAt: "now",
+    });
+
+    render(
+      <CourseCompletionModal isOpen onClose={() => {}} courseId="crypto-101" />,
+    );
+
+    const claimButton = screen.getByRole("button", { name: /claim badge/i });
+    act(() => {
+      claimButton.click();
+    });
+
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1));
+    const [calledCourseId, idempotencyKey] = mockedSubmit.mock.calls[0];
+    expect(calledCourseId).toBe("crypto-101");
+    expect(idempotencyKey).toContain("crypto-101");
+  });
+
+  it("shows an error with retry on failure, and reuses the same idempotency key on retry", async () => {
+    mockedSubmit.mockRejectedValueOnce(new Error("network down"));
+    mockedSubmit.mockResolvedValueOnce({
+      courseId: "crypto-101",
+      status: "completed",
+      awardedAt: "now",
+    });
+
+    render(
+      <CourseCompletionModal isOpen onClose={() => {}} courseId="crypto-101" />,
+    );
+
+    const claimButton = screen.getByRole("button", { name: /claim badge/i });
+    act(() => {
+      claimButton.click();
+    });
+
+    await waitFor(() => expect(screen.getByText(/failed to claim badge/i)).toBeInTheDocument());
+    const retryButton = screen.getByRole("button", { name: /retry/i });
+
+    act(() => {
+      retryButton.click();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/badge claimed successfully/i)).toBeInTheDocument(),
+    );
+
+    expect(mockedSubmit).toHaveBeenCalledTimes(2);
+    const [, firstKey] = mockedSubmit.mock.calls[0];
+    const [, secondKey] = mockedSubmit.mock.calls[1];
+    expect(firstKey).toBe(secondKey);
+  });
+
+  it("generates a fresh idempotency key each time the modal is reopened", async () => {
+    mockedSubmit.mockResolvedValue({
+      courseId: "crypto-101",
+      status: "completed",
+      awardedAt: "now",
+    });
+
+    const { rerender } = render(
+      <CourseCompletionModal isOpen onClose={() => {}} courseId="crypto-101" />,
+    );
+    act(() => {
+      screen.getByRole("button", { name: /claim badge/i }).click();
+    });
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1));
+    const [, firstOpenKey] = mockedSubmit.mock.calls[0];
+
+    rerender(<CourseCompletionModal isOpen={false} onClose={() => {}} courseId="crypto-101" />);
+    rerender(<CourseCompletionModal isOpen onClose={() => {}} courseId="crypto-101" />);
+
+    act(() => {
+      screen.getByRole("button", { name: /claim badge/i }).click();
+    });
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(2));
+    const [, secondOpenKey] = mockedSubmit.mock.calls[1];
+
+    expect(secondOpenKey).not.toBe(firstOpenKey);
+  });
+});

--- a/frontend/src/component/CourseCompletionModal.tsx
+++ b/frontend/src/component/CourseCompletionModal.tsx
@@ -1,15 +1,39 @@
-import React, { useState } from 'react';
-import { X, Users, Award, Check } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { X, Users, Award, Check, AlertCircle, RotateCcw } from 'lucide-react';
+import { ApiError, generateIdempotencyKey, submitCourseCompletion } from '@/lib/api';
 
 interface CourseCompletionModalProps {
   isOpen: boolean;
   onClose: () => void;
+  courseId?: string;
 }
 
-const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) => {
-  const [isClaimLoading, setIsClaimLoading] = useState(false);
+type ClaimStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+const CourseCompletionModal = ({
+  isOpen,
+  onClose,
+  courseId = 'stark-academy',
+}: CourseCompletionModalProps) => {
   const [isJoinLoading, setIsJoinLoading] = useState(false);
-  const [badgeClaimed, setBadgeClaimed] = useState(false);
+  const [claimStatus, setClaimStatus] = useState<ClaimStatus>('idle');
+  const [claimError, setClaimError] = useState<string | null>(null);
+
+  // A ref (not state) guards the double-submit check: state updates from the
+  // first click aren't guaranteed to have re-rendered the disabled button
+  // before a second click event is dispatched, but a ref read is synchronous.
+  const isSubmittingRef = useRef(false);
+  const idempotencyKeyRef = useRef<string>(generateIdempotencyKey(courseId));
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // A fresh attempt each time the modal opens — a new idempotency key,
+    // and a clean slate for the submit guard and status.
+    idempotencyKeyRef.current = generateIdempotencyKey(courseId);
+    isSubmittingRef.current = false;
+    setClaimStatus('idle');
+    setClaimError(null);
+  }, [isOpen, courseId]);
 
   const handleJoinCommunity = async () => {
     setIsJoinLoading(true);
@@ -22,16 +46,30 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
   };
 
   const handleClaimBadge = async () => {
-    setIsClaimLoading(true);
+    if (isSubmittingRef.current || claimStatus === 'success') return;
+    isSubmittingRef.current = true;
+    setClaimStatus('submitting');
+    setClaimError(null);
+
     try {
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      setBadgeClaimed(true);
-    } finally {
-      setIsClaimLoading(false);
+      // Retries of the same attempt reuse this key so the backend can
+      // de-duplicate a request that actually landed before a retry fired.
+      await submitCourseCompletion(courseId, idempotencyKeyRef.current);
+      setClaimStatus('success');
+    } catch (error) {
+      isSubmittingRef.current = false;
+      setClaimStatus('error');
+      setClaimError(
+        error instanceof ApiError ? error.message : 'Failed to claim badge. Please try again.',
+      );
     }
   };
 
   if (!isOpen) return null;
+
+  const isClaimLoading = claimStatus === 'submitting';
+  const badgeClaimed = claimStatus === 'success';
+  const claimFailed = claimStatus === 'error';
 
   return (
     <div
@@ -58,7 +96,7 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
                 <X className="w-4 h-4" />
               </button>
             </div>
-        
+
 
         {/* Content */}
         <div className="p-6">
@@ -71,7 +109,17 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
             <p className="mb-4 text-center pt-2">
             CONGRATULATION ON FINISHING YOUR COURSE  TIME TO CLAIM YOUR BADGE.
             </p>
-            
+
+            {claimFailed && claimError && (
+              <div
+                className="flex items-center gap-2 text-red-400 bg-red-500/10 border border-red-500/20 p-3 rounded-lg mb-4"
+                role="alert"
+              >
+                <AlertCircle className="w-5 h-5 flex-shrink-0" />
+                <span>{claimError}</span>
+              </div>
+            )}
+
             {badgeClaimed && (
               <div className="flex items-center gap-2  text-green-700 p-3 rounded-lg mb-4">
                 <Check className="w-5 h-5" />
@@ -87,17 +135,29 @@ const CourseCompletionModal = ({ isOpen, onClose }: CourseCompletionModalProps) 
               onClick={handleClaimBadge}
               disabled={isClaimLoading || badgeClaimed}
               className={`flex-1 py-3 px-4 rounded-lg font-medium flex items-center justify-center gap-2 ${
-                badgeClaimed 
+                badgeClaimed
                   ? 'bg-gray-100 text-gray-500 cursor-not-allowed'
-                  : 'bg-amber-500 hover:bg-amber-600 text-white'
+                  : claimFailed
+                    ? 'bg-red-600 hover:bg-red-700 text-white'
+                    : 'bg-amber-500 hover:bg-amber-600 text-white'
               }`}
             >
               {isClaimLoading ? (
                 <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
+              ) : badgeClaimed ? (
+                <>
+                  <Check className="w-5 h-5" />
+                  Claimed
+                </>
+              ) : claimFailed ? (
+                <>
+                  <RotateCcw className="w-5 h-5" />
+                  Retry
+                </>
               ) : (
                 <>
                   <Award className="w-5 h-5" />
-                  {badgeClaimed ? 'Claimed' : 'Claim Badge'}
+                  Claim Badge
                 </>
               )}
             </button>

--- a/frontend/src/component/NotificationsCard.tsx
+++ b/frontend/src/component/NotificationsCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { TrendingUp, Trophy, Gift, Users } from "lucide-react";
+import { TrendingUp, Trophy, Gift, Users, Bell } from "lucide-react";
+import { EmptyState } from "@/component/ui/empty-state";
 
 interface NotificationItem {
   id: string;
@@ -68,8 +69,14 @@ const iconBgMap = {
   users: "bg-white/10",
 };
 
-export default function NotificationsCard() {
-  const unreadCount = mockNotifications.filter((n) => !n.isRead).length;
+interface NotificationsCardProps {
+  notifications?: NotificationItem[];
+}
+
+export default function NotificationsCard({
+  notifications = mockNotifications,
+}: NotificationsCardProps) {
+  const unreadCount = notifications.filter((n) => !n.isRead).length;
 
   return (
     <div className="relative rounded-2xl border border-white/10 bg-white/5 p-6 w-full overflow-hidden">
@@ -85,40 +92,48 @@ export default function NotificationsCard() {
       </div>
 
       {/* Notifications List */}
-      <div className="space-y-0">
-        {mockNotifications.map((notification, index) => {
-          const IconComponent = iconMap[notification.icon];
-          const isLast = index === mockNotifications.length - 1;
+      {notifications.length === 0 ? (
+        <EmptyState
+          icon={<Bell className="h-7 w-7" />}
+          title="No notifications yet"
+          description="We'll let you know when there's something new for you."
+        />
+      ) : (
+        <div className="space-y-0">
+          {notifications.map((notification, index) => {
+            const IconComponent = iconMap[notification.icon];
+            const isLast = index === notifications.length - 1;
 
-          return (
-            <div key={notification.id}>
-              <div className="flex items-start gap-4 py-4">
-                {/* Icon Box */}
-                <div
-                  className={`flex-shrink-0 w-10 h-10 rounded-xl ${iconBgMap[notification.icon]} flex items-center justify-center`}
-                >
-                  <IconComponent
-                    className={`h-5 w-5 ${iconColorMap[notification.icon]}`}
-                  />
+            return (
+              <div key={notification.id}>
+                <div className="flex items-start gap-4 py-4">
+                  {/* Icon Box */}
+                  <div
+                    className={`flex-shrink-0 w-10 h-10 rounded-xl ${iconBgMap[notification.icon]} flex items-center justify-center`}
+                  >
+                    <IconComponent
+                      className={`h-5 w-5 ${iconColorMap[notification.icon]}`}
+                    />
+                  </div>
+
+                  {/* Content */}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-gray-300 text-sm leading-relaxed mb-1">
+                      {notification.message}
+                    </p>
+                    <span className="text-xs text-gray-500">
+                      {notification.timestamp}
+                    </span>
+                  </div>
                 </div>
 
-                {/* Content */}
-                <div className="flex-1 min-w-0">
-                  <p className="text-gray-300 text-sm leading-relaxed mb-1">
-                    {notification.message}
-                  </p>
-                  <span className="text-xs text-gray-500">
-                    {notification.timestamp}
-                  </span>
-                </div>
+                {/* Divider line (subtle, matching Figma stroke color) */}
+                {!isLast && <div className="border-b border-white/5 ml-14" />}
               </div>
-
-              {/* Divider line (subtle, matching Figma stroke color) */}
-              {!isLast && <div className="border-b border-white/5 ml-14" />}
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/component/ProfileGateWrapper.test.tsx
+++ b/frontend/src/component/ProfileGateWrapper.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProfileGateWrapper } from "./ProfileGateWrapper";
+import { useWallet } from "@/context/WalletContext";
+import { usePathname } from "next/navigation";
+
+vi.mock("@/context/WalletContext", () => ({
+  useWallet: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@/component/dashboard-shell", () => ({
+  DashboardShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dashboard-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/component/PageBackground", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/component/Header", () => ({ default: () => <div>header</div> }));
+vi.mock("@/component/Footer", () => ({ default: () => <div>footer</div> }));
+
+const mockedUseWallet = vi.mocked(useWallet);
+const mockedUsePathname = vi.mocked(usePathname);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.sessionStorage.clear();
+});
+
+describe("ProfileGateWrapper", () => {
+  it("renders children unchanged on routes that aren't profile-gated", () => {
+    mockedUsePathname.mockReturnValue("/dashboard");
+    mockedUseWallet.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "" },
+    } as unknown as ReturnType<typeof useWallet>);
+
+    render(
+      <ProfileGateWrapper>
+        <div>page content</div>
+      </ProfileGateWrapper>,
+    );
+
+    expect(screen.getByText("page content")).toBeInTheDocument();
+  });
+
+  it("lists exactly the missing profile fields with a CTA to complete them", () => {
+    mockedUsePathname.mockReturnValue("/my-markets");
+    mockedUseWallet.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "Alex" }, // avatarUrl and bio are missing
+    } as unknown as ReturnType<typeof useWallet>);
+
+    render(
+      <ProfileGateWrapper>
+        <div>my markets page</div>
+      </ProfileGateWrapper>,
+    );
+
+    expect(screen.queryByText("my markets page")).not.toBeInTheDocument();
+    expect(screen.getByText("Profile picture")).toBeInTheDocument();
+    expect(screen.getByText("Bio")).toBeInTheDocument();
+    expect(screen.queryByText("Username")).not.toBeInTheDocument();
+
+    const cta = screen.getByRole("link", { name: /complete profile/i });
+    expect(cta).toHaveAttribute("href", "/settings#profile");
+  });
+
+  it("keeps the dashboard chrome around the gate prompt", () => {
+    mockedUsePathname.mockReturnValue("/my-markets");
+    mockedUseWallet.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "Alex" },
+    } as unknown as ReturnType<typeof useWallet>);
+
+    render(
+      <ProfileGateWrapper>
+        <div>my markets page</div>
+      </ProfileGateWrapper>,
+    );
+
+    expect(screen.getByTestId("dashboard-shell")).toBeInTheDocument();
+  });
+
+  it("does not allow dismissing a critical gate", () => {
+    mockedUsePathname.mockReturnValue("/my-markets");
+    mockedUseWallet.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "Alex" },
+    } as unknown as ReturnType<typeof useWallet>);
+
+    render(
+      <ProfileGateWrapper>
+        <div>gated</div>
+      </ProfileGateWrapper>,
+    );
+
+    expect(screen.queryByRole("button", { name: /not now/i })).not.toBeInTheDocument();
+  });
+
+  it("allows dismiss-for-now on a non-critical gate and remembers the choice", () => {
+    mockedUsePathname.mockReturnValue("/competitions");
+    mockedUseWallet.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "Alex" },
+    } as unknown as ReturnType<typeof useWallet>);
+
+    const { rerender } = render(
+      <ProfileGateWrapper>
+        <div>competitions</div>
+      </ProfileGateWrapper>,
+    );
+    expect(screen.queryByText("competitions")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /not now/i }));
+    expect(screen.getByText("competitions")).toBeInTheDocument();
+
+    rerender(
+      <ProfileGateWrapper>
+        <div>competitions</div>
+      </ProfileGateWrapper>,
+    );
+    expect(screen.getByText("competitions")).toBeInTheDocument();
+  });
+
+  it("renders normally once the profile is complete", () => {
+    mockedUsePathname.mockReturnValue("/my-markets");
+    mockedUseWallet.mockReturnValue({
+      isAuthenticated: true,
+      user: { username: "Alex", avatarUrl: "https://example.com/a.png", bio: "hi" },
+    } as unknown as ReturnType<typeof useWallet>);
+
+    render(
+      <ProfileGateWrapper>
+        <div>my markets page</div>
+      </ProfileGateWrapper>,
+    );
+
+    expect(screen.getByText("my markets page")).toBeInTheDocument();
+  });
+
+  it("bypasses DashboardShell for unauthenticated visitors to /profile", () => {
+    mockedUsePathname.mockReturnValue("/profile");
+    mockedUseWallet.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+    } as unknown as ReturnType<typeof useWallet>);
+
+    render(
+      <ProfileGateWrapper>
+        <div>profile gate card</div>
+      </ProfileGateWrapper>,
+    );
+
+    expect(screen.getByText("profile gate card")).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-shell")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/component/ProfileGateWrapper.tsx
+++ b/frontend/src/component/ProfileGateWrapper.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { AlertCircle } from "lucide-react";
 import { useWallet } from "@/context/WalletContext";
+import { PROFILE_GATED_ROUTES } from "@/component/AuthGuard";
+import { DashboardShell } from "@/component/dashboard-shell";
+import { getMissingProfileFields, type ProfileFieldDef } from "@/lib/api";
 import PageBackground from "@/component/PageBackground";
 import Header from "@/component/Header";
 import Footer from "@/component/Footer";
@@ -11,14 +16,105 @@ interface ProfileGateWrapperProps {
   children: ReactNode;
 }
 
+const DISMISSED_STORAGE_KEY = "insightarena.profile-gate-dismissed.v1";
+
+function readDismissedRoutes(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.sessionStorage.getItem(DISMISSED_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return new Set(
+      Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : [],
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissedRoutes(routes: Set<string>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(DISMISSED_STORAGE_KEY, JSON.stringify(Array.from(routes)));
+  } catch {
+    // Storage unavailable — dismissal just won't persist across reloads.
+  }
+}
+
+function ProfileGatePrompt({
+  missingFields,
+  critical,
+  onDismiss,
+}: {
+  missingFields: ProfileFieldDef[];
+  critical: boolean;
+  onDismiss?: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-6 py-12">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/5 p-8 text-center backdrop-blur">
+        <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-full border border-orange-400/30 bg-orange-500/10">
+          <AlertCircle className="h-6 w-6 text-orange-400" />
+        </div>
+        <h2 className="text-xl font-bold text-white">
+          Complete your profile to continue
+        </h2>
+        <p className="mt-3 text-sm leading-relaxed text-gray-400">
+          {critical
+            ? "This page needs a few more details on your profile before you can use it."
+            : "Finish setting up your profile to get the full experience here."}
+        </p>
+
+        <ul className="mt-6 space-y-3 text-left" data-testid="missing-fields">
+          {missingFields.map((field) => (
+            <li key={field.key} className="flex items-start gap-2.5 text-sm text-gray-300">
+              <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-orange-400" />
+              <span>
+                <span className="font-medium text-white">{field.label}</span>{" "}
+                — {field.description}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <Link
+          href="/settings#profile"
+          className="mt-8 block w-full rounded-xl bg-orange-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-orange-600"
+        >
+          Complete Profile
+        </Link>
+
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="mt-3 w-full rounded-xl px-6 py-2 text-xs font-medium text-gray-500 transition hover:text-gray-300"
+          >
+            Not now
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 /**
  * When an unauthenticated user visits /profile, bypass the DashboardShell
  * and render the page directly with the standard public page layout instead.
  * The profile page itself renders the "connect wallet" gate card.
+ *
+ * For authenticated users on routes in PROFILE_GATED_ROUTES, an incomplete
+ * profile shows a guided prompt (still inside the DashboardShell) instead of
+ * the page — listing exactly which fields are missing and linking straight
+ * to where they're fixed. Non-critical gates can be dismissed for now.
  */
 export function ProfileGateWrapper({ children }: ProfileGateWrapperProps) {
   const pathname = usePathname();
-  const { isAuthenticated } = useWallet();
+  const { isAuthenticated, user } = useWallet();
+  const [dismissedRoutes, setDismissedRoutes] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setDismissedRoutes(readDismissedRoutes());
+  }, []);
 
   if (pathname === "/profile" && !isAuthenticated) {
     return (
@@ -30,6 +126,35 @@ export function ProfileGateWrapper({ children }: ProfileGateWrapperProps) {
     );
   }
 
-  // Authenticated or not a self-gated route — render normally (DashboardShell wraps)
+  const gateConfig = pathname ? PROFILE_GATED_ROUTES[pathname] : undefined;
+
+  if (isAuthenticated && gateConfig) {
+    const missingFields = getMissingProfileFields(user);
+    const isDismissed = pathname ? dismissedRoutes.has(pathname) : false;
+
+    if (missingFields.length > 0 && (gateConfig.critical || !isDismissed)) {
+      return (
+        <DashboardShell>
+          <ProfileGatePrompt
+            missingFields={missingFields}
+            critical={gateConfig.critical}
+            onDismiss={
+              gateConfig.critical
+                ? undefined
+                : () => {
+                    setDismissedRoutes((prev) => {
+                      const next = new Set(prev).add(pathname!);
+                      writeDismissedRoutes(next);
+                      return next;
+                    });
+                  }
+            }
+          />
+        </DashboardShell>
+      );
+    }
+  }
+
+  // Authenticated with a complete profile, or not a gated route — render normally.
   return <>{children}</>;
 }

--- a/frontend/src/component/RouteProgress.test.tsx
+++ b/frontend/src/component/RouteProgress.test.tsx
@@ -1,0 +1,168 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RouteProgress } from "./RouteProgress";
+import { beginRouteContentLoad } from "@/lib/utils";
+
+let mockPathname = "/a";
+let mockSearch = "";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(mockSearch),
+}));
+
+function mockMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  );
+}
+
+function getProgress(): number {
+  return Number(screen.getByRole("progressbar").getAttribute("aria-valuenow"));
+}
+
+describe("RouteProgress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockPathname = "/a";
+    mockSearch = "";
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("stays hidden until a navigation actually starts", () => {
+    render(<RouteProgress />);
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("trickles up but never completes while content is still pending", () => {
+    render(<RouteProgress />);
+
+    act(() => {
+      window.history.pushState({}, "", "/b");
+    });
+    act(() => {
+      vi.advanceTimersByTime(160); // past SHOW_DELAY_MS
+    });
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(getProgress()).toBeGreaterThan(0);
+    expect(getProgress()).toBeLessThan(100);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(getProgress()).toBeLessThan(100);
+  });
+
+  it("does not complete before route content settles on a slow transition", () => {
+    const { rerender } = render(<RouteProgress />);
+
+    // Simulate the destination's loading.tsx mounting before its content is ready.
+    const release = beginRouteContentLoad();
+
+    act(() => {
+      window.history.pushState({}, "", "/b");
+    });
+    act(() => {
+      vi.advanceTimersByTime(160);
+    });
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+
+    // Next commits the URL immediately, even though content is still pending.
+    mockPathname = "/b";
+    rerender(<RouteProgress />);
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(getProgress()).toBeLessThan(100);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(getProgress()).toBeLessThan(100);
+
+    // Content is finally ready.
+    act(() => {
+      release();
+    });
+    expect(getProgress()).toBe(100);
+
+    act(() => {
+      vi.advanceTimersByTime(250); // past FINISH_HOLD_MS
+    });
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("completes immediately on route settle when no content is pending", () => {
+    const { rerender } = render(<RouteProgress />);
+
+    act(() => {
+      window.history.pushState({}, "", "/b");
+    });
+    act(() => {
+      vi.advanceTimersByTime(160);
+    });
+
+    mockPathname = "/b";
+    act(() => {
+      rerender(<RouteProgress />);
+    });
+
+    expect(getProgress()).toBe(100);
+  });
+
+  it("resets progress instead of jumping to complete when a new navigation starts mid-flight", () => {
+    render(<RouteProgress />);
+
+    act(() => {
+      window.history.pushState({}, "", "/b");
+    });
+    act(() => {
+      vi.advanceTimersByTime(160);
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const valueBeforeRenav = getProgress();
+    expect(valueBeforeRenav).toBeGreaterThan(0);
+    expect(valueBeforeRenav).toBeLessThan(100);
+
+    // A second navigation starts before the first one ever settles.
+    act(() => {
+      window.history.pushState({}, "", "/c");
+    });
+
+    // Reset, not jumped ahead to complete.
+    expect(getProgress()).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(160);
+    });
+    expect(getProgress()).toBeGreaterThan(0);
+    expect(getProgress()).toBeLessThan(100);
+  });
+
+  it("jumps straight to 100% and skips the hold when reduced motion is preferred", () => {
+    mockMatchMedia(true);
+    render(<RouteProgress />);
+
+    act(() => {
+      window.history.pushState({}, "", "/b");
+    });
+    act(() => {
+      vi.advanceTimersByTime(160);
+    });
+
+    expect(getProgress()).toBe(100);
+  });
+});

--- a/frontend/src/component/RouteProgress.tsx
+++ b/frontend/src/component/RouteProgress.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
-import { cn } from "@/lib/utils";
+import { cn, isRouteContentPending, subscribeRouteContentPending } from "@/lib/utils";
 
 /** Navigations that resolve within this window never show the bar. */
 const SHOW_DELAY_MS = 150;
@@ -33,6 +33,9 @@ export function RouteProgress() {
   const [value, setValue] = useState(0);
 
   const isNavigating = useRef(false);
+  // True once the URL has settled on the destination route, even if its
+  // loading.tsx fallback is still mounted (content not actually ready yet).
+  const routeSettled = useRef(true);
   const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const trickleTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -45,12 +48,17 @@ export function RouteProgress() {
       if (showTimer.current) clearTimeout(showTimer.current);
       if (trickleTimer.current) clearInterval(trickleTimer.current);
       if (hideTimer.current) clearTimeout(hideTimer.current);
+      showTimer.current = null;
+      trickleTimer.current = null;
+      hideTimer.current = null;
     }
 
     function start() {
-      if (isNavigating.current) return;
-      isNavigating.current = true;
+      // A new navigation cancels and resets any in-flight one, rather than
+      // letting a stale trickle silently continue (or jumping to complete).
       clearAllTimers();
+      isNavigating.current = true;
+      routeSettled.current = false;
       setValue(0);
 
       showTimer.current = setTimeout(() => {
@@ -66,11 +74,12 @@ export function RouteProgress() {
       }, SHOW_DELAY_MS);
     }
 
-    function finish() {
-      if (!isNavigating.current) return;
+    function finishNow() {
       isNavigating.current = false;
       if (showTimer.current) clearTimeout(showTimer.current);
       if (trickleTimer.current) clearInterval(trickleTimer.current);
+      showTimer.current = null;
+      trickleTimer.current = null;
 
       setValue(100);
       hideTimer.current = setTimeout(
@@ -81,6 +90,21 @@ export function RouteProgress() {
         reducedMotion ? 0 : FINISH_HOLD_MS,
       );
     }
+
+    function finish() {
+      if (!isNavigating.current) return;
+      routeSettled.current = true;
+      // The URL commits before a slow destination's loading.tsx unmounts —
+      // don't call it "done" until that content-pending signal clears too.
+      if (isRouteContentPending()) return;
+      finishNow();
+    }
+
+    const unsubscribeContentPending = subscribeRouteContentPending((pending) => {
+      if (!pending && isNavigating.current && routeSettled.current) {
+        finishNow();
+      }
+    });
 
     const originalPushState = window.history.pushState.bind(window.history);
     const originalReplaceState = window.history.replaceState.bind(window.history);
@@ -104,6 +128,7 @@ export function RouteProgress() {
       window.history.pushState = originalPushState;
       window.history.replaceState = originalReplaceState;
       window.removeEventListener("popstate", start);
+      unsubscribeContentPending();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeKey, reducedMotion]);

--- a/frontend/src/component/ui/empty-state.test.tsx
+++ b/frontend/src/component/ui/empty-state.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EmptyState } from "./empty-state";
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+describe("EmptyState", () => {
+  it("renders the icon, title, and description with no action", () => {
+    render(
+      <EmptyState
+        icon={<span data-testid="icon">icon</span>}
+        title="Nothing here"
+        description="Nothing to see yet."
+      />,
+    );
+
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+    expect(screen.getByText("Nothing to see yet.")).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders a button action and fires its onClick", () => {
+    const onClick = vi.fn();
+    render(<EmptyState title="Empty" description="desc" action={{ label: "Do it", onClick }} />);
+
+    const button = screen.getByRole("button", { name: "Do it" });
+    button.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a link action when href is provided instead of a button", () => {
+    render(<EmptyState title="Empty" description="desc" action={{ label: "Go", href: "/markets" }} />);
+
+    expect(screen.getByRole("link", { name: "Go" })).toHaveAttribute("href", "/markets");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders a secondary action alongside the primary one", () => {
+    const onSecondaryClick = vi.fn();
+    render(
+      <EmptyState
+        title="Empty"
+        description="desc"
+        action={{ label: "Primary", href: "/a" }}
+        secondaryAction={{ label: "Secondary", onClick: onSecondaryClick }}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Primary" })).toBeInTheDocument();
+    const secondary = screen.getByRole("button", { name: "Secondary" });
+    secondary.click();
+    expect(onSecondaryClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies error-variant styling to the icon container", () => {
+    render(
+      <EmptyState
+        icon={<span data-testid="icon">icon</span>}
+        title="Failed"
+        description="Something broke."
+        variant="error"
+      />,
+    );
+
+    expect(screen.getByTestId("icon").parentElement).toHaveClass("bg-red-500/10");
+  });
+});

--- a/frontend/src/component/ui/empty-state.tsx
+++ b/frontend/src/component/ui/empty-state.tsx
@@ -1,14 +1,50 @@
 import React from "react";
+import Link from "next/link";
+
+export interface EmptyStateAction {
+  label: string;
+  onClick?: () => void;
+  /** When set, renders as a Link instead of a button. */
+  href?: string;
+}
 
 export interface EmptyStateProps {
   icon?: React.ReactNode;
   title: string;
   description: string;
-  action?: {
-    label: string;
-    onClick: () => void;
-  };
+  action?: EmptyStateAction;
+  /** A lower-emphasis action alongside the primary one, e.g. "Clear filters". */
+  secondaryAction?: EmptyStateAction;
   variant?: "empty" | "error";
+  className?: string;
+}
+
+const PRIMARY_ACTION_CLASSES =
+  "inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50";
+
+const SECONDARY_ACTION_CLASSES =
+  "inline-flex items-center justify-center rounded-md border border-border bg-transparent px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50";
+
+function EmptyStateActionButton({
+  action,
+  className,
+}: {
+  action: EmptyStateAction;
+  className: string;
+}) {
+  if (action.href) {
+    return (
+      <Link href={action.href} onClick={action.onClick} className={className}>
+        {action.label}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={action.onClick} className={className}>
+      {action.label}
+    </button>
+  );
 }
 
 export function EmptyState({
@@ -16,12 +52,16 @@ export function EmptyState({
   title,
   description,
   action,
+  secondaryAction,
   variant = "empty",
+  className,
 }: EmptyStateProps) {
   const isError = variant === "error";
 
   return (
-    <div className="flex flex-col items-center justify-center py-12 px-4">
+    <div
+      className={`flex flex-col items-center justify-center py-12 px-4${className ? ` ${className}` : ""}`}
+    >
       {icon && (
         <div
           className={`mb-4 flex h-16 w-16 items-center justify-center rounded-full ${
@@ -39,13 +79,15 @@ export function EmptyState({
         {description}
       </p>
 
-      {action && (
-        <button
-          onClick={action.onClick}
-          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-        >
-          {action.label}
-        </button>
+      {(action || secondaryAction) && (
+        <div className="flex flex-col items-center gap-3 sm:flex-row">
+          {action && (
+            <EmptyStateActionButton action={action} className={PRIMARY_ACTION_CLASSES} />
+          )}
+          {secondaryAction && (
+            <EmptyStateActionButton action={secondaryAction} className={SECONDARY_ACTION_CLASSES} />
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -14,6 +14,8 @@ import ConnectWalletModal from "@/component/ConnectWalletModal";
 
 export interface AuthUser {
   username: string;
+  avatarUrl?: string;
+  bio?: string;
 }
 
 export interface WalletContextValue {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,7 +26,7 @@ if (!BASE_URL) {
   console.warn('NEXT_PUBLIC_API_URL is not set. API calls may fail.');
 }
 
-interface ApiOptions extends Omit<RequestInit, 'body'> {
+export interface ApiOptions extends Omit<RequestInit, 'body'> {
   body?: unknown;
   signal?: AbortSignal;
 }
@@ -98,3 +98,60 @@ export const apiClient = {
   patch: <T>(path: string, body?: unknown, options?: ApiOptions) => request<T>(path, 'PATCH', { ...options, body }),
   delete: <T>(path: string, options?: ApiOptions) => request<T>(path, 'DELETE', options),
 };
+
+// ── Profile completeness ────────────────────────────────────────────────────
+
+export interface ProfileFieldValues {
+  username?: string;
+  avatarUrl?: string;
+  bio?: string;
+}
+
+export interface ProfileFieldDef {
+  key: keyof ProfileFieldValues;
+  label: string;
+  description: string;
+}
+
+export const REQUIRED_PROFILE_FIELDS: ProfileFieldDef[] = [
+  { key: 'username', label: 'Username', description: 'Choose a display name for your account.' },
+  { key: 'avatarUrl', label: 'Profile picture', description: 'Add an avatar so others recognize you.' },
+  { key: 'bio', label: 'Bio', description: 'Tell the community a little about yourself.' },
+];
+
+/** Returns the required profile fields that are still empty for `user`. */
+export function getMissingProfileFields(
+  user: ProfileFieldValues | null | undefined,
+): ProfileFieldDef[] {
+  if (!user) return REQUIRED_PROFILE_FIELDS;
+  return REQUIRED_PROFILE_FIELDS.filter((field) => !user[field.key]?.trim());
+}
+
+// ── Course completion ───────────────────────────────────────────────────────
+
+export interface CourseCompletionResponse {
+  courseId: string;
+  status: 'completed';
+  awardedAt: string;
+}
+
+/** A fresh idempotency key identifying one completion attempt for a course. */
+export function generateIdempotencyKey(courseId: string): string {
+  const random =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `course-complete:${courseId}:${random}`;
+}
+
+export function submitCourseCompletion(
+  courseId: string,
+  idempotencyKey: string,
+  options: ApiOptions = {},
+): Promise<CourseCompletionResponse> {
+  return apiClient.post<CourseCompletionResponse>(
+    `/courses/${encodeURIComponent(courseId)}/complete`,
+    { idempotencyKey },
+    { ...options, headers: { 'Idempotency-Key': idempotencyKey, ...options.headers } },
+  );
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,55 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+// ── Route content pending signal ────────────────────────────────────────────
+//
+// Next.js updates the URL (usePathname/useSearchParams) as soon as a client
+// navigation is committed, even while the destination's loading.tsx Suspense
+// fallback is still showing. A route-change listener that treats "pathname
+// changed" as "route settled" therefore fires early on slow transitions.
+// Route-level loading.tsx files call `beginRouteContentLoad()` on mount and
+// release it on unmount so anything that needs to know when the *content*
+// (not just the URL) is actually ready — like RouteProgress — can wait for it.
+
+type RouteContentPendingListener = (pending: boolean) => void;
+
+let pendingRouteContentCount = 0;
+const routeContentPendingListeners = new Set<RouteContentPendingListener>();
+
+function notifyRouteContentPendingListeners() {
+  const pending = pendingRouteContentCount > 0;
+  routeContentPendingListeners.forEach((listener) => listener(pending));
+}
+
+export function isRouteContentPending(): boolean {
+  return pendingRouteContentCount > 0;
+}
+
+/** Marks route content as loading; call the returned function once it's ready. */
+export function beginRouteContentLoad(): () => void {
+  pendingRouteContentCount += 1;
+  notifyRouteContentPendingListeners();
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    pendingRouteContentCount = Math.max(0, pendingRouteContentCount - 1);
+    notifyRouteContentPendingListeners();
+  };
+}
+
+/** Subscribes to route-content-pending changes; returns an unsubscribe function. */
+export function subscribeRouteContentPending(
+  listener: RouteContentPendingListener,
+): () => void {
+  routeContentPendingListeners.add(listener);
+  listener(isRouteContentPending());
+  return () => {
+    routeContentPendingListeners.delete(listener);
+  };
+}
+
 export interface CourseLesson {
   id: string;
   title: string;


### PR DESCRIPTION

1. ProfileGateWrapper — now shows a card listing exactly which profile fields (username/avatar/bio) are missing, with a "Complete Profile" link to /settings#profile, inside the normal dashboard chrome (not a bare block). Routes are configured as critical (no dismiss — /my-markets, /creator-events) or non-critical (dismissible, remembered in sessionStorage — /competitions) via a new PROFILE_GATED_ROUTES map in AuthGuard.tsx. Missing-field detection lives in lib/api.ts as a pure, testable function.

2. RouteProgress — fixed the root cause: Next.js updates the URL before a slow route's loading.tsx fallback unmounts, so "pathname changed" isn't "content ready." Added a small pub/sub in lib/utils.ts (beginRouteContentLoad/subscribeRouteContentPending) that app/loading.tsx now reports into, so the bar only completes once content actually settles. Also fixed rapid re-navigation to reset the trickle instead of leaving it stuck or jumping ahead.

3. CourseCompletionModal — double-submit is now guarded by a ref (checked synchronously, unlike state, which can lag a re-render), each attempt gets a fresh idempotency key sent as a header via submitCourseCompletion in api.ts, and retry-after-failure reuses the same key. Added distinct success/error/retry UI states.

4. EmptyState — action/secondaryAction now support href (renders a Link) alongside onClick. Migrated my-predictions, my-markets (three tabs → one config-driven empty state + a "Clear Filters" secondary action), and NotificationsCard (used by the notifications page) to use it; tidied watchlist's existing usage to use href for consistency.

Note: npm run lint doesn't work in this repo currently — Next 16 removed next lint and there's no eslint config/binary installed — that's pre-existing and unrelated to this change, not something I fixed.


closes #1586
closes #1588
closes #1589
closes #1591
