### PR TITLE
feat(frontend): async form validation with debounce and race cancellation (#1594)

### DIFF
--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 
+/**
+ * Returns a debounced copy of `value` that only updates after `delay` ms of
+ * inactivity. Useful for read-only derived state (e.g. driving a search query).
+ */
 export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
@@ -11,4 +15,64 @@ export function useDebounce<T>(value: T, delay: number): T {
   }, [value, delay]);
 
   return debouncedValue;
+}
+
+/**
+ * Returns a stable debounced function that delays invoking `fn` until after
+ * `delay` ms have elapsed since the last call. Any in-flight call is cancelled
+ * when a new one arrives.
+ *
+ * The returned function also exposes a `.cancel()` method to clear any pending
+ * invocation imperatively (e.g. on component unmount or form reset).
+ *
+ * @example
+ * const debouncedValidate = useDebouncedCallback(
+ *   (value: string) => checkAvailability(value),
+ *   300,
+ * );
+ *
+ * // In onChange handler:
+ * debouncedValidate(inputValue);
+ *
+ * // On unmount / reset:
+ * debouncedValidate.cancel();
+ */
+export function useDebouncedCallback<T extends (...args: any[]) => any>(
+  fn: T,
+  delay: number
+): T & { cancel: () => void } {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  // Keep a stable ref to the latest `fn` so callers don't need to memo it.
+  const fnRef = useRef<T>(fn);
+  useEffect(() => {
+    fnRef.current = fn;
+  });
+
+  const cancel = useCallback(() => {
+    if (timerRef.current !== undefined) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+  }, []);
+
+  const debounced = useCallback(
+    (...args: Parameters<T>) => {
+      cancel();
+      timerRef.current = setTimeout(() => {
+        timerRef.current = undefined;
+        fnRef.current(...args);
+      }, delay);
+    },
+    [cancel, delay]
+  ) as T;
+
+  // Attach cancel so consumers can call debounced.cancel().
+  (debounced as T & { cancel: () => void }).cancel = cancel;
+
+  // Clean up on unmount.
+  useEffect(() => cancel, [cancel]);
+
+  return debounced as T & { cancel: () => void };
 }

--- a/frontend/src/hooks/useFormValidation.test.ts
+++ b/frontend/src/hooks/useFormValidation.test.ts
@@ -1,0 +1,717 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFormValidation } from "./useFormValidation";
+import type { AsyncValidatorFn, ValidatorFn } from "./useFormValidation";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves after `ms` milliseconds.
+ * With ms=0 we use a real microtask (queueMicrotask) so it settles even under
+ * fake timers without needing to advance the clock.
+ * With ms>0 we use setTimeout so fake-timer advancement controls it.
+ */
+function delay(ms: number): Promise<void> {
+  if (ms === 0) {
+    return new Promise<void>((resolve) => queueMicrotask(resolve));
+  }
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+/** Builds a sync required validator for test use. */
+const required =
+  (fieldName = "Field"): ValidatorFn =>
+  (value: any) =>
+    !value || String(value).trim() === ""
+      ? `${fieldName} is required.`
+      : undefined;
+
+/**
+ * Async validator that resolves to an error when value equals `takenValue`.
+ * resolveAfterMs=0 → settles in the microtask queue (no fake-timer needed).
+ * resolveAfterMs>0 → uses setTimeout so vi.advanceTimersByTime controls it.
+ */
+function makeTakenCheck(
+  takenValue: string,
+  errorMsg = "Already taken.",
+  resolveAfterMs = 0
+): AsyncValidatorFn {
+  return async (value: any, signal: AbortSignal) => {
+    await delay(resolveAfterMs);
+    if (signal.aborted) return undefined;
+    return value === takenValue ? errorMsg : undefined;
+  };
+}
+
+/** Async validator that rejects (simulates a network error). */
+function makeFailingAsyncValidator(resolveAfterMs = 0): AsyncValidatorFn {
+  return async (_value: any, signal: AbortSignal) => {
+    await delay(resolveAfterMs);
+    if (signal.aborted) return undefined;
+    throw new Error("Network error");
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("useFormValidation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    // Flush all pending timers so nothing leaks into the next test.
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Existing sync behaviour (regression guard)
+  // -------------------------------------------------------------------------
+
+  describe("sync validation (regression)", () => {
+    it("initialises with the provided values and no errors", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({ initialValues: { name: "Alice" } })
+      );
+      expect(result.current.values.name).toBe("Alice");
+      expect(result.current.errors.name).toBeUndefined();
+      expect(result.current.pending.name).toBe(false);
+    });
+
+    it("validateField returns false and sets error when a sync rule fails", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          validators: { name: [required("Name")] },
+        })
+      );
+
+      let valid: boolean;
+      act(() => {
+        valid = result.current.validateField("name");
+      });
+
+      expect(valid!).toBe(false);
+      expect(result.current.errors.name).toBe("Name is required.");
+    });
+
+    it("validateField returns true and clears error when all sync rules pass", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "Alice" },
+          validators: { name: [required("Name")] },
+        })
+      );
+
+      let valid: boolean;
+      act(() => {
+        valid = result.current.validateField("name");
+      });
+
+      expect(valid!).toBe(true);
+      expect(result.current.errors.name).toBeUndefined();
+    });
+
+    it("validateAll returns false when any field fails sync validation", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "", email: "alice@example.com" },
+          validators: {
+            name: [required("Name")],
+            email: [required("Email")],
+          },
+        })
+      );
+
+      let valid: boolean;
+      act(() => {
+        valid = result.current.validateAll();
+      });
+
+      expect(valid!).toBe(false);
+      expect(result.current.errors.name).toBe("Name is required.");
+      expect(result.current.errors.email).toBeUndefined();
+    });
+
+    it("reset restores initial values and clears errors", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          validators: { name: [required("Name")] },
+        })
+      );
+
+      act(() => {
+        result.current.setState("name", "Alice");
+        result.current.validateField("name");
+      });
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.values.name).toBe("");
+      expect(result.current.errors.name).toBeUndefined();
+      expect(result.current.pending.name).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Async validator resolves → field state updates correctly
+  // -------------------------------------------------------------------------
+
+  describe("async validator resolves", () => {
+    it("sets pending=true while async validator is in-flight", async () => {
+      // resolveAfterMs=100 → needs timer advancement to complete.
+      const asyncValidator = makeTakenCheck("taken", "Already taken.", 100);
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "taken" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let promise: Promise<boolean>;
+      act(() => {
+        promise = result.current.validateFieldAsync("name");
+      });
+
+      // Before the 100 ms async work completes the field should be pending.
+      expect(result.current.pending.name).toBe(true);
+      expect(result.current.errors.name).toBeUndefined();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+        await promise!;
+      });
+
+      expect(result.current.pending.name).toBe(false);
+      expect(result.current.errors.name).toBe("Already taken.");
+    });
+
+    it("sets error when async validator resolves with an error message", async () => {
+      // resolveAfterMs=0 → settles via microtask, no timer needed.
+      const asyncValidator = makeTakenCheck("taken");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "taken" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      await act(async () => {
+        await result.current.validateFieldAsync("name");
+      });
+
+      expect(result.current.errors.name).toBe("Already taken.");
+      expect(result.current.pending.name).toBe(false);
+    });
+
+    it("clears error when async validator resolves valid", async () => {
+      const asyncValidator = makeTakenCheck("taken");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "available" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      await act(async () => {
+        await result.current.validateFieldAsync("name");
+      });
+
+      expect(result.current.errors.name).toBeUndefined();
+      expect(result.current.pending.name).toBe(false);
+    });
+
+    it("surfaces network-level errors as a field error", async () => {
+      const asyncValidator = makeFailingAsyncValidator();
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "anything" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      await act(async () => {
+        await result.current.validateFieldAsync("name");
+      });
+
+      expect(result.current.errors.name).toBe("Network error");
+      expect(result.current.pending.name).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Async validator cancellation on rapid input changes
+  // -------------------------------------------------------------------------
+
+  describe("async validator cancellation on rapid input changes", () => {
+    it("cancels in-flight async validation when a newer call arrives", async () => {
+      const calls: string[] = [];
+
+      // resolveAfterMs=200 so we can fire two before either completes.
+      const slowValidator: AsyncValidatorFn = async (value, signal) => {
+        await delay(200);
+        if (signal.aborted) return undefined;
+        calls.push(value as string);
+        return value === "taken" ? "Already taken." : undefined;
+      };
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          asyncValidators: { name: [slowValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let p1: Promise<boolean>;
+      let p2: Promise<boolean>;
+
+      act(() => {
+        result.current.setState("name", "taken");
+      });
+      act(() => {
+        p1 = result.current.validateFieldAsync("name");
+      });
+
+      // Immediately fire a second one — this should abort p1.
+      act(() => {
+        result.current.setState("name", "free");
+        p2 = result.current.validateFieldAsync("name");
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+        await Promise.allSettled([p1!, p2!]);
+      });
+
+      // Only the second ("free") call should have resolved into state.
+      expect(calls).toEqual(["free"]);
+      expect(result.current.errors.name).toBeUndefined();
+      expect(result.current.pending.name).toBe(false);
+    });
+
+    it("does not write stale results after signal is aborted", async () => {
+      // Validator that ignores the abort signal on purpose.
+      // The hook itself checks signal.aborted after the await, so results from
+      // the aborted call must never reach state.
+      const ignorantValidator: AsyncValidatorFn = async (value, _signal) => {
+        await delay(100);
+        return "error from stale call";
+      };
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          asyncValidators: { name: [ignorantValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let p1: Promise<boolean>;
+      let p2: Promise<boolean>;
+
+      act(() => {
+        result.current.setState("name", "first");
+      });
+      act(() => {
+        p1 = result.current.validateFieldAsync("name");
+      });
+
+      // Immediately supersede — aborts p1.
+      act(() => {
+        result.current.setState("name", "second");
+      });
+      act(() => {
+        p2 = result.current.validateFieldAsync("name");
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+        await Promise.allSettled([p1!, p2!]);
+      });
+
+      // p1 was aborted, so its result is discarded.
+      // p2 is NOT aborted: it resolved "error from stale call" for "second".
+      // The state should reflect only p2's outcome — exactly one error entry.
+      expect(result.current.errors.name).toBe("error from stale call");
+      expect(result.current.pending.name).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Debouncing via setState
+  // -------------------------------------------------------------------------
+
+  describe("debounced async validation on setState", () => {
+    it("does not fire async validators before the debounce delay elapses", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(async () => undefined);
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 300,
+        })
+      );
+
+      act(() => {
+        result.current.setState("name", "hello");
+      });
+
+      // Advance only 200 ms — debounce has NOT fired yet.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+
+      expect(asyncValidator).not.toHaveBeenCalled();
+    });
+
+    it("fires async validator once after the debounce delay", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(async () => undefined);
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 300,
+        })
+      );
+
+      act(() => {
+        result.current.setState("name", "hello");
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+        // Drain the microtask queue so the async validator settles.
+        await Promise.resolve();
+      });
+
+      expect(asyncValidator).toHaveBeenCalledTimes(1);
+      expect(asyncValidator).toHaveBeenCalledWith(
+        "hello",
+        expect.any(AbortSignal)
+      );
+    });
+
+    it("resets debounce timer on each keystroke and fires only once", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(async () => undefined);
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 300,
+        })
+      );
+
+      act(() => {
+        result.current.setState("name", "h");
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+        result.current.setState("name", "he");
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+        result.current.setState("name", "hel");
+      });
+
+      // 300 ms after the last keystroke.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+        await Promise.resolve();
+      });
+
+      expect(asyncValidator).toHaveBeenCalledTimes(1);
+      expect(asyncValidator).toHaveBeenCalledWith(
+        "hel",
+        expect.any(AbortSignal)
+      );
+    });
+
+    it("does not run async validators when sync validation fails after debounce", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(async () => undefined);
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          validators: { name: [required("Name")] },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 300,
+        })
+      );
+
+      // Value is empty — sync required will fail.
+      act(() => {
+        result.current.setState("name", "");
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+        await Promise.resolve();
+      });
+
+      // Sync failed → async should never have run.
+      expect(asyncValidator).not.toHaveBeenCalled();
+      expect(result.current.errors.name).toBe("Name is required.");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sync + async aggregation
+  // -------------------------------------------------------------------------
+
+  describe("sync + async error aggregation", () => {
+    it("shows sync error without running async when sync fails", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(async () => "async error");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "" },
+          validators: { name: [required("Name")] },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let valid: boolean;
+      await act(async () => {
+        valid = await result.current.validateFieldAsync("name");
+      });
+
+      expect(valid!).toBe(false);
+      expect(result.current.errors.name).toBe("Name is required.");
+      expect(asyncValidator).not.toHaveBeenCalled();
+    });
+
+    it("runs async only after all sync validators pass", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(async () => "async error");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "Alice" },
+          validators: { name: [required("Name")] },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let valid: boolean;
+      await act(async () => {
+        valid = await result.current.validateFieldAsync("name");
+      });
+
+      expect(valid!).toBe(false);
+      expect(asyncValidator).toHaveBeenCalledOnce();
+      expect(result.current.errors.name).toBe("async error");
+    });
+
+    it("validateAllAsync resolves false when any field has an async error", async () => {
+      const takenCheck = makeTakenCheck("taken");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "taken", email: "alice@example.com" },
+          asyncValidators: { name: [takenCheck] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let valid: boolean;
+      await act(async () => {
+        valid = await result.current.validateAllAsync();
+      });
+
+      expect(valid!).toBe(false);
+      expect(result.current.errors.name).toBe("Already taken.");
+    });
+
+    it("validateAllAsync resolves true when all fields pass", async () => {
+      const takenCheck = makeTakenCheck("taken");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "available", email: "alice@example.com" },
+          asyncValidators: { name: [takenCheck] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let valid: boolean;
+      await act(async () => {
+        valid = await result.current.validateAllAsync();
+      });
+
+      expect(valid!).toBe(true);
+      expect(result.current.errors.name).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isValid reflects pending and error state
+  // -------------------------------------------------------------------------
+
+  describe("isValid", () => {
+    it("is false while a field has a pending async validation", async () => {
+      const asyncValidator = makeTakenCheck("taken", "Already taken.", 100);
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "taken" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      let promise: Promise<boolean>;
+      act(() => {
+        promise = result.current.validateFieldAsync("name");
+      });
+
+      // Mid-flight: isValid must be false because pending=true.
+      expect(result.current.isValid).toBe(false);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+        await promise!;
+      });
+
+      // After resolution there's an error → still false.
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it("is true when no errors and no pending validations", async () => {
+      const asyncValidator = makeTakenCheck("taken");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "available" },
+          asyncValidators: { name: [asyncValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      await act(async () => {
+        await result.current.validateFieldAsync("name");
+      });
+
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reset cancels in-flight work
+  // -------------------------------------------------------------------------
+
+  describe("reset", () => {
+    it("cancels in-flight async validators and clears pending state", async () => {
+      const calls: string[] = [];
+      const slowValidator: AsyncValidatorFn = async (value, signal) => {
+        await delay(200);
+        if (signal.aborted) return undefined;
+        calls.push("resolved");
+        return "error";
+      };
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "Alice" },
+          asyncValidators: { name: [slowValidator] },
+          asyncDebounceMs: 0,
+        })
+      );
+
+      act(() => {
+        result.current.validateFieldAsync("name");
+      });
+
+      // Should be pending while in-flight.
+      expect(result.current.pending.name).toBe(true);
+
+      // Reset before the async work completes.
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.pending.name).toBe(false);
+      expect(result.current.values.name).toBe("Alice");
+
+      // Advance past the delay — the aborted call must NOT write into state.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+        await Promise.resolve();
+      });
+
+      expect(calls).toHaveLength(0);
+      expect(result.current.errors.name).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // validateOnBlur triggers async validation
+  // -------------------------------------------------------------------------
+
+  describe("validateOnBlur with async validators", () => {
+    it("runs async validators when setTouched(field, true) is called", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(makeTakenCheck("taken"));
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "taken" },
+          asyncValidators: { name: [asyncValidator] },
+          validateOnBlur: true,
+          asyncDebounceMs: 0,
+        })
+      );
+
+      // setTouched fires _runAsyncValidators as a fire-and-forget.
+      // We need to fully drain microtasks and then let act flush the state
+      // update that the async validator schedules.
+      await act(async () => {
+        result.current.setTouched("name", true);
+        // Drain the microtask queue so the zero-delay validator resolves.
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+      });
+
+      expect(result.current.errors.name).toBe("Already taken.");
+      expect(asyncValidator).toHaveBeenCalledOnce();
+    });
+
+    it("does not run async validators when validateOnBlur is false", async () => {
+      const asyncValidator = vi.fn<AsyncValidatorFn>(async () => "error");
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialValues: { name: "anything" },
+          asyncValidators: { name: [asyncValidator] },
+          validateOnBlur: false,
+          asyncDebounceMs: 0,
+        })
+      );
+
+      act(() => {
+        result.current.setTouched("name", true);
+      });
+
+      expect(asyncValidator).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/hooks/useFormValidation.ts
+++ b/frontend/src/hooks/useFormValidation.ts
@@ -1,216 +1,494 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface FieldValidation {
-    value: string | number | boolean;
-    touched: boolean;
-    error?: string;
+  value: string | number | boolean;
+  touched: boolean;
+  error?: string;
+  /** True while an async validator is in-flight for this field. */
+  pending: boolean;
 }
 
 export interface FormValidationState {
-    [fieldName: string]: FieldValidation;
+  [fieldName: string]: FieldValidation;
 }
 
-export interface ValidatorFn {
-    (value: any): string | undefined;
-}
+/** Synchronous validator — returns an error string or undefined. */
+export type ValidatorFn = (value: any) => string | undefined;
+
+/**
+ * Async validator — receives the current value and an AbortSignal so callers
+ * can cancel in-flight network requests when a newer validation supersedes this
+ * one. Should return a Promise that resolves to an error string or undefined.
+ * Throw / reject if the request itself failed (the hook will silently ignore
+ * aborted requests).
+ */
+export type AsyncValidatorFn = (
+  value: any,
+  signal: AbortSignal
+) => Promise<string | undefined>;
 
 export interface FieldValidator {
-    [fieldName: string]: ValidatorFn[];
+  [fieldName: string]: ValidatorFn[];
 }
 
+export interface AsyncFieldValidator {
+  [fieldName: string]: AsyncValidatorFn[];
+}
+
+// ---------------------------------------------------------------------------
+// Options & return shape
+// ---------------------------------------------------------------------------
+
 interface UseFormValidationOptions {
-    initialValues?: Record<string, any>;
-    validators?: FieldValidator;
-    validateOnBlur?: boolean;
+  initialValues?: Record<string, any>;
+  validators?: FieldValidator;
+  /** Async validators keyed by field name. Run after all sync validators pass. */
+  asyncValidators?: AsyncFieldValidator;
+  validateOnBlur?: boolean;
+  /**
+   * Debounce delay in ms before async validators fire after a value change.
+   * Defaults to 300 ms.
+   */
+  asyncDebounceMs?: number;
 }
 
 interface UseFormValidationReturn {
-    values: Record<string, any>;
-    touched: Record<string, boolean>;
-    errors: Record<string, string | undefined>;
-    setState: (field: string, value: any) => void;
-    setTouched: (field: string, touched: boolean) => void;
-    setFieldError: (field: string, error?: string) => void;
-    clearFieldError: (field: string) => void;
-    clearErrors: () => void;
-    validateField: (field: string) => boolean;
-    validateAll: () => boolean;
-    reset: () => void;
-    isValid: boolean;
+  values: Record<string, any>;
+  touched: Record<string, boolean>;
+  errors: Record<string, string | undefined>;
+  /** True when any async validator for a field is in-flight. */
+  pending: Record<string, boolean>;
+  setState: (field: string, value: any) => void;
+  setTouched: (field: string, touched: boolean) => void;
+  setFieldError: (field: string, error?: string) => void;
+  clearFieldError: (field: string) => void;
+  clearErrors: () => void;
+  /** Runs sync validators for the field. Returns true if all pass. */
+  validateField: (field: string) => boolean;
+  /**
+   * Runs async validators for the field after sync validators pass.
+   * Returns a Promise that resolves to true when the field is valid.
+   */
+  validateFieldAsync: (field: string) => Promise<boolean>;
+  /** Runs sync validators for all fields. Returns true if all pass. */
+  validateAll: () => boolean;
+  /**
+   * Runs sync then async validators for all fields.
+   * Resolves to true only when every field is valid.
+   */
+  validateAllAsync: () => Promise<boolean>;
+  reset: () => void;
+  /** True when no field has a sync error and no async validation is pending. */
+  isValid: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
 export function useFormValidation({
-    initialValues = {},
-    validators = {},
-    validateOnBlur = true,
+  initialValues = {},
+  validators = {},
+  asyncValidators = {},
+  validateOnBlur = true,
+  asyncDebounceMs = 300,
 }: UseFormValidationOptions): UseFormValidationReturn {
-    const [formState, setFormState] = useState<FormValidationState>(() => {
-        const initial: FormValidationState = {};
-        for (const [key, value] of Object.entries(initialValues)) {
-            initial[key] = {
-                value,
-                touched: false,
-                error: undefined,
-            };
-        }
-        return initial;
+  const [formState, setFormState] = useState<FormValidationState>(() => {
+    const initial: FormValidationState = {};
+    for (const [key, value] of Object.entries(initialValues)) {
+      initial[key] = { value, touched: false, error: undefined, pending: false };
+    }
+    return initial;
+  });
+
+  // Always-current mirror of formState for use in callbacks that close over
+  // stale state (e.g. async validators that run after a re-render).
+  const formStateRef = useRef<FormValidationState>(formState);
+  useEffect(() => {
+    formStateRef.current = formState;
+  });
+
+  // Eagerly-updated per-field value cache so callers like validateFieldAsync
+  // always see the value from the most recent setState call, even when React
+  // has not yet committed the next render (i.e. within the same act() block).
+  const latestValues = useRef<Record<string, any>>({});
+  for (const [k, v] of Object.entries(initialValues)) {
+    if (!(k in latestValues.current)) latestValues.current[k] = v;
+  }
+
+  // Refs for debounce timers per field (keyed by field name).
+  const debounceTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>(
+    {}
+  );
+
+  // Refs for AbortControllers per field so we can cancel in-flight async work.
+  const abortControllers = useRef<Record<string, AbortController>>({});
+
+  // ---------------------------------------------------------------------------
+  // Sync helpers
+  // ---------------------------------------------------------------------------
+
+  const setState = useCallback((field: string, value: any) => {
+    setFormState((prev) => ({
+      ...prev,
+      [field]: {
+        ...prev[field],
+        value,
+      },
+    }));
+  }, []);
+
+  const setFieldError = useCallback((field: string, error?: string) => {
+    setFormState((prev) => ({
+      ...prev,
+      [field]: { ...prev[field], error },
+    }));
+  }, []);
+
+  const clearFieldError = useCallback((field: string) => {
+    setFormState((prev) => ({
+      ...prev,
+      [field]: { ...prev[field], error: undefined },
+    }));
+  }, []);
+
+  const clearErrors = useCallback(() => {
+    setFormState((prev) => {
+      const next = { ...prev };
+      for (const key of Object.keys(next)) {
+        next[key] = { ...next[key], error: undefined };
+      }
+      return next;
     });
+  }, []);
 
-    const setState = useCallback((field: string, value: any) => {
-        setFormState((prev) => ({
+  // ---------------------------------------------------------------------------
+  // Sync validation
+  // ---------------------------------------------------------------------------
+
+  const validateField = useCallback(
+    (field: string): boolean => {
+      const fieldValidators = validators[field] ?? [];
+      // Read from latestValues so this always sees the most recent value even
+      // if called synchronously after setState in the same act() block.
+      const value = latestValues.current[field] ?? formState[field]?.value;
+
+      for (const validator of fieldValidators) {
+        const error = validator(value);
+        if (error) {
+          setFormState((prev) => ({
             ...prev,
-            [field]: {
-                ...prev[field],
-                value,
-            },
-        }));
-    }, []);
+            [field]: { ...prev[field], error },
+          }));
+          return false;
+        }
+      }
 
-    const validateField = useCallback(
-        (field: string): boolean => {
-            const fieldValidators = validators[field] || [];
-            const value = formState[field]?.value;
+      setFormState((prev) => ({
+        ...prev,
+        [field]: { ...prev[field], error: undefined },
+      }));
+      return true;
+    },
+    [validators, formState]
+  );
 
-            for (const validator of fieldValidators) {
-                const error = validator(value);
-                if (error) {
-                    setFormState((prev) => ({
-                        ...prev,
-                        [field]: {
-                            ...prev[field],
-                            error,
-                        },
-                    }));
-                    return false;
-                }
-            }
+  const validateAll = useCallback((): boolean => {
+    let allValid = true;
+    for (const field of Object.keys(validators)) {
+      if (!validateField(field)) allValid = false;
+    }
+    return allValid;
+  }, [validators, validateField]);
 
+  // ---------------------------------------------------------------------------
+  // Async validation (with cancellation + debouncing)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Internal: run async validators for a single field immediately (no debounce).
+   * Cancels any previous in-flight call for the same field via AbortController.
+   */
+  const _runAsyncValidators = useCallback(
+    async (field: string, value: any): Promise<boolean> => {
+      const fieldAsyncValidators = asyncValidators[field];
+      if (!fieldAsyncValidators?.length) return true;
+
+      // Cancel previous in-flight request for this field.
+      abortControllers.current[field]?.abort();
+      const controller = new AbortController();
+      abortControllers.current[field] = controller;
+      const { signal } = controller;
+
+      // Mark field as pending.
+      setFormState((prev) => ({
+        ...prev,
+        [field]: { ...prev[field], pending: true },
+      }));
+
+      try {
+        for (const asyncValidator of fieldAsyncValidators) {
+          const error = await asyncValidator(value, signal);
+          if (signal.aborted) return false; // superseded — don't touch state
+          if (error) {
             setFormState((prev) => ({
-                ...prev,
-                [field]: {
-                    ...prev[field],
-                    error: undefined,
-                },
+              ...prev,
+              [field]: { ...prev[field], error, pending: false },
             }));
-            return true;
-        },
-        [formState, validators]
-    );
+            return false;
+          }
+        }
 
-    const setTouched = useCallback(
-        (field: string, touched: boolean) => {
-            setFormState((prev) => ({
-                ...prev,
-                [field]: {
-                    ...prev[field],
-                    touched,
-                },
-            }));
-
-            if (validateOnBlur && touched) {
-                validateField(field);
-            }
-        },
-        [validateOnBlur, validateField]
-    );
-
-    const setFieldError = useCallback((field: string, error?: string) => {
+        // All async validators passed.
         setFormState((prev) => ({
-            ...prev,
-            [field]: {
-                ...prev[field],
-                error,
-            },
+          ...prev,
+          [field]: { ...prev[field], error: undefined, pending: false },
         }));
-    }, []);
-
-    const clearFieldError = useCallback((field: string) => {
+        return true;
+      } catch (err) {
+        // Ignore aborted-request errors silently.
+        if (signal.aborted) return false;
+        // Re-surface unexpected errors as a field error.
+        const message =
+          err instanceof Error ? err.message : "Validation failed";
         setFormState((prev) => ({
-            ...prev,
-            [field]: {
-                ...prev[field],
-                error: undefined,
-            },
+          ...prev,
+          [field]: { ...prev[field], error: message, pending: false },
         }));
-    }, []);
+        return false;
+      }
+    },
+    [asyncValidators]
+  );
 
-    const clearErrors = useCallback(() => {
-        setFormState((prev) => {
-            const next = { ...prev };
-            for (const key of Object.keys(next)) {
-                next[key] = { ...next[key], error: undefined };
-            }
-            return next;
-        });
-    }, []);
+  /**
+   * Public: run sync then async validators for one field.
+   * The async part is NOT debounced here (use validateFieldDebounced for
+   * onChange scenarios). This is intended for onBlur / explicit submit checks.
+   */
+  const validateFieldAsync = useCallback(
+    async (field: string): Promise<boolean> => {
+      if (debounceTimers.current[field] !== undefined) {
+        clearTimeout(debounceTimers.current[field]);
+        delete debounceTimers.current[field];
+      }
 
-    const validateAll = useCallback((): boolean => {
-        let isValid = true;
-        const fieldsToValidate = Object.keys(validators);
+      if (!validateField(field)) return false;
+      // latestValues gives us the value written in the most recent setState
+      // even before React commits the next render.
+      const value = latestValues.current[field] ?? formState[field]?.value;
+      return _runAsyncValidators(field, value);
+    },
+    [validateField, formState, _runAsyncValidators]
+  );
 
-        for (const field of fieldsToValidate) {
-            if (!validateField(field)) {
-                isValid = false;
-            }
+  /**
+   * Public: run sync then async validators for ALL fields.
+   * Runs all fields concurrently once sync passes.
+   */
+  const validateAllAsync = useCallback(async (): Promise<boolean> => {
+    for (const timer of Object.values(debounceTimers.current)) {
+      clearTimeout(timer);
+    }
+    debounceTimers.current = {};
+
+    if (!validateAll()) return false;
+
+    const results = await Promise.all(
+      Object.keys({ ...validators, ...asyncValidators }).map((field) => {
+        const value = latestValues.current[field] ?? formState[field]?.value;
+        return _runAsyncValidators(field, value);
+      })
+    );
+    return results.every(Boolean);
+  }, [validateAll, validators, asyncValidators, formState, _runAsyncValidators]);
+
+  // ---------------------------------------------------------------------------
+  // setTouched — triggers validation (sync + debounced async) on blur
+  // ---------------------------------------------------------------------------
+
+  const setTouched = useCallback(
+    (field: string, touched: boolean) => {
+      setFormState((prev) => ({
+        ...prev,
+        [field]: { ...prev[field], touched },
+      }));
+
+      if (validateOnBlur && touched) {
+        const syncPassed = validateField(field);
+        if (syncPassed && asyncValidators[field]?.length) {
+          const value = latestValues.current[field] ?? formState[field]?.value;
+          _runAsyncValidators(field, value);
+        }
+      }
+    },
+    [validateOnBlur, validateField, asyncValidators, formState, _runAsyncValidators]
+  );
+
+  // ---------------------------------------------------------------------------
+  // setState variant that also triggers debounced async validation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Override setState to additionally schedule a debounced async validation
+   * whenever the field has async validators configured.
+   */
+  const setStateWithAsyncValidation = useCallback(
+    (field: string, value: any) => {
+      // Eagerly update the value cache so subsequent reads in the same
+      // synchronous call stack see the latest value.
+      latestValues.current[field] = value;
+
+      // Update value in state.
+      setFormState((prev) => ({
+        ...prev,
+        [field]: { ...prev[field], value },
+      }));
+
+      if (!asyncValidators[field]?.length) return;
+
+      // Cancel any existing debounce timer for this field.
+      if (debounceTimers.current[field] !== undefined) {
+        clearTimeout(debounceTimers.current[field]);
+      }
+
+      // Also abort the previous in-flight async call immediately so it doesn't
+      // resolve into stale state while the debounce is counting down.
+      abortControllers.current[field]?.abort();
+
+      // Clear pending state while debounce is counting down.
+      setFormState((prev) => ({
+        ...prev,
+        [field]: { ...prev[field], pending: false },
+      }));
+
+      // Schedule async validators after the debounce delay.
+      debounceTimers.current[field] = setTimeout(() => {
+        delete debounceTimers.current[field];
+
+        // Run sync validators first; only proceed to async if sync passes.
+        const fieldValidators = validators[field] ?? [];
+        let syncError: string | undefined;
+        for (const validator of fieldValidators) {
+          const err = validator(value);
+          if (err) {
+            syncError = err;
+            break;
+          }
         }
 
-        return isValid;
-    }, [validators, validateField]);
-
-    const reset = useCallback(() => {
-        setFormState((prev) => {
-            const next: FormValidationState = {};
-            for (const [key, state] of Object.entries(prev)) {
-                next[key] = {
-                    value: initialValues[key] ?? "",
-                    touched: false,
-                    error: undefined,
-                };
-            }
-            return next;
-        });
-    }, [initialValues]);
-
-    const values = useMemo(() => {
-        const vals: Record<string, any> = {};
-        for (const [key, state] of Object.entries(formState)) {
-            vals[key] = state.value;
+        if (syncError) {
+          setFormState((prev) => ({
+            ...prev,
+            [field]: { ...prev[field], error: syncError, pending: false },
+          }));
+          return;
         }
-        return vals;
-    }, [formState]);
 
-    const touched = useMemo(() => {
-        const t: Record<string, boolean> = {};
-        for (const [key, state] of Object.entries(formState)) {
-            t[key] = state.touched;
-        }
-        return t;
-    }, [formState]);
+        // Sync is clean — run async.
+        _runAsyncValidators(field, value);
+      }, asyncDebounceMs);
+    },
+    [asyncValidators, validators, asyncDebounceMs, _runAsyncValidators]
+  );
 
-    const errors = useMemo(() => {
-        const e: Record<string, string | undefined> = {};
-        for (const [key, state] of Object.entries(formState)) {
-            e[key] = state.error;
-        }
-        return e;
-    }, [formState]);
+  // ---------------------------------------------------------------------------
+  // Reset
+  // ---------------------------------------------------------------------------
 
-    const isValid = useMemo(() => {
-        return Object.values(formState).every((state) => !state.error);
-    }, [formState]);
+  const reset = useCallback(() => {
+    for (const controller of Object.values(abortControllers.current)) {
+      controller.abort();
+    }
+    abortControllers.current = {};
 
-    return {
-        values,
-        touched,
-        errors,
-        setState,
-        setTouched,
-        setFieldError,
-        clearFieldError,
-        clearErrors,
-        validateField,
-        validateAll,
-        reset,
-        isValid,
-    };
+    for (const timer of Object.values(debounceTimers.current)) {
+      clearTimeout(timer);
+    }
+    debounceTimers.current = {};
+
+    // Reset the eager value cache to initial values.
+    latestValues.current = { ...initialValues };
+
+    setFormState((prev) => {
+      const next: FormValidationState = {};
+      for (const key of Object.keys(prev)) {
+        next[key] = {
+          value: initialValues[key] ?? "",
+          touched: false,
+          error: undefined,
+          pending: false,
+        };
+      }
+      return next;
+    });
+  }, [initialValues]);
+
+  // ---------------------------------------------------------------------------
+  // Derived memos
+  // ---------------------------------------------------------------------------
+
+  const values = useMemo(() => {
+    const vals: Record<string, any> = {};
+    for (const [key, state] of Object.entries(formState)) {
+      vals[key] = state.value;
+    }
+    return vals;
+  }, [formState]);
+
+  const touched = useMemo(() => {
+    const t: Record<string, boolean> = {};
+    for (const [key, state] of Object.entries(formState)) {
+      t[key] = state.touched;
+    }
+    return t;
+  }, [formState]);
+
+  const errors = useMemo(() => {
+    const e: Record<string, string | undefined> = {};
+    for (const [key, state] of Object.entries(formState)) {
+      e[key] = state.error;
+    }
+    return e;
+  }, [formState]);
+
+  const pending = useMemo(() => {
+    const p: Record<string, boolean> = {};
+    for (const [key, state] of Object.entries(formState)) {
+      p[key] = state.pending ?? false;
+    }
+    return p;
+  }, [formState]);
+
+  const isValid = useMemo(() => {
+    return Object.values(formState).every(
+      (state) => !state.error && !state.pending
+    );
+  }, [formState]);
+
+  // ---------------------------------------------------------------------------
+  // Return
+  // ---------------------------------------------------------------------------
+
+  return {
+    values,
+    touched,
+    errors,
+    pending,
+    setState: setStateWithAsyncValidation,
+    setTouched,
+    setFieldError,
+    clearFieldError,
+    clearErrors,
+    validateField,
+    validateFieldAsync,
+    validateAll,
+    validateAllAsync,
+    reset,
+    isValid,
+  };
 }

--- a/frontend/src/lib/validators.ts
+++ b/frontend/src/lib/validators.ts
@@ -1,111 +1,216 @@
 /**
- * Shared validation utilities for forms
+ * Shared validation utilities for forms.
+ *
+ * Two categories:
+ *  - `validators`      — synchronous, return `string | undefined`
+ *  - `asyncValidators` — asynchronous, receive an AbortSignal, return
+ *                        `Promise<string | undefined>`
  */
 
+import type { AsyncValidatorFn, ValidatorFn } from "@/hooks/useFormValidation";
+
+// ---------------------------------------------------------------------------
+// Sync validators
+// ---------------------------------------------------------------------------
+
 export const validators = {
-    /**
-     * Required field validator
-     */
-    required: (fieldName: string = "This field") => (value: any): string | undefined => {
-        if (!value || (typeof value === "string" && !value.trim())) {
-            return `${fieldName} is required.`;
-        }
-        return undefined;
+  /**
+   * Required field validator.
+   */
+  required:
+    (fieldName = "This field"): ValidatorFn =>
+    (value: any): string | undefined => {
+      if (!value || (typeof value === "string" && !value.trim())) {
+        return `${fieldName} is required.`;
+      }
+      return undefined;
     },
 
-    /**
-     * Minimum length validator
-     */
-    minLength: (min: number, fieldName: string = "This field") => (value: any): string | undefined => {
-        if (!value) return undefined;
-        if (String(value).length < min) {
-            return `${fieldName} must be at least ${min} characters.`;
-        }
-        return undefined;
+  /**
+   * Minimum length validator.
+   */
+  minLength:
+    (min: number, fieldName = "This field"): ValidatorFn =>
+    (value: any): string | undefined => {
+      if (!value) return undefined;
+      if (String(value).length < min) {
+        return `${fieldName} must be at least ${min} characters.`;
+      }
+      return undefined;
     },
 
-    /**
-     * Maximum length validator
-     */
-    maxLength: (max: number, fieldName: string = "This field") => (value: any): string | undefined => {
-        if (!value) return undefined;
-        if (String(value).length > max) {
-            return `${fieldName} must be at most ${max} characters.`;
-        }
-        return undefined;
+  /**
+   * Maximum length validator.
+   */
+  maxLength:
+    (max: number, fieldName = "This field"): ValidatorFn =>
+    (value: any): string | undefined => {
+      if (!value) return undefined;
+      if (String(value).length > max) {
+        return `${fieldName} must be at most ${max} characters.`;
+      }
+      return undefined;
     },
 
-    /**
-     * Email validator
-     */
-    email: (value: any): string | undefined => {
-        if (!value) return undefined;
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(String(value))) {
-            return "Please enter a valid email address.";
-        }
-        return undefined;
+  /**
+   * Email format validator. Can be used directly (not a factory).
+   */
+  email: (value: any): string | undefined => {
+    if (!value) return undefined;
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(String(value))) {
+      return "Please enter a valid email address.";
+    }
+    return undefined;
+  },
+
+  /**
+   * Numeric value validator.
+   */
+  number:
+    (fieldName = "This field"): ValidatorFn =>
+    (value: any): string | undefined => {
+      if (value === "" || value === null || value === undefined) return undefined;
+      if (isNaN(Number(value))) {
+        return `${fieldName} must be a valid number.`;
+      }
+      return undefined;
     },
 
-    /**
-     * Number validator
-     */
-    number: (fieldName: string = "This field") => (value: any): string | undefined => {
-        if (value === "" || value === null || value === undefined) return undefined;
-        if (isNaN(Number(value))) {
-            return `${fieldName} must be a valid number.`;
-        }
-        return undefined;
+  /**
+   * Minimum numeric value validator.
+   */
+  minValue:
+    (min: number, fieldName = "This field"): ValidatorFn =>
+    (value: any): string | undefined => {
+      if (value === "" || value === null || value === undefined) return undefined;
+      const num = Number(value);
+      if (isNaN(num) || num < min) {
+        return `${fieldName} must be at least ${min}.`;
+      }
+      return undefined;
     },
 
-    /**
-     * Minimum number validator
-     */
-    minValue: (min: number, fieldName: string = "This field") => (value: any): string | undefined => {
-        if (value === "" || value === null || value === undefined) return undefined;
-        const num = Number(value);
-        if (isNaN(num) || num < min) {
-            return `${fieldName} must be at least ${min}.`;
-        }
-        return undefined;
+  /**
+   * Maximum numeric value validator.
+   */
+  maxValue:
+    (max: number, fieldName = "This field"): ValidatorFn =>
+    (value: any): string | undefined => {
+      if (value === "" || value === null || value === undefined) return undefined;
+      const num = Number(value);
+      if (isNaN(num) || num > max) {
+        return `${fieldName} must be at most ${max}.`;
+      }
+      return undefined;
     },
 
-    /**
-     * Maximum number validator
-     */
-    maxValue: (max: number, fieldName: string = "This field") => (value: any): string | undefined => {
-        if (value === "" || value === null || value === undefined) return undefined;
-        const num = Number(value);
-        if (isNaN(num) || num > max) {
-            return `${fieldName} must be at most ${max}.`;
-        }
-        return undefined;
+  /**
+   * Regex pattern validator.
+   */
+  pattern:
+    (regex: RegExp, fieldName = "This field"): ValidatorFn =>
+    (value: any): string | undefined => {
+      if (!value) return undefined;
+      if (!regex.test(String(value))) {
+        return `${fieldName} format is invalid.`;
+      }
+      return undefined;
     },
 
-    /**
-     * Pattern/Regex validator
-     */
-    pattern: (regex: RegExp, fieldName: string = "This field") => (value: any): string | undefined => {
-        if (!value) return undefined;
-        if (!regex.test(String(value))) {
-            return `${fieldName} format is invalid.`;
-        }
-        return undefined;
+  /**
+   * Identity wrapper — pass through a custom validator function as-is.
+   */
+  custom: (fn: ValidatorFn): ValidatorFn => fn,
+
+  /**
+   * Run multiple validators in order; return the first error encountered.
+   */
+  compose:
+    (...validatorFns: ValidatorFn[]): ValidatorFn =>
+    (value: any): string | undefined => {
+      for (const validator of validatorFns) {
+        const error = validator(value);
+        if (error) return error;
+      }
+      return undefined;
+    },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Async validators
+// ---------------------------------------------------------------------------
+
+export const asyncValidators = {
+  /**
+   * Checks uniqueness by calling a provided async lookup function.
+   *
+   * The lookup receives the current value and must resolve to `true` when the
+   * value is already taken. It also receives the AbortSignal so it can cancel
+   * an underlying fetch if the validation is superseded.
+   *
+   * @example
+   * asyncValidators.unique(
+   *   (name, signal) => checkEventNameTaken(name, signal),
+   *   "Event name"
+   * )
+   */
+  unique:
+    (
+      lookupFn: (value: any, signal: AbortSignal) => Promise<boolean>,
+      fieldName = "This value"
+    ): AsyncValidatorFn =>
+    async (value: any, signal: AbortSignal): Promise<string | undefined> => {
+      if (!value && value !== 0) return undefined;
+      const isTaken = await lookupFn(value, signal);
+      if (signal.aborted) return undefined;
+      return isTaken ? `${fieldName} is already taken.` : undefined;
     },
 
-    /**
-     * Custom validator function
-     */
-    custom: (fn: (value: any) => string | undefined) => fn,
+  /**
+   * Wraps any async check function as a validator.
+   *
+   * `checkFn` should resolve to an error string when invalid, or `undefined`
+   * when valid. The AbortSignal is forwarded so network requests can be
+   * cancelled.
+   *
+   * @example
+   * asyncValidators.custom(async (value, signal) => {
+   *   const ok = await verifyCode(value, signal);
+   *   return ok ? undefined : "Invalid verification code.";
+   * })
+   */
+  custom:
+    (checkFn: AsyncValidatorFn): AsyncValidatorFn =>
+    (value: any, signal: AbortSignal) =>
+      checkFn(value, signal),
 
-    /**
-     * Compose multiple validators (first error is returned)
-     */
-    compose: (...validatorFns: Array<(value: any) => string | undefined>) => (value: any): string | undefined => {
-        for (const validator of validatorFns) {
-            const error = validator(value);
-            if (error) return error;
-        }
-        return undefined;
+  /**
+   * Compose multiple async validators, running them in series.
+   * Stops and returns the first error encountered.
+   *
+   * Sync validators can be mixed in by wrapping them with `asyncValidators.fromSync`.
+   */
+  compose:
+    (...fns: AsyncValidatorFn[]): AsyncValidatorFn =>
+    async (value: any, signal: AbortSignal): Promise<string | undefined> => {
+      for (const fn of fns) {
+        if (signal.aborted) return undefined;
+        const error = await fn(value, signal);
+        if (error) return error;
+      }
+      return undefined;
     },
-};
+
+  /**
+   * Lift a synchronous validator into an async validator so it can be used
+   * inside `asyncValidators.compose` or directly in `asyncValidators` config.
+   *
+   * @example
+   * asyncValidators.fromSync(validators.required("Username"))
+   */
+  fromSync:
+    (syncFn: ValidatorFn): AsyncValidatorFn =>
+    async (value: any, _signal: AbortSignal): Promise<string | undefined> =>
+      syncFn(value),
+} as const;


### PR DESCRIPTION
## Summary

Resolves #1594. `useFormValidation` only supported sync validators, making inline uniqueness checks (e.g. event name availability) impossible. This PR adds full async validation support with pending state, debouncing, and AbortController-based cancellation.

---

## Changes

### `frontend/src/hooks/useFormValidation.ts`
- Added `AsyncValidatorFn` type: `(value, signal: AbortSignal) => Promise<string | undefined>`
- Added `asyncValidators` and `asyncDebounceMs` (default 300ms) options
- Added `pending` map — `true` per field while async work is in-flight
- Added `validateFieldAsync(field)` — runs sync first, then async; returns `Promise<boolean>`
- Added `validateAllAsync()` — same for all fields concurrently
- `setState` debounces async validation on each change, cancels the previous timer and aborts the previous in-flight call via `AbortController`
- `setTouched(field, true)` triggers async validators immediately (no debounce) when `validateOnBlur: true`
- `isValid` is `false` while any field has `pending: true`
- `reset()` aborts all in-flight async work and clears all debounce timers
- Added `latestValues` ref for eager value tracking so validators always read the current value within the same React render cycle

### `frontend/src/hooks/useDebounce.ts`
- Added `useDebouncedCallback` — returns a stable debounced function with a `.cancel()` method
- Uses a `fnRef` internally so callers never need to memoize the callback they pass in
- Auto-cancels on unmount via cleanup effect

### `frontend/src/lib/validators.ts`
- Added `asyncValidators` export with:
  - `unique(lookupFn, fieldName)` — checks availability via a caller-supplied async lookup
  - `custom(fn)` — identity wrapper for ad-hoc async validators
  - `compose(...fns)` — runs async validators in series, stops at first error
  - `fromSync(syncFn)` — lifts a sync validator into the async interface

### `frontend/src/hooks/useFormValidation.test.ts` *(new file)*

24 tests across 7 suites:

| Suite | Tests |
|---|---|
| Sync regression | 5 |
| Async validator resolves/rejects | 4 |
| Cancellation on rapid input | 2 |
| Debounced async on setState | 4 |
| Sync + async aggregation | 4 |
| isValid reflects pending state | 2 |
| Reset cancels in-flight work | 1 |
| validateOnBlur with async validators | 2 |

---

## Usage example

```ts
const { errors, pending, setState, validateAllAsync } = useFormValidation({
  initialValues: { eventName: '' },
  validators: {
    eventName: [validators.required('Event name'), validators.minLength(3, 'Event name')],
  },
  asyncValidators: {
    eventName: [
      asyncValidators.unique(
        (name, signal) => checkEventNameAvailability(name, signal),
        'Event name',
      ),
    ],
  },
  asyncDebounceMs: 300,
});

// In JSX:
// <input onChange={e => setState('eventName', e.target.value)} />
// {pending.eventName && <Spinner />}
// {errors.eventName && <FieldError message={errors.eventName} />}

// On submit:
// const ok = await validateAllAsync();
```

---

## Tests

```
Tests  24 passed (24)
```

```bash
pnpm test src/hooks/useFormValidation.test.ts
```


Closes #1594