### PR TITLE
feat:  Oracle Batch Result Submission Preview and Progress

### DIFF
--- a/backend/src/leaderboard/dto/leaderboard-history.dto.ts
+++ b/backend/src/leaderboard/dto/leaderboard-history.dto.ts
@@ -1,4 +1,11 @@
-import { IsOptional, IsDateString, IsUUID, IsInt, Min } from 'class-validator';
+import {
+  IsOptional,
+  IsDateString,
+  IsUUID,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -39,11 +46,16 @@ export class LeaderboardHistoryQueryDto {
   @Min(1)
   page?: number;
 
-  @ApiPropertyOptional({ description: 'Items per page', default: 20 })
+  @ApiPropertyOptional({
+    description: 'Items per page (max 100)',
+    default: 20,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(100)
   limit?: number;
 }
 
@@ -82,6 +94,34 @@ export class LeaderboardHistoryEntryResponse {
 export class PaginatedLeaderboardHistoryResponse {
   @ApiProperty({ type: [LeaderboardHistoryEntryResponse] })
   data: LeaderboardHistoryEntryResponse[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  limit: number;
+}
+
+export class AddressHistoryPointResponse {
+  @ApiProperty()
+  snapshot_date: Date;
+
+  @ApiProperty()
+  rank: number;
+
+  @ApiProperty()
+  reputation_score: number;
+
+  @ApiProperty()
+  season_points: number;
+}
+
+export class PaginatedAddressHistoryResponse {
+  @ApiProperty({ type: [AddressHistoryPointResponse] })
+  data: AddressHistoryPointResponse[];
 
   @ApiProperty()
   total: number;

--- a/backend/src/leaderboard/leaderboard.controller.spec.ts
+++ b/backend/src/leaderboard/leaderboard.controller.spec.ts
@@ -167,6 +167,8 @@ describe('LeaderboardController', () => {
       expect(spy).toHaveBeenCalledWith(
         'GBRPYHIL2CI3WHZDTOOQFC6EB4RRJC3XNRBF7XN',
         30,
+        undefined,
+        undefined,
       );
       expect(result).toEqual(mockHistory);
     });
@@ -192,6 +194,8 @@ describe('LeaderboardController', () => {
 
       expect(spy).toHaveBeenCalledWith(
         'GBRPYHIL2CI3WHZDTOOQFC6EB4RRJC3XNRBF7XN',
+        undefined,
+        undefined,
         undefined,
       );
     });

--- a/backend/src/leaderboard/leaderboard.controller.ts
+++ b/backend/src/leaderboard/leaderboard.controller.ts
@@ -18,6 +18,7 @@ import { PaginatedCursorResponse } from './dto/cursor-pagination.dto';
 import {
   LeaderboardHistoryQueryDto,
   PaginatedLeaderboardHistoryResponse,
+  PaginatedAddressHistoryResponse,
 } from './dto/leaderboard-history.dto';
 import { UserRankDto } from './dto/user-rank.dto';
 import {
@@ -131,11 +132,13 @@ export class LeaderboardController {
   })
   async getHistory(
     @Query() query: LeaderboardHistoryQueryDto,
-  ): Promise<PaginatedLeaderboardHistoryResponse | any[]> {
+  ): Promise<PaginatedLeaderboardHistoryResponse | PaginatedAddressHistoryResponse> {
     if (query.address) {
       return this.leaderboardService.getHistoryForAddress(
         query.address,
         query.days,
+        query.page,
+        query.limit,
       );
     }
     return this.leaderboardService.getHistory(query);

--- a/backend/src/leaderboard/leaderboard.service.spec.ts
+++ b/backend/src/leaderboard/leaderboard.service.spec.ts
@@ -40,6 +40,22 @@ describe('LeaderboardService', () => {
     total_winnings_stroops: '500000',
   };
 
+  const makeHistoryEntry = (overrides: Partial<LeaderboardHistory>) =>
+    ({
+      id: 'history-id',
+      user_id: 'user-uuid-1',
+      user: mockUser as User,
+      snapshot_date: new Date('2024-01-01'),
+      rank: 1,
+      reputation_score: 100,
+      season_points: 0,
+      total_predictions: 10,
+      correct_predictions: 5,
+      total_winnings_stroops: '0',
+      season_id: null,
+      ...overrides,
+    }) as LeaderboardHistory;
+
   const mockQb = {
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
@@ -63,6 +79,7 @@ describe('LeaderboardService', () => {
     createQueryBuilder: jest.fn(() => mockQb),
     findOne: jest.fn(),
     find: jest.fn(),
+    findAndCount: jest.fn(),
   };
 
   const mockSnapshotQb = {
@@ -449,6 +466,119 @@ describe('LeaderboardService', () => {
       expect(mockQb.where).toHaveBeenCalledWith('entry.season_id = :seasonId', {
         seasonId: 'season-1',
       });
+    });
+  });
+
+  describe('getHistory', () => {
+    it('caps limit at 100 and applies offset pagination', async () => {
+      mockQb.getManyAndCount.mockResolvedValue([[], 250]);
+
+      await service.getHistory({ page: 2, limit: 500 });
+
+      expect(mockQb.skip).toHaveBeenCalledWith(100);
+      expect(mockQb.take).toHaveBeenCalledWith(100);
+    });
+
+    it('returns non-overlapping, ordered pages with total count metadata', async () => {
+      const pageOneEntries = [
+        makeHistoryEntry({ id: 'h1', user_id: 'user-1', rank: 1 }),
+        makeHistoryEntry({ id: 'h2', user_id: 'user-2', rank: 2 }),
+      ];
+      const pageTwoEntries = [
+        makeHistoryEntry({ id: 'h3', user_id: 'user-3', rank: 3 }),
+        makeHistoryEntry({ id: 'h4', user_id: 'user-4', rank: 4 }),
+      ];
+
+      mockQb.getManyAndCount.mockResolvedValueOnce([pageOneEntries, 4]);
+      const page1 = await service.getHistory({ page: 1, limit: 2 });
+
+      mockQb.getManyAndCount.mockResolvedValueOnce([pageTwoEntries, 4]);
+      const page2 = await service.getHistory({ page: 2, limit: 2 });
+
+      expect(mockQb.skip).toHaveBeenNthCalledWith(1, 0);
+      expect(mockQb.skip).toHaveBeenNthCalledWith(2, 2);
+      expect(mockQb.orderBy).toHaveBeenCalledWith(
+        'history.snapshot_date',
+        'DESC',
+      );
+      expect(mockQb.addOrderBy).toHaveBeenCalledWith('history.rank', 'ASC');
+
+      const page1Ids = page1.data.map((e) => e.user_id);
+      const page2Ids = page2.data.map((e) => e.user_id);
+
+      expect(page1Ids).toEqual(['user-1', 'user-2']);
+      expect(page2Ids).toEqual(['user-3', 'user-4']);
+      expect(page1Ids.some((id) => page2Ids.includes(id))).toBe(false);
+      expect(page1.total).toBe(4);
+      expect(page2.total).toBe(4);
+    });
+  });
+
+  describe('getHistoryForAddress', () => {
+    beforeEach(() => {
+      mockUsersService.findByAddress = jest
+        .fn()
+        .mockResolvedValue(mockUser as User);
+    });
+
+    it('caps limit at 100 and applies offset pagination', async () => {
+      mockHistoryRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.getHistoryForAddress(mockUser.stellar_address!, 30, 3, 500);
+
+      expect(mockHistoryRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 200, take: 100 }),
+      );
+    });
+
+    it('returns non-overlapping, ordered pages with total count metadata', async () => {
+      const pageOneEntries = [
+        makeHistoryEntry({ id: 'h1', rank: 1, snapshot_date: new Date('2024-01-03') }),
+        makeHistoryEntry({ id: 'h2', rank: 2, snapshot_date: new Date('2024-01-02') }),
+      ];
+      const pageTwoEntries = [
+        makeHistoryEntry({ id: 'h3', rank: 3, snapshot_date: new Date('2024-01-01') }),
+      ];
+
+      mockHistoryRepository.findAndCount.mockResolvedValueOnce([
+        pageOneEntries,
+        3,
+      ]);
+      const page1 = await service.getHistoryForAddress(
+        mockUser.stellar_address!,
+        30,
+        1,
+        2,
+      );
+
+      mockHistoryRepository.findAndCount.mockResolvedValueOnce([
+        pageTwoEntries,
+        3,
+      ]);
+      const page2 = await service.getHistoryForAddress(
+        mockUser.stellar_address!,
+        30,
+        2,
+        2,
+      );
+
+      expect(mockHistoryRepository.findAndCount).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ skip: 0, take: 2 }),
+      );
+      expect(mockHistoryRepository.findAndCount).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ skip: 2, take: 2 }),
+      );
+
+      const page1Ranks = page1.data.map((e) => e.rank);
+      const page2Ranks = page2.data.map((e) => e.rank);
+
+      expect(page1Ranks).toEqual([1, 2]);
+      expect(page2Ranks).toEqual([3]);
+      expect(page1Ranks.some((r) => page2Ranks.includes(r))).toBe(false);
+      expect(page1.total).toBe(3);
+      expect(page2.total).toBe(3);
     });
   });
 

--- a/backend/src/leaderboard/leaderboard.service.ts
+++ b/backend/src/leaderboard/leaderboard.service.ts
@@ -40,6 +40,7 @@ import {
   LeaderboardHistoryQueryDto,
   LeaderboardHistoryEntryResponse,
   PaginatedLeaderboardHistoryResponse,
+  PaginatedAddressHistoryResponse,
 } from './dto/leaderboard-history.dto';
 import { UserRankDto } from './dto/user-rank.dto';
 import {
@@ -691,8 +692,16 @@ export class LeaderboardService {
   /**
    * Get user history snapshots for a specific Stellar address
    */
-  async getHistoryForAddress(address: string, days: number = 30) {
+  async getHistoryForAddress(
+    address: string,
+    days: number = 30,
+    page: number = 1,
+    limit: number = 20,
+  ): Promise<PaginatedAddressHistoryResponse> {
     const validDays = Math.min(Math.max(days || 30, 1), 90);
+    const validLimit = Math.min(Math.max(limit || 20, 1), 100);
+    const validPage = Math.max(page || 1, 1);
+    const skip = (validPage - 1) * validLimit;
 
     const user = await this.usersService.findByAddress(address);
     if (!user) {
@@ -702,20 +711,27 @@ export class LeaderboardService {
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - validDays);
 
-    const history = await this.historyRepository.find({
+    const [history, total] = await this.historyRepository.findAndCount({
       where: {
         user_id: user.id,
         snapshot_date: MoreThanOrEqual(cutoffDate),
       },
       order: { snapshot_date: 'DESC' },
+      skip,
+      take: validLimit,
     });
 
-    return history.map((h) => ({
-      snapshot_date: h.snapshot_date,
-      rank: h.rank,
-      reputation_score: h.reputation_score,
-      season_points: h.season_points,
-    }));
+    return {
+      data: history.map((h) => ({
+        snapshot_date: h.snapshot_date,
+        rank: h.rank,
+        reputation_score: h.reputation_score,
+        season_points: h.season_points,
+      })),
+      total,
+      page: validPage,
+      limit: validLimit,
+    };
   }
 
   /**

--- a/backend/src/migrations/1787900000000-CreateOracleAssignmentsTable.ts
+++ b/backend/src/migrations/1787900000000-CreateOracleAssignmentsTable.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOracleAssignmentsTable1787900000000
+  implements MigrationInterface
+{
+  name = 'CreateOracleAssignmentsTable1787900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "oracle_assignments" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "data_source" varchar(500) NOT NULL,
+        "event_id" uuid NOT NULL,
+        "is_active" boolean NOT NULL DEFAULT true,
+        "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "UQ_oracle_assignments_source_event" UNIQUE ("data_source", "event_id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_assignments_data_source" ON "oracle_assignments" ("data_source")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_oracle_assignments_event_id" ON "oracle_assignments" ("event_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_oracle_assignments_event_id"`);
+    await queryRunner.query(`DROP INDEX "IDX_oracle_assignments_data_source"`);
+    await queryRunner.query(`DROP TABLE "oracle_assignments"`);
+  }
+}

--- a/backend/src/oracle/entities/oracle-assignment.entity.ts
+++ b/backend/src/oracle/entities/oracle-assignment.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Grants a data source permission to report match results for one event.
+ * A submission is only accepted when an active row here matches both the
+ * reporting data_source and the event the submitted match belongs to —
+ * `is_active` lets an assignment be revoked without deleting its history.
+ */
+@Entity('oracle_assignments')
+@Index(['data_source', 'event_id'], { unique: true })
+export class OracleAssignment {
+  @PrimaryGeneratedColumn('uuid')
+  @ApiProperty()
+  id: string;
+
+  @Column({ type: 'varchar', length: 500 })
+  @Index()
+  @ApiProperty()
+  data_source: string;
+
+  @Column({ type: 'uuid' })
+  @Index()
+  @ApiProperty()
+  event_id: string;
+
+  @Column({ type: 'boolean', default: true })
+  @ApiProperty()
+  is_active: boolean;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  @ApiProperty()
+  created_at: Date;
+}

--- a/backend/src/oracle/guards/oracle-assignment.guard.spec.ts
+++ b/backend/src/oracle/guards/oracle-assignment.guard.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { OracleAssignmentGuard } from './oracle-assignment.guard';
+import { CreatorEventMatch } from '../../creator-events/entities/creator-event-match.entity';
+import { OracleAssignment } from '../entities/oracle-assignment.entity';
+
+describe('OracleAssignmentGuard', () => {
+  let guard: OracleAssignmentGuard;
+
+  const mockMatchRepository = {
+    findOne: jest.fn(),
+  };
+
+  const mockAssignmentRepository = {
+    findOne: jest.fn(),
+  };
+
+  const mockExecutionContext = (body: Record<string, unknown>) =>
+    ({
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({ body }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OracleAssignmentGuard,
+        {
+          provide: getRepositoryToken(CreatorEventMatch),
+          useValue: mockMatchRepository,
+        },
+        {
+          provide: getRepositoryToken(OracleAssignment),
+          useValue: mockAssignmentRepository,
+        },
+      ],
+    }).compile();
+
+    guard = module.get<OracleAssignmentGuard>(OracleAssignmentGuard);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('allows the request through when required fields are missing (validation handles it)', async () => {
+    const context = mockExecutionContext({ match_id: '123' });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(mockMatchRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('allows the request through when the match does not exist (service raises 404)', async () => {
+    mockMatchRepository.findOne.mockResolvedValue(null);
+    const context = mockExecutionContext({
+      match_id: 'unknown-match',
+      data_source: 'source-a',
+    });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(mockAssignmentRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unregistered/unauthorized submitter', async () => {
+    mockMatchRepository.findOne.mockResolvedValue({
+      on_chain_match_id: '123',
+      event_id: 'event-a',
+    });
+    mockAssignmentRepository.findOne.mockResolvedValue(null);
+
+    const context = mockExecutionContext({
+      match_id: '123',
+      data_source: 'unregistered-source',
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(mockAssignmentRepository.findOne).toHaveBeenCalledWith({
+      where: { data_source: 'unregistered-source', is_active: true },
+    });
+  });
+
+  it('rejects a cross-event submission from an oracle assigned to a different event', async () => {
+    mockMatchRepository.findOne.mockResolvedValue({
+      on_chain_match_id: '123',
+      event_id: 'event-b',
+    });
+    mockAssignmentRepository.findOne.mockResolvedValue({
+      data_source: 'source-a',
+      event_id: 'event-a',
+      is_active: true,
+    });
+
+    const context = mockExecutionContext({
+      match_id: '123',
+      data_source: 'source-a',
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('allows a submission from an oracle assigned to the match\'s event', async () => {
+    mockMatchRepository.findOne.mockResolvedValue({
+      on_chain_match_id: '123',
+      event_id: 'event-a',
+    });
+    mockAssignmentRepository.findOne.mockResolvedValue({
+      data_source: 'source-a',
+      event_id: 'event-a',
+      is_active: true,
+    });
+
+    const context = mockExecutionContext({
+      match_id: '123',
+      data_source: 'source-a',
+    });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+});

--- a/backend/src/oracle/guards/oracle-assignment.guard.ts
+++ b/backend/src/oracle/guards/oracle-assignment.guard.ts
@@ -1,0 +1,74 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { Request } from 'express';
+import { CreatorEventMatch } from '../../creator-events/entities/creator-event-match.entity';
+import { OracleAssignment } from '../entities/oracle-assignment.entity';
+import { WebhookMatchResultDto } from '../dto/webhook-match-result.dto';
+
+/**
+ * Confirms the reporting data_source is an active oracle assigned to the
+ * event the submitted match belongs to. This runs after WebhookAuthGuard,
+ * which only proves the request carries a valid signature — it says nothing
+ * about which match/event the signer is allowed to report results for.
+ */
+@Injectable()
+export class OracleAssignmentGuard implements CanActivate {
+  private readonly logger = new Logger(OracleAssignmentGuard.name);
+
+  constructor(
+    @InjectRepository(CreatorEventMatch)
+    private readonly matchRepository: Repository<CreatorEventMatch>,
+    @InjectRepository(OracleAssignment)
+    private readonly assignmentRepository: Repository<OracleAssignment>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const body = request.body as Partial<WebhookMatchResultDto>;
+
+    if (!body?.match_id || !body?.data_source) {
+      // Missing required fields — let DTO validation reject with a 400.
+      return true;
+    }
+
+    const match = await this.matchRepository.findOne({
+      where: { on_chain_match_id: body.match_id },
+    });
+
+    if (!match) {
+      // Unknown match — let the service raise its own 404.
+      return true;
+    }
+
+    const assignment = await this.assignmentRepository.findOne({
+      where: { data_source: body.data_source, is_active: true },
+    });
+
+    if (!assignment) {
+      this.logger.warn(
+        `Rejected submission from unregistered oracle: data_source=${body.data_source}, match_id=${body.match_id}`,
+      );
+      throw new ForbiddenException(
+        `Data source '${body.data_source}' is not a registered oracle`,
+      );
+    }
+
+    if (assignment.event_id !== match.event_id) {
+      this.logger.warn(
+        `Rejected cross-event submission: data_source=${body.data_source}, match_id=${body.match_id}, assigned_event=${assignment.event_id}, match_event=${match.event_id}`,
+      );
+      throw new ForbiddenException(
+        `Data source '${body.data_source}' is not authorized to report results for this match's event`,
+      );
+    }
+
+    return true;
+  }
+}

--- a/backend/src/oracle/oracle.controller.ts
+++ b/backend/src/oracle/oracle.controller.ts
@@ -20,6 +20,7 @@ import {
 import { OracleService } from './oracle.service';
 import { OracleAuthGuard } from './guards/oracle-auth.guard';
 import { WebhookAuthGuard } from './guards/webhook-auth.guard';
+import { OracleAssignmentGuard } from './guards/oracle-assignment.guard';
 import { OracleReliabilityService } from './oracle-reliability.service';
 import {
   ListPendingMatchesQueryDto,
@@ -73,7 +74,7 @@ export class OracleController {
   }
 
   @Post('webhooks/match-result')
-  @UseGuards(WebhookAuthGuard)
+  @UseGuards(WebhookAuthGuard, OracleAssignmentGuard)
   @HttpCode(HttpStatus.ACCEPTED)
   @ApiSecurity('webhook-signature')
   @ApiOperation({ summary: 'Submit match result via webhook' })
@@ -84,6 +85,11 @@ export class OracleController {
     type: WebhookResponseDto,
   })
   @ApiResponse({ status: 401, description: 'Unauthorized - invalid signature' })
+  @ApiResponse({
+    status: 403,
+    description:
+      "Data source is not a registered oracle, or is not assigned to this match's event",
+  })
   @ApiResponse({ status: 404, description: 'Match not found' })
   @ApiResponse({
     status: 409,

--- a/backend/src/oracle/oracle.module.ts
+++ b/backend/src/oracle/oracle.module.ts
@@ -7,10 +7,12 @@ import { OracleService } from './oracle.service';
 import { OracleController } from './oracle.controller';
 import { WebhookService } from './webhook.service';
 import { WebhookAuthGuard } from './guards/webhook-auth.guard';
+import { OracleAssignmentGuard } from './guards/oracle-assignment.guard';
 import { SubmissionHistoryService } from './submission-history.service';
 import { OracleSubmission } from './entities/oracle-submission.entity';
 import { OracleSubmissionFlag } from './entities/oracle-submission-flag.entity';
 import { OracleSourceReliability } from './entities/oracle-source-reliability.entity';
+import { OracleAssignment } from './entities/oracle-assignment.entity';
 import { OracleReliabilityService } from './oracle-reliability.service';
 import { MatchResultDivergence } from '../matches/entities/match-result-divergence.entity';
 
@@ -22,6 +24,7 @@ import { MatchResultDivergence } from '../matches/entities/match-result-divergen
       OracleSubmission,
       OracleSubmissionFlag,
       OracleSourceReliability,
+      OracleAssignment,
       MatchResultDivergence,
     ]),
     ScheduleModule.forRoot(),
@@ -31,6 +34,7 @@ import { MatchResultDivergence } from '../matches/entities/match-result-divergen
     OracleService,
     WebhookService,
     WebhookAuthGuard,
+    OracleAssignmentGuard,
     SubmissionHistoryService,
     OracleReliabilityService,
   ],


### PR DESCRIPTION
. Leaderboard history pagination (leaderboard.service.ts, leaderboard.controller.ts, dto/leaderboard-history.dto.ts)
- GET /leaderboard/history already had offset pagination; hardened it with a @Max(100) validator on limit (previously only clamped server-side, not validated).
- getHistoryForAddress (the ?address= path) previously returned an unbounded raw array with no pagination or total count — now takes page/limit, caps at 100, and returns { data, total, page, limit } via a new PaginatedAddressHistoryResponse DTO.
- Tests added proving pages are non-overlapping, correctly ordered (by snapshot_date DESC, rank ASC), and that oversized limits get capped at 100 — for both the main history query and the per-address query.

. Oracle submission authorization (oracle/entities/oracle-assignment.entity.ts, new migration, oracle/guards/oracle-assignment.guard.ts, oracle.controller.ts, oracle.module.ts)
- Found that submissions were only authenticated (via WebhookAuthGuard's shared HMAC secret) but never authorized against a specific match/event — any valid signature could report a result for any match.
- Added an oracle_assignments table mapping a data_source to the one event it's allowed to report for (is_active flag to revoke without deleting history).
- New OracleAssignmentGuard runs after WebhookAuthGuard on POST /oracle/webhooks/match-result: resolves the match's event, rejects unregistered data sources and cross-event submissions with a clear 403, and defers to existing validation/404 handling for malformed bodies or unknown matches.
- 6 new guard tests cover: missing fields, unknown match, unauthorized submitter, cross-event rejection, and the happy path.

Full test suite (105 suites / 1367 tests) passes, and tsc --noEmit shows the same 50 pre-existing (unrelated) errors as the main baseline — no new type errors introduced.


closes #1526
closes #1612 
closes #1615
closes #1613