### PR TITLE
 feat(frontend): active prediction cash-out estimate from live odds

### DIFF
--- a/frontend/src/component/ActivePrediction.tsx
+++ b/frontend/src/component/ActivePrediction.tsx
@@ -1,38 +1,131 @@
 // frontend/src/component/ActivePrediction.tsx
+"use client";
+
 import React from "react";
+import { useLiveOdds } from "@/hooks/useLiveOdds";
+import {
+  estimateCashOut,
+  formatPnlXlm,
+  formatXlm,
+} from "@/lib/utils";
 
 type Prediction = {
+  id: string;
+  marketId: string;
   category: string;
   market: string;
-  stance: string;
+  stance: "Yes" | "No";
   status: string;
   timeRemaining: string;
-  reward: string;
+  /** Stake in XLM */
+  stake: number;
+  /** Entry implied price 0–1 for the chosen side */
+  entryOdds: number;
+  marketLocked?: boolean;
 };
 
 const predictions: Prediction[] = [
   {
+    id: "1",
+    marketId: "btc-95k-friday",
     category: "Crypto",
     market: "BTC above $95,000 by Friday",
     stance: "Yes",
     status: "Live",
     timeRemaining: "Ends in 19h",
-    reward: "92 XLM",
+    stake: 50,
+    entryOdds: 0.55,
+    marketLocked: false,
   },
   {
+    id: "2",
+    marketId: "spx-4500-friday",
     category: "Finance",
     market: "S&P 500 above 4500 by Friday",
     stance: "No",
     status: "Live",
     timeRemaining: "Ends in 12h",
-    reward: "50 XLM",
+    stake: 40,
+    entryOdds: 0.48,
+    marketLocked: true,
   },
 ];
+
+function PredictionCard({ p }: { p: Prediction }) {
+  const { odds, status: oddsStatus } = useLiveOdds(
+    p.marketLocked ? null : p.marketId,
+  );
+
+  const live =
+    odds && Number.isFinite(odds.yesOdds) && Number.isFinite(odds.noOdds)
+      ? { yes: odds.yesOdds, no: odds.noOdds }
+      : null;
+
+  const estimate = estimateCashOut({
+    stake: p.stake,
+    stance: p.stance,
+    entryOdds: p.entryOdds,
+    live,
+    marketLocked: p.marketLocked,
+  });
+
+  return (
+    <div className="min-w-[250px] bg-gray-50 rounded-lg p-4 flex flex-col gap-2 shadow-sm">
+      <span className="text-xs font-medium text-gray-500">{p.category}</span>
+      <h3 className="font-bold text-md">{p.market}</h3>
+      <span className="text-sm">Prediction: {p.stance}</span>
+      <span className="text-sm text-gray-600">Stake: {formatXlm(p.stake)}</span>
+
+      <div className="flex items-center gap-2 text-sm">
+        <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+        <span>{p.status}</span>
+        <span className="ml-auto text-gray-500">{p.timeRemaining}</span>
+      </div>
+
+      <div className="mt-1 text-sm">
+        <div className="flex justify-between">
+          <span className="text-gray-600">Est. value</span>
+          <span className="font-semibold text-blue-600">
+            {formatXlm(estimate.estimatedValue)}
+          </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-gray-600">Unrealized P/L</span>
+          <span
+            className={
+              estimate.unrealizedPnl >= 0 ? "text-green-600" : "text-red-600"
+            }
+          >
+            {formatPnlXlm(estimate.unrealizedPnl)}
+          </span>
+        </div>
+        {oddsStatus === "polling" || oddsStatus === "connecting" ? (
+          <p className="text-xs text-gray-400 mt-1">Updating live odds…</p>
+        ) : null}
+      </div>
+
+      <button
+        type="button"
+        disabled={!estimate.canExit}
+        className={
+          estimate.canExit
+            ? "mt-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white"
+            : "mt-2 rounded-md bg-gray-300 px-3 py-2 text-sm font-medium text-gray-600 cursor-not-allowed"
+        }
+        title={estimate.exitBlockedReason ?? "Cash out at live estimate"}
+      >
+        {estimate.canExit ? "Cash out" : "Exit unavailable"}
+      </button>
+      {!estimate.canExit && estimate.exitBlockedReason ? (
+        <p className="text-xs text-amber-700">{estimate.exitBlockedReason}</p>
+      ) : null}
+    </div>
+  );
+}
 
 const ActivePrediction: React.FC = () => {
   return (
     <div className="p-4 bg-white rounded-lg shadow-md">
-      {/* Header */}
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-lg font-semibold">Active Predictions</h2>
         <a href="/predictions" className="text-blue-600 hover:underline">
@@ -40,31 +133,9 @@ const ActivePrediction: React.FC = () => {
         </a>
       </div>
 
-      {/* Predictions List */}
       <div className="flex gap-4 overflow-x-auto">
-        {predictions.map((p, idx) => (
-          <div
-            key={idx}
-            className="min-w-[250px] bg-gray-50 rounded-lg p-4 flex flex-col gap-2 shadow-sm"
-          >
-            <span className="text-xs font-medium text-gray-500">
-              {p.category}
-            </span>
-            <h3 className="font-bold text-md">{p.market}</h3>
-            <span className="text-sm">Prediction: {p.stance}</span>
-
-            {/* Status & Time */}
-            <div className="flex items-center gap-2 text-sm">
-              <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></span>
-              <span>{p.status}</span>
-              <span className="ml-auto text-gray-500">{p.timeRemaining}</span>
-            </div>
-
-            {/* Footer Reward */}
-            <div className="mt-2 font-semibold text-right text-blue-600">
-              Potential Reward → {p.reward}
-            </div>
-          </div>
+        {predictions.map((p) => (
+          <PredictionCard key={p.id} p={p} />
         ))}
       </div>
     </div>

--- a/frontend/src/lib/utils.cashout.test.ts
+++ b/frontend/src/lib/utils.cashout.test.ts
@@ -1,0 +1,56 @@
+import { estimateCashOut } from "./utils";
+
+describe("estimateCashOut", () => {
+  test("matches sample odds for a Yes position", () => {
+    // stake 100 at entry 0.50 → 200 shares; live yes 0.60 → value 120, pnl +20
+    const result = estimateCashOut({
+      stake: 100,
+      stance: "Yes",
+      entryOdds: 0.5,
+      live: { yes: 0.6, no: 0.4 },
+      marketLocked: false,
+    });
+    expect(result.estimatedValue).toBeCloseTo(120, 5);
+    expect(result.unrealizedPnl).toBeCloseTo(20, 5);
+    expect(result.canExit).toBe(true);
+    expect(result.exitBlockedReason).toBeNull();
+  });
+
+  test("uses no price for No stance", () => {
+    const result = estimateCashOut({
+      stake: 50,
+      stance: "No",
+      entryOdds: 0.4,
+      live: { yes: 0.7, no: 0.3 },
+      marketLocked: false,
+    });
+    // shares = 50/0.4 = 125; value = 125 * 0.3 = 37.5; pnl = -12.5
+    expect(result.estimatedValue).toBeCloseTo(37.5, 5);
+    expect(result.unrealizedPnl).toBeCloseTo(-12.5, 5);
+    expect(result.canExit).toBe(true);
+  });
+
+  test("locked market disables exit", () => {
+    const result = estimateCashOut({
+      stake: 50,
+      stance: "Yes",
+      entryOdds: 0.5,
+      live: { yes: 0.6, no: 0.4 },
+      marketLocked: true,
+    });
+    expect(result.canExit).toBe(false);
+    expect(result.exitBlockedReason).toMatch(/locked/i);
+  });
+
+  test("missing live odds disables exit", () => {
+    const result = estimateCashOut({
+      stake: 50,
+      stance: "Yes",
+      entryOdds: 0.5,
+      live: null,
+      marketLocked: false,
+    });
+    expect(result.canExit).toBe(false);
+    expect(result.exitBlockedReason).toMatch(/odds/i);
+  });
+});

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -245,3 +245,106 @@ export function downloadCsv(filename: string, content: string): void {
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
 }
+
+// ── Active prediction cash-out estimate (#1600) ─────────────────────────────
+
+/** Odds as implied probabilities in (0, 1]. */
+export interface LiveOddsPrices {
+  yes: number;
+  no: number;
+}
+
+export type PredictionStance = "Yes" | "No" | "yes" | "no";
+
+export interface CashOutEstimateInput {
+  /** Stake in the same unit shown in the UI (e.g. XLM). */
+  stake: number;
+  /** Side the user took. */
+  stance: PredictionStance;
+  /** Implied price when the position was opened (0–1). */
+  entryOdds: number;
+  /** Latest live prices. */
+  live: LiveOddsPrices | null;
+  /** When true, early exit is unavailable. */
+  marketLocked?: boolean;
+}
+
+export interface CashOutEstimate {
+  /** Mark-to-market value if the user exited now. */
+  estimatedValue: number;
+  /** estimatedValue − stake */
+  unrealizedPnl: number;
+  /** Whether the UI should allow an early-exit action. */
+  canExit: boolean;
+  /** Short reason when canExit is false. */
+  exitBlockedReason: string | null;
+}
+
+function clampProb(p: number): number {
+  if (!Number.isFinite(p) || p <= 0) return 0;
+  if (p > 1) return 1;
+  return p;
+}
+
+/**
+ * Estimate cash-out value from live odds.
+ *
+ * Model: shares = stake / entryOdds; value = shares * currentOddsForSide.
+ * If the market is locked or prices are missing/invalid, exit is disabled.
+ */
+export function estimateCashOut(input: CashOutEstimateInput): CashOutEstimate {
+  const stake = Number(input.stake);
+  const entry = clampProb(Number(input.entryOdds));
+  const locked = Boolean(input.marketLocked);
+
+  if (locked) {
+    return {
+      estimatedValue: Number.isFinite(stake) ? stake : 0,
+      unrealizedPnl: 0,
+      canExit: false,
+      exitBlockedReason: "Market locked — early exit unavailable",
+    };
+  }
+
+  if (!input.live || !Number.isFinite(stake) || stake <= 0 || entry <= 0) {
+    return {
+      estimatedValue: Number.isFinite(stake) ? stake : 0,
+      unrealizedPnl: 0,
+      canExit: false,
+      exitBlockedReason: "Live odds unavailable",
+    };
+  }
+
+  const stance = String(input.stance).toLowerCase();
+  const current = clampProb(stance === "no" ? input.live.no : input.live.yes);
+  if (current <= 0) {
+    return {
+      estimatedValue: 0,
+      unrealizedPnl: -stake,
+      canExit: false,
+      exitBlockedReason: "Live odds unavailable",
+    };
+  }
+
+  const shares = stake / entry;
+  const estimatedValue = shares * current;
+  const unrealizedPnl = estimatedValue - stake;
+
+  return {
+    estimatedValue,
+    unrealizedPnl,
+    canExit: true,
+    exitBlockedReason: null,
+  };
+}
+
+export function formatXlm(amount: number, digits = 2): string {
+  if (!Number.isFinite(amount)) return "—";
+  return `${amount.toFixed(digits)} XLM`;
+}
+
+export function formatPnlXlm(pnl: number, digits = 2): string {
+  if (!Number.isFinite(pnl)) return "—";
+  const sign = pnl > 0 ? "+" : "";
+  return `\( {sign} \){pnl.toFixed(digits)} XLM`;
+      }


### PR DESCRIPTION
## Summary
Implements #1600 — Active Prediction cards show estimated exit value and unrealized P/L from live odds, and disable cash-out when the market is locked.

## Changes
- `estimateCashOut` helper in `frontend/src/lib/utils.ts`
- `ActivePrediction` uses `useLiveOdds` + estimate UI
- Unit tests for sample odds and locked state

## Acceptance criteria
- [x] Users see live estimated value / unrealized P/L
- [x] Early exit unavailable when market locked
- [x] Tests cover estimate math and locked state

Closes #1600