### PR TITLE
fix(indexer): resume from persisted chain-sync checkpoint on restart

### DIFF
--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -7,13 +7,18 @@ import {
   Repository,
   SelectQueryBuilder,
 } from 'typeorm';
-import { IndexerService, EVENT_DECODER_VERSION } from './indexer.service';
+import {
+  IndexerService,
+  EVENT_DECODER_VERSION,
+  CHECKPOINT_LEDGER_KEY,
+} from './indexer.service';
 import {
   ContractEvent,
   ContractEventStatus,
 } from './entities/contract-event.entity';
 import { FeeHistory } from './entities/fee-history.entity';
 import { IndexerCheckpoint } from './entities/indexer-checkpoint.entity';
+import { ChainSyncCheckpoint } from './entities/chain-sync-checkpoint.entity';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { CreatorEventLeaderboardEntry } from '../matches/entities/creator-event-leaderboard-entry.entity';
 import { CreatorEventPayout } from '../matches/entities/creator-event-payout.entity';
@@ -52,6 +57,9 @@ describe('IndexerService', () => {
   let checkpointRepository: jest.Mocked<
     Pick<Repository<IndexerCheckpoint>, 'findOne' | 'save' | 'upsert'>
   >;
+  let chainSyncCheckpointRepository: jest.Mocked<
+    Pick<Repository<ChainSyncCheckpoint>, 'findOne' | 'save'>
+  >;
   let creatorEventRepository: jest.Mocked<
     Pick<
       Repository<CreatorEvent>,
@@ -88,6 +96,11 @@ describe('IndexerService', () => {
       findOne: jest.fn(),
       save: jest.fn(),
       upsert: jest.fn(),
+    };
+
+    chainSyncCheckpointRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(),
     };
 
     creatorEventRepository = {
@@ -144,6 +157,10 @@ describe('IndexerService', () => {
         {
           provide: getRepositoryToken(IndexerCheckpoint),
           useValue: checkpointRepository,
+        },
+        {
+          provide: getRepositoryToken(ChainSyncCheckpoint),
+          useValue: chainSyncCheckpointRepository,
         },
         {
           provide: getRepositoryToken(CreatorEvent),
@@ -218,6 +235,202 @@ describe('IndexerService', () => {
         expect.objectContaining({
           key: 'indexer:last_processed_ledger',
           value: 99,
+        }),
+        ['key'],
+      );
+    });
+
+    it('rewinds the persisted chain-sync checkpoint so a restart does not resurrect the old position', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        return undefined;
+      });
+      checkpointRepository.upsert.mockResolvedValue({} as InsertResult);
+      const chainSync = {
+        contract_id: 'CCONTRACT',
+        last_indexed_ledger: 500,
+        last_indexed_ledger_hash: 'hash-500',
+      } as ChainSyncCheckpoint;
+      chainSyncCheckpointRepository.findOne.mockResolvedValue(chainSync);
+
+      await service.reindex(50);
+
+      expect(chainSync.last_indexed_ledger).toBe(49);
+      expect(chainSync.last_indexed_ledger_hash).toBeNull();
+      expect(chainSyncCheckpointRepository.save).toHaveBeenCalledWith(
+        chainSync,
+      );
+    });
+  });
+
+  describe('startup checkpoint resume', () => {
+    it('resumes from the persisted chain-sync checkpoint instead of genesis when the working cursor is missing', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        return undefined;
+      });
+
+      // No key/value checkpoint row exists yet (missing after restart).
+      checkpointRepository.findOne.mockResolvedValue(null);
+      chainSyncCheckpointRepository.findOne.mockResolvedValue({
+        contract_id: 'CCONTRACT',
+        last_indexed_ledger: 1234,
+      } as ChainSyncCheckpoint);
+      checkpointRepository.upsert.mockResolvedValue({} as InsertResult);
+
+      await (service as any).onModuleInit();
+
+      // Adopts the persisted ledger (1234) rather than starting at genesis.
+      expect(checkpointRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: CHECKPOINT_LEDGER_KEY,
+          value: 1234,
+        }),
+        ['key'],
+      );
+    });
+
+    it('resumes from the persisted chain-sync checkpoint when the working cursor is behind', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        return undefined;
+      });
+
+      checkpointRepository.findOne.mockResolvedValue({
+        key: CHECKPOINT_LEDGER_KEY,
+        value: 10,
+      } as IndexerCheckpoint);
+      chainSyncCheckpointRepository.findOne.mockResolvedValue({
+        contract_id: 'CCONTRACT',
+        last_indexed_ledger: 999,
+      } as ChainSyncCheckpoint);
+      checkpointRepository.upsert.mockResolvedValue({} as InsertResult);
+
+      await (service as any).onModuleInit();
+
+      expect(checkpointRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: CHECKPOINT_LEDGER_KEY,
+          value: 999,
+        }),
+        ['key'],
+      );
+    });
+
+    it('never regresses a working cursor that is already ahead of the persisted checkpoint', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        return undefined;
+      });
+
+      checkpointRepository.findOne.mockResolvedValue({
+        key: CHECKPOINT_LEDGER_KEY,
+        value: 5000,
+      } as IndexerCheckpoint);
+      chainSyncCheckpointRepository.findOne.mockResolvedValue({
+        contract_id: 'CCONTRACT',
+        last_indexed_ledger: 1234,
+      } as ChainSyncCheckpoint);
+
+      await (service as any).onModuleInit();
+
+      expect(checkpointRepository.upsert).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: CHECKPOINT_LEDGER_KEY,
+          value: 1234,
+        }),
+        ['key'],
+      );
+    });
+  });
+
+  describe('pollContractEvents checkpoint advance', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('advances the checkpoint to the last processed ledger, not the chain head', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_RPC_URL') return 'https://rpc.example';
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        return undefined;
+      });
+
+      // Working cursor sits at ledger 100 (bigint column read back as string).
+      checkpointRepository.findOne.mockResolvedValue({
+        key: CHECKPOINT_LEDGER_KEY,
+        value: '100', // Postgres returns bigint as a string
+      } as unknown as IndexerCheckpoint);
+
+      // Chain head is at 10_000, but this batch only returns one event at 101.
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          result: {
+            events: [
+              {
+                id: 'evt-1',
+                ledger: 101,
+                log_index: 0,
+                topic: [{ symbol: 'event' }, { symbol: 'created' }],
+                value: { event_id: { u64: '1' } },
+              },
+            ],
+            latestLedger: 10000,
+          },
+        }),
+      } as unknown as Response);
+
+      // No need to exercise the full handler chain for this test.
+      jest
+        .spyOn(service as any, 'storeAndProcessEvent')
+        .mockResolvedValue(undefined);
+
+      await service.pollContractEvents();
+
+      // The checkpoint must land on the processed ledger (101), never jump to
+      // the chain head (10_000) and skip events 102..10_000.
+      expect(checkpointRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: CHECKPOINT_LEDGER_KEY,
+          value: 101,
+        }),
+        ['key'],
+      );
+      expect(checkpointRepository.upsert).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: CHECKPOINT_LEDGER_KEY,
+          value: 10000,
+        }),
+        ['key'],
+      );
+    });
+
+    it('still advances the checkpoint to the chain head when a poll returns no events', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_RPC_URL') return 'https://rpc.example';
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        return undefined;
+      });
+
+      checkpointRepository.findOne.mockResolvedValue({
+        key: CHECKPOINT_LEDGER_KEY,
+        value: 100,
+      } as IndexerCheckpoint);
+
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          result: { events: [], latestLedger: 5000 },
+        }),
+      } as unknown as Response);
+
+      await service.pollContractEvents();
+
+      expect(checkpointRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: CHECKPOINT_LEDGER_KEY,
+          value: 5000,
         }),
         ['key'],
       );

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -9,6 +9,7 @@ import {
 } from './entities/contract-event.entity';
 import { FeeHistory } from './entities/fee-history.entity';
 import { IndexerCheckpoint } from './entities/indexer-checkpoint.entity';
+import { ChainSyncCheckpoint } from './entities/chain-sync-checkpoint.entity';
 import { IndexerMetricsDto } from './dto/indexer-metrics.dto';
 import { Match, WinningTeam } from '../matches/entities/match.entity';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
@@ -64,6 +65,9 @@ export class IndexerService implements OnModuleInit {
     @InjectRepository(IndexerCheckpoint)
     private readonly checkpointRepository: Repository<IndexerCheckpoint>,
 
+    @InjectRepository(ChainSyncCheckpoint)
+    private readonly chainSyncCheckpointRepository: Repository<ChainSyncCheckpoint>,
+
     @InjectRepository(CreatorEvent)
     private readonly creatorEventRepository: Repository<CreatorEvent>,
 
@@ -89,6 +93,44 @@ export class IndexerService implements OnModuleInit {
 
   async onModuleInit(): Promise<void> {
     await this.ensureCheckpoints();
+    await this.resumeFromPersistedCheckpoint();
+  }
+
+  /**
+   * Resumes the indexer from the persisted chain-sync checkpoint ledger
+   * (chain_sync_checkpoints, keyed by contract_id) instead of defaulting to
+   * genesis.
+   *
+   * The key/value checkpoint (indexer_checkpoints) is used as the working
+   * cursor during polls, but it can be missing or stale after a restart (for
+   * example when its row was wiped or the table was recreated). The
+   * chain-sync checkpoint table is created by a dedicated migration and is
+   * treated as the durable source of truth, so if it is ahead of the working
+   * cursor we adopt it. The cursor is never moved backwards here.
+   */
+  private async resumeFromPersistedCheckpoint(): Promise<void> {
+    const contractId = this.configService.get<string>('SOROBAN_CONTRACT_ID');
+    if (!contractId || contractId === 'your-contract-id-here') return;
+
+    const chainSync = await this.chainSyncCheckpointRepository.findOne({
+      where: { contract_id: contractId },
+    });
+    if (!chainSync) return;
+
+    const persistedLedger = Number(chainSync.last_indexed_ledger);
+    if (!Number.isFinite(persistedLedger) || persistedLedger <= 0) return;
+
+    const current = await this.checkpointRepository.findOne({
+      where: { key: CHECKPOINT_LEDGER_KEY },
+    });
+    const currentLedger = Number(current?.value ?? 0);
+
+    if (persistedLedger > currentLedger) {
+      await this.saveCheckpoint(CHECKPOINT_LEDGER_KEY, persistedLedger);
+      this.logger.log(
+        `Indexer resumed from persisted checkpoint ledger ${persistedLedger} (was ${currentLedger})`,
+      );
+    }
   }
 
   private async ensureCheckpoints(): Promise<void> {
@@ -176,7 +218,13 @@ export class IndexerService implements OnModuleInit {
         }
       }
 
-      const finalLedger = Math.max(maxProcessedLedger, latestLedger);
+      // Advance the checkpoint only to the highest ledger that was actually
+      // processed in this batch. `latestLedger` is the chain head at query
+      // time and can be far ahead of the events this batch returned (e.g.
+      // when the RPC result was truncated by the limit), so advancing to it
+      // would skip any events between the last processed ledger and the head.
+      // The next poll resumes at finalLedger + 1 and keeps going from there.
+      const finalLedger = maxProcessedLedger;
       await this.saveCheckpoint(CHECKPOINT_LEDGER_KEY, finalLedger);
 
       const activeContractId = this.configService.get<string>(
@@ -1307,10 +1355,22 @@ export class IndexerService implements OnModuleInit {
 
   async reindex(fromLedger: number): Promise<void> {
     this.logger.log(`Reindex triggered from ledger ${fromLedger}`);
-    await this.saveCheckpoint(
-      CHECKPOINT_LEDGER_KEY,
-      Math.max(0, fromLedger - 1),
-    );
+    const rewindTo = Math.max(0, fromLedger - 1);
+    await this.saveCheckpoint(CHECKPOINT_LEDGER_KEY, rewindTo);
+
+    // Rewind the persisted chain-sync checkpoint too, so a subsequent restart
+    // (which resumes from it) does not resurrect the pre-reindex position.
+    const contractId = this.configService.get<string>('SOROBAN_CONTRACT_ID');
+    if (contractId && contractId !== 'your-contract-id-here') {
+      const chainSync = await this.chainSyncCheckpointRepository.findOne({
+        where: { contract_id: contractId },
+      });
+      if (chainSync && Number(chainSync.last_indexed_ledger) > rewindTo) {
+        chainSync.last_indexed_ledger = rewindTo;
+        chainSync.last_indexed_ledger_hash = null;
+        await this.chainSyncCheckpointRepository.save(chainSync);
+      }
+    }
   }
 
   async triggerManualSync(): Promise<void> {
@@ -1540,7 +1600,11 @@ export class IndexerService implements OnModuleInit {
 
   private async getCheckpointValue(key: string): Promise<number> {
     const cp = await this.checkpointRepository.findOne({ where: { key } });
-    return cp ? cp.value : 0;
+    if (!cp) return 0;
+    // bigint columns are returned as strings by the Postgres driver; coerce
+    // so arithmetic like `lastLedger + 1` is numeric, not string concat.
+    const parsed = Number(cp.value);
+    return Number.isFinite(parsed) ? parsed : 0;
   }
 
   private async saveCheckpoint(key: string, value: number): Promise<void> {


### PR DESCRIPTION
## Overview

Fixes the indexer so it never re-scans from genesis after a restart. The indexer previously kept its cursor only in the ad-hoc `indexer_checkpoints` key/value table and never consulted the persisted `chain_sync_checkpoints` ledger on startup — so a missing/stale row meant a full re-scan from genesis. It also advanced its checkpoint to the RPC chain head rather than the last ledger it actually processed, which could silently skip events when a batch was truncated by the RPC limit.

This PR wires the indexer to the persisted chain-sync checkpoint on startup, advances the checkpoint only after a batch is fully processed, and reads `bigint` checkpoint values correctly so the resume cursor is never corrupted by string concatenation.

## Related Issue

Closes [#1634](https://github.com/Arena1X/InsightArena/issues/1634)

## Changes

### 🔄 Indexer checkpoint resume

- **[MODIFY]** `backend/src/indexer/indexer.service.ts`
  - On startup, resume from the persisted `chain_sync_checkpoints.last_indexed_ledger` (keyed by `contract_id`) when it is ahead of the working key/value cursor. The cursor is never moved backwards.
  - Advance the checkpoint only to the highest ledger actually processed in a batch (`maxProcessedLedger`) instead of the RPC chain head, so truncated batches don't skip events.
  - Coerce `bigint` checkpoint values to numbers so `lastLedger + 1` is numeric arithmetic, not string concatenation.
  - `reindex()` also rewinds the persisted chain-sync checkpoint so a subsequent restart cannot resurrect the pre-reindex position.

- **[ADD]** `backend/src/indexer/indexer.service.spec.ts`
  - Startup resumes from the persisted checkpoint when the working cursor is missing or behind.
  - Startup never regresses a working cursor that is already ahead.
  - Checkpoint advances to the last processed ledger (not the chain head) and still advances to the head when a poll returns no events.
  - `reindex()` rewinds the persisted chain-sync checkpoint.

## Verification Results

```
npx jest src/indexer --silent
Test Suites: 5 passed, 5 total
Tests:       81 passed, 81 total

npx tsc --noEmit -p tsconfig.build.json
✅ no output (clean)

npx eslint src/indexer/indexer.service.ts src/indexer/indexer.service.spec.ts
✅ 0 errors
```

Acceptance Criteria | Status
--- | ---
Indexer resumes from its last checkpoint on startup, not genesis | ✅ startup resume from persisted ledger, tested
Checkpoint advances only after a batch is fully processed | ✅ advanced to last processed ledger, not chain head, tested
Restart resumes from checkpoint (covered by tests) | ✅ 4 new tests covering resume + advance semantics
