### PR TITLE
feat(users): add user bookmarks CRUD with ownership and duplicate checks

### DIFF
--- a/backend/src/users/dto/create-bookmark.dto.ts
+++ b/backend/src/users/dto/create-bookmark.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class CreateBookmarkDto {
+  @ApiProperty({
+    description: 'ID of the market to bookmark',
+    example: '27c91229-34ac-44fd-b343-a96db4108bb3',
+  })
+  @IsUUID()
+  market_id: string;
+}

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -35,6 +35,9 @@ describe('UsersController', () => {
             findByAddress: jest.fn(),
             findPublicPredictionsByAddress: jest.fn(),
             getMyStats: jest.fn(),
+            findUserBookmarks: jest.fn(),
+            addBookmark: jest.fn(),
+            removeBookmark: jest.fn(),
           },
         },
       ],
@@ -168,6 +171,37 @@ describe('UsersController', () => {
         { page: 1, limit: 20 },
       );
       expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('createBookmark', () => {
+    it('creates a bookmark scoped to the authenticated user', async () => {
+      const bookmark = { id: 'bookmark-uuid', user: { id: mockUser.id } };
+      jest.spyOn(service, 'addBookmark').mockResolvedValue(bookmark as never);
+
+      const result = await controller.createBookmark(mockUser, {
+        market_id: 'market-uuid',
+      });
+
+      expect(service.addBookmark).toHaveBeenCalledWith(
+        mockUser.id,
+        'market-uuid',
+      );
+      expect(result).toEqual(bookmark);
+    });
+  });
+
+  describe('deleteBookmark', () => {
+    it('deletes a bookmark owned by the authenticated user', async () => {
+      jest.spyOn(service, 'removeBookmark').mockResolvedValue(undefined);
+
+      const result = await controller.deleteBookmark(mockUser, 'bookmark-uuid');
+
+      expect(service.removeBookmark).toHaveBeenCalledWith(
+        mockUser.id,
+        'bookmark-uuid',
+      );
+      expect(result).toEqual({ success: true });
     });
   });
 });

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -9,6 +9,9 @@ import {
   Query,
   UsePipes,
   ValidationPipe,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
@@ -38,6 +41,8 @@ import {
   ListUserBookmarksDto,
   PaginatedUserBookmarksResponse,
 } from './dto/list-user-bookmarks.dto';
+import { CreateBookmarkDto } from './dto/create-bookmark.dto';
+import { UserBookmark } from '../markets/entities/user-bookmark.entity';
 import { ApiBearerAuth } from '@nestjs/swagger';
 
 import { ListUserCompetitionsDto } from './dto/list-user-competitions.dto';
@@ -96,6 +101,35 @@ export class UsersController {
     @Query() query: ListUserBookmarksDto,
   ): Promise<PaginatedUserBookmarksResponse> {
     return this.usersService.findUserBookmarks(user.id, query);
+  }
+
+  @Post('me/bookmarks')
+  @ApiBearerAuth()
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Bookmark a market for the current user' })
+  @ApiResponse({ status: 201, description: 'Market bookmarked' })
+  @ApiResponse({ status: 404, description: 'Market not found' })
+  @ApiResponse({ status: 409, description: 'Market already bookmarked' })
+  async createBookmark(
+    @CurrentUser() user: User,
+    @Body() dto: CreateBookmarkDto,
+  ): Promise<UserBookmark> {
+    return this.usersService.addBookmark(user.id, dto.market_id);
+  }
+
+  @Delete('me/bookmarks/:id')
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remove a bookmark owned by the current user' })
+  @ApiResponse({ status: 200, description: 'Bookmark removed' })
+  @ApiResponse({ status: 404, description: 'Bookmark not found' })
+  async deleteBookmark(
+    @CurrentUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ success: true }> {
+    await this.usersService.removeBookmark(user.id, id);
+    return { success: true };
   }
 
   @Get('me/referrals')

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -33,6 +33,7 @@ describe('UsersService', () => {
   let participantsRepository: Repository<CompetitionParticipant>;
   let marketsRepository: Repository<Market>;
   let referralsRepository: Repository<UserReferral>;
+  let bookmarksRepository: Repository<UserBookmark>;
 
   const mockUser: User = {
     id: '123e4567-e89b-12d3-a456-426614174000',
@@ -95,6 +96,7 @@ describe('UsersService', () => {
           provide: getRepositoryToken(Market),
           useValue: {
             find: jest.fn(),
+            findOneBy: jest.fn(),
             createQueryBuilder: jest.fn(),
           },
         },
@@ -148,6 +150,9 @@ describe('UsersService', () => {
     );
     referralsRepository = module.get<Repository<UserReferral>>(
       getRepositoryToken(UserReferral),
+    );
+    bookmarksRepository = module.get<Repository<UserBookmark>>(
+      getRepositoryToken(UserBookmark),
     );
   });
 
@@ -878,6 +883,87 @@ describe('UsersService', () => {
 
       expect(result.username).toBe('keep_me');
       expect(result.avatar_url).toBe('https://example.com/original.png');
+    });
+  });
+
+  describe('addBookmark', () => {
+    const market = { id: 'market-uuid' } as Market;
+
+    it('creates a bookmark scoped to the authenticated user', async () => {
+      jest.spyOn(marketsRepository, 'findOneBy').mockResolvedValue(market);
+      jest.spyOn(bookmarksRepository, 'findOne').mockResolvedValue(null);
+      const created = {
+        id: 'bookmark-uuid',
+        user: { id: mockUser.id },
+        market,
+      };
+      jest
+        .spyOn(bookmarksRepository, 'create')
+        .mockReturnValue(created as UserBookmark);
+      jest
+        .spyOn(bookmarksRepository, 'save')
+        .mockResolvedValue(created as UserBookmark);
+
+      const result = await service.addBookmark(mockUser.id, market.id);
+
+      expect(result).toEqual(created);
+      expect(bookmarksRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: { id: mockUser.id },
+          market,
+        }),
+      );
+    });
+
+    it('throws NotFoundException when the market does not exist', async () => {
+      jest.spyOn(marketsRepository, 'findOneBy').mockResolvedValue(null);
+
+      await expect(
+        service.addBookmark(mockUser.id, 'missing-market'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects duplicate bookmarks of the same market with ConflictException', async () => {
+      jest.spyOn(marketsRepository, 'findOneBy').mockResolvedValue(market);
+      jest.spyOn(bookmarksRepository, 'findOne').mockResolvedValue({
+        id: 'existing-bookmark',
+        user: { id: mockUser.id },
+        market,
+      } as UserBookmark);
+
+      await expect(service.addBookmark(mockUser.id, market.id)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(bookmarksRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeBookmark', () => {
+    it('deletes a bookmark owned by the authenticated user', async () => {
+      jest.spyOn(bookmarksRepository, 'findOne').mockResolvedValue({
+        id: 'bookmark-uuid',
+        user: { id: mockUser.id },
+      } as UserBookmark);
+      const deleteSpy = jest
+        .spyOn(bookmarksRepository, 'delete')
+        .mockResolvedValue({ affected: 1 } as never);
+
+      await service.removeBookmark(mockUser.id, 'bookmark-uuid');
+
+      expect(bookmarksRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'bookmark-uuid', user: { id: mockUser.id } },
+      });
+      expect(deleteSpy).toHaveBeenCalledWith({ id: 'bookmark-uuid' });
+    });
+
+    it('enforces ownership — a bookmark owned by another user is not found', async () => {
+      jest.spyOn(bookmarksRepository, 'findOne').mockResolvedValue(null);
+      const deleteSpy = jest.spyOn(bookmarksRepository, 'delete');
+
+      await expect(
+        service.removeBookmark(mockUser.id, 'other-users-bookmark'),
+      ).rejects.toThrow(NotFoundException);
+      expect(deleteSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -323,6 +323,49 @@ export class UsersService {
     return { data, total, page, limit };
   }
 
+  /**
+   * Bookmark a market on behalf of the authenticated user.
+   * Throws NotFoundException when the market does not exist and
+   * ConflictException when the market is already bookmarked by the user.
+   */
+  async addBookmark(userId: string, marketId: string): Promise<UserBookmark> {
+    const market = await this.marketsRepository.findOneBy({ id: marketId });
+    if (!market) {
+      throw new NotFoundException(`Market with ID "${marketId}" not found`);
+    }
+
+    const existing = await this.userBookmarksRepository.findOne({
+      where: { user: { id: userId }, market: { id: marketId } },
+    });
+    if (existing) {
+      throw new ConflictException('Market is already bookmarked');
+    }
+
+    const bookmark = this.userBookmarksRepository.create({
+      user: { id: userId } as User,
+      market,
+    });
+
+    return this.userBookmarksRepository.save(bookmark);
+  }
+
+  /**
+   * Remove a bookmark owned by the authenticated user.
+   * Ownership is enforced by scoping the lookup to the caller's userId —
+   * another user's bookmark is indistinguishable from a missing one (404).
+   */
+  async removeBookmark(userId: string, bookmarkId: string): Promise<void> {
+    const bookmark = await this.userBookmarksRepository.findOne({
+      where: { id: bookmarkId, user: { id: userId } },
+    });
+
+    if (!bookmark) {
+      throw new NotFoundException('Bookmark not found');
+    }
+
+    await this.userBookmarksRepository.delete({ id: bookmarkId });
+  }
+
   async exportUserData(userId: string) {
     const user = await this.findById(userId);
 


### PR DESCRIPTION
## Overview

This PR adds the missing **User Bookmarks CRUD** endpoints. The \user_bookmarks\ table and a list endpoint already existed, but create/delete endpoints with ownership enforcement and duplicate rejection were missing, so users could not fully manage their bookmarks securely.

## Related Issue

Closes [#1644](https://github.com/Arena1X/InsightArena/issues/1644)

## Changes

- **[ADD]** \ackend/src/users/dto/create-bookmark.dto.ts\
  - \CreateBookmarkDto\ requiring a UUID \market_id\.
- **[MODIFY]** \ackend/src/users/users.service.ts\
  - \ddBookmark(userId, marketId)\ — verifies the market exists (\404\), rejects duplicate bookmarks of the same market (\409 Conflict\), and creates the bookmark scoped to the authenticated user.
  - \emoveBookmark(userId, bookmarkId)\ — scopes the lookup to the caller's \userId\, so another user's bookmark is indistinguishable from a missing one (\404\).
- **[MODIFY]** \ackend/src/users/users.controller.ts\
  - \POST /users/me/bookmarks\ (\201\) — bookmark a market for the current user.
  - \DELETE /users/me/bookmarks/:id\ — remove a bookmark owned by the current user.
  - The existing \GET /users/me/bookmarks\ list endpoint is unchanged.
- **[ADD]** \ackend/src/users/users.service.spec.ts\ + \users.controller.spec.ts\
  - Tests: ownership enforced (another user's bookmark → \404\); duplicates rejected (\409\).

The DB-level unique index on \(user_id, market_id)\ (existing migration + entity) backs the duplicate prevention.

## Verification Results

\\\
pnpm run test          # 111 suites / 1414 tests passed
pnpm run build         # passed
pnpm run migration:check-timestamps  # passed
eslint changed files   # no new errors
\\\

## Acceptance Criteria

| Criteria | Status |
| --- | --- |
| Users manage their bookmarks securely | ✅ create/list/delete scoped to the authenticated user with ownership checks |
| Covered by tests | ✅ ownership enforced + duplicates rejected (unit tests)