### PR TITLE
feat(frontend): admin user search, flag actions, confirm dialog (#1601)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.6.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.6
+        version: 14.6.6(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20
         version: 20.19.37
@@ -2172,6 +2175,12 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@testing-library/user-event@14.6.6':
+    resolution: {integrity: sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@trezor/analytics@1.5.0':
     resolution: {integrity: sha512-evILW5XJEmfPlf0TY1duOLtGJ47pdGeSKVE3P75ODEUsRNxtPVqlkOUBPmYpCxPnzS8XDmkatT8lf9/DF0G6nA==}
     peerDependencies:
@@ -3471,6 +3480,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -8082,6 +8092,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.6(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@trezor/analytics@1.5.0(tslib@2.8.1)':
     dependencies:

--- a/frontend/src/app/admin/users/page.test.tsx
+++ b/frontend/src/app/admin/users/page.test.tsx
@@ -1,0 +1,585 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  within,
+  act,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as api from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    listAdminUsers: vi.fn(),
+    banAdminUser: vi.fn(),
+    unbanAdminUser: vi.fn(),
+    flagAdminUser: vi.fn(),
+  };
+});
+
+// WalletContext — provide a token so API helpers are called
+vi.mock("@/context/WalletContext", () => ({
+  useWallet: () => ({
+    address: "GADMIN_ADDRESS",
+    token: "test-admin-token",
+    isAuthenticated: true,
+    openConnectModal: vi.fn(),
+  }),
+}));
+
+// AdminGuard — bypass auth check in unit tests
+vi.mock("@/component/admin/AdminGuard", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// useDebounce — return value immediately (no timer needed in tests)
+vi.mock("@/hooks/useDebounce", () => ({
+  useDebounce: <T,>(value: T) => value,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockListAdminUsers = vi.mocked(api.listAdminUsers);
+const mockBanAdminUser = vi.mocked(api.banAdminUser);
+const mockUnbanAdminUser = vi.mocked(api.unbanAdminUser);
+const mockFlagAdminUser = vi.mocked(api.flagAdminUser);
+
+function makeUser(overrides: Partial<api.AdminUser> = {}): api.AdminUser {
+  return {
+    id: "user-1",
+    stellar_address: "GADDR1111111111111111111111111111111111111111111111111111",
+    username: "alice",
+    role: "user",
+    reputation_score: 80,
+    total_predictions: 42,
+    is_banned: false,
+    ban_reason: null,
+    banned_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  users: api.AdminUser[],
+  total = users.length,
+): api.PaginatedAdminUsersResponse {
+  return {
+    data: users,
+    meta: { total, page: 1, limit: 20, totalPages: 1 },
+  };
+}
+
+// Lazily import the page after mocks are in place
+async function renderPage() {
+  const { default: AdminUsersPage } = await import("./page");
+  render(<AdminUsersPage />);
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("AdminUsersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAdminUsers.mockResolvedValue(
+      makeResponse([
+        makeUser({ id: "user-1", username: "alice", is_banned: false }),
+        makeUser({
+          id: "user-2",
+          username: "bob",
+          stellar_address:
+            "GADDR2222222222222222222222222222222222222222222222222222",
+          is_banned: true,
+        }),
+      ]),
+    );
+    mockBanAdminUser.mockResolvedValue(
+      makeUser({ id: "user-1", is_banned: true }),
+    );
+    mockUnbanAdminUser.mockResolvedValue(
+      makeUser({ id: "user-2", is_banned: false }),
+    );
+    mockFlagAdminUser.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Initial render ─────────────────────────────────────────────────────────
+
+  it("renders the page heading", async () => {
+    await renderPage();
+    expect(
+      screen.getByRole("heading", { name: /search and moderate users/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the search input", async () => {
+    await renderPage();
+    expect(
+      screen.getByRole("searchbox", {
+        name: /search by wallet address or username/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls listAdminUsers on mount with no search term", async () => {
+    await renderPage();
+    await waitFor(() =>
+      expect(mockListAdminUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ search: undefined, page: 1 }),
+        "test-admin-token",
+      ),
+    );
+  });
+
+  it("displays fetched users in the table", async () => {
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+    expect(screen.getByText("bob")).toBeInTheDocument();
+  });
+
+  // ── Search filters ─────────────────────────────────────────────────────────
+
+  it("calls listAdminUsers with the search term when user types", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(mockListAdminUsers).toHaveBeenCalledTimes(1));
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: /search by wallet address or username/i,
+    });
+
+    // Type into the search box
+    await user.type(searchInput, "alice");
+
+    await waitFor(() =>
+      expect(mockListAdminUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: "alice" }),
+        "test-admin-token",
+      ),
+    );
+  });
+
+  it("filters the displayed list when a search term is active", async () => {
+    const user = userEvent.setup();
+
+    // Default mock returns both alice and bob.
+    // When called with search="alice" it returns only alice.
+    mockListAdminUsers.mockImplementation(async (query) => {
+      if (query.search === "alice") {
+        return makeResponse([makeUser({ id: "user-1", username: "alice" })]);
+      }
+      return makeResponse([
+        makeUser({ id: "user-1", username: "alice" }),
+        makeUser({ id: "user-2", username: "bob" }),
+      ]);
+    });
+
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+    expect(screen.getByText("bob")).toBeInTheDocument();
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: /search by wallet address or username/i,
+    });
+    await user.type(searchInput, "alice");
+
+    // Wait for bob to disappear once the filtered fetch settles.
+    await waitFor(() =>
+      expect(screen.queryByText("bob")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("alice")).toBeInTheDocument();
+  });
+
+  it("resets to page 1 when the search term changes", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(mockListAdminUsers).toHaveBeenCalledTimes(1));
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: /search by wallet address or username/i,
+    });
+    await user.type(searchInput, "x");
+
+    await waitFor(() =>
+      expect(mockListAdminUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 1 }),
+        "test-admin-token",
+      ),
+    );
+  });
+
+  it("shows 'No users found' when the server returns an empty list", async () => {
+    mockListAdminUsers.mockResolvedValue(makeResponse([]));
+    await renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/no users found/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows an error message when the fetch fails", async () => {
+    mockListAdminUsers.mockRejectedValue(new Error("Network error"));
+    await renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toBeInTheDocument(),
+    );
+  });
+
+  // ── Ban action ─────────────────────────────────────────────────────────────
+
+  it("opens the ban confirm dialog when Ban is clicked", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    const banButton = screen.getByRole("button", { name: /ban alice/i });
+    await user.click(banButton);
+
+    expect(
+      screen.getByRole("heading", { name: /ban alice/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the Ban confirm button until a reason is entered", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /ban alice/i }));
+
+    const confirmBtn = screen.getByRole("button", { name: /ban user/i });
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it("enables the Ban confirm button once a reason is typed", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /ban alice/i }));
+
+    const reasonField = screen.getByLabelText(/reason for ban/i);
+    await user.type(reasonField, "Spam activity");
+
+    const confirmBtn = screen.getByRole("button", { name: /ban user/i });
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it("calls banAdminUser with the entered reason on confirm", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /ban alice/i }));
+    await user.type(screen.getByLabelText(/reason for ban/i), "Spam activity");
+    await user.click(screen.getByRole("button", { name: /ban user/i }));
+
+    await waitFor(() =>
+      expect(mockBanAdminUser).toHaveBeenCalledWith(
+        "user-1",
+        "Spam activity",
+        "test-admin-token",
+      ),
+    );
+  });
+
+  it("does not call banAdminUser when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /ban alice/i }));
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(mockBanAdminUser).not.toHaveBeenCalled();
+  });
+
+  // ── Unban action ───────────────────────────────────────────────────────────
+
+  it("opens the unban confirm dialog when Unban is clicked", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("bob")).toBeInTheDocument());
+
+    const unbanButton = screen.getByRole("button", { name: /unban bob/i });
+    await user.click(unbanButton);
+
+    expect(
+      screen.getByRole("heading", { name: /unban bob/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT require a reason for unban — confirm is enabled immediately", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("bob")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /unban bob/i }));
+
+    const confirmBtn = screen.getByRole("button", { name: /unban user/i });
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it("calls unbanAdminUser on confirm", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("bob")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /unban bob/i }));
+    await user.click(screen.getByRole("button", { name: /unban user/i }));
+
+    await waitFor(() =>
+      expect(mockUnbanAdminUser).toHaveBeenCalledWith(
+        "user-2",
+        "test-admin-token",
+      ),
+    );
+  });
+
+  // ── Flag action ────────────────────────────────────────────────────────────
+
+  it("opens the flag confirm dialog when Flag is clicked", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    const flagButton = screen.getByRole("button", {
+      name: /flag alice for review/i,
+    });
+    await user.click(flagButton);
+
+    expect(
+      screen.getByRole("heading", { name: /flag alice/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("flag action requires a reason — confirm disabled when reason is empty", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(
+      screen.getByRole("button", { name: /flag alice for review/i }),
+    );
+
+    const confirmBtn = screen.getByRole("button", { name: /submit flag/i });
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it("flag action requires a non-empty reason — whitespace-only is rejected", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(
+      screen.getByRole("button", { name: /flag alice for review/i }),
+    );
+
+    const reasonField = screen.getByLabelText(/reason for flag/i);
+    await user.type(reasonField, "   "); // whitespace only
+
+    const confirmBtn = screen.getByRole("button", { name: /submit flag/i });
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it("flag action enables confirm once a reason is entered", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(
+      screen.getByRole("button", { name: /flag alice for review/i }),
+    );
+
+    const reasonField = screen.getByLabelText(/reason for flag/i);
+    await user.type(reasonField, "Suspicious activity");
+
+    const confirmBtn = screen.getByRole("button", { name: /submit flag/i });
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it("calls flagAdminUser with the entered reason on confirm", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(
+      screen.getByRole("button", { name: /flag alice for review/i }),
+    );
+    await user.type(
+      screen.getByLabelText(/reason for flag/i),
+      "Suspicious activity",
+    );
+    await user.click(screen.getByRole("button", { name: /submit flag/i }));
+
+    await waitFor(() =>
+      expect(mockFlagAdminUser).toHaveBeenCalledWith(
+        "user-1",
+        "Suspicious activity",
+        "test-admin-token",
+      ),
+    );
+  });
+
+  it("does not call flagAdminUser when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    await user.click(
+      screen.getByRole("button", { name: /flag alice for review/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(mockFlagAdminUser).not.toHaveBeenCalled();
+  });
+
+  // ── Reason resets between opens ────────────────────────────────────────────
+
+  it("clears the reason field when dialog is reopened after cancel", async () => {
+    const user = userEvent.setup();
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+
+    // Open, type, cancel
+    await user.click(
+      screen.getByRole("button", { name: /flag alice for review/i }),
+    );
+    await user.type(screen.getByLabelText(/reason for flag/i), "First reason");
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    // Reopen — textarea should be empty
+    await user.click(
+      screen.getByRole("button", { name: /flag alice for review/i }),
+    );
+    const textarea = screen.getByLabelText(/reason for flag/i);
+    expect((textarea as HTMLTextAreaElement).value).toBe("");
+  });
+
+  // ── AdminGuard wrapping ────────────────────────────────────────────────────
+
+  it("renders the admin page content (AdminGuard bypassed in tests)", async () => {
+    await renderPage();
+    expect(
+      screen.getByTestId("admin-users-page"),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConfirmDialog standalone unit tests — reason required logic
+// ---------------------------------------------------------------------------
+
+import { render as renderComponent } from "@testing-library/react";
+import { ConfirmDialog } from "@/component/ui/confirm-dialog";
+
+describe("ConfirmDialog — reason required logic", () => {
+  it("confirm button is enabled when no reasonLabel is set", () => {
+    renderComponent(
+      <ConfirmDialog
+        open={true}
+        title="Are you sure?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /^confirm$/i }),
+    ).not.toBeDisabled();
+  });
+
+  it("confirm button is disabled when reasonLabel is set and textarea is empty", () => {
+    renderComponent(
+      <ConfirmDialog
+        open={true}
+        title="Flag user?"
+        reasonLabel="Reason"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^confirm$/i })).toBeDisabled();
+  });
+
+  it("confirm button becomes enabled once reason textarea has content", async () => {
+    const user = userEvent.setup();
+    renderComponent(
+      <ConfirmDialog
+        open={true}
+        title="Flag user?"
+        reasonLabel="Reason"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await user.type(screen.getByLabelText(/reason/i), "Bad actor");
+    expect(screen.getByRole("button", { name: /^confirm$/i })).not.toBeDisabled();
+  });
+
+  it("passes the trimmed reason to onConfirm", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    renderComponent(
+      <ConfirmDialog
+        open={true}
+        title="Flag user?"
+        reasonLabel="Reason"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await user.type(screen.getByLabelText(/reason/i), "  Bad actor  ");
+    await user.click(screen.getByRole("button", { name: /^confirm$/i }));
+    expect(onConfirm).toHaveBeenCalledWith("Bad actor");
+  });
+
+  it("calls onConfirm with undefined when no reasonLabel is set", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    renderComponent(
+      <ConfirmDialog
+        open={true}
+        title="Are you sure?"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /^confirm$/i }));
+    expect(onConfirm).toHaveBeenCalledWith(undefined);
+  });
+
+  it("calls onCancel when Cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    renderComponent(
+      <ConfirmDialog
+        open={true}
+        title="Are you sure?"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,156 +1,500 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { Flag, ShieldOff, ShieldCheck, Search, Loader2 } from "lucide-react";
 
-interface AdminUser {
-  id: string;
-  wallet: string;
-  reputation: number;
-  predictions: number;
-  status: "Active" | "Banned";
+import AdminGuard from "@/component/admin/AdminGuard";
+import { ConfirmDialog } from "@/component/ui/confirm-dialog";
+import { useDebounce } from "@/hooks/useDebounce";
+import { useWallet } from "@/context/WalletContext";
+import {
+  listAdminUsers,
+  banAdminUser,
+  unbanAdminUser,
+  flagAdminUser,
+  type AdminUser,
+} from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PendingAction =
+  | { kind: "ban"; user: AdminUser }
+  | { kind: "unban"; user: AdminUser }
+  | { kind: "flag"; user: AdminUser };
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ isBanned }: { isBanned: boolean }) {
+  return (
+    <span
+      className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${
+        isBanned
+          ? "bg-rose-500/15 text-rose-300"
+          : "bg-emerald-500/15 text-emerald-300"
+      }`}
+    >
+      {isBanned ? "Banned" : "Active"}
+    </span>
+  );
 }
 
-const initialUsers: AdminUser[] = [
-  {
-    id: "USR-001",
-    wallet: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
-    reputation: 97,
-    predictions: 152,
-    status: "Active",
-  },
-  {
-    id: "USR-002",
-    wallet: "GBXPHQAK66K2CSLZQLIX4B4MJVNQH4K3HYQ6N4HB63XOF6A6ZDIK3ZB5",
-    reputation: 81,
-    predictions: 118,
-    status: "Active",
-  },
-  {
-    id: "USR-003",
-    wallet: "GAQ6YEVV7D44CT5P6YAXQ7KNS6OBVUTW7R4OTIR4PPSI6N3ZEU7QWHEV",
-    reputation: 42,
-    predictions: 34,
-    status: "Banned",
-  },
-];
-
-export default function AdminUsersPage() {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [users, setUsers] = useState<AdminUser[]>(initialUsers);
-
-  const filteredUsers = useMemo(
-    () =>
-      users.filter((user) =>
-        user.wallet.toLowerCase().includes(searchQuery.trim().toLowerCase()),
-      ),
-    [searchQuery, users],
+function ActionButtons({
+  user,
+  onBan,
+  onUnban,
+  onFlag,
+  busy,
+}: {
+  user: AdminUser;
+  onBan: (user: AdminUser) => void;
+  onUnban: (user: AdminUser) => void;
+  onFlag: (user: AdminUser) => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      {user.is_banned ? (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onUnban(user)}
+          aria-label={`Unban ${user.username ?? user.stellar_address}`}
+          className="flex items-center gap-1.5 rounded-2xl bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-emerald-400 disabled:opacity-50"
+        >
+          <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+          Unban
+        </button>
+      ) : (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onBan(user)}
+          aria-label={`Ban ${user.username ?? user.stellar_address}`}
+          className="flex items-center gap-1.5 rounded-2xl bg-rose-500 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-rose-400 disabled:opacity-50"
+        >
+          <ShieldOff className="h-3.5 w-3.5" aria-hidden="true" />
+          Ban
+        </button>
+      )}
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => onFlag(user)}
+        aria-label={`Flag ${user.username ?? user.stellar_address} for review`}
+        className="flex items-center gap-1.5 rounded-2xl border border-orange-500/30 bg-orange-500/10 px-3 py-1.5 text-xs font-semibold text-orange-300 transition hover:bg-orange-500/20 disabled:opacity-50"
+      >
+        <Flag className="h-3.5 w-3.5" aria-hidden="true" />
+        Flag
+      </button>
+    </div>
   );
+}
 
-  const toggleBan = (userId: string) => {
-    setUsers((current) =>
-      current.map((user) =>
-        user.id === userId
-          ? {
-              ...user,
-              status: user.status === "Banned" ? "Active" : "Banned",
-            }
-          : user,
-      ),
-    );
-  };
+// ---------------------------------------------------------------------------
+// Page (inner — rendered after AdminGuard confirms access)
+// ---------------------------------------------------------------------------
+
+function AdminUsersPageInner() {
+  const { token } = useWallet();
+
+  // Search / pagination state
+  const [rawSearch, setRawSearch] = useState("");
+  const debouncedSearch = useDebounce(rawSearch, 400);
+  const [page, setPage] = useState(1);
+  const PAGE_SIZE = 20;
+
+  // Data state
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  // Action state
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [actionBusy, setActionBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  // Track which user IDs are currently being mutated for per-row busy state
+  const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
+
+  // ---------------------------------------------------------------------------
+  // Fetch users
+  // ---------------------------------------------------------------------------
+
+  const fetchUsers = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setFetchError(null);
+    try {
+      const result = await listAdminUsers(
+        { search: debouncedSearch || undefined, page, limit: PAGE_SIZE },
+        token,
+      );
+      setUsers(result.data);
+      setTotalPages(result.meta.totalPages);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to load users.";
+      setFetchError(msg);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, debouncedSearch, page]);
+
+  // Re-fetch when debounced search or page changes
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  // Reset to page 1 when search term changes
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch]);
+
+  // ---------------------------------------------------------------------------
+  // Action handlers
+  // ---------------------------------------------------------------------------
+
+  function handleBan(user: AdminUser) {
+    setActionError(null);
+    setPendingAction({ kind: "ban", user });
+  }
+  function handleUnban(user: AdminUser) {
+    setActionError(null);
+    setPendingAction({ kind: "unban", user });
+  }
+  function handleFlag(user: AdminUser) {
+    setActionError(null);
+    setPendingAction({ kind: "flag", user });
+  }
+
+  async function handleConfirm(reason?: string) {
+    if (!pendingAction || !token) return;
+    const { kind, user } = pendingAction;
+
+    setPendingAction(null);
+    setActionBusy(true);
+    setBusyIds((prev) => new Set(prev).add(user.id));
+    setActionError(null);
+
+    try {
+      if (kind === "ban") {
+        const updated = await banAdminUser(user.id, reason!, token);
+        setUsers((prev) =>
+          prev.map((u) => (u.id === updated.id ? updated : u)),
+        );
+      } else if (kind === "unban") {
+        const updated = await unbanAdminUser(user.id, token);
+        setUsers((prev) =>
+          prev.map((u) => (u.id === updated.id ? updated : u)),
+        );
+      } else {
+        await flagAdminUser(user.id, reason!, token);
+        // Flag doesn't change ban state; just show success by refreshing
+        await fetchUsers();
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Action failed.";
+      setActionError(msg);
+    } finally {
+      setActionBusy(false);
+      setBusyIds((prev) => {
+        const next = new Set(prev);
+        next.delete(user.id);
+        return next;
+      });
+    }
+  }
+
+  function handleCancel() {
+    setPendingAction(null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dialog config derived from pendingAction
+  // ---------------------------------------------------------------------------
+
+  const dialogOpen = pendingAction !== null;
+
+  const dialogProps = (() => {
+    if (!pendingAction) return null;
+    const displayName =
+      pendingAction.user.username ??
+      pendingAction.user.stellar_address.slice(0, 12) + "…";
+
+    if (pendingAction.kind === "ban") {
+      return {
+        title: `Ban ${displayName}?`,
+        description:
+          "This will immediately restrict the user from the platform. You must provide a reason.",
+        confirmLabel: "Ban user",
+        variant: "destructive" as const,
+        reasonLabel: "Reason for ban",
+        reasonPlaceholder: "Describe why this account is being banned…",
+      };
+    }
+    if (pendingAction.kind === "unban") {
+      return {
+        title: `Unban ${displayName}?`,
+        description: "This will restore the user's access to the platform.",
+        confirmLabel: "Unban user",
+        variant: "default" as const,
+        reasonLabel: undefined,
+        reasonPlaceholder: undefined,
+      };
+    }
+    // flag
+    return {
+      title: `Flag ${displayName} for review?`,
+      description:
+        "A flag will queue this account for manual moderation review.",
+      confirmLabel: "Submit flag",
+      variant: "destructive" as const,
+      reasonLabel: "Reason for flag",
+      reasonPlaceholder: "Describe the concern with this account…",
+    };
+  })();
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-8" data-testid="admin-users-page">
+      {/* Header */}
       <header className="rounded-3xl border border-white/10 bg-slate-950/90 p-8 shadow-xl">
-        <p className="text-sm uppercase tracking-[0.3em] text-orange-400/90">User management</p>
-        <h1 className="mt-3 text-3xl font-semibold text-white">Search and moderate users</h1>
+        <p className="text-sm uppercase tracking-[0.3em] text-orange-400/90">
+          User management
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-white">
+          Search and moderate users
+        </h1>
         <p className="mt-3 max-w-2xl text-sm text-gray-400">
-          Lookup wallet addresses, check reputation, and ban or unban users from the platform.
+          Lookup wallet addresses, check reputation, and ban, unban, or flag
+          users for review.
         </p>
       </header>
 
+      {/* Search bar */}
       <div className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-sm">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-white">Wallet search</h2>
+            <h2 className="text-xl font-semibold text-white">Search users</h2>
             <p className="mt-2 text-sm text-gray-400">
-              Filter user records by wallet address or partial hash.
+              Filter by wallet address or username.
             </p>
           </div>
-          <div className="w-full max-w-md">
+          <div className="relative w-full max-w-md">
+            <Search
+              className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+              aria-hidden="true"
+            />
             <label htmlFor="user-search" className="sr-only">
-              Search wallet address
+              Search by wallet address or username
             </label>
             <input
               id="user-search"
               type="search"
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search by wallet address"
-              className="w-full rounded-3xl border border-white/10 bg-slate-950/80 px-4 py-3 text-white outline-none transition focus:border-orange-400 focus:ring-2 focus:ring-orange-400/20"
+              value={rawSearch}
+              onChange={(e) => setRawSearch(e.target.value)}
+              placeholder="Address or username…"
+              aria-label="Search by wallet address or username"
+              className="w-full rounded-3xl border border-white/10 bg-slate-950/80 py-3 pl-10 pr-4 text-white outline-none transition focus:border-orange-400 focus:ring-2 focus:ring-orange-400/20"
             />
+            {isLoading && (
+              <Loader2
+                className="absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-gray-500"
+                aria-hidden="true"
+              />
+            )}
           </div>
         </div>
       </div>
 
+      {/* Action error banner */}
+      {actionError && (
+        <div
+          role="alert"
+          className="rounded-2xl border border-rose-500/20 bg-rose-500/5 px-4 py-3 text-sm text-rose-400"
+        >
+          {actionError}
+        </div>
+      )}
+
+      {/* Users table */}
       <div className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-sm">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-white">Reputation stats</h2>
-            <p className="mt-2 text-sm text-gray-400">Track top users and manage account status quickly.</p>
+            <h2 className="text-xl font-semibold text-white">
+              Reputation &amp; status
+            </h2>
+            <p className="mt-2 text-sm text-gray-400">
+              Manage account access quickly.
+            </p>
           </div>
           <span className="rounded-full bg-white/5 px-3 py-1 text-sm text-gray-300">
-            {filteredUsers.length} records shown
+            {isLoading ? "Loading…" : `${users.length} records shown`}
           </span>
         </div>
 
         <div className="mt-6 overflow-hidden rounded-3xl border border-white/10 bg-slate-950/90">
-          <table className="min-w-full text-left text-sm text-gray-200">
-            <thead className="bg-slate-950/90 text-gray-400">
-              <tr>
-                <th className="px-4 py-4">Wallet</th>
-                <th className="px-4 py-4">Reputation</th>
-                <th className="px-4 py-4">Predictions</th>
-                <th className="px-4 py-4">Status</th>
-                <th className="px-4 py-4">Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredUsers.map((user) => (
-                <tr key={user.id} className="border-t border-white/5 hover:bg-white/5">
-                  <td className="px-4 py-4 break-all text-white">{user.wallet}</td>
-                  <td className="px-4 py-4 text-gray-300">{user.reputation}%</td>
-                  <td className="px-4 py-4 text-gray-300">{user.predictions}</td>
-                  <td className="px-4 py-4">
-                    <span
-                      className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${
-                        user.status === "Active"
-                          ? "bg-emerald-500/15 text-emerald-300"
-                          : "bg-rose-500/15 text-rose-300"
-                      }`}
-                    >
-                      {user.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-4">
-                    <button
-                      type="button"
-                      onClick={() => toggleBan(user.id)}
-                      className={`rounded-2xl px-4 py-2 text-sm font-semibold transition ${
-                        user.status === "Banned"
-                          ? "bg-emerald-500 text-slate-950 hover:bg-emerald-400"
-                          : "bg-rose-500 text-white hover:bg-rose-400"
-                      }`}
-                    >
-                      {user.status === "Banned" ? "Unban" : "Ban"}
-                    </button>
-                  </td>
+          {fetchError ? (
+            <p
+              role="alert"
+              className="p-6 text-center text-sm text-rose-400"
+            >
+              {fetchError}
+            </p>
+          ) : (
+            <table
+              className="min-w-full text-left text-sm text-gray-200"
+              aria-label="Users table"
+            >
+              <thead className="bg-slate-950/90 text-gray-400">
+                <tr>
+                  <th scope="col" className="px-4 py-4">
+                    Address / Username
+                  </th>
+                  <th scope="col" className="px-4 py-4 hidden sm:table-cell">
+                    Reputation
+                  </th>
+                  <th scope="col" className="px-4 py-4 hidden md:table-cell">
+                    Predictions
+                  </th>
+                  <th scope="col" className="px-4 py-4">
+                    Status
+                  </th>
+                  <th scope="col" className="px-4 py-4">
+                    Actions
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {isLoading && users.length === 0 ? (
+                  // Skeleton rows while loading
+                  [...Array(5)].map((_, i) => (
+                    <tr
+                      key={i}
+                      className="animate-pulse border-t border-white/5"
+                    >
+                      {[...Array(5)].map((__, j) => (
+                        <td key={j} className="px-4 py-4">
+                          <div className="h-4 rounded bg-white/10" />
+                        </td>
+                      ))}
+                    </tr>
+                  ))
+                ) : users.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-4 py-10 text-center text-sm text-gray-500"
+                    >
+                      No users found
+                      {rawSearch ? ` matching "${rawSearch}"` : ""}.
+                    </td>
+                  </tr>
+                ) : (
+                  users.map((user) => (
+                    <tr
+                      key={user.id}
+                      data-testid={`user-row-${user.id}`}
+                      className="border-t border-white/5 hover:bg-white/5"
+                    >
+                      <td className="px-4 py-4">
+                        <div className="flex flex-col gap-0.5">
+                          {user.username && (
+                            <span className="font-medium text-white">
+                              {user.username}
+                            </span>
+                          )}
+                          <span className="break-all text-xs text-gray-400">
+                            {user.stellar_address}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-4 text-gray-300 hidden sm:table-cell">
+                        {user.reputation_score}
+                      </td>
+                      <td className="px-4 py-4 text-gray-300 hidden md:table-cell">
+                        {user.total_predictions}
+                      </td>
+                      <td className="px-4 py-4">
+                        <StatusBadge isBanned={user.is_banned} />
+                      </td>
+                      <td className="px-4 py-4">
+                        <ActionButtons
+                          user={user}
+                          onBan={handleBan}
+                          onUnban={handleUnban}
+                          onFlag={handleFlag}
+                          busy={
+                            actionBusy || busyIds.has(user.id)
+                          }
+                        />
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          )}
         </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="mt-4 flex items-center justify-between text-sm text-gray-400">
+            <button
+              type="button"
+              disabled={page <= 1 || isLoading}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="rounded-xl border border-white/10 px-3 py-1.5 transition hover:bg-white/5 disabled:opacity-40"
+            >
+              ← Previous
+            </button>
+            <span>
+              Page {page} of {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={page >= totalPages || isLoading}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              className="rounded-xl border border-white/10 px-3 py-1.5 transition hover:bg-white/5 disabled:opacity-40"
+            >
+              Next →
+            </button>
+          </div>
+        )}
       </div>
+
+      {/* Confirmation dialog */}
+      {dialogProps && (
+        <ConfirmDialog
+          open={dialogOpen}
+          title={dialogProps.title}
+          description={dialogProps.description}
+          confirmLabel={dialogProps.confirmLabel}
+          variant={dialogProps.variant}
+          reasonLabel={dialogProps.reasonLabel}
+          reasonPlaceholder={dialogProps.reasonPlaceholder}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
     </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Default export — wrapped in AdminGuard
+// ---------------------------------------------------------------------------
+
+export default function AdminUsersPage() {
+  return (
+    <AdminGuard>
+      <AdminUsersPageInner />
+    </AdminGuard>
   );
 }

--- a/frontend/src/component/ui/confirm-dialog.tsx
+++ b/frontend/src/component/ui/confirm-dialog.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from "@headlessui/react";
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from "@headlessui/react";
 import { AlertTriangle } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -14,7 +20,15 @@ export interface ConfirmDialogProps {
   confirmLabel?: string;
   cancelLabel?: string;
   variant?: ConfirmVariant;
-  onConfirm: () => void;
+  /**
+   * When provided the dialog renders a labelled textarea for capturing a
+   * reason before confirming.  The confirm button is disabled until the user
+   * types at least one non-whitespace character.
+   */
+  reasonLabel?: string;
+  /** Placeholder text for the reason textarea. */
+  reasonPlaceholder?: string;
+  onConfirm: (reason?: string) => void;
   onCancel: () => void;
 }
 
@@ -25,9 +39,37 @@ export function ConfirmDialog({
   confirmLabel = "Confirm",
   cancelLabel = "Cancel",
   variant = "default",
+  reasonLabel,
+  reasonPlaceholder = "Enter a reason…",
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  const [reason, setReason] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Reset reason each time the dialog opens so old text doesn't bleed through.
+  useEffect(() => {
+    if (open) {
+      setReason("");
+    }
+  }, [open]);
+
+  // Auto-focus the textarea when it is shown.
+  useEffect(() => {
+    if (open && reasonLabel && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [open, reasonLabel]);
+
+  const requiresReason = Boolean(reasonLabel);
+  const reasonTrimmed = reason.trim();
+  const confirmDisabled = requiresReason && reasonTrimmed.length === 0;
+
+  function handleConfirm() {
+    if (confirmDisabled) return;
+    onConfirm(requiresReason ? reasonTrimmed : undefined);
+  }
+
   return (
     <Dialog open={open} onClose={onCancel} transition className="relative z-[300]">
       <DialogBackdrop
@@ -45,15 +87,60 @@ export function ConfirmDialog({
           <div className="flex items-start gap-4">
             {variant === "destructive" && (
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-500/10">
-                <AlertTriangle className="h-5 w-5 text-red-400" aria-hidden="true" />
+                <AlertTriangle
+                  className="h-5 w-5 text-red-400"
+                  aria-hidden="true"
+                />
               </div>
             )}
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <DialogTitle as="h2" className="text-lg font-semibold text-white">
                 {title}
               </DialogTitle>
               {description && (
                 <p className="mt-2 text-sm text-[#9aa4bc]">{description}</p>
+              )}
+
+              {/* Optional reason input */}
+              {reasonLabel && (
+                <div className="mt-4">
+                  <label
+                    htmlFor="confirm-dialog-reason"
+                    className="block text-sm font-medium text-gray-300"
+                  >
+                    {reasonLabel}
+                    <span className="ml-1 text-red-400" aria-hidden="true">
+                      *
+                    </span>
+                  </label>
+                  <textarea
+                    id="confirm-dialog-reason"
+                    ref={textareaRef}
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    placeholder={reasonPlaceholder}
+                    rows={3}
+                    maxLength={500}
+                    aria-required="true"
+                    aria-describedby={
+                      reasonTrimmed.length === 0
+                        ? "confirm-dialog-reason-hint"
+                        : undefined
+                    }
+                    className="mt-1.5 w-full resize-none rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-orange-500/50 focus:outline-none focus:ring-1 focus:ring-orange-500/30"
+                  />
+                  {reasonTrimmed.length === 0 && (
+                    <p
+                      id="confirm-dialog-reason-hint"
+                      className="mt-1 text-xs text-gray-500"
+                    >
+                      A reason is required before confirming.
+                    </p>
+                  )}
+                  <p className="mt-1 text-right text-xs text-gray-600">
+                    {reason.length}/500
+                  </p>
+                </div>
               )}
             </div>
           </div>
@@ -68,13 +155,15 @@ export function ConfirmDialog({
             </button>
             <button
               type="button"
-              onClick={onConfirm}
-              autoFocus
+              onClick={handleConfirm}
+              disabled={confirmDisabled}
+              autoFocus={!reasonLabel}
+              aria-disabled={confirmDisabled}
               className={cn(
                 "rounded-xl px-4 py-2 text-sm font-semibold transition",
                 variant === "destructive"
-                  ? "bg-red-500 text-white hover:bg-red-600"
-                  : "bg-[#4FD1C5] text-[#0a0f1a] hover:bg-[#43bfb4]",
+                  ? "bg-red-500 text-white hover:bg-red-600 disabled:bg-red-500/40 disabled:cursor-not-allowed"
+                  : "bg-[#4FD1C5] text-[#0a0f1a] hover:bg-[#43bfb4] disabled:bg-[#4FD1C5]/40 disabled:cursor-not-allowed",
               )}
             >
               {confirmLabel}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -434,3 +434,103 @@ export function getSeasons(
 export function getActiveSeason(options?: ApiOptions): Promise<SeasonListItem> {
   return apiClient.get<SeasonListItem>('/api/seasons/active', options);
 }
+
+// ---------------------------------------------------------------------------
+// Admin — Users
+// ---------------------------------------------------------------------------
+
+export interface AdminUser {
+  id: string;
+  stellar_address: string;
+  username: string | null;
+  role: string;
+  reputation_score: number;
+  total_predictions: number;
+  is_banned: boolean;
+  ban_reason: string | null;
+  banned_at: string | null;
+  is_flagged?: boolean;
+  created_at: string;
+}
+
+export interface AdminUsersQuery {
+  search?: string;
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: 'ASC' | 'DESC';
+}
+
+export interface PaginatedAdminUsersResponse {
+  data: AdminUser[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+function adminHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}
+
+/** `GET /api/admin/users?search=&page=&limit=` */
+export function listAdminUsers(
+  query: AdminUsersQuery,
+  token: string,
+  options?: ApiOptions,
+): Promise<PaginatedAdminUsersResponse> {
+  const params = new URLSearchParams();
+  if (query.search) params.set('search', query.search);
+  if (query.page !== undefined) params.set('page', String(query.page));
+  if (query.limit !== undefined) params.set('limit', String(query.limit));
+  if (query.sortBy) params.set('sortBy', query.sortBy);
+  if (query.sortOrder) params.set('sortOrder', query.sortOrder);
+  const qs = params.toString();
+  return apiClient.get<PaginatedAdminUsersResponse>(
+    `/api/admin/users${qs ? `?${qs}` : ''}`,
+    { ...options, headers: { ...adminHeaders(token), ...options?.headers } },
+  );
+}
+
+/** `PATCH /api/admin/users/:id/ban` — requires a non-empty reason */
+export function banAdminUser(
+  id: string,
+  reason: string,
+  token: string,
+  options?: ApiOptions,
+): Promise<AdminUser> {
+  return apiClient.patch<AdminUser>(
+    `/api/admin/users/${encodeURIComponent(id)}/ban`,
+    { reason },
+    { ...options, headers: { ...adminHeaders(token), ...options?.headers } },
+  );
+}
+
+/** `PATCH /api/admin/users/:id/unban` */
+export function unbanAdminUser(
+  id: string,
+  token: string,
+  options?: ApiOptions,
+): Promise<AdminUser> {
+  return apiClient.patch<AdminUser>(
+    `/api/admin/users/${encodeURIComponent(id)}/unban`,
+    undefined,
+    { ...options, headers: { ...adminHeaders(token), ...options?.headers } },
+  );
+}
+
+/** `POST /api/admin/users/bulk-action` with action='flag' */
+export function flagAdminUser(
+  id: string,
+  reason: string,
+  token: string,
+  options?: ApiOptions,
+): Promise<unknown> {
+  return apiClient.post<unknown>(
+    '/api/admin/users/bulk-action',
+    { user_ids: [id], action: 'flag', reason },
+    { ...options, headers: { ...adminHeaders(token), ...options?.headers } },
+  );
+}


### PR DESCRIPTION
## Summary

Resolves #1601. The admin users page used hardcoded placeholder data, had no real API calls, no debounce on search, no confirmation before destructive actions, and no reason capture. This PR replaces it entirely with a fully wired, accessible, tested implementation.

---

## Changes

### `frontend/src/lib/api.ts`
New types and helpers appended:
- `AdminUser` — matches backend User entity fields relevant to moderation
- `AdminUsersQuery`, `PaginatedAdminUsersResponse`
- `listAdminUsers(query, token)` — `GET /api/admin/users?search=&page=&limit=`
- `banAdminUser(id, reason, token)` — `PATCH /api/admin/users/:id/ban`
- `unbanAdminUser(id, token)` — `PATCH /api/admin/users/:id/unban`
- `flagAdminUser(id, reason, token)` — `POST /api/admin/users/bulk-action` with `action: 'flag'`

All helpers inject `Authorization: Bearer <token>` from WalletContext.

### `frontend/src/component/ui/confirm-dialog.tsx`
Extended with optional reason capture:
- `reasonLabel?: string` — when set, renders a labelled `<textarea>`
- `reasonPlaceholder?: string`
- Confirm button disabled until textarea has at least one non-whitespace character
- `onConfirm(reason?: string)` — passes trimmed reason when `reasonLabel` is set, `undefined` otherwise
- Textarea auto-focuses when dialog opens; resets to `""` on every open

### `frontend/src/app/admin/users/page.tsx`
Fully rewritten:
- `useDebounce(rawSearch, 400)` — delays search API calls by 400 ms, no spamming on keystrokes
- `listAdminUsers` called on mount, on debounced search change, on page change
- Page resets to 1 on search change
- **Ban** — opens `ConfirmDialog` (destructive variant); confirm disabled until reason is entered
- **Unban** — opens `ConfirmDialog` (default variant); no reason required
- **Flag** — opens `ConfirmDialog` (destructive variant); confirm disabled until reason is entered
- Optimistic UI update after ban/unban using the server's returned user object
- Per-row busy state: action buttons disabled while a mutation is in-flight
- Skeleton loading rows, empty-state row, paginated navigation
- Action error banner (`role="alert"`)
- Entire page guarded by `AdminGuard`

### `frontend/src/app/admin/users/page.test.tsx` *(new)*

31 tests across two suites:

| Suite | Tests |
|---|---|
| `AdminUsersPage` | 25 |
| `ConfirmDialog — reason required logic` | 6 |

Key acceptance-criteria tests:
- **Search filters** — typing triggers `listAdminUsers` with the search term; filtered list removes non-matching users
- **Flag action requires a reason** — confirm button disabled when empty or whitespace-only; enabled once a real reason is typed
- **Ban action requires a reason** — same guard
- **Unban requires no reason** — confirm immediately enabled
- **Cancel skips API call** — `banAdminUser`/`flagAdminUser` never called when user cancels
- **Reason resets between opens** — stale text from a previous session doesn't leak through

---

## Tests

```
Tests  31 passed (31)
```

```bash
pnpm test src/app/admin/users/page.test.tsx
```


Closes #1601