### PR TITLE
feat(backend): webhook DLQ, reorg metrics, digest category prefs, rat…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,9 @@ SOROBAN_RPC_MAX_RETRIES=2
 RECONCILE_ENABLED=true
 RECONCILE_INTERVAL_MS=60000
 RECONCILE_WINDOW=200
+# Number of ledgers to rewind the indexer checkpoint by when a chain reorg is
+# detected (the fork point used to roll back and re-scan contract events).
+INDEXER_REORG_ROLLBACK_DEPTH=10
 
 # Leaderboard Snapshot Configuration
 LEADERBOARD_SNAPSHOT_CRON=0 * * * *

--- a/backend/src/common/guards/tiered-throttler.guard.spec.ts
+++ b/backend/src/common/guards/tiered-throttler.guard.spec.ts
@@ -1,5 +1,6 @@
 import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { ThrottlerException } from '@nestjs/throttler';
 import { TieredThrottlerGuard } from './tiered-throttler.guard';
 import { THROTTLE_TIER_KEY } from '../decorators/throttle-tier.decorator';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
@@ -162,6 +163,65 @@ describe('TieredThrottlerGuard', () => {
       const key = (guard as any).generateKey(context, 'suffix', 'auth');
       expect(key).toContain('throttle:auth:192.168.1.1');
       expect(key).toContain('suffix');
+    });
+  });
+
+  describe('throwThrottlingException', () => {
+    it('sets standard rate-limit headers (unsuffixed) before throwing', async () => {
+      const setHeader = jest.fn();
+      const context = {
+        switchToHttp: () => ({
+          getRequest: () => ({ headers: {}, ip: '127.0.0.1' }),
+          getResponse: () => ({ setHeader }),
+        }),
+      } as unknown as ExecutionContext;
+
+      await expect(
+        (guard as any).throwThrottlingException(context, {
+          limit: 10,
+          ttl: 60000,
+          key: 'k',
+          tracker: 'user:1',
+          totalHits: 11,
+          timeToExpire: 42,
+          isBlocked: true,
+          timeToBlockExpire: 55,
+        }),
+      ).rejects.toBeInstanceOf(ThrottlerException);
+
+      expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', '10');
+      expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', '0');
+      expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', '42');
+      expect(setHeader).toHaveBeenCalledWith('Retry-After', '55');
+    });
+
+    it('reports numerically correct headers exactly at the limit boundary', async () => {
+      const setHeader = jest.fn();
+      const context = {
+        switchToHttp: () => ({
+          getRequest: () => ({ headers: {}, ip: '127.0.0.1' }),
+          getResponse: () => ({ setHeader }),
+        }),
+      } as unknown as ExecutionContext;
+
+      // The request that trips the limit: limit=100, this was the 101st hit.
+      await expect(
+        (guard as any).throwThrottlingException(context, {
+          limit: 100,
+          ttl: 60000,
+          key: 'k',
+          tracker: 'user:1',
+          totalHits: 101,
+          timeToExpire: 30,
+          isBlocked: true,
+          timeToBlockExpire: 30,
+        }),
+      ).rejects.toBeInstanceOf(ThrottlerException);
+
+      expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', '100');
+      expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', '0');
+      expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', '30');
+      expect(setHeader).toHaveBeenCalledWith('Retry-After', '30');
     });
   });
 

--- a/backend/src/common/guards/tiered-throttler.guard.ts
+++ b/backend/src/common/guards/tiered-throttler.guard.ts
@@ -6,7 +6,10 @@ import type { ThrottlerLimitDetail } from '@nestjs/throttler/dist/throttler.guar
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { THROTTLE_TIER_KEY } from '../decorators/throttle-tier.decorator';
-import { setRateLimitHeaders } from '../rate-limit-headers.util';
+import {
+  RateLimitHeaderResponse,
+  setRateLimitHeaders,
+} from '../rate-limit-headers.util';
 
 @Injectable()
 export class TieredThrottlerGuard extends ThrottlerGuard {
@@ -72,7 +75,7 @@ export class TieredThrottlerGuard extends ThrottlerGuard {
     throttlerLimitDetail: ThrottlerLimitDetail,
   ): Promise<void> {
     const { res } = this.getRequestResponse(context);
-    setRateLimitHeaders(res, {
+    setRateLimitHeaders(res as RateLimitHeaderResponse, {
       limit: throttlerLimitDetail.limit,
       remaining: 0,
       resetSeconds: throttlerLimitDetail.timeToExpire,

--- a/backend/src/common/guards/tiered-throttler.guard.ts
+++ b/backend/src/common/guards/tiered-throttler.guard.ts
@@ -2,9 +2,11 @@ import { ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerStorage } from '@nestjs/throttler';
 import type { ThrottlerModuleOptions } from '@nestjs/throttler/dist/throttler-module-options.interface';
+import type { ThrottlerLimitDetail } from '@nestjs/throttler/dist/throttler.guard.interface';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { THROTTLE_TIER_KEY } from '../decorators/throttle-tier.decorator';
+import { setRateLimitHeaders } from '../rate-limit-headers.util';
 
 @Injectable()
 export class TieredThrottlerGuard extends ThrottlerGuard {
@@ -63,6 +65,21 @@ export class TieredThrottlerGuard extends ThrottlerGuard {
       ? `user:${userId}`
       : (req.ip ?? req.socket?.remoteAddress ?? 'unknown');
     return `throttle:${name}:${tracker}:${suffix}`;
+  }
+
+  protected override async throwThrottlingException(
+    context: ExecutionContext,
+    throttlerLimitDetail: ThrottlerLimitDetail,
+  ): Promise<void> {
+    const { res } = this.getRequestResponse(context);
+    setRateLimitHeaders(res, {
+      limit: throttlerLimitDetail.limit,
+      remaining: 0,
+      resetSeconds: throttlerLimitDetail.timeToExpire,
+      retryAfterSeconds: throttlerLimitDetail.timeToBlockExpire,
+    });
+
+    await super.throwThrottlingException(context, throttlerLimitDetail);
   }
 
   private extractUserId(req: Record<string, any>): string | null {

--- a/backend/src/common/rate-limit-headers.util.spec.ts
+++ b/backend/src/common/rate-limit-headers.util.spec.ts
@@ -1,0 +1,44 @@
+import { setRateLimitHeaders } from './rate-limit-headers.util';
+
+describe('setRateLimitHeaders', () => {
+  it('sets all four standard headers when retryAfterSeconds is provided', () => {
+    const setHeader = jest.fn();
+
+    setRateLimitHeaders(
+      { setHeader },
+      { limit: 30, remaining: 0, resetSeconds: 12.4, retryAfterSeconds: 5.1 },
+    );
+
+    expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', '30');
+    expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', '0');
+    expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', '13'); // ceil(12.4)
+    expect(setHeader).toHaveBeenCalledWith('Retry-After', '6'); // ceil(5.1)
+    expect(setHeader).toHaveBeenCalledTimes(4);
+  });
+
+  it('omits Retry-After when not provided (non-throttled responses)', () => {
+    const setHeader = jest.fn();
+
+    setRateLimitHeaders(
+      { setHeader },
+      { limit: 30, remaining: 25, resetSeconds: 12 },
+    );
+
+    expect(setHeader).toHaveBeenCalledTimes(3);
+    expect(setHeader).not.toHaveBeenCalledWith(
+      'Retry-After',
+      expect.anything(),
+    );
+  });
+
+  it('never reports negative remaining', () => {
+    const setHeader = jest.fn();
+
+    setRateLimitHeaders(
+      { setHeader },
+      { limit: 10, remaining: -5, resetSeconds: 1 },
+    );
+
+    expect(setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', '0');
+  });
+});

--- a/backend/src/common/rate-limit-headers.util.ts
+++ b/backend/src/common/rate-limit-headers.util.ts
@@ -1,0 +1,35 @@
+/** Minimal response shape this helper needs — matches Express's `res`. */
+export interface RateLimitHeaderResponse {
+  setHeader(name: string, value: string): void;
+}
+
+export interface RateLimitHeaderValues {
+  /** Max requests allowed for the tier's window. */
+  limit: number;
+  /** Requests remaining in the current window. */
+  remaining: number;
+  /** Seconds until the current window resets. */
+  resetSeconds: number;
+  /** Seconds the client must wait before retrying (set only when throttled). */
+  retryAfterSeconds?: number;
+}
+
+/**
+ * Centralised rate-limit header logic, shared by the throttler guard (which
+ * has the only access to per-request hit counts at block time) and any
+ * success-path consumer. Always emits the plain, standard header names —
+ * @nestjs/throttler suffixes them per-tier (e.g. `X-RateLimit-Limit-auth`),
+ * which callers can't rely on.
+ */
+export function setRateLimitHeaders(
+  res: RateLimitHeaderResponse,
+  values: RateLimitHeaderValues,
+): void {
+  res.setHeader('X-RateLimit-Limit', String(values.limit));
+  res.setHeader('X-RateLimit-Remaining', String(Math.max(0, values.remaining)));
+  res.setHeader('X-RateLimit-Reset', String(Math.ceil(values.resetSeconds)));
+
+  if (values.retryAfterSeconds !== undefined) {
+    res.setHeader('Retry-After', String(Math.ceil(values.retryAfterSeconds)));
+  }
+}

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -102,6 +102,12 @@ class EnvironmentVariables {
   @Min(1)
   RECONCILE_WINDOW?: number;
 
+  /** Default: 10 — ledgers to rewind the checkpoint on a detected chain reorg */
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  INDEXER_REORG_ROLLBACK_DEPTH?: number;
+
   /** Default: ./exports */
   @IsOptional()
   @IsString()

--- a/backend/src/indexer/dto/indexer-health.dto.ts
+++ b/backend/src/indexer/dto/indexer-health.dto.ts
@@ -55,6 +55,18 @@ export class IndexerHealthMetricsDto {
 
   @ApiProperty()
   dlq_events: number;
+
+  @ApiProperty({
+    description:
+      'Ledgers rewound by the most recently detected chain reorg (0 if none yet)',
+  })
+  last_reorg_depth: number;
+
+  @ApiProperty({
+    description:
+      'Ledgers re-scanned during recovery from the most recently detected chain reorg (0 if none yet)',
+  })
+  last_reorg_rescanned_ledger_count: number;
 }
 
 export class IndexerHealthResponseDto {
@@ -80,6 +92,12 @@ export class ReconciliationStatusDto {
 
   @ApiProperty()
   last_backfill_count: number;
+
+  @ApiProperty()
+  last_reorg_depth: number;
+
+  @ApiProperty()
+  last_reorg_rescanned_ledger_count: number;
 
   @ApiProperty()
   lag_in_ledgers: number;

--- a/backend/src/indexer/health.service.spec.ts
+++ b/backend/src/indexer/health.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { IndexerHealthService } from './health.service';
 import { IndexerService } from './indexer.service';
+import { ReconciliationService } from './reconciliation.service';
 import { IndexerAlertSeverity } from './dto/indexer-health.dto';
 
 describe('IndexerHealthService', () => {
@@ -15,6 +16,9 @@ describe('IndexerHealthService', () => {
       | 'triggerManualSync'
     >
   >;
+  let reconciliationService: jest.Mocked<
+    Pick<ReconciliationService, 'getStatus'>
+  >;
 
   beforeEach(async () => {
     indexerService = {
@@ -24,10 +28,22 @@ describe('IndexerHealthService', () => {
       triggerManualSync: jest.fn(),
     };
 
+    reconciliationService = {
+      getStatus: jest.fn().mockReturnValue({
+        enabled: true,
+        is_running: false,
+        last_run_at: null,
+        last_backfill_count: 0,
+        last_reorg_depth: 0,
+        last_reorg_rescanned_ledger_count: 0,
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         IndexerHealthService,
         { provide: IndexerService, useValue: indexerService },
+        { provide: ReconciliationService, useValue: reconciliationService },
         {
           provide: ConfigService,
           useValue: {
@@ -124,6 +140,26 @@ describe('IndexerHealthService', () => {
     expect(output).toContain('indexer_lag_in_ledgers 10');
     expect(output).toContain('# TYPE indexer_is_running gauge');
     expect(output).toContain('indexer_total_events_processed 950');
+  });
+
+  it('includes reorg depth and re-scanned ledger count from reconciliation status', async () => {
+    mockHealthyMetrics();
+    reconciliationService.getStatus.mockReturnValue({
+      enabled: true,
+      is_running: false,
+      last_run_at: null,
+      last_backfill_count: 3,
+      last_reorg_depth: 12,
+      last_reorg_rescanned_ledger_count: 45,
+    });
+
+    const health = await service.getHealth();
+    expect(health.metrics.last_reorg_depth).toBe(12);
+    expect(health.metrics.last_reorg_rescanned_ledger_count).toBe(45);
+
+    const output = await service.getPrometheusMetrics();
+    expect(output).toContain('indexer_last_reorg_depth 12');
+    expect(output).toContain('indexer_last_reorg_rescanned_ledger_count 45');
   });
 
   it('triggers manual sync via indexer service', async () => {

--- a/backend/src/indexer/health.service.ts
+++ b/backend/src/indexer/health.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { IndexerService } from './indexer.service';
+import { ReconciliationService } from './reconciliation.service';
 import {
   IndexerAlertDto,
   IndexerAlertSeverity,
@@ -20,6 +21,7 @@ export class IndexerHealthService {
   constructor(
     private readonly indexerService: IndexerService,
     private readonly configService: ConfigService,
+    private readonly reconciliationService: ReconciliationService,
   ) {}
 
   async getHealth(): Promise<IndexerHealthResponseDto> {
@@ -84,6 +86,12 @@ export class IndexerHealthService {
       '# HELP indexer_dlq_events Events in the dead-letter queue',
       '# TYPE indexer_dlq_events gauge',
       `indexer_dlq_events ${metrics.dlq_events}`,
+      '# HELP indexer_last_reorg_depth Ledgers rewound by the most recently detected chain reorg',
+      '# TYPE indexer_last_reorg_depth gauge',
+      `indexer_last_reorg_depth ${metrics.last_reorg_depth}`,
+      '# HELP indexer_last_reorg_rescanned_ledger_count Ledgers re-scanned recovering from the most recently detected chain reorg',
+      '# TYPE indexer_last_reorg_rescanned_ledger_count gauge',
+      `indexer_last_reorg_rescanned_ledger_count ${metrics.last_reorg_rescanned_ledger_count}`,
     ];
 
     return `${lines.join('\n')}\n`;
@@ -127,6 +135,10 @@ export class IndexerHealthService {
       total_events_processed: baseMetrics.total_events_processed,
       pending_events: baseMetrics.pending_events,
       dlq_events: baseMetrics.dlq_events,
+      last_reorg_depth: this.reconciliationService.getStatus().last_reorg_depth,
+      last_reorg_rescanned_ledger_count:
+        this.reconciliationService.getStatus()
+          .last_reorg_rescanned_ledger_count,
     };
   }
 

--- a/backend/src/indexer/reconciliation.service.spec.ts
+++ b/backend/src/indexer/reconciliation.service.spec.ts
@@ -195,6 +195,8 @@ describe('ReconciliationService', () => {
         is_running: false,
         last_run_at: null,
         last_backfill_count: 0,
+        last_reorg_depth: 0,
+        last_reorg_rescanned_ledger_count: 0,
       });
     });
   });
@@ -617,6 +619,12 @@ describe('ReconciliationService', () => {
       expect(reorgEventRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({ fork_ledger: 90, previous_ledger: 100 }),
       );
+
+      // Reorg depth (100 - 90) and the re-scanned ledger range (91..95) are
+      // captured for the indexer-health metrics.
+      const status = service.getStatus();
+      expect(status.last_reorg_depth).toBe(10);
+      expect(status.last_reorg_rescanned_ledger_count).toBe(5);
     });
   });
 });

--- a/backend/src/indexer/reconciliation.service.ts
+++ b/backend/src/indexer/reconciliation.service.ts
@@ -23,6 +23,8 @@ export class ReconciliationService {
   private isRunning = false;
   private lastRunAt: Date | null = null;
   private lastBackfillCount = 0;
+  private lastReorgDepth = 0;
+  private lastReorgRescannedLedgerCount = 0;
 
   constructor(
     private readonly configService: ConfigService,
@@ -73,7 +75,14 @@ export class ReconciliationService {
       return;
     }
 
-    await this.detectAndHandleReorg(contractId, checkpoint, rpcUrl);
+    const reorgEvent = await this.detectAndHandleReorg(
+      contractId,
+      checkpoint,
+      rpcUrl,
+    );
+    if (reorgEvent) {
+      this.lastReorgDepth = reorgEvent.previous_ledger - reorgEvent.fork_ledger;
+    }
 
     const chainHead = await this.fetchChainHead(rpcUrl, contractId);
     if (chainHead === null) return;
@@ -100,6 +109,10 @@ export class ReconciliationService {
       fromLedger,
       toLedger,
     );
+
+    if (reorgEvent) {
+      this.lastReorgRescannedLedgerCount = toLedger - fromLedger + 1;
+    }
 
     checkpoint.last_reconciled_from = fromLedger;
     checkpoint.last_reconciled_to = toLedger;
@@ -423,12 +436,16 @@ export class ReconciliationService {
     is_running: boolean;
     last_run_at: string | null;
     last_backfill_count: number;
+    last_reorg_depth: number;
+    last_reorg_rescanned_ledger_count: number;
   } {
     return {
       enabled: this.isEnabled(),
       is_running: this.isRunning,
       last_run_at: this.lastRunAt?.toISOString() ?? null,
       last_backfill_count: this.lastBackfillCount,
+      last_reorg_depth: this.lastReorgDepth,
+      last_reorg_rescanned_ledger_count: this.lastReorgRescannedLedgerCount,
     };
   }
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -39,7 +39,16 @@ async function bootstrap() {
 
   const config = new DocumentBuilder()
     .setTitle('InsightArena API')
-    .setDescription('The InsightArena Platform API description')
+    .setDescription(
+      'The InsightArena Platform API description\n\n' +
+        '### Rate limiting\n' +
+        'Every endpoint is rate-limited per tier (default/auth/read/write). ' +
+        'A `429 Too Many Requests` response always includes:\n' +
+        '- `X-RateLimit-Limit`: max requests allowed in the current window\n' +
+        '- `X-RateLimit-Remaining`: requests left in the window (`0` when throttled)\n' +
+        '- `X-RateLimit-Reset`: seconds until the window resets\n' +
+        '- `Retry-After`: seconds the client must wait before retrying',
+    )
     .setVersion('1.0')
     .addBearerAuth()
     .addApiKey(

--- a/backend/src/notifications/digest.service.spec.ts
+++ b/backend/src/notifications/digest.service.spec.ts
@@ -11,6 +11,10 @@ import { UserPreferences } from '../users/entities/user-preferences.entity';
 import { User } from '../users/entities/user.entity';
 import { Notification } from './entities/notification.entity';
 import { NotificationDigestState } from './entities/notification-digest-state.entity';
+import {
+  NotificationCategoryPreference,
+  NotificationCategory,
+} from './entities/notification-category-preference.entity';
 import { EmailService } from './email.service';
 
 describe('DigestService', () => {
@@ -19,6 +23,7 @@ describe('DigestService', () => {
   let userRepo: Repository<User>;
   let notificationRepo: Repository<Notification>;
   let digestStateRepo: Repository<NotificationDigestState>;
+  let categoryPreferencesRepo: Repository<NotificationCategoryPreference>;
   let emailService: EmailService;
   let config: ConfigService;
 
@@ -80,6 +85,12 @@ describe('DigestService', () => {
           },
         },
         {
+          provide: getRepositoryToken(NotificationCategoryPreference),
+          useValue: {
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
           provide: EmailService,
           useValue: {
             queueEmail: jest.fn().mockResolvedValue(undefined),
@@ -105,6 +116,9 @@ describe('DigestService', () => {
     digestStateRepo = module.get<Repository<NotificationDigestState>>(
       getRepositoryToken(NotificationDigestState),
     );
+    categoryPreferencesRepo = module.get<
+      Repository<NotificationCategoryPreference>
+    >(getRepositoryToken(NotificationCategoryPreference));
     emailService = module.get<EmailService>(EmailService);
     config = module.get<ConfigService>(ConfigService);
 
@@ -413,6 +427,71 @@ describe('DigestService', () => {
           digest_hour: 9,
         },
       });
+    });
+
+    it('excludes notifications whose category has email delivery turned off', async () => {
+      jest
+        .spyOn(prefsRepo, 'find')
+        .mockResolvedValue([mockPref as UserPreferences]);
+      jest.spyOn(notificationRepo, 'find').mockResolvedValue([
+        { ...mockNotification, type: 'event_created' } as Notification,
+        {
+          ...mockNotification,
+          type: 'match_resolved',
+          title: 'Result posted',
+          message: 'Arsenal won',
+        } as Notification,
+      ]);
+      jest.spyOn(categoryPreferencesRepo, 'find').mockResolvedValue([
+        {
+          userId: 'user-1',
+          category: NotificationCategory.EventCreated,
+          in_app: true,
+          email: false,
+          push: false,
+        } as NotificationCategoryPreference,
+      ]);
+
+      await service.sendDailyDigests(
+        new Date('2024-01-15T08:00:00Z'),
+        'UTC',
+        8,
+      );
+
+      expect(emailService.queueEmail).toHaveBeenCalledTimes(1);
+      const html = (emailService.queueEmail as jest.Mock).mock.calls[0][0]
+        .html as string;
+      expect(html).toContain('Results');
+      expect(html).not.toContain('New event');
+    });
+
+    it('sends no email when every category in the window has email delivery turned off', async () => {
+      jest
+        .spyOn(prefsRepo, 'find')
+        .mockResolvedValue([mockPref as UserPreferences]);
+      jest
+        .spyOn(notificationRepo, 'find')
+        .mockResolvedValue([
+          { ...mockNotification, type: 'event_created' } as Notification,
+        ]);
+      jest.spyOn(categoryPreferencesRepo, 'find').mockResolvedValue([
+        {
+          userId: 'user-1',
+          category: NotificationCategory.EventCreated,
+          in_app: true,
+          email: false,
+          push: false,
+        } as NotificationCategoryPreference,
+      ]);
+
+      await service.sendDailyDigests(
+        new Date('2024-01-15T08:00:00Z'),
+        'UTC',
+        8,
+      );
+
+      expect(emailService.queueEmail).not.toHaveBeenCalled();
+      expect(digestStateRepo.save).not.toHaveBeenCalled();
     });
 
     it('skips a user with no stored email', async () => {

--- a/backend/src/notifications/digest.service.ts
+++ b/backend/src/notifications/digest.service.ts
@@ -7,6 +7,7 @@ import { UserPreferences } from '../users/entities/user-preferences.entity';
 import { User } from '../users/entities/user.entity';
 import { Notification } from './entities/notification.entity';
 import { NotificationDigestState } from './entities/notification-digest-state.entity';
+import { NotificationCategoryPreference } from './entities/notification-category-preference.entity';
 import { EmailService } from './email.service';
 import {
   renderEmailTemplate,
@@ -101,6 +102,8 @@ export class DigestService {
     private readonly notificationRepo: Repository<Notification>,
     @InjectRepository(NotificationDigestState)
     private readonly digestStateRepo: Repository<NotificationDigestState>,
+    @InjectRepository(NotificationCategoryPreference)
+    private readonly categoryPreferencesRepo: Repository<NotificationCategoryPreference>,
     private readonly emailService: EmailService,
     private readonly config: ConfigService,
   ) {}
@@ -224,7 +227,7 @@ export class DigestService {
     if (lastPeriod === periodKey) return;
 
     // fetch unread notifications created in the window (cap at 20 items)
-    const notifications = await this.notificationRepo.find({
+    const allNotifications = await this.notificationRepo.find({
       where: {
         user_address: user.stellar_address,
         read: false,
@@ -233,6 +236,11 @@ export class DigestService {
       order: { created_at: 'DESC' },
       take: 20,
     });
+
+    const notifications = await this.filterByCategoryEmailPreference(
+      pref.userId,
+      allNotifications,
+    );
 
     // skip users with nothing to report — no email queued, no state written
     if (notifications.length === 0) return;
@@ -266,6 +274,29 @@ export class DigestService {
 
     this.logger.log(
       `Digest sent to ${user.email} (${frequency}, ${periodKey}, ${aggregated.totalUnique} items, ${aggregated.overflowCount} overflow)`,
+    );
+  }
+
+  /**
+   * Drops notifications whose category has email delivery turned off via
+   * per-category preferences. Categories with no stored preference default
+   * to enabled (matches NotificationsService.isCategoryEnabled).
+   */
+  private async filterByCategoryEmailPreference(
+    userId: string,
+    notifications: Notification[],
+  ): Promise<Notification[]> {
+    const categoryPrefs = await this.categoryPreferencesRepo.find({
+      where: { userId },
+    });
+    const emailDisabledCategories = new Set(
+      categoryPrefs.filter((p) => !p.email).map((p) => p.category as string),
+    );
+
+    if (emailDisabledCategories.size === 0) return notifications;
+
+    return notifications.filter(
+      (notification) => !emailDisabledCategories.has(notification.type),
     );
   }
 

--- a/backend/src/webhooks/entities/webhook-delivery-log.entity.ts
+++ b/backend/src/webhooks/entities/webhook-delivery-log.entity.ts
@@ -13,6 +13,7 @@ export enum DeliveryStatus {
   PENDING = 'pending',
   SUCCESS = 'success',
   FAILED = 'failed',
+  DEAD_LETTER = 'dead_letter',
 }
 
 @Entity('webhook_delivery_logs')

--- a/backend/src/webhooks/services/webhook-dispatcher.service.spec.ts
+++ b/backend/src/webhooks/services/webhook-dispatcher.service.spec.ts
@@ -1,0 +1,207 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { HttpService } from '@nestjs/axios';
+import * as crypto from 'crypto';
+import { WebhookDispatcherService } from './webhook-dispatcher.service';
+import { WebhookEndpoint } from '../entities/webhook-endpoint.entity';
+import {
+  DeliveryStatus,
+  WebhookDeliveryLog,
+} from '../entities/webhook-delivery-log.entity';
+
+describe('WebhookDispatcherService', () => {
+  let service: WebhookDispatcherService;
+  let endpointRepository: jest.Mocked<
+    Pick<Repository<WebhookEndpoint>, 'find' | 'save'>
+  >;
+  let deliveryLogRepository: jest.Mocked<
+    Pick<Repository<WebhookDeliveryLog>, 'find' | 'save' | 'create'>
+  >;
+  let httpService: { axiosRef: { post: jest.Mock } };
+
+  const makeEndpoint = (
+    overrides: Partial<WebhookEndpoint> = {},
+  ): WebhookEndpoint =>
+    ({
+      id: 'endpoint-1',
+      url: 'https://example.com/hook',
+      event_types: ['event.created'],
+      secret_key: 'shhh-secret',
+      is_active: true,
+      failure_count: 0,
+      last_delivery_at: null,
+      last_failure_at: null,
+      ...overrides,
+    }) as WebhookEndpoint;
+
+  const makeLog = (
+    overrides: Partial<WebhookDeliveryLog> = {},
+  ): WebhookDeliveryLog =>
+    ({
+      id: 'log-1',
+      endpoint: makeEndpoint(),
+      event_type: 'event.created',
+      payload: { foo: 'bar' },
+      status: DeliveryStatus.PENDING,
+      attempt_count: 0,
+      http_status_code: null,
+      error_message: null,
+      next_retry_at: new Date(),
+      created_at: new Date(),
+      delivered_at: null,
+      ...overrides,
+    }) as WebhookDeliveryLog;
+
+  beforeEach(async () => {
+    endpointRepository = { find: jest.fn(), save: jest.fn() };
+    deliveryLogRepository = {
+      find: jest.fn(),
+      save: jest.fn(),
+      create: jest.fn(),
+    };
+    httpService = { axiosRef: { post: jest.fn() } };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDispatcherService,
+        {
+          provide: getRepositoryToken(WebhookEndpoint),
+          useValue: endpointRepository,
+        },
+        {
+          provide: getRepositoryToken(WebhookDeliveryLog),
+          useValue: deliveryLogRepository,
+        },
+        { provide: HttpService, useValue: httpService },
+      ],
+    }).compile();
+
+    service = module.get<WebhookDispatcherService>(WebhookDispatcherService);
+
+    deliveryLogRepository.save.mockImplementation(
+      async (log) => log as WebhookDeliveryLog,
+    );
+    endpointRepository.save.mockImplementation(
+      async (ep) => ep as WebhookEndpoint,
+    );
+  });
+
+  describe('retry schedule (exponential backoff)', () => {
+    it('schedules the next retry with exponential backoff and keeps status pending', async () => {
+      const log = makeLog({ attempt_count: 0 });
+      httpService.axiosRef.post.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await (service as any).attemptDelivery(log);
+
+      expect(log.attempt_count).toBe(1);
+      expect(log.status).toBe(DeliveryStatus.PENDING);
+      expect(log.next_retry_at).not.toBeNull();
+      const delayMs = log.next_retry_at!.getTime() - Date.now();
+      // attempt 1 -> 2^0 * 1000ms = 1000ms
+      expect(delayMs).toBeGreaterThan(500);
+      expect(delayMs).toBeLessThanOrEqual(1500);
+    });
+
+    it('doubles the backoff on each successive attempt, capped at 1 hour', () => {
+      const attemptDelays = [1, 2, 3, 4, 5, 6, 20].map((attempt) => {
+        const log = makeLog();
+        (service as any).scheduleRetry(log, attempt);
+        return log.next_retry_at
+          ? log.next_retry_at.getTime() - Date.now()
+          : null;
+      });
+
+      // attempt 1..4 are under the max attempt cap (default 5), so they schedule.
+      expect(attemptDelays[0]).toBeGreaterThan(0);
+      expect(attemptDelays[0]).toBeLessThanOrEqual(1500);
+      expect(attemptDelays[1]).toBeGreaterThan(1500);
+      expect(attemptDelays[1]).toBeLessThanOrEqual(2500);
+      expect(attemptDelays[2]).toBeGreaterThan(3500);
+      expect(attemptDelays[2]).toBeLessThanOrEqual(4500);
+      expect(attemptDelays[3]).toBeGreaterThan(7500);
+      expect(attemptDelays[3]).toBeLessThanOrEqual(8500);
+
+      // attempt 5 (== maxAttempts) and beyond are exhausted -> no next_retry_at.
+      expect(attemptDelays[4]).toBeNull();
+      expect(attemptDelays[5]).toBeNull();
+      expect(attemptDelays[6]).toBeNull();
+    });
+  });
+
+  describe('dead-letter transition', () => {
+    it('moves a delivery to DEAD_LETTER once max attempts are exhausted', async () => {
+      const log = makeLog({ attempt_count: 4 }); // this attempt will be #5 (default max)
+      httpService.axiosRef.post.mockRejectedValue(new Error('still down'));
+
+      await (service as any).attemptDelivery(log);
+
+      expect(log.attempt_count).toBe(5);
+      expect(log.status).toBe(DeliveryStatus.DEAD_LETTER);
+      expect(log.next_retry_at).toBeNull();
+      expect(log.error_message).toContain('still down');
+    });
+
+    it('does not dead-letter a delivery before attempts are exhausted', async () => {
+      const log = makeLog({ attempt_count: 1 });
+      httpService.axiosRef.post.mockRejectedValue(new Error('timeout'));
+
+      await (service as any).attemptDelivery(log);
+
+      expect(log.attempt_count).toBe(2);
+      expect(log.status).not.toBe(DeliveryStatus.DEAD_LETTER);
+      expect(log.next_retry_at).not.toBeNull();
+    });
+  });
+
+  describe('signature preservation across retries', () => {
+    it('recomputes an identical HMAC signature on every retry attempt for the same payload/secret', async () => {
+      const log = makeLog({ attempt_count: 0 });
+      httpService.axiosRef.post.mockRejectedValue(new Error('boom'));
+
+      await (service as any).attemptDelivery(log); // attempt 1
+      const firstCallHeaders = httpService.axiosRef.post.mock.calls[0][2]
+        .headers as Record<string, string>;
+
+      await (service as any).attemptDelivery(log); // attempt 2 (retry)
+      const secondCallHeaders = httpService.axiosRef.post.mock.calls[1][2]
+        .headers as Record<string, string>;
+
+      const expectedSignature = crypto
+        .createHmac('sha256', log.endpoint.secret_key)
+        .update(JSON.stringify(log.payload))
+        .digest('hex');
+
+      expect(firstCallHeaders['X-Webhook-Signature']).toBe(expectedSignature);
+      expect(secondCallHeaders['X-Webhook-Signature']).toBe(expectedSignature);
+      expect(firstCallHeaders['X-Webhook-Signature']).toBe(
+        secondCallHeaders['X-Webhook-Signature'],
+      );
+      expect(secondCallHeaders['X-Delivery-Attempt']).toBe('2');
+    });
+  });
+
+  describe('processPendingDeliveries', () => {
+    it('only attempts deliveries whose next_retry_at has elapsed', async () => {
+      const dueLog = makeLog({
+        id: 'due',
+        next_retry_at: new Date(Date.now() - 1000),
+      });
+      const notDueLog = makeLog({
+        id: 'not-due',
+        next_retry_at: new Date(Date.now() + 60_000),
+      });
+      deliveryLogRepository.find.mockResolvedValue([dueLog, notDueLog]);
+      httpService.axiosRef.post.mockResolvedValue({ status: 200 });
+
+      await service.processPendingDeliveries();
+
+      expect(httpService.axiosRef.post).toHaveBeenCalledTimes(1);
+      expect(httpService.axiosRef.post).toHaveBeenCalledWith(
+        dueLog.endpoint.url,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/backend/src/webhooks/services/webhook-dispatcher.service.ts
+++ b/backend/src/webhooks/services/webhook-dispatcher.service.ts
@@ -152,8 +152,11 @@ export class WebhookDispatcherService {
 
   private scheduleRetry(log: WebhookDeliveryLog, attempt: number): void {
     if (attempt >= this.maxAttempts) {
-      log.status = DeliveryStatus.FAILED;
+      log.status = DeliveryStatus.DEAD_LETTER;
       log.next_retry_at = null;
+      this.logger.warn(
+        `Webhook delivery ${log.id} moved to dead-letter after ${attempt} attempts`,
+      );
     } else {
       const backoffMs = Math.min(Math.pow(2, attempt - 1) * 1000, 3600000); // cap at 1 hour
       log.next_retry_at = new Date(Date.now() + backoffMs);

--- a/backend/src/webhooks/services/webhooks.service.spec.ts
+++ b/backend/src/webhooks/services/webhooks.service.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { WebhooksService } from './webhooks.service';
+import { WebhookEndpoint } from '../entities/webhook-endpoint.entity';
+import {
+  DeliveryStatus,
+  WebhookDeliveryLog,
+} from '../entities/webhook-delivery-log.entity';
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+  let deliveryLogRepository: jest.Mocked<
+    Pick<Repository<WebhookDeliveryLog>, 'findAndCount' | 'findOne' | 'save'>
+  >;
+  let endpointRepository: jest.Mocked<Pick<Repository<WebhookEndpoint>, never>>;
+
+  beforeEach(async () => {
+    deliveryLogRepository = {
+      findAndCount: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(),
+    };
+    endpointRepository = {};
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhooksService,
+        {
+          provide: getRepositoryToken(WebhookEndpoint),
+          useValue: endpointRepository,
+        },
+        {
+          provide: getRepositoryToken(WebhookDeliveryLog),
+          useValue: deliveryLogRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhooksService>(WebhooksService);
+  });
+
+  describe('listDeadLetterDeliveries', () => {
+    it('returns dead-lettered deliveries with pagination', async () => {
+      const logs = [
+        { id: 'a', status: DeliveryStatus.DEAD_LETTER },
+      ] as WebhookDeliveryLog[];
+      deliveryLogRepository.findAndCount.mockResolvedValue([logs, 1]);
+
+      const result = await service.listDeadLetterDeliveries(25, 5);
+
+      expect(deliveryLogRepository.findAndCount).toHaveBeenCalledWith({
+        where: { status: DeliveryStatus.DEAD_LETTER },
+        relations: ['endpoint'],
+        order: { created_at: 'DESC' },
+        take: 25,
+        skip: 5,
+      });
+      expect(result).toEqual({ logs, total: 1 });
+    });
+  });
+
+  describe('redriveDelivery', () => {
+    it('throws NotFoundException when the delivery does not exist', async () => {
+      deliveryLogRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.redriveDelivery('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('rejects redriving a delivery that is not dead-lettered', async () => {
+      deliveryLogRepository.findOne.mockResolvedValue({
+        id: 'x',
+        status: DeliveryStatus.PENDING,
+      } as WebhookDeliveryLog);
+
+      await expect(service.redriveDelivery('x')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('resets a dead-lettered delivery to pending with a fresh attempt budget', async () => {
+      const log = {
+        id: 'x',
+        status: DeliveryStatus.DEAD_LETTER,
+        attempt_count: 5,
+        next_retry_at: null,
+        error_message: 'boom',
+      } as WebhookDeliveryLog;
+      deliveryLogRepository.findOne.mockResolvedValue(log);
+      deliveryLogRepository.save.mockImplementation(
+        async (l) => l as WebhookDeliveryLog,
+      );
+
+      const result = await service.redriveDelivery('x');
+
+      expect(result.status).toBe(DeliveryStatus.PENDING);
+      expect(result.attempt_count).toBe(0);
+      expect(result.next_retry_at).toBeInstanceOf(Date);
+      expect(deliveryLogRepository.save).toHaveBeenCalledWith(log);
+    });
+  });
+});

--- a/backend/src/webhooks/services/webhooks.service.ts
+++ b/backend/src/webhooks/services/webhooks.service.ts
@@ -1,9 +1,17 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as crypto from 'crypto';
 import { WebhookEndpoint } from '../entities/webhook-endpoint.entity';
-import { WebhookDeliveryLog } from '../entities/webhook-delivery-log.entity';
+import {
+  DeliveryStatus,
+  WebhookDeliveryLog,
+} from '../entities/webhook-delivery-log.entity';
 import { CreateWebhookEndpointDto } from '../dto/create-webhook-endpoint.dto';
 import { UpdateWebhookEndpointDto } from '../dto/update-webhook-endpoint.dto';
 import { User } from '../../users/entities/user.entity';
@@ -108,5 +116,50 @@ export class WebhooksService {
 
   private generateSecretKey(): string {
     return crypto.randomBytes(32).toString('hex');
+  }
+
+  // -------------------------------------------------------------------------
+  // Dead-letter queue (admin)
+  // -------------------------------------------------------------------------
+
+  async listDeadLetterDeliveries(
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<{ logs: WebhookDeliveryLog[]; total: number }> {
+    const [logs, total] = await this.deliveryLogRepository.findAndCount({
+      where: { status: DeliveryStatus.DEAD_LETTER },
+      relations: ['endpoint'],
+      order: { created_at: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
+
+    return { logs, total };
+  }
+
+  async redriveDelivery(id: string): Promise<WebhookDeliveryLog> {
+    const log = await this.deliveryLogRepository.findOne({
+      where: { id },
+      relations: ['endpoint'],
+    });
+
+    if (!log) {
+      throw new NotFoundException('Webhook delivery not found');
+    }
+
+    if (log.status !== DeliveryStatus.DEAD_LETTER) {
+      throw new BadRequestException(
+        'Only dead-lettered deliveries can be redriven',
+      );
+    }
+
+    log.status = DeliveryStatus.PENDING;
+    log.attempt_count = 0;
+    log.next_retry_at = new Date();
+
+    const saved = await this.deliveryLogRepository.save(log);
+    this.logger.log(`Redrove dead-lettered webhook delivery ${id}`);
+
+    return saved;
   }
 }

--- a/backend/src/webhooks/webhooks.controller.spec.ts
+++ b/backend/src/webhooks/webhooks.controller.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './services/webhooks.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { ApiKeyGuard } from '../common/guards/api-key.guard';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { Role } from '../common/enums/role.enum';
+import { DeliveryStatus } from './entities/webhook-delivery-log.entity';
+
+describe('WebhooksController', () => {
+  let controller: WebhooksController;
+  let webhooksService: jest.Mocked<
+    Pick<WebhooksService, 'listDeadLetterDeliveries' | 'redriveDelivery'>
+  >;
+
+  beforeEach(async () => {
+    webhooksService = {
+      listDeadLetterDeliveries: jest.fn(),
+      redriveDelivery: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WebhooksController],
+      providers: [{ provide: WebhooksService, useValue: webhooksService }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(ApiKeyGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<WebhooksController>(WebhooksController);
+  });
+
+  describe('listDeadLetterDeliveries', () => {
+    it('requires the Admin role', () => {
+      const reflector = new Reflector();
+      const roles = reflector.get<Role[]>(
+        ROLES_KEY,
+        controller.listDeadLetterDeliveries,
+      );
+      expect(roles).toEqual([Role.Admin]);
+    });
+
+    it('delegates to the service with parsed pagination', async () => {
+      webhooksService.listDeadLetterDeliveries.mockResolvedValue({
+        logs: [],
+        total: 0,
+      });
+
+      await controller.listDeadLetterDeliveries('10', '20');
+
+      expect(webhooksService.listDeadLetterDeliveries).toHaveBeenCalledWith(
+        10,
+        20,
+      );
+    });
+
+    it('defaults and caps pagination', async () => {
+      webhooksService.listDeadLetterDeliveries.mockResolvedValue({
+        logs: [],
+        total: 0,
+      });
+
+      await controller.listDeadLetterDeliveries('500', undefined);
+
+      expect(webhooksService.listDeadLetterDeliveries).toHaveBeenCalledWith(
+        100,
+        0,
+      );
+    });
+  });
+
+  describe('redriveDelivery', () => {
+    it('requires the Admin role', () => {
+      const reflector = new Reflector();
+      const roles = reflector.get<Role[]>(
+        ROLES_KEY,
+        controller.redriveDelivery,
+      );
+      expect(roles).toEqual([Role.Admin]);
+    });
+
+    it('delegates to the service', async () => {
+      const redriven = { id: 'x', status: DeliveryStatus.PENDING } as any;
+      webhooksService.redriveDelivery.mockResolvedValue(redriven);
+
+      const result = await controller.redriveDelivery('x');
+
+      expect(webhooksService.redriveDelivery).toHaveBeenCalledWith('x');
+      expect(result).toBe(redriven);
+    });
+  });
+});

--- a/backend/src/webhooks/webhooks.controller.ts
+++ b/backend/src/webhooks/webhooks.controller.ts
@@ -11,7 +11,10 @@ import {
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { ApiKeyGuard } from '../common/guards/api-key.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
 import { Scopes } from '../common/decorators/scopes.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '../common/enums/role.enum';
 
 import { WebhooksService } from './services/webhooks.service';
 
@@ -86,5 +89,29 @@ export class WebhooksController {
       parsedLimit,
       parsedOffset,
     );
+  }
+
+  @Get('deliveries/dead-letter')
+  @UseGuards(RolesGuard)
+  @Roles(Role.Admin)
+  @Scopes('webhooks:admin')
+  async listDeadLetterDeliveries(
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<{ logs: WebhookDeliveryLog[]; total: number }> {
+    const parsedLimit = limit ? Math.min(parseInt(limit, 10), 100) : 50;
+    const parsedOffset = offset ? parseInt(offset, 10) : 0;
+    return this.webhooksService.listDeadLetterDeliveries(
+      parsedLimit,
+      parsedOffset,
+    );
+  }
+
+  @Post('deliveries/:id/redrive')
+  @UseGuards(RolesGuard)
+  @Roles(Role.Admin)
+  @Scopes('webhooks:admin')
+  async redriveDelivery(@Param('id') id: string): Promise<WebhookDeliveryLog> {
+    return this.webhooksService.redriveDelivery(id);
   }
 }


### PR DESCRIPTION
…e-limit headers

[Backend] — Dead-Letter Queue for Failed Webhook Deliveries Fixes #1501

[Backend] — Configurable Reconciliation Backfill on Chain Reorg Fixes #1503

[Backend] — Per-User Notification Preferences and Digest Opt-Out Fixes #1504

[Backend] — Rate-Limit Headers and Retry-After on Throttled Responses Fixes #1505