### PR TITLE
[Backend] Indexer Reorg Detection and Rollback

### DIFF
--- a/backend/src/indexer/indexer.service.spec.ts
+++ b/backend/src/indexer/indexer.service.spec.ts
@@ -19,6 +19,7 @@ import {
 import { FeeHistory } from './entities/fee-history.entity';
 import { IndexerCheckpoint } from './entities/indexer-checkpoint.entity';
 import { ChainSyncCheckpoint } from './entities/chain-sync-checkpoint.entity';
+import { ReorgEvent } from './entities/reorg-event.entity';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
 import { CreatorEventLeaderboardEntry } from '../matches/entities/creator-event-leaderboard-entry.entity';
 import { CreatorEventPayout } from '../matches/entities/creator-event-payout.entity';
@@ -58,7 +59,10 @@ describe('IndexerService', () => {
     Pick<Repository<IndexerCheckpoint>, 'findOne' | 'save' | 'upsert'>
   >;
   let chainSyncCheckpointRepository: jest.Mocked<
-    Pick<Repository<ChainSyncCheckpoint>, 'findOne' | 'save'>
+    Pick<Repository<ChainSyncCheckpoint>, 'findOne' | 'create' | 'save'>
+  >;
+  let reorgEventRepository: jest.Mocked<
+    Pick<Repository<ReorgEvent>, 'create' | 'save'>
   >;
   let creatorEventRepository: jest.Mocked<
     Pick<
@@ -100,6 +104,12 @@ describe('IndexerService', () => {
 
     chainSyncCheckpointRepository = {
       findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    reorgEventRepository = {
+      create: jest.fn(),
       save: jest.fn(),
     };
 
@@ -161,6 +171,10 @@ describe('IndexerService', () => {
         {
           provide: getRepositoryToken(ChainSyncCheckpoint),
           useValue: chainSyncCheckpointRepository,
+        },
+        {
+          provide: getRepositoryToken(ReorgEvent),
+          useValue: reorgEventRepository,
         },
         {
           provide: getRepositoryToken(CreatorEvent),
@@ -432,6 +446,320 @@ describe('IndexerService', () => {
           key: CHECKPOINT_LEDGER_KEY,
           value: 5000,
         }),
+        ['key'],
+      );
+    });
+  });
+
+  describe('detectAndHandleReorg', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('returns null when there is no chain-sync checkpoint yet', async () => {
+      chainSyncCheckpointRepository.findOne.mockResolvedValue(null);
+
+      const result = await (service as any).detectAndHandleReorg(
+        'CTEST',
+        'https://rpc.example',
+      );
+
+      expect(result).toBeNull();
+      expect(contractEventRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns null on first run when no ledger hash has been stored yet', async () => {
+      chainSyncCheckpointRepository.findOne.mockResolvedValue({
+        contract_id: 'CTEST',
+        last_indexed_ledger: 100,
+        last_indexed_ledger_hash: null,
+      } as ChainSyncCheckpoint);
+
+      const result = await (service as any).detectAndHandleReorg(
+        'CTEST',
+        'https://rpc.example',
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the RPC ledger-hash lookup fails (skips silently)', async () => {
+      chainSyncCheckpointRepository.findOne.mockResolvedValue({
+        contract_id: 'CTEST',
+        last_indexed_ledger: 100,
+        last_indexed_ledger_hash: 'hash-100',
+      } as ChainSyncCheckpoint);
+
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      } as unknown as Response);
+
+      const result = await (service as any).detectAndHandleReorg(
+        'CTEST',
+        'https://rpc.example',
+      );
+
+      expect(result).toBeNull();
+      expect(contractEventRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the stored hash still matches the chain', async () => {
+      chainSyncCheckpointRepository.findOne.mockResolvedValue({
+        contract_id: 'CTEST',
+        last_indexed_ledger: 100,
+        last_indexed_ledger_hash: 'hash-100',
+      } as ChainSyncCheckpoint);
+
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ result: { ledgers: [{ hash: 'hash-100' }] } }),
+      } as unknown as Response);
+
+      const result = await (service as any).detectAndHandleReorg(
+        'CTEST',
+        'https://rpc.example',
+      );
+
+      expect(result).toBeNull();
+      expect(contractEventRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('rolls back events, rewinds both checkpoints, and records a ReorgEvent when a divergence is detected', async () => {
+      const chainSync = {
+        contract_id: 'CTEST',
+        last_indexed_ledger: 100,
+        last_indexed_ledger_hash: 'hash-100',
+      } as ChainSyncCheckpoint;
+      chainSyncCheckpointRepository.findOne.mockResolvedValue(chainSync);
+      chainSyncCheckpointRepository.save.mockImplementation(
+        async (cp) => cp as ChainSyncCheckpoint,
+      );
+
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'INDEXER_REORG_ROLLBACK_DEPTH') return 10;
+        return undefined;
+      });
+
+      jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(async (_url, init: any) => {
+          const body = JSON.parse(init.body as string);
+          const ledger = body.params.startLedger;
+          if (ledger === 100) {
+            return {
+              ok: true,
+              json: async () => ({
+                result: { ledgers: [{ hash: 'hash-100-DIVERGED' }] },
+              }),
+            } as unknown as Response;
+          }
+          if (ledger === 90) {
+            return {
+              ok: true,
+              json: async () => ({
+                result: { ledgers: [{ hash: 'hash-90' }] },
+              }),
+            } as unknown as Response;
+          }
+          return {
+            ok: true,
+            json: async () => ({ result: { ledgers: [] } }),
+          } as unknown as Response;
+        });
+
+      contractEventRepository.delete.mockResolvedValue({
+        affected: 7,
+        raw: [],
+      } as unknown as DeleteResult);
+
+      checkpointRepository.upsert.mockResolvedValue({} as InsertResult);
+
+      const savedReorgEvent = { id: 'reorg-1' } as ReorgEvent;
+      reorgEventRepository.create.mockReturnValue(savedReorgEvent);
+      reorgEventRepository.save.mockResolvedValue(savedReorgEvent);
+
+      const result = await (service as any).detectAndHandleReorg(
+        'CTEST',
+        'https://rpc.example',
+      );
+
+      // Rolls back ContractEvent rows past the fork ledger (100 - 10 = 90).
+      expect(contractEventRepository.delete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ledger: expect.objectContaining({ _type: 'moreThan', _value: 90 }),
+        }),
+      );
+
+      // Mutates the same ChainSyncCheckpoint instance in place.
+      expect(chainSync.last_indexed_ledger).toBe(90);
+      expect(chainSync.last_indexed_ledger_hash).toBe('hash-90');
+      expect(chainSyncCheckpointRepository.save).toHaveBeenCalledWith(
+        chainSync,
+      );
+
+      // Rewinds the working (key/value) checkpoint to the same fork point so
+      // the next poll re-indexes from there.
+      expect(checkpointRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: CHECKPOINT_LEDGER_KEY,
+          value: 90,
+        }),
+        ['key'],
+      );
+
+      // Persists a ReorgEvent audit row capturing depth (100 - 90) and range.
+      expect(reorgEventRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contract_id: 'CTEST',
+          fork_ledger: 90,
+          previous_ledger: 100,
+          previous_hash: 'hash-100',
+          new_hash: 'hash-100-DIVERGED',
+          rolled_back_event_count: 7,
+        }),
+      );
+      expect(reorgEventRepository.save).toHaveBeenCalledWith(savedReorgEvent);
+      expect(result).toBe(savedReorgEvent);
+    });
+  });
+
+  describe('pollContractEvents reorg integration', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('rolls back an injected reorg and re-indexes from the fork point within the same poll', async () => {
+      configService.get.mockImplementation((key: string) => {
+        if (key === 'SOROBAN_RPC_URL') return 'https://rpc.example';
+        if (key === 'SOROBAN_CONTRACT_ID') return 'CCONTRACT';
+        if (key === 'INDEXER_REORG_ROLLBACK_DEPTH') return 10;
+        return undefined;
+      });
+
+      // The chain-sync checkpoint holds a hash for ledger 100 that no longer
+      // matches what the chain reports for that ledger - a reorg happened
+      // since the last successful poll.
+      const chainSync = {
+        contract_id: 'CCONTRACT',
+        last_indexed_ledger: 100,
+        last_indexed_ledger_hash: 'hash-100',
+      } as ChainSyncCheckpoint;
+      chainSyncCheckpointRepository.findOne.mockResolvedValue(chainSync);
+      chainSyncCheckpointRepository.save.mockImplementation(
+        async (cp) => cp as ChainSyncCheckpoint,
+      );
+
+      // Stateful working-cursor mock so the rewind (during reorg handling)
+      // is visible to the getLastProcessedLedger() read later in the same
+      // poll call.
+      let workingCursor = 100;
+      checkpointRepository.findOne.mockImplementation(
+        async ({ where }: any) => {
+          if (where?.key === CHECKPOINT_LEDGER_KEY) {
+            return {
+              key: CHECKPOINT_LEDGER_KEY,
+              value: workingCursor,
+            } as IndexerCheckpoint;
+          }
+          return null;
+        },
+      );
+      checkpointRepository.upsert.mockImplementation(async (entity: any) => {
+        if (entity.key === CHECKPOINT_LEDGER_KEY) {
+          workingCursor = entity.value;
+        }
+        return {} as InsertResult;
+      });
+
+      contractEventRepository.delete.mockResolvedValue({
+        affected: 3,
+        raw: [],
+      } as unknown as DeleteResult);
+
+      const savedReorgEvent = { id: 'reorg-1' } as ReorgEvent;
+      reorgEventRepository.create.mockReturnValue(savedReorgEvent);
+      reorgEventRepository.save.mockResolvedValue(savedReorgEvent);
+
+      jest
+        .spyOn(service as any, 'storeAndProcessEvent')
+        .mockResolvedValue(undefined);
+
+      jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(async (_url, init: any) => {
+          const body = JSON.parse(init.body as string);
+
+          if (body.method === 'getLedgers') {
+            const ledger = body.params.startLedger;
+            if (ledger === 100) {
+              return {
+                ok: true,
+                json: async () => ({
+                  result: { ledgers: [{ hash: 'hash-100-DIVERGED' }] },
+                }),
+              } as unknown as Response;
+            }
+            return {
+              ok: true,
+              json: async () => ({
+                result: { ledgers: [{ hash: `hash-${ledger}` }] },
+              }),
+            } as unknown as Response;
+          }
+
+          // getEvents: re-fetch must resume right after the fork point (91),
+          // not from the pre-reorg position (101).
+          expect(body.params.startLedger).toBe(91);
+          return {
+            ok: true,
+            json: async () => ({
+              result: {
+                events: [
+                  {
+                    id: 'evt-canonical',
+                    ledger: 95,
+                    log_index: 0,
+                    topic: [{ symbol: 'event' }, { symbol: 'created' }],
+                    value: { event_id: { u64: '99' } },
+                  },
+                ],
+                latestLedger: 95,
+              },
+            }),
+          } as unknown as Response;
+        });
+
+      await service.pollContractEvents();
+
+      // Reorg rolled back ContractEvent rows past the fork ledger
+      // (100 - rollback depth 10 = 90).
+      expect(contractEventRepository.delete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ledger: expect.objectContaining({ _type: 'moreThan', _value: 90 }),
+        }),
+      );
+      expect(reorgEventRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contract_id: 'CCONTRACT',
+          fork_ledger: 90,
+          previous_ledger: 100,
+          rolled_back_event_count: 3,
+        }),
+      );
+      expect(reorgEventRepository.save).toHaveBeenCalledWith(savedReorgEvent);
+
+      // Re-indexing resumed from the fork point and processed the canonical
+      // event the reorged chain now reports.
+      expect(
+        (service as any).storeAndProcessEvent,
+      ).toHaveBeenCalledWith(expect.objectContaining({ ledger: 95 }));
+
+      // The working checkpoint lands on the newly re-indexed ledger (95),
+      // never on the pre-reorg position it was rewound from.
+      expect(checkpointRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ key: CHECKPOINT_LEDGER_KEY, value: 95 }),
         ['key'],
       );
     });

--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { LessThan, Repository } from 'typeorm';
+import { LessThan, MoreThan, Repository } from 'typeorm';
 import {
   ContractEvent,
   ContractEventStatus,
@@ -10,6 +10,7 @@ import {
 import { FeeHistory } from './entities/fee-history.entity';
 import { IndexerCheckpoint } from './entities/indexer-checkpoint.entity';
 import { ChainSyncCheckpoint } from './entities/chain-sync-checkpoint.entity';
+import { ReorgEvent } from './entities/reorg-event.entity';
 import { IndexerMetricsDto } from './dto/indexer-metrics.dto';
 import { Match, WinningTeam } from '../matches/entities/match.entity';
 import { CreatorEvent } from '../matches/entities/creator-event.entity';
@@ -29,6 +30,11 @@ const CHECKPOINT_LEDGER_KEY_LATEST = 'indexer:latest_contract_ledger';
 const MAX_RETRIES = 5;
 const DLQ_THRESHOLD = 5;
 const BATCH_SIZE = 100;
+// How many ledgers to roll back past the last-known-good ledger when a reorg
+// is detected. Kept configurable via INDEXER_REORG_ROLLBACK_DEPTH (shared
+// with ReconciliationService's own reorg guard) since the "right" depth
+// depends on the target network's finality characteristics.
+const DEFAULT_REORG_ROLLBACK_DEPTH = 10;
 /**
  * Version of the event decoder's output shape. Bumped when a field is
  * renamed or removed (never for a purely additive change - new fields are
@@ -67,6 +73,9 @@ export class IndexerService implements OnModuleInit {
 
     @InjectRepository(ChainSyncCheckpoint)
     private readonly chainSyncCheckpointRepository: Repository<ChainSyncCheckpoint>,
+
+    @InjectRepository(ReorgEvent)
+    private readonly reorgEventRepository: Repository<ReorgEvent>,
 
     @InjectRepository(CreatorEvent)
     private readonly creatorEventRepository: Repository<CreatorEvent>,
@@ -172,6 +181,15 @@ export class IndexerService implements OnModuleInit {
     const batchStart = Date.now();
 
     try {
+      const rpcUrl = this.configService.get<string>('SOROBAN_RPC_URL');
+      if (rpcUrl) {
+        // Detect a chain reorg before fetching new events, so a poll that
+        // starts right after a fork immediately rewinds to the fork point
+        // and re-indexes from there instead of building on top of
+        // now-orphaned ledgers.
+        await this.detectAndHandleReorg(contractId, rpcUrl);
+      }
+
       const lastLedger = await this.getLastProcessedLedger();
       const fromLedger = Math.max(lastLedger + 1, 1);
 
@@ -191,6 +209,13 @@ export class IndexerService implements OnModuleInit {
           if (activeContractId) {
             await this.reconciliationService.advanceCheckpoint(
               activeContractId,
+              latestLedger,
+            );
+          }
+          if (rpcUrl) {
+            await this.persistIndexedLedgerHash(
+              contractId,
+              rpcUrl,
               latestLedger,
             );
           }
@@ -235,6 +260,9 @@ export class IndexerService implements OnModuleInit {
           activeContractId,
           finalLedger,
         );
+      }
+      if (rpcUrl) {
+        await this.persistIndexedLedgerHash(contractId, rpcUrl, finalLedger);
       }
 
       const elapsed = Date.now() - batchStart;
@@ -1375,6 +1403,161 @@ export class IndexerService implements OnModuleInit {
 
   async triggerManualSync(): Promise<void> {
     await this.pollContractEvents();
+  }
+
+  /**
+   * Compares the hash the chain currently reports for our last-indexed
+   * ledger against the hash we stored for that same ledger number. A
+   * mismatch means the ledger we built on has been orphaned by a reorg, so
+   * we roll back the affected ContractEvent rows and both checkpoint
+   * systems to a fork point a configurable number of ledgers behind the
+   * divergence, and record a ReorgEvent audit row capturing the depth
+   * (previous_ledger - fork_ledger) and affected range. The caller resumes
+   * polling from the rewound checkpoint immediately afterwards, so the
+   * fork-to-head range gets re-indexed from the canonical chain in the same
+   * cycle.
+   *
+   * Returns null (and makes no changes) when there is nothing to compare
+   * yet, the RPC hash lookup fails, or the stored hash still matches.
+   */
+  private async detectAndHandleReorg(
+    contractId: string,
+    rpcUrl: string,
+  ): Promise<ReorgEvent | null> {
+    const chainSync = await this.chainSyncCheckpointRepository.findOne({
+      where: { contract_id: contractId },
+    });
+    if (!chainSync) return null;
+
+    const previousLedger = Number(chainSync.last_indexed_ledger);
+    if (previousLedger <= 0 || !chainSync.last_indexed_ledger_hash) {
+      return null;
+    }
+
+    const currentHash = await this.fetchLedgerHash(rpcUrl, previousLedger);
+    if (currentHash === null) return null;
+    if (currentHash === chainSync.last_indexed_ledger_hash) return null;
+
+    const rollbackDepth =
+      this.configService.get<number>('INDEXER_REORG_ROLLBACK_DEPTH') ??
+      DEFAULT_REORG_ROLLBACK_DEPTH;
+    const forkLedger = Math.max(0, previousLedger - rollbackDepth);
+
+    const deleteResult = await this.contractEventRepository.delete({
+      ledger: MoreThan(forkLedger),
+    });
+    const rolledBackEventCount = deleteResult.affected ?? 0;
+
+    const previousHash = chainSync.last_indexed_ledger_hash;
+
+    chainSync.last_indexed_ledger = forkLedger;
+    chainSync.last_indexed_ledger_hash =
+      (await this.fetchLedgerHash(rpcUrl, forkLedger)) ?? null;
+    await this.chainSyncCheckpointRepository.save(chainSync);
+
+    // Rewind the working cursor too, so the caller's very next
+    // getLastProcessedLedger() call re-fetches from the fork point instead
+    // of continuing to build on the orphaned ledgers.
+    await this.saveCheckpoint(CHECKPOINT_LEDGER_KEY, forkLedger);
+
+    const reorgEvent = this.reorgEventRepository.create({
+      contract_id: contractId,
+      fork_ledger: forkLedger,
+      previous_ledger: previousLedger,
+      previous_hash: previousHash,
+      new_hash: currentHash,
+      rolled_back_event_count: rolledBackEventCount,
+    });
+    const saved = await this.reorgEventRepository.save(reorgEvent);
+
+    this.logger.error(
+      `Chain reorg detected for contract ${contractId}: rolled back ${rolledBackEventCount} event(s) from ledger ${previousLedger} to fork point ${forkLedger}`,
+    );
+
+    return saved;
+  }
+
+  /**
+   * Records the ledger hash for a ledger we just finished indexing, so the
+   * next poll's detectAndHandleReorg has a baseline to compare against.
+   * Creates the chain-sync checkpoint row on first use.
+   */
+  private async persistIndexedLedgerHash(
+    contractId: string,
+    rpcUrl: string,
+    ledger: number,
+  ): Promise<void> {
+    if (ledger <= 0) return;
+
+    const hash = await this.fetchLedgerHash(rpcUrl, ledger);
+    if (hash === null) return;
+
+    const chainSync = await this.getOrCreateChainSyncCheckpoint(contractId);
+    if (ledger >= Number(chainSync.last_indexed_ledger)) {
+      chainSync.last_indexed_ledger = ledger;
+    }
+    chainSync.last_indexed_ledger_hash = hash;
+    await this.chainSyncCheckpointRepository.save(chainSync);
+  }
+
+  private async getOrCreateChainSyncCheckpoint(
+    contractId: string,
+  ): Promise<ChainSyncCheckpoint> {
+    const existing = await this.chainSyncCheckpointRepository.findOne({
+      where: { contract_id: contractId },
+    });
+    if (existing) return existing;
+
+    const created = this.chainSyncCheckpointRepository.create({
+      contract_id: contractId,
+      last_indexed_ledger: 0,
+      last_indexed_ledger_hash: null,
+      chain_head_ledger: 0,
+      last_reconciled_from: 0,
+      last_reconciled_to: 0,
+      last_reconciled_at: null,
+      last_backfill_count: 0,
+    });
+    return this.chainSyncCheckpointRepository.save(created);
+  }
+
+  private async fetchLedgerHash(
+    rpcUrl: string,
+    ledger: number,
+  ): Promise<string | null> {
+    try {
+      const response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'insightarena-indexer-ledger-hash',
+          method: 'getLedgers',
+          params: {
+            startLedger: ledger,
+            limit: 1,
+          },
+        }),
+      });
+
+      if (!response.ok) return null;
+
+      const body = (await response.json()) as {
+        result?: { ledgers?: unknown[] };
+      };
+
+      const ledgers = body.result?.ledgers;
+      if (!Array.isArray(ledgers) || ledgers.length === 0) return null;
+
+      const first = ledgers[0];
+      if (!first || typeof first !== 'object') return null;
+
+      const hash = (first as Record<string, unknown>).hash;
+      return typeof hash === 'string' ? hash : null;
+    } catch {
+      this.logger.error(`Failed to fetch ledger hash for ledger ${ledger}`);
+      return null;
+    }
   }
 
   getEventsProcessedPerMinute(): number {


### PR DESCRIPTION
## Summary

The `reorg_events` table and its supporting `chain_sync_checkpoints.last_indexed_ledger_hash` column already existed (scaffolding migrations), but the primary indexer poll loop (`IndexerService.pollContractEvents`) never used them: it advanced its checkpoint purely by ledger number and never checked whether the ledger it last indexed was still part of the canonical chain. The only reorg-aware code path was the separate `ReconciliationService` cron, which runs independently on a slower cadence and is not on the hot indexing path.

This PR adds reorg detection, rollback, and re-indexing directly to `IndexerService`'s main poll loop:

- Before fetching new events on each poll, `detectAndHandleReorg` compares the chain's current ledger hash for our last-indexed ledger against the hash we persisted after the previous poll.
- On a mismatch, it deletes the `ContractEvent` rows past a fork point (`last_indexed_ledger - INDEXER_REORG_ROLLBACK_DEPTH`, default 10 ledgers), rewinds both checkpoint systems (`chain_sync_checkpoints` and the working `indexer_checkpoints` cursor) to that fork point, and records a `ReorgEvent` row capturing `fork_ledger`, `previous_ledger`, `previous_hash`, `new_hash`, and `rolled_back_event_count` (depth = `previous_ledger - fork_ledger`; affected range = `fork_ledger+1..previous_ledger`).
- Execution falls through into the normal fetch/process flow, which now resumes from the rewound checkpoint and re-indexes the fork-to-head range from the canonical chain within the same poll cycle.
- The ledger hash for whatever ledger was just indexed is persisted at the end of every poll (both the "no new events" branch and the normal branch), so the next cycle always has a baseline to compare against.

## Before / after

**Before:** `pollContractEvents` tracked only a ledger number. If a reorg occurred, the indexer kept building on orphaned events indefinitely from the main loop's perspective; only the independent `ReconciliationService` cron (a separate safety net, different cadence) could ever catch and correct it.

**After:** Every poll cycle verifies the last-indexed ledger's hash before doing new work. A detected reorg immediately rolls back the affected `ContractEvent` rows, rewinds both checkpoints to the fork point, records an auditable `ReorgEvent`, and re-indexes from the fork point onward in the same cycle.

## Testing

No `node_modules` in this environment, so tests were reviewed manually rather than executed. Added to `backend/src/indexer/indexer.service.spec.ts`:

- `detectAndHandleReorg` unit tests: no checkpoint yet, no stored hash yet (first run), RPC hash-lookup failure (skips silently), matching hash (no-op), and the full divergence path (rolls back events, rewinds both checkpoints, records the `ReorgEvent` with correct depth/range).
- A `pollContractEvents` integration test that injects a hash mismatch and asserts the poll rolls back the stale events, records the reorg, resumes fetching from the fork point (not the pre-reorg position), and lands the checkpoint on the newly re-indexed canonical ledger.

Closes #1635