### PR TITLE
Feat/1512 1510 1513 1507 twap achievements decay apikeys

### DIFF
--- a/backend/src/achievements/achievements.module.ts
+++ b/backend/src/achievements/achievements.module.ts
@@ -6,11 +6,13 @@ import { AchievementsService } from './achievements.service';
 import { AchievementsController } from './achievements.controller';
 import { User } from '../users/entities/user.entity';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { WebsocketModule } from '../websocket/websocket.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Achievement, UserAchievement, User]),
     NotificationsModule,
+    WebsocketModule,
   ],
   providers: [AchievementsService],
   controllers: [AchievementsController],

--- a/backend/src/achievements/achievements.service.spec.ts
+++ b/backend/src/achievements/achievements.service.spec.ts
@@ -7,6 +7,7 @@ import { UserAchievement } from './entities/user-achievement.entity';
 import { User } from '../users/entities/user.entity';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
+import { NotificationBroadcasterService } from '../websocket/notification-broadcaster.service';
 
 describe('AchievementsService', () => {
   let service: AchievementsService;
@@ -14,6 +15,7 @@ describe('AchievementsService', () => {
   let userAchievementsRepository: jest.Mocked<Repository<UserAchievement>>;
   let usersRepository: jest.Mocked<Repository<User>>;
   let notificationsService: jest.Mocked<NotificationsService>;
+  let notificationBroadcaster: jest.Mocked<NotificationBroadcasterService>;
 
   const mockUser = {
     id: 'user-1',
@@ -81,6 +83,11 @@ describe('AchievementsService', () => {
       create: jest.fn().mockResolvedValue({}),
     } as any;
 
+    notificationBroadcaster = {
+      broadcastAchievementUnlocked: jest.fn(),
+      broadcastAchievementProgress: jest.fn(),
+    } as any;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AchievementsService,
@@ -99,6 +106,10 @@ describe('AchievementsService', () => {
         {
           provide: NotificationsService,
           useValue: notificationsService,
+        },
+        {
+          provide: NotificationBroadcasterService,
+          useValue: notificationBroadcaster,
         },
       ],
     }).compile();
@@ -131,6 +142,12 @@ describe('AchievementsService', () => {
       expect.any(String),
       expect.objectContaining({ achievementId: mockAchievement.id }),
       mockUser.id,
+    );
+    expect(
+      notificationBroadcaster.broadcastAchievementUnlocked,
+    ).toHaveBeenCalledWith(
+      mockUser.stellar_address,
+      expect.objectContaining({ achievement_id: mockAchievement.id }),
     );
   });
 
@@ -353,6 +370,85 @@ describe('AchievementsService', () => {
       ]);
 
       expect(notificationsService.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('achievement progress broadcasting', () => {
+    const lockedAchievement = {
+      id: 'ach-locked',
+      type: AchievementType.CORRECT_PREDICTIONS_10,
+      title: 'Rising Star',
+    } as Achievement;
+
+    const progressingUser = {
+      id: 'user-2',
+      stellar_address: 'GXYZ789',
+      total_predictions: 10,
+      correct_predictions: 5,
+      total_staked_stroops: '0',
+      reputation_score: 0,
+    } as User;
+
+    beforeEach(() => {
+      achievementsRepository.find.mockResolvedValue([lockedAchievement]);
+    });
+
+    it('broadcasts progress when current_value changed from the stored row', async () => {
+      userAchievementsRepository.findOne.mockResolvedValue({
+        current_value: 3,
+        is_unlocked: false,
+      } as UserAchievement);
+      userAchievementsRepository.save.mockResolvedValue({} as UserAchievement);
+
+      await service.updateAchievementProgress(progressingUser);
+
+      expect(
+        notificationBroadcaster.broadcastAchievementProgress,
+      ).toHaveBeenCalledWith(
+        progressingUser.stellar_address,
+        expect.objectContaining({
+          achievement_id: lockedAchievement.id,
+          current_progress: 5,
+          threshold: 10,
+        }),
+      );
+    });
+
+    it('does not broadcast progress when current_value is unchanged', async () => {
+      userAchievementsRepository.findOne.mockResolvedValue({
+        current_value: 5,
+        is_unlocked: false,
+      } as UserAchievement);
+      userAchievementsRepository.save.mockResolvedValue({} as UserAchievement);
+
+      await service.updateAchievementProgress(progressingUser);
+
+      expect(
+        notificationBroadcaster.broadcastAchievementProgress,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('broadcasts an achievement:unlocked event exactly once when threshold is met', async () => {
+      const unlockingUser = {
+        id: 'user-3',
+        stellar_address: 'GUNLOCK1',
+        total_predictions: 10,
+        correct_predictions: 10,
+        total_staked_stroops: '0',
+        reputation_score: 0,
+      } as User;
+
+      achievementsRepository.find.mockResolvedValue([lockedAchievement]);
+      makeInsertOrIgnoreMock(userAchievementsRepository);
+
+      await service.updateAchievementProgress(unlockingUser);
+
+      expect(
+        notificationBroadcaster.broadcastAchievementUnlocked,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        notificationBroadcaster.broadcastAchievementProgress,
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/achievements/achievements.service.ts
+++ b/backend/src/achievements/achievements.service.ts
@@ -7,6 +7,7 @@ import { User } from '../users/entities/user.entity';
 import { AchievementResponseDto } from './dto/achievement-response.dto';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
+import { NotificationBroadcasterService } from '../websocket/notification-broadcaster.service';
 
 @Injectable()
 export class AchievementsService {
@@ -20,6 +21,7 @@ export class AchievementsService {
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
     private readonly notificationsService: NotificationsService,
+    private readonly notificationBroadcaster: NotificationBroadcasterService,
   ) {}
 
   async initializeAchievements(): Promise<void> {
@@ -226,6 +228,7 @@ export class AchievementsService {
     user: User,
     achievement: Achievement,
   ): Promise<void> {
+    const unlockedAt = new Date();
     await this.notificationsService.create(
       user.stellar_address,
       NotificationType.AchievementUnlocked,
@@ -233,6 +236,19 @@ export class AchievementsService {
       `You unlocked "${achievement.title}"`,
       { achievementId: achievement.id, achievementType: achievement.type },
       user.id,
+    );
+
+    this.notificationBroadcaster.broadcastAchievementUnlocked(
+      user.stellar_address,
+      {
+        achievement_id: achievement.id,
+        type: achievement.type,
+        title: achievement.title,
+        description: achievement.description,
+        icon_url: achievement.icon_url,
+        reward_points: achievement.reward_points,
+        unlocked_at: unlockedAt,
+      },
     );
   }
 
@@ -375,6 +391,8 @@ export class AchievementsService {
         where: { user: { id: user.id }, achievement: { id: achievement.id } },
       });
 
+      const previousProgress = existing?.current_value ?? 0;
+
       if (existing) {
         existing.current_value = currentProgress;
         await this.userAchievementsRepository.save(existing);
@@ -391,6 +409,25 @@ export class AchievementsService {
           })
           .orIgnore()
           .execute();
+      }
+
+      // Only push a live update when progress actually moved — avoids
+      // spamming unchanged progress on every profile view/poll.
+      if (currentProgress !== previousProgress) {
+        const percentage =
+          threshold > 0
+            ? Math.min(100, Math.round((currentProgress / threshold) * 100))
+            : 0;
+        this.notificationBroadcaster.broadcastAchievementProgress(
+          user.stellar_address,
+          {
+            achievement_id: achievement.id,
+            type: achievement.type,
+            current_progress: currentProgress,
+            threshold,
+            progress_percentage: percentage,
+          },
+        );
       }
     }
   }

--- a/backend/src/auth/api-key.controller.spec.ts
+++ b/backend/src/auth/api-key.controller.spec.ts
@@ -13,6 +13,7 @@ describe('ApiKeyController', () => {
       create: jest.fn(),
       listForUser: jest.fn(),
       revoke: jest.fn(),
+      rotate: jest.fn(),
     } as unknown as jest.Mocked<ApiKeyService>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -55,6 +56,55 @@ describe('ApiKeyController', () => {
 
       expect(apiKeyService.create).toHaveBeenCalledWith(mockUser.id, dto);
       expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe('rotate', () => {
+    it('should rotate a key and pass through the grace period override', async () => {
+      const mockUser = { id: 'user123' } as User;
+      const expectedResponse = {
+        id: 'key2',
+        name: 'Test Key',
+        key: 'ia_newrawkey',
+        key_prefix: 'ia_newra',
+        scopes: ['read'],
+        expires_at: null,
+        created_at: new Date(),
+      };
+
+      apiKeyService.rotate.mockResolvedValue(expectedResponse);
+
+      const result = await controller.rotate(mockUser, 'key1', {
+        grace_period_ms: 3600_000,
+      });
+
+      expect(apiKeyService.rotate).toHaveBeenCalledWith(
+        'key1',
+        mockUser.id,
+        3600_000,
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('should rotate a key without an explicit grace period', async () => {
+      const mockUser = { id: 'user123' } as User;
+      apiKeyService.rotate.mockResolvedValue({
+        id: 'key2',
+        name: 'Test Key',
+        key: 'ia_newrawkey',
+        key_prefix: 'ia_newra',
+        scopes: ['read'],
+        expires_at: null,
+        created_at: new Date(),
+      });
+
+      await controller.rotate(mockUser, 'key1', {});
+
+      expect(apiKeyService.rotate).toHaveBeenCalledWith(
+        'key1',
+        mockUser.id,
+        undefined,
+      );
     });
   });
 });

--- a/backend/src/auth/api-key.controller.ts
+++ b/backend/src/auth/api-key.controller.ts
@@ -21,6 +21,7 @@ import {
   ApiKeyCreatedResponseDto,
   ApiKeyListItemDto,
 } from './dto/api-key-response.dto';
+import { RotateApiKeyDto } from './dto/rotate-api-key.dto';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { User } from '../users/entities/user.entity';
 
@@ -91,5 +92,36 @@ export class ApiKeyController {
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<ApiKeyListItemDto> {
     return this.apiKeyService.revoke(id, user.id);
+  }
+
+  /**
+   * Rotate an API key by ID: issues a new key with the same name/scopes,
+   * and grace-expires the old raw key so in-flight integrations have time
+   * to switch over.
+   */
+  @Post(':id/rotate')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Rotate an API key',
+    description:
+      'Issues a new raw key preserving name/scopes, and grace-expires the old key. The new raw key is shown once.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'New key issued — raw key shown once',
+    type: ApiKeyCreatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Key already revoked or already rotated',
+  })
+  @ApiResponse({ status: 404, description: 'Key not found' })
+  rotate(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RotateApiKeyDto,
+  ): Promise<ApiKeyCreatedResponseDto> {
+    return this.apiKeyService.rotate(id, user.id, dto?.grace_period_ms);
   }
 }

--- a/backend/src/auth/api-key.service.spec.ts
+++ b/backend/src/auth/api-key.service.spec.ts
@@ -94,5 +94,119 @@ describe('ApiKeyService', () => {
         UnauthorizedException,
       );
     });
+
+    it('should reject a rotated key whose grace window has expired', async () => {
+      const rawKey = 'ia_rotatedkey12345';
+      const mockApiKey = {
+        id: 'key123',
+        key_hash: 'hashed',
+        revoked_at: null,
+        expires_at: null,
+        rotated_at: new Date(Date.now() - 1000),
+        grace_expires_at: new Date(Date.now() - 500),
+      };
+
+      repository.find.mockResolvedValue([mockApiKey]);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      await expect(service.validateKey(rawKey)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should accept a rotated key still within its grace window', async () => {
+      const rawKey = 'ia_rotatedkey12345';
+      const mockApiKey = {
+        id: 'key123',
+        key_hash: 'hashed',
+        revoked_at: null,
+        expires_at: null,
+        rotated_at: new Date(Date.now() - 1000),
+        grace_expires_at: new Date(Date.now() + 60_000),
+      };
+
+      repository.find.mockResolvedValue([mockApiKey]);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.validateKey(rawKey);
+      expect(result).toEqual(mockApiKey);
+    });
+  });
+
+  describe('rotate', () => {
+    it('should issue a new key preserving name/scopes and grace-expire the old one', async () => {
+      const existing = {
+        id: 'key123',
+        userId: 'user123',
+        name: 'My Key',
+        scopes: ['read:markets'],
+        expires_at: null,
+        revoked_at: null,
+        rotated_at: null,
+        grace_expires_at: null,
+        replaced_by_id: null,
+      };
+      const replacement = {
+        id: 'key456',
+        name: existing.name,
+        key_prefix: 'ia_newpre',
+        scopes: existing.scopes,
+        expires_at: null,
+        created_at: new Date(),
+      };
+
+      repository.findOne.mockResolvedValue(existing);
+      repository.create.mockReturnValue(replacement);
+      repository.save
+        .mockResolvedValueOnce(replacement)
+        .mockResolvedValueOnce({ ...existing, rotated_at: new Date() });
+
+      const result = await service.rotate('key123', 'user123');
+
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user123',
+          name: existing.name,
+          scopes: existing.scopes,
+        }),
+      );
+      expect(result.id).toBe(replacement.id);
+      expect(result.key).toMatch(/^ia_/);
+
+      // Second save call persists the grace-expiry state on the old row.
+      const oldRowSaveArg = repository.save.mock.calls[1][0];
+      expect(oldRowSaveArg.rotated_at).toBeInstanceOf(Date);
+      expect(oldRowSaveArg.grace_expires_at).toBeInstanceOf(Date);
+      expect(oldRowSaveArg.replaced_by_id).toBe(replacement.id);
+    });
+
+    it('should throw NotFoundException for an unknown key', async () => {
+      repository.findOne.mockResolvedValue(null);
+      await expect(service.rotate('missing', 'user123')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when rotating a revoked key', async () => {
+      repository.findOne.mockResolvedValue({
+        id: 'key123',
+        revoked_at: new Date(),
+        rotated_at: null,
+      });
+      await expect(service.rotate('key123', 'user123')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw ForbiddenException when rotating an already-rotated key', async () => {
+      repository.findOne.mockResolvedValue({
+        id: 'key123',
+        revoked_at: null,
+        rotated_at: new Date(),
+      });
+      await expect(service.rotate('key123', 'user123')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
   });
 });

--- a/backend/src/auth/api-key.service.ts
+++ b/backend/src/auth/api-key.service.ts
@@ -19,6 +19,9 @@ import {
 /** Throttle window for last_used_at writes (60 seconds) */
 const LAST_USED_THROTTLE_MS = 60_000;
 
+/** Default grace window (ms) a rotated-out key remains valid for */
+const DEFAULT_ROTATION_GRACE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
 /** bcrypt cost factor */
 const BCRYPT_ROUNDS = 10;
 
@@ -151,7 +154,83 @@ export class ApiKeyService {
       throw new UnauthorizedException('API key has expired');
     }
 
+    if (
+      matched.rotated_at &&
+      (!matched.grace_expires_at || matched.grace_expires_at < new Date())
+    ) {
+      throw new UnauthorizedException('API key has been rotated');
+    }
+
     return matched;
+  }
+
+  /**
+   * Rotate a key owned by userId: issues a brand-new raw key/hash under the
+   * same row (preserving id, name, and scopes), and marks the *previous*
+   * value as grace-expiring by recording it on a fresh row so the old raw
+   * key keeps validating for `graceMs` while callers switch over.
+   *
+   * Implementation: since only one (key_prefix, key_hash) pair can live on a
+   * row, rotation inserts a new row carrying the new key material and points
+   * the old row at it via `replaced_by_id`/`rotated_at`/`grace_expires_at` —
+   * the old row's own key_hash is untouched, so it keeps validating until
+   * grace_expires_at. Mirrors `RefreshToken`'s rotation-chain pattern.
+   */
+  async rotate(
+    id: string,
+    userId: string,
+    graceMs: number = DEFAULT_ROTATION_GRACE_MS,
+  ): Promise<ApiKeyCreatedResponseDto> {
+    const existing = await this.apiKeyRepository.findOne({
+      where: { id, userId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('API key not found');
+    }
+
+    if (existing.revoked_at) {
+      throw new ForbiddenException('Cannot rotate a revoked API key');
+    }
+
+    if (existing.rotated_at) {
+      throw new ForbiddenException('API key has already been rotated');
+    }
+
+    const rawKey = `${KEY_PREFIX}${randomBytes(32).toString('hex')}`;
+    const key_prefix = rawKey.slice(0, 10);
+    const key_hash = await bcrypt.hash(rawKey, BCRYPT_ROUNDS);
+
+    const replacement = this.apiKeyRepository.create({
+      userId,
+      name: existing.name,
+      key_prefix,
+      key_hash,
+      scopes: existing.scopes,
+      expires_at: existing.expires_at,
+      revoked_at: null,
+      last_used_at: null,
+    });
+    const savedReplacement = await this.apiKeyRepository.save(replacement);
+
+    existing.rotated_at = new Date();
+    existing.grace_expires_at = new Date(Date.now() + graceMs);
+    existing.replaced_by_id = savedReplacement.id;
+    await this.apiKeyRepository.save(existing);
+
+    this.logger.log(
+      `API key rotated: id=${id} userId=${userId} replacedBy=${savedReplacement.id}`,
+    );
+
+    return {
+      id: savedReplacement.id,
+      name: savedReplacement.name,
+      key: rawKey,
+      key_prefix: savedReplacement.key_prefix,
+      scopes: savedReplacement.scopes,
+      expires_at: savedReplacement.expires_at,
+      created_at: savedReplacement.created_at,
+    };
   }
 
   /**
@@ -190,6 +269,9 @@ export class ApiKeyService {
       expires_at: k.expires_at,
       last_used_at: k.last_used_at,
       revoked_at: k.revoked_at,
+      rotated_at: k.rotated_at,
+      grace_expires_at: k.grace_expires_at,
+      replaced_by_id: k.replaced_by_id,
       created_at: k.created_at,
     };
   }

--- a/backend/src/auth/dto/api-key-response.dto.ts
+++ b/backend/src/auth/dto/api-key-response.dto.ts
@@ -59,6 +59,25 @@ export class ApiKeyListItemDto {
   @ApiPropertyOptional({ nullable: true })
   revoked_at: Date | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Set once this key has been rotated out',
+  })
+  rotated_at: Date | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'End of the grace window during which a rotated key still validates',
+  })
+  grace_expires_at: Date | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'ID of the key that replaced this one via rotation',
+  })
+  replaced_by_id: string | null;
+
   @ApiProperty()
   created_at: Date;
 }

--- a/backend/src/auth/dto/rotate-api-key.dto.ts
+++ b/backend/src/auth/dto/rotate-api-key.dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsOptional, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class RotateApiKeyDto {
+  @ApiPropertyOptional({
+    example: 86_400_000,
+    description:
+      'Grace window (ms) the old key remains valid for after rotation; defaults to 24 hours',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  grace_period_ms?: number;
+}

--- a/backend/src/auth/entities/api-key.entity.ts
+++ b/backend/src/auth/entities/api-key.entity.ts
@@ -62,6 +62,31 @@ export class ApiKey {
   @Column({ name: 'last_used_at', type: 'timestamptz', nullable: true })
   last_used_at: Date | null;
 
+  /**
+   * Set when this key is rotated out via `ApiKeyService.rotate`. A non-null
+   * value means a replacement key exists; this key keeps working only until
+   * `grace_expires_at`.
+   */
+  @Column({ name: 'rotated_at', type: 'timestamptz', nullable: true })
+  rotated_at: Date | null;
+
+  /**
+   * End of the grace window during which a rotated-out key still validates,
+   * so in-flight integrations have time to switch to the replacement key.
+   * Null unless `rotated_at` is set.
+   */
+  @Column({ name: 'grace_expires_at', type: 'timestamptz', nullable: true })
+  grace_expires_at: Date | null;
+
+  /**
+   * The key that replaced this one via rotation. Null unless `rotated_at` is
+   * set. Plain indexed uuid rather than a FK — mirrors
+   * `RefreshToken.previous_token_id`, avoiding self-referential FK ordering
+   * issues on delete.
+   */
+  @Column({ name: 'replaced_by_id', type: 'uuid', nullable: true })
+  replaced_by_id: string | null;
+
   @CreateDateColumn({ type: 'timestamptz' })
   created_at: Date;
 
@@ -72,6 +97,12 @@ export class ApiKey {
   get isActive(): boolean {
     if (this.revoked_at) return false;
     if (this.expires_at && this.expires_at < new Date()) return false;
+    if (
+      this.rotated_at &&
+      (!this.grace_expires_at || this.grace_expires_at < new Date())
+    ) {
+      return false;
+    }
     return true;
   }
 }

--- a/backend/src/migrations/1787800000000-AddApiKeyRotationFields.ts
+++ b/backend/src/migrations/1787800000000-AddApiKeyRotationFields.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddApiKeyRotationFields1787800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('api_keys', [
+      new TableColumn({
+        name: 'rotated_at',
+        type: 'timestamptz',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'grace_expires_at',
+        type: 'timestamptz',
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: 'replaced_by_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('api_keys', 'replaced_by_id');
+    await queryRunner.dropColumn('api_keys', 'grace_expires_at');
+    await queryRunner.dropColumn('api_keys', 'rotated_at');
+  }
+}

--- a/backend/src/websocket/notification-broadcaster.service.ts
+++ b/backend/src/websocket/notification-broadcaster.service.ts
@@ -27,6 +27,24 @@ export interface EventWinnerPayload {
   total_matches: number;
 }
 
+export interface AchievementUnlockedPayload {
+  achievement_id: string;
+  type: string;
+  title: string;
+  description: string;
+  icon_url: string;
+  reward_points: number;
+  unlocked_at: Date;
+}
+
+export interface AchievementProgressPayload {
+  achievement_id: string;
+  type: string;
+  current_progress: number;
+  threshold: number;
+  progress_percentage: number;
+}
+
 @Injectable()
 export class NotificationBroadcasterService implements OnModuleDestroy {
   private readonly logger = new Logger(NotificationBroadcasterService.name);
@@ -117,6 +135,60 @@ export class NotificationBroadcasterService implements OnModuleDestroy {
     this.gateway.server.to(`user:${userAddress}`).emit('event:winner', payload);
     this.logger.log(
       `Broadcast event:winner → user:${userAddress} (event=${winner.event_id}, rank=${winner.rank})`,
+    );
+  }
+
+  /**
+   * Notify user that an achievement was unlocked
+   */
+  broadcastAchievementUnlocked(
+    userAddress: string,
+    achievement: AchievementUnlockedPayload,
+  ): void {
+    const payload = {
+      event: 'achievement:unlocked',
+      data: {
+        achievement_id: achievement.achievement_id,
+        type: achievement.type,
+        title: achievement.title,
+        description: achievement.description,
+        icon_url: achievement.icon_url,
+        reward_points: achievement.reward_points,
+        unlocked_at: achievement.unlocked_at,
+        timestamp: new Date(),
+      },
+    };
+    this.gateway.server
+      .to(`user:${userAddress}`)
+      .emit('achievement:unlocked', payload);
+    this.logger.log(
+      `Broadcast achievement:unlocked → user:${userAddress} (achievement=${achievement.achievement_id})`,
+    );
+  }
+
+  /**
+   * Notify user of updated progress toward a locked achievement
+   */
+  broadcastAchievementProgress(
+    userAddress: string,
+    progress: AchievementProgressPayload,
+  ): void {
+    const payload = {
+      event: 'achievement:progress',
+      data: {
+        achievement_id: progress.achievement_id,
+        type: progress.type,
+        current_progress: progress.current_progress,
+        threshold: progress.threshold,
+        progress_percentage: progress.progress_percentage,
+        timestamp: new Date(),
+      },
+    };
+    this.gateway.server
+      .to(`user:${userAddress}`)
+      .emit('achievement:progress', payload);
+    this.logger.log(
+      `Broadcast achievement:progress → user:${userAddress} (achievement=${progress.achievement_id}, pct=${progress.progress_percentage})`,
     );
   }
 

--- a/contracts/open-market/README.md
+++ b/contracts/open-market/README.md
@@ -217,7 +217,44 @@ price spikes.
   the TWAP of the market's primary outcome (`outcome_options[0]`), for
   consumers (indexer, UI) that track a single headline price per market.
 
-## 11) Links to Related Docs
+## 11) Reputation Decay Over Inactive Seasons
+
+A creator's reputation score (`reputation::calculate_creator_reputation`) is
+decayed lazily, at read time, in two layers — neither ever mutates stored
+counters, so there is no unbounded loop over elapsed time or seasons:
+
+1. **Time-based decay** (`reputation::apply_reputation_decay`) — decays
+   toward zero as seconds elapse since `CreatorStats::last_updated`, per the
+   governance-configured `reputation_half_life_seconds` /
+   `reputation_decay_mode` (Linear or Exponential).
+2. **Season-inactivity decay** (`reputation::apply_season_inactivity_decay`)
+   — for each season that has become the active season since the creator was
+   last active, beyond a configurable grace period, the score is multiplied
+   by `(10_000 - reputation_season_decay_bps) / 10_000`, compounding:
+
+   ```
+   decaying_seasons = inactive_seasons - grace_seasons   (0 if inactive_seasons <= grace_seasons)
+   score' = score * ((10_000 - decay_bps) / 10_000) ^ decaying_seasons
+   ```
+
+   `inactive_seasons` is `current_active_season_id - last_active_season_id`.
+   A creator's `last_active_season_id` is recorded (via a compact storage
+   key, not a new field) whenever they create, resolve, or have a dispute
+   raised against a market — the same hooks that already reset
+   `last_updated` for time-based decay. Both decay layers apply in sequence
+   (time-based first, then season-based) and neither can push the score
+   below `0` (`u32` floor) or above its pre-decay value.
+
+Governance parameters (`config.rs`, admin-settable via
+`set_season_decay_config`):
+
+- `reputation_season_decay_grace` — inactive seasons tolerated before decay
+  starts. Defaults to `1`.
+- `reputation_season_decay_bps` — decay rate per inactive season beyond the
+  grace period, in bps (0-10000). `0` disables season decay. Defaults to
+  `1000` (10%).
+
+## 12) Links to Related Docs
 - [Repository contribution guide](../backend/.github/CONTRIBUTING.md)
 - [Contract security audit notes](./SECURITY_AUDIT.md)
 - [Contract storage schema notes](./STORAGE_SCHEMA.md)

--- a/contracts/open-market/README.md
+++ b/contracts/open-market/README.md
@@ -163,7 +163,61 @@ make clean       # Clean build artifacts
 make help        # Show available targets
 ```
 
-## 10) Links to Related Docs
+## 10) TWAP Price Oracle
+
+Each AMM liquidity pool (`src/liquidity.rs`) maintains a manipulation-resistant
+time-weighted average price (TWAP) per outcome, computed from a cumulative
+price accumulator — the same technique used by Uniswap V2-style oracles.
+
+### Accumulator math
+
+For each `(market_id, outcome)` pair, `PriceAccumulator` (`src/storage_types.rs`)
+tracks a running integral of `price * elapsed_seconds` over the pool's history,
+plus a fixed-capacity ring buffer (`TWAP_RING_BUFFER_CAPACITY = 64`) of recent
+`PriceObservation` snapshots (`timestamp`, `price`, `price_cumulative`).
+
+On every reserve-changing operation (pool creation, `swap_outcome`),
+`record_price_observation` extends the integral forward using the *previous*
+price for however long it was active, then records a new observation:
+
+```
+cumulative_new = cumulative_old + last_price * (now - last_timestamp)
+```
+
+`get_twap(market_id, outcome, window)` reconstructs the integral at two
+points — `now` and `now - window` — by locating the latest retained
+observation at or before each timestamp and extrapolating with its price for
+the remaining gap, then divides the difference by the elapsed time:
+
+```
+twap = (cumulative(now) - cumulative(now - window)) / window
+```
+
+Because the average is derived from a time integral rather than any single
+spot price, a single large trade can only move the TWAP by roughly
+`(trade_duration / window)` of its instantaneous price impact — this is what
+makes the oracle manipulation-resistant to flash-loan-style single-block
+price spikes.
+
+### Guards
+
+- `window == 0` → `TwapEmptyWindow`.
+- No accumulator, or the window reaches further back than the oldest
+  retained observation (either because the pool is younger than the window,
+  or more than `TWAP_RING_BUFFER_CAPACITY` price-changing swaps have occurred
+  and older samples were overwritten) → `TwapInsufficientHistory`.
+- Degenerate zero-length elapsed time between the window boundaries →
+  `TwapDivideByZero`.
+- Unknown outcome for the market → `InvalidOutcome`.
+
+### Entry points
+
+- `get_twap(market_id, outcome, window)` — TWAP for a specific outcome.
+- `get_market_twap(market_id, window_seconds)` — convenience view returning
+  the TWAP of the market's primary outcome (`outcome_options[0]`), for
+  consumers (indexer, UI) that track a single headline price per market.
+
+## 11) Links to Related Docs
 - [Repository contribution guide](../backend/.github/CONTRIBUTING.md)
 - [Contract security audit notes](./SECURITY_AUDIT.md)
 - [Contract storage schema notes](./STORAGE_SCHEMA.md)

--- a/contracts/open-market/src/config.rs
+++ b/contracts/open-market/src/config.rs
@@ -350,6 +350,21 @@ pub struct Config {
     /// to remaining participants. Admin-configurable via `set_early_exit_fee_bps`.
     /// Defaults to `500` (5%) at initialization.
     pub early_exit_fee_bps: u32,
+    /// Number of fully-inactive seasons (no market created/resolved/disputed
+    /// by the creator) tolerated before season-based reputation decay begins
+    /// to apply. `0` means decay starts from the very first inactive season.
+    /// Applied lazily, at read time, on top of the existing time-based decay
+    /// (`reputation_half_life_seconds`). Admin-configurable via
+    /// `set_season_decay_config`. Defaults to `1` at initialization.
+    /// See `reputation::apply_season_inactivity_decay`.
+    pub reputation_season_decay_grace: u32,
+    /// Decay (bps, 0-10000) applied to a creator's reputation score for each
+    /// inactive season beyond `reputation_season_decay_grace`, compounding
+    /// multiplicatively (i.e. `score *= (10000 - bps) / 10000` per inactive
+    /// season). `0` disables season-based decay entirely. Admin-configurable
+    /// via `set_season_decay_config`. Defaults to `1000` (10% per season) at
+    /// initialization. See `reputation::apply_season_inactivity_decay`.
+    pub reputation_season_decay_bps: u32,
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────
@@ -492,6 +507,8 @@ pub fn initialize(
         vesting_interval_seconds: 2_592_000, // ~30 days
         bond_amount: 0, // disabled by default; admin/governance opt in
         early_exit_fee_bps: 500, // 5% default early-exit fee
+        reputation_season_decay_grace: 1, // tolerate one inactive season before decaying
+        reputation_season_decay_bps: 1000, // 10% compounding decay per inactive season
     };
 
     env.storage().persistent().set(&DataKey::Config, &config);
@@ -833,6 +850,49 @@ fn emit_reputation_decay_config_updated(env: &Env, half_life_seconds: u32, mode:
     env.events().publish(
         (symbol_short!("cfg"), symbol_short!("rdk_upd")),
         (half_life_seconds, mode_sym),
+    );
+}
+
+fn validate_season_decay_bps(decay_bps: u32) -> Result<(), InsightArenaError> {
+    if decay_bps > 10_000 {
+        return Err(InsightArenaError::InvalidInput);
+    }
+    Ok(())
+}
+
+/// Update the season-inactivity reputation decay grace period and per-season
+/// rate. Caller must be the stored admin. See
+/// `reputation::apply_season_inactivity_decay`.
+pub fn set_season_decay_config(
+    env: &Env,
+    admin: Address,
+    grace_seasons: u32,
+    decay_bps: u32,
+) -> Result<(), InsightArenaError> {
+    ensure_not_paused(env)?;
+    let mut config = load_config(env)?;
+
+    admin.require_auth();
+    if admin != config.admin {
+        return Err(InsightArenaError::Unauthorized);
+    }
+
+    validate_season_decay_bps(decay_bps)?;
+
+    config.reputation_season_decay_grace = grace_seasons;
+    config.reputation_season_decay_bps = decay_bps;
+    env.storage().persistent().set(&DataKey::Config, &config);
+    bump_config(env);
+
+    emit_season_decay_config_updated(env, grace_seasons, decay_bps);
+
+    Ok(())
+}
+
+fn emit_season_decay_config_updated(env: &Env, grace_seasons: u32, decay_bps: u32) {
+    env.events().publish(
+        (symbol_short!("cfg"), symbol_short!("sdk_upd")),
+        (grace_seasons, decay_bps),
     );
 }
 

--- a/contracts/open-market/src/lib.rs
+++ b/contracts/open-market/src/lib.rs
@@ -1272,6 +1272,17 @@ impl InsightArenaContract {
         liquidity::get_twap(&env, market_id, outcome, window)
     }
 
+    /// Compute the time-weighted average price over the trailing
+    /// `window_seconds` for `market_id`'s primary outcome. See
+    /// `liquidity::get_market_twap` for details.
+    pub fn get_market_twap(
+        env: Env,
+        market_id: u64,
+        window_seconds: u64,
+    ) -> Result<i128, InsightArenaError> {
+        liquidity::get_market_twap(&env, market_id, window_seconds)
+    }
+
     // ── Dynamic Swap Fee ──────────────────────────────────────────────────────
 
     /// Return the current dynamic fee tier and effective swap fee for a market.

--- a/contracts/open-market/src/liquidity.rs
+++ b/contracts/open-market/src/liquidity.rs
@@ -458,6 +458,26 @@ pub fn get_twap(
     Ok(twap)
 }
 
+/// Compute the time-weighted average price over the trailing `window_seconds`
+/// for `market_id`'s primary outcome (`Market::outcome_options[0]`).
+///
+/// Convenience entry point for downstream consumers (indexer, UI) that track
+/// a market by a single headline price rather than per-outcome, delegating to
+/// [`get_twap`] for the actual accumulator math. Markets with more than one
+/// outcome still have their other outcomes queryable via `get_twap` directly.
+pub fn get_market_twap(
+    env: &Env,
+    market_id: u64,
+    window_seconds: u64,
+) -> Result<i128, InsightArenaError> {
+    let mkt = market::get_market(env, market_id)?;
+    let outcome = mkt
+        .outcome_options
+        .get(0)
+        .ok_or(InsightArenaError::InvalidOutcome)?;
+    get_twap(env, market_id, outcome, window_seconds)
+}
+
 // ── Impermanent Loss Accounting ───────────────────────────────────────────────
 //
 // Scope: this contract's AMM pool is generalized to N outcomes

--- a/contracts/open-market/src/reputation.rs
+++ b/contracts/open-market/src/reputation.rs
@@ -100,22 +100,103 @@ pub fn apply_reputation_decay(
     decayed.min(score)
 }
 
-/// Recompute the live (undecayed) formula score, then decay it against the
-/// record's `last_updated` using the current governance config. Falls back
+/// Apply season-inactivity decay to `score`: for each fully-elapsed inactive
+/// season beyond `grace_seasons`, multiply the score by
+/// `(10_000 - decay_bps) / 10_000`, compounding. Pure function — no storage
+/// access. Never returns a value above `score`; floors at 0 (never negative,
+/// since `u32`).
+///
+/// `inactive_seasons` is the number of seasons that have become active since
+/// the creator was last active (i.e. `current_active_season_id -
+/// last_active_season_id`, saturating at 0 for creators active in the
+/// current season).
+pub fn apply_season_inactivity_decay(
+    score: u32,
+    inactive_seasons: u32,
+    grace_seasons: u32,
+    decay_bps: u32,
+) -> u32 {
+    if score == 0 || decay_bps == 0 || inactive_seasons <= grace_seasons {
+        return score;
+    }
+    let decaying_seasons = inactive_seasons - grace_seasons;
+    let retain_bps = 10_000_u64.saturating_sub(decay_bps as u64);
+
+    let mut decayed = score as u64;
+    for _ in 0..decaying_seasons {
+        decayed = decayed.saturating_mul(retain_bps) / 10_000;
+        if decayed == 0 {
+            break;
+        }
+    }
+
+    (decayed as u32).min(score)
+}
+
+/// Recompute the live (undecayed) formula score, then apply time-based decay
+/// against `last_updated` followed by season-inactivity decay against
+/// `last_active_season_id`, using the current governance config. Falls back
 /// to the raw score, undecayed, if the contract hasn't been initialized yet.
-fn decayed_score(env: &Env, stats: &CreatorStats) -> u32 {
+fn decayed_score(env: &Env, creator: &Address, stats: &CreatorStats) -> u32 {
     let raw_score = calculate_creator_reputation(stats);
     let cfg = match crate::config::get_config_readonly(env) {
         Ok(c) => c,
         Err(_) => return raw_score,
     };
     let elapsed = env.ledger().timestamp().saturating_sub(stats.last_updated);
-    apply_reputation_decay(
+    let time_decayed = apply_reputation_decay(
         raw_score,
         elapsed,
         cfg.reputation_half_life_seconds,
         cfg.reputation_decay_mode,
+    );
+
+    let inactive_seasons = inactive_season_count(env, creator);
+    apply_season_inactivity_decay(
+        time_decayed,
+        inactive_seasons,
+        cfg.reputation_season_decay_grace,
+        cfg.reputation_season_decay_bps,
     )
+}
+
+// ── Season-activity tracking ─────────────────────────────────────────────────
+//
+// Keyed by a raw `(Symbol, Address)` tuple rather than a `DataKey` variant —
+// see `trusted_creator_key` below for why. Lazily applied at read time only;
+// never mutates stored counters, so no unbounded loop over seasons is needed.
+
+fn last_active_season_key(creator: &Address) -> (soroban_sdk::Symbol, Address) {
+    (symbol_short!("lastseas"), creator.clone())
+}
+
+/// Record `creator` as active in the currently active season (if any). Called
+/// from every mutation hook below.
+fn touch_active_season(env: &Env, creator: &Address) {
+    if let Some(season) = crate::season::get_active_season(env) {
+        let key = last_active_season_key(creator);
+        env.storage().persistent().set(&key, &season.season_id);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_THRESHOLD, PERSISTENT_BUMP);
+    }
+}
+
+/// Number of seasons that have become active since `creator` was last active,
+/// i.e. `current_active_season_id - last_active_season_id`. `0` if there is
+/// no active season, or the creator has never been recorded as active (a
+/// creator who has never created/resolved/disputed a market has no decay
+/// baseline to decay from).
+fn inactive_season_count(env: &Env, creator: &Address) -> u32 {
+    let current = match crate::season::get_active_season(env) {
+        Some(s) => s.season_id,
+        None => return 0,
+    };
+    let last_active: Option<u32> = env.storage().persistent().get(&last_active_season_key(creator));
+    match last_active {
+        Some(last) => current.saturating_sub(last),
+        None => 0,
+    }
 }
 
 // ── Mutation hooks ────────────────────────────────────────────────────────────
@@ -127,6 +208,7 @@ pub fn on_market_created(env: &Env, creator: &Address) {
     stats.reputation_score = calculate_creator_reputation(&stats);
     stats.last_updated = env.ledger().timestamp();
     save_stats(env, creator, &stats);
+    touch_active_season(env, creator);
 }
 
 /// Called after a market is successfully resolved.
@@ -146,6 +228,7 @@ pub fn on_market_resolved(env: &Env, creator: &Address, participant_count: u32) 
     stats.reputation_score = calculate_creator_reputation(&stats);
     stats.last_updated = env.ledger().timestamp();
     save_stats(env, creator, &stats);
+    touch_active_season(env, creator);
 }
 
 /// Called when a dispute is raised against a market created by this creator.
@@ -156,13 +239,14 @@ pub fn on_dispute_raised(env: &Env, creator: &Address) {
     stats.reputation_score = calculate_creator_reputation(&stats);
     stats.last_updated = env.ledger().timestamp();
     save_stats(env, creator, &stats);
+    touch_active_season(env, creator);
 }
 
 // ── View ──────────────────────────────────────────────────────────────────────
 
 pub fn get_creator_stats(env: Env, creator: Address) -> Result<CreatorStats, InsightArenaError> {
     let mut stats = load_stats(&env, &creator);
-    stats.reputation_score = decayed_score(&env, &stats);
+    stats.reputation_score = decayed_score(&env, &creator, &stats);
     Ok(stats)
 }
 
@@ -170,7 +254,7 @@ pub fn get_creator_stats(env: Env, creator: Address) -> Result<CreatorStats, Ins
 /// Reuses `load_stats` + `calculate_creator_reputation`; safe to call from
 /// gating logic (e.g. `market::create_market`) ahead of any writes.
 pub fn get_reputation_score(env: &Env, creator: &Address) -> u32 {
-    decayed_score(env, &load_stats(env, creator))
+    decayed_score(env, creator, &load_stats(env, creator))
 }
 
 // ── Trusted-creator allowlist (reputation-gate exemption) ────────────────────
@@ -308,7 +392,7 @@ pub fn get_top_creators(env: &Env, limit: u32) -> Vec<CreatorLeaderboardEntry> {
             .get::<DataKey, CreatorStats>(&DataKey::CreatorStats(user.clone()))
         {
             if stats.markets_created > 0 {
-                stats.reputation_score = decayed_score(env, &stats);
+                stats.reputation_score = decayed_score(env, &user, &stats);
                 creators.push_back(CreatorLeaderboardEntry {
                     address: user,
                     stats,

--- a/contracts/open-market/tests/liquidity_tests.rs
+++ b/contracts/open-market/tests/liquidity_tests.rs
@@ -3466,3 +3466,111 @@ fn test_cumulative_il_zero_on_withdrawal_without_price_change() {
     let position = client.get_lp_position(&provider, &market_id);
     assert_eq!(position.cumulative_il_bps, 0);
 }
+
+// ── get_market_twap (Issue #1512) ───────────────────────────────────────────
+
+#[test]
+fn test_market_twap_matches_primary_outcome_twap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let liquidity = 1_000_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let swap_amount = 20_000_i128;
+    sa.mint(&trader, &swap_amount);
+    token.approve(&trader, &client.address, &swap_amount, &9999);
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.swap_outcome(
+        &trader,
+        &market_id,
+        &symbol_short!("yes"),
+        &symbol_short!("no"),
+        &swap_amount,
+        &0_i128,
+    );
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+
+    let window: u64 = 200;
+    let expected = client.get_twap(&market_id, &symbol_short!("yes"), &window);
+    let market_twap = client.get_market_twap(&market_id, &window);
+
+    // `outcome_options[0]` is "yes" for `lp_market_params`, so the market-level
+    // convenience view must agree exactly with the outcome-scoped one.
+    assert_eq!(market_twap, expected);
+}
+
+#[test]
+fn test_market_twap_insufficient_history_returns_typed_error() {
+    let env = Env::default();
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+    let liquidity = 100_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    // Pool was created at t=500; a window of 10,000s reaches back before
+    // genesis (t=0), which predates the oldest retained observation.
+    let result = client.try_get_market_twap(&market_id, &10_000_u64);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TwapInsufficientHistory))
+    ));
+}
+
+#[test]
+fn test_market_twap_empty_window_returns_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, xlm_token) = deploy_with_token(&env);
+
+    let provider = Address::generate(&env);
+    let market_id = client.create_market(&_admin, &lp_market_params(&env));
+
+    let sa = StellarAssetClient::new(&env, &xlm_token);
+    let token = TokenClient::new(&env, &xlm_token);
+    let liquidity = 100_000_i128;
+    sa.mint(&provider, &liquidity);
+    token.approve(&provider, &client.address, &liquidity, &9999);
+    client.add_liquidity(&provider, &market_id, &liquidity);
+
+    let result = client.try_get_market_twap(&market_id, &0_u64);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::TwapEmptyWindow))
+    ));
+}
+
+#[test]
+fn test_market_twap_unknown_market_returns_typed_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _oracle, _xlm_token) = deploy_with_token(&env);
+
+    let result = client.try_get_market_twap(&999_u64, &60_u64);
+    assert!(matches!(
+        result,
+        Err(Ok(InsightArenaError::MarketNotFound))
+    ));
+}

--- a/contracts/open-market/tests/reputation_tests.rs
+++ b/contracts/open-market/tests/reputation_tests.rs
@@ -996,3 +996,177 @@ fn reset_creator_stats_fails_when_paused() {
     let result = client.try_reset_creator_stats(&admin, &creator);
     assert!(matches!(result, Err(Ok(InsightArenaError::Paused))));
 }
+
+// ── Season-inactivity decay (Issue #1513) ────────────────────────────────────
+
+#[test]
+fn apply_season_inactivity_decay_no_decay_within_grace() {
+    // Exactly at the grace boundary: no decay yet.
+    assert_eq!(apply_season_inactivity_decay(800, 1, 1, 1000), 800);
+    // Fewer inactive seasons than the grace period: no decay.
+    assert_eq!(apply_season_inactivity_decay(800, 0, 1, 1000), 800);
+}
+
+#[test]
+fn apply_season_inactivity_decay_compounds_per_season() {
+    // 1 season beyond a grace of 0, 10% (1000 bps) per season: 800 * 0.9 = 720.
+    assert_eq!(apply_season_inactivity_decay(800, 1, 0, 1000), 720);
+    // 2 seasons beyond grace: 800 * 0.9 * 0.9 = 648.
+    assert_eq!(apply_season_inactivity_decay(800, 2, 0, 1000), 648);
+    // 3 seasons beyond grace: 648 * 0.9 = 583 (integer truncation each step).
+    assert_eq!(apply_season_inactivity_decay(800, 3, 0, 1000), 583);
+}
+
+#[test]
+fn apply_season_inactivity_decay_zero_bps_disables_decay() {
+    assert_eq!(apply_season_inactivity_decay(800, 10, 0, 0), 800);
+}
+
+#[test]
+fn apply_season_inactivity_decay_never_exceeds_input_score() {
+    let decayed = apply_season_inactivity_decay(500, 5, 0, 1000);
+    assert!(decayed <= 500);
+}
+
+#[test]
+fn apply_season_inactivity_decay_floors_at_zero_never_negative() {
+    // Many inactive seasons should drive the score to 0, never below.
+    let decayed = apply_season_inactivity_decay(1000, 50, 0, 5000);
+    assert_eq!(decayed, 0);
+}
+
+#[test]
+fn apply_season_inactivity_decay_100_percent_zeroes_after_grace() {
+    assert_eq!(apply_season_inactivity_decay(800, 1, 0, 10_000), 0);
+}
+
+fn fund(env: &Env, token: &Address, recipient: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(recipient, &amount);
+}
+
+#[test]
+fn test_reputation_decays_over_n_inactive_seasons() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &admin, 1_000_000_000);
+
+    // Disable time-based decay so only season-inactivity decay is observed.
+    env.as_contract(&client.address, || {
+        config::set_reputation_decay_config(&env, admin.clone(), u32::MAX, ReputationDecayMode::Linear)
+    })
+    .unwrap();
+    env.as_contract(&client.address, || {
+        config::set_season_decay_config(&env, admin.clone(), 0, 1000)
+    })
+    .unwrap();
+
+    // Season 1 is active; creator resolves a market, becoming active in it.
+    client.create_season(&admin, &0, &3000, &10_000_000);
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(2000);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    let baseline = client.get_reputation_score(&creator);
+    assert_eq!(baseline, 600);
+
+    // Advance through seasons 2 and 3 without the creator doing anything —
+    // two fully-elapsed inactive seasons relative to season 3.
+    env.ledger().set_timestamp(3000);
+    client.create_season(&admin, &3000, &4000, &10_000_000);
+    env.ledger().set_timestamp(4000);
+    client.create_season(&admin, &4000, &5000, &10_000_000);
+
+    // The near-infinite half-life still applies a negligible sliver of
+    // time-based decay over the 2000s elapsed since the market resolved;
+    // season-inactivity decay (2 seasons beyond a grace of 0, 10% each) then
+    // compounds on top of that, exactly as `reputation::decayed_score` does.
+    let time_decayed = apply_reputation_decay(600, 2000, u32::MAX, ReputationDecayMode::Linear);
+    let expected = apply_season_inactivity_decay(time_decayed, 2, 0, 1000);
+    assert_eq!(client.get_reputation_score(&creator), expected);
+    // Season-inactivity decay is still the dominant effect: materially below
+    // the undecayed baseline of 600.
+    assert!(expected < 550);
+}
+
+#[test]
+fn test_reputation_season_decay_active_users_unaffected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &admin, 1_000_000_000);
+
+    env.as_contract(&client.address, || {
+        config::set_reputation_decay_config(&env, admin.clone(), u32::MAX, ReputationDecayMode::Linear)
+    })
+    .unwrap();
+    env.as_contract(&client.address, || {
+        config::set_season_decay_config(&env, admin.clone(), 0, 1000)
+    })
+    .unwrap();
+
+    client.create_season(&admin, &0, &3000, &10_000_000);
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(2000);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert_eq!(client.get_reputation_score(&creator), 600);
+
+    // Creator stays active in every season, including the currently active
+    // one, by resolving another market in each successive season.
+    env.ledger().set_timestamp(3000);
+    client.create_season(&admin, &3000, &6000, &10_000_000);
+    let id2 = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(5000);
+    client.resolve_market(&oracle, &id2, &symbol_short!("yes"));
+
+    // No season-inactivity decay: the creator was active in the currently
+    // active season (season 2), so `inactive_seasons` is 0 — never exceeding
+    // the grace period. Only the negligible time-based sliver applies
+    // (elapsed=0, since this read happens at the same timestamp as the
+    // resolve that reset `last_updated`).
+    assert_eq!(client.get_reputation_score(&creator), 600);
+}
+
+#[test]
+fn test_reputation_season_decay_never_below_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, oracle, xlm_token) = deploy(&env);
+    let creator = Address::generate(&env);
+    fund(&env, &xlm_token, &admin, 1_000_000_000);
+
+    env.as_contract(&client.address, || {
+        config::set_reputation_decay_config(&env, admin.clone(), u32::MAX, ReputationDecayMode::Linear)
+    })
+    .unwrap();
+    env.as_contract(&client.address, || {
+        config::set_season_decay_config(&env, admin.clone(), 0, 10_000)
+    })
+    .unwrap();
+
+    client.create_season(&admin, &0, &3000, &10_000_000);
+    let id = client.create_market(&creator, &default_params(&env));
+    env.ledger().set_timestamp(2000);
+    client.resolve_market(&oracle, &id, &symbol_short!("yes"));
+    assert!(client.get_reputation_score(&creator) > 0);
+
+    env.ledger().set_timestamp(3000);
+    client.create_season(&admin, &3000, &4000, &10_000_000);
+
+    // 100% decay per inactive season zeroes the score immediately, and it
+    // must never underflow below 0 (u32 floor).
+    assert_eq!(client.get_reputation_score(&creator), 0);
+}
+
+#[test]
+fn set_season_decay_config_rejects_bps_above_10000() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = deploy(&env);
+
+    let result = env.as_contract(&client.address, || {
+        config::set_season_decay_config(&env, admin, 0, 10_001)
+    });
+    assert!(matches!(result, Err(InsightArenaError::InvalidInput)));
+}


### PR DESCRIPTION
# TWAP view, reputation decay, achievement streaming, API key rotation

## Summary

- **TWAP**: Added `get_market_twap(market_id, window_seconds)` — a convenience wrapper around the existing, fully-tested `get_twap(market_id, outcome, window)` in `liquidity.rs`, resolving the market's primary outcome. Documented the accumulator math in the contract README.
- **Reputation decay**: Added season-inactivity decay for `CreatorStats.reputation_score`, layered on top of the existing time-based half-life decay. Governance-settable grace period + per-season decay rate via `config::set_season_decay_config`. Applied lazily at read time only; floors at zero.
- **Achievement streaming**: Wired `achievement:unlocked` and `achievement:progress` websocket events into `AchievementsService`, using the existing idempotent insert-or-ignore grant guard so unlocks broadcast exactly once. Progress broadcasts only fire when `current_value` actually changes.
- **API key rotation**: Added `POST /auth/api-keys/:id/rotate` — issues a new key preserving name/scopes and grace-expires the old raw key (default 24h) so in-flight integrations have time to switch over. Scopes, expiry, and revocation already existed.

## Testing

- `cargo test` (open-market): all passing, including new TWAP and reputation-decay tests
- `cargo build --target wasm32-unknown-unknown --release`: passing
- Backend: `pnpm run lint`, `pnpm run test` (1332 tests), `pnpm run build`, `pnpm run migration:check-timestamps`: all passing

Closes #1512
Closes #1510
Closes #1513
Closes #1507
