### PR TITLE
fix: rotate featured events in hero

### DIFF
--- a/frontend/src/component/events/EventsCompetitionsHero.test.tsx
+++ b/frontend/src/component/events/EventsCompetitionsHero.test.tsx
@@ -1,0 +1,51 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import EventsCompetitionsHero from "./EventsCompetitionsHero";
+
+describe("EventsCompetitionsHero", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rotates through featured events", () => {
+    render(<EventsCompetitionsHero />);
+
+    expect(screen.getByRole("heading", { name: "Apollo Tournament" })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(screen.getByRole("heading", { name: "Rising Stars Invite" })).toBeInTheDocument();
+  });
+
+  it("pauses rotation while hovered", () => {
+    render(<EventsCompetitionsHero />);
+    const carousel = screen.getByRole("region", { name: "Featured events" });
+
+    fireEvent.mouseEnter(carousel);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(screen.getByRole("heading", { name: "Apollo Tournament" })).toBeInTheDocument();
+  });
+
+  it("navigates with previous, next, and dot controls", () => {
+    render(<EventsCompetitionsHero />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Next featured event" }));
+    expect(screen.getByRole("heading", { name: "Rising Stars Invite" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous featured event" }));
+    expect(screen.getByRole("heading", { name: "Apollo Tournament" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show Season Finale Challenge" }));
+    expect(screen.getByRole("heading", { name: "Season Finale Challenge" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/component/events/EventsCompetitionsHero.tsx
+++ b/frontend/src/component/events/EventsCompetitionsHero.tsx
@@ -1,10 +1,54 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronDown, Search, SlidersHorizontal } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Search,
+  SlidersHorizontal,
+} from "lucide-react";
 
 import { Button } from "@/component/ui/button";
 import { cn } from "@/lib/utils";
+
+interface FeaturedEvent {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  prize: string;
+  joined: boolean;
+}
+
+const FEATURED_EVENTS: FeaturedEvent[] = [
+  {
+    id: "apollo-tournament",
+    title: "Apollo Tournament",
+    description: "Join the live prediction tournament and compete for exclusive rewards.",
+    category: "Eligible for you",
+    prize: "5,000 XLM prize pool",
+    joined: true,
+  },
+  {
+    id: "rising-stars-invite",
+    title: "Rising Stars Invite",
+    description: "Back emerging creators in a small-group prediction event.",
+    category: "Recommended",
+    prize: "1,200 XLM prize pool",
+    joined: false,
+  },
+  {
+    id: "season-finale-challenge",
+    title: "Season Finale Challenge",
+    description: "Explore the final creator event and its milestone rewards.",
+    category: "Popular",
+    prize: "2,500 XLM prize pool",
+    joined: false,
+  },
+];
+
+const ROTATION_INTERVAL_MS = 5000;
 
 const tabs = ["Events", "Competitions", "Past"];
 const sortOptions = ["Most Popular", "Newest", "Ending Soon"];
@@ -12,6 +56,30 @@ const sortOptions = ["Most Popular", "Newest", "Ending Soon"];
 export default function EventsCompetitionsHero() {
   const [activeTab, setActiveTab] = useState("Events");
   const [sortBy, setSortBy] = useState(sortOptions[0]);
+  const [activeEventIndex, setActiveEventIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  const featuredEvents = [
+    ...FEATURED_EVENTS.filter((event) => event.joined),
+    ...FEATURED_EVENTS.filter((event) => !event.joined),
+  ];
+  const activeEvent = featuredEvents[activeEventIndex];
+
+  useEffect(() => {
+    if (isPaused || featuredEvents.length < 2) return;
+
+    const interval = window.setInterval(() => {
+      setActiveEventIndex((currentIndex) =>
+        (currentIndex + 1) % featuredEvents.length,
+      );
+    }, ROTATION_INTERVAL_MS);
+
+    return () => window.clearInterval(interval);
+  }, [isPaused, featuredEvents.length]);
+
+  const goToEvent = (index: number) => {
+    setActiveEventIndex((index + featuredEvents.length) % featuredEvents.length);
+  };
 
   return (
     <section className="relative overflow-hidden border border-white/6 bg-[radial-gradient(circle_at_top,_rgba(81,88,255,0.16),_transparent_32%),linear-gradient(180deg,_#16152F_0%,_#0E1228_100%)] px-5 py-12 text-white shadow-[0_24px_80px_rgba(7,10,24,0.55)] sm:px-8 md:px-10 md:py-24">
@@ -41,6 +109,79 @@ export default function EventsCompetitionsHero() {
           >
             View Competitions
           </Button>
+        </div>
+
+        <div
+          className="mt-10 w-full rounded-[24px] border border-white/6 bg-[#1B1F39]/95 p-6 text-left shadow-[0_12px_36px_rgba(4,8,20,0.35)] backdrop-blur-xl"
+          role="region"
+          aria-roledescription="carousel"
+          aria-label="Featured events"
+          onMouseEnter={() => setIsPaused(true)}
+          onMouseLeave={() => setIsPaused(false)}
+          onFocus={() => setIsPaused(true)}
+          onBlur={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget)) {
+              setIsPaused(false);
+            }
+          }}
+        >
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#8B5CFF]">
+                Featured event
+              </p>
+              <p className="mt-2 text-xs text-[#8D95BD]">{activeEvent.category}</p>
+              <h2 className="mt-2 text-2xl font-bold text-white sm:text-3xl">
+                {activeEvent.title}
+              </h2>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-[#A7AED1]">
+                {activeEvent.description}
+              </p>
+              <p className="mt-3 text-sm font-semibold text-orange-300">
+                {activeEvent.prize}
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2" aria-label="Carousel controls">
+              <button
+                type="button"
+                aria-label="Previous featured event"
+                onClick={() => goToEvent(activeEventIndex - 1)}
+                className="rounded-full border border-white/10 p-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-[#8B5CFF]"
+              >
+                <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label="Next featured event"
+                onClick={() => goToEvent(activeEventIndex + 1)}
+                className="rounded-full border border-white/10 p-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-[#8B5CFF]"
+              >
+                <ChevronRight className="h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+          <div className="mt-5 flex items-center justify-between gap-4">
+            <div className="flex gap-2" aria-label="Choose featured event">
+              {featuredEvents.map((event, index) => (
+                <button
+                  key={event.id}
+                  type="button"
+                  aria-label={`Show ${event.title}`}
+                  aria-current={index === activeEventIndex ? "true" : undefined}
+                  onClick={() => goToEvent(index)}
+                  className={cn(
+                    "h-2 rounded-full transition-all focus:outline-none focus:ring-2 focus:ring-[#8B5CFF]",
+                    index === activeEventIndex
+                      ? "w-8 bg-[#8B5CFF]"
+                      : "w-2 bg-white/30 hover:bg-white/60",
+                  )}
+                />
+              ))}
+            </div>
+            <span className="text-xs text-[#8D95BD]" aria-live="polite">
+              {activeEventIndex + 1} of {featuredEvents.length}
+            </span>
+          </div>
         </div>
 
         <div className="mt-10 w-full rounded-[24px] border border-white/6 bg-[#1B1F39]/95 p-4 shadow-[0_12px_36px_rgba(4,8,20,0.35)] backdrop-blur-xl">


### PR DESCRIPTION
Closes #1587

## Summary
- Replace the static hero feature with a rotating set of featured events.
- Prioritize the event the user has already joined as the first feature.
- Add pause-on-hover/focus behavior and accessible previous, next, and dot controls.

## Scope
Does not touch the related value grid or event data hook; no backend eligibility changes were required for the existing `joined` signal.

## Testing
- `pnpm exec vitest run src/component/events/EventsCompetitionsHero.test.tsx` — passed (3 tests).
- `pnpm build` — passed.
- `pnpm test --run` — the focused tests passed; the full suite has one unrelated pre-existing failure in `src/app/contracts/page.test.tsx` because `useConfirm` is outside `ConfirmProvider`.
- `pnpm lint` — blocked by the existing `next lint` script incompatibility (`lint` is interpreted as a project directory).
- `pnpm exec tsc --noEmit` — reports existing unrelated missing SVG modules and test globals; the production build TypeScript phase passed.

## Files changed
- `frontend/src/component/events/EventsCompetitionsHero.tsx` — adds the eligible-first rotating carousel and controls.
- `frontend/src/component/events/EventsCompetitionsHero.test.tsx` — covers rotation, hover pause, and navigation.