### PR TITLE
[Backend] Auth Audit Event Logging

### DIFF
--- a/backend/src/auth/auth-audit-event-types.ts
+++ b/backend/src/auth/auth-audit-event-types.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical `event_type` values written to `auth_audit_events`.
+ *
+ * Keep these strings stable once shipped — dashboards/alerts built on top of
+ * the audit table filter on them directly.
+ */
+export const AuthAuditEventType = {
+  LOGIN_SUCCESS: 'login_success',
+  LOGIN_FAILURE: 'login_failure',
+  REFRESH_SUCCESS: 'refresh_success',
+  REFRESH_FAILURE: 'refresh_failure',
+  REFRESH_TOKEN_REUSE_DETECTED: 'refresh_token_reuse_detected',
+  REVOKE_SUCCESS: 'revoke_success',
+  REVOKE_FAILURE: 'revoke_failure',
+} as const;
+
+export type AuthAuditEventTypeValue =
+  (typeof AuthAuditEventType)[keyof typeof AuthAuditEventType];
+
+/** Outcome recorded on every auth audit event's `metadata.outcome`. */
+export type AuthAuditOutcome = 'success' | 'failure';

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,6 +1,7 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
 import { User } from '../users/entities/user.entity';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -16,6 +17,7 @@ const mockAuthService = () => ({
   verifyChallenge: jest.fn(),
   verifyStellarSignature: jest.fn(),
   rotateRefreshToken: jest.fn(),
+  revokeSession: jest.fn(),
 });
 
 const mockConfigService = () => ({
@@ -74,8 +76,29 @@ describe('AuthController', () => {
       expect(authService.verifyChallenge).toHaveBeenCalledWith(
         dto.stellar_address,
         dto.signed_challenge,
+        null,
       );
       expect(result).toEqual({ access_token: 'signed.jwt.token', user });
+    });
+
+    it('forwards the client IP from the request to the service', async () => {
+      const user = Object.assign(new User(), {
+        id: 'uuid-1',
+        stellar_address: dto.stellar_address,
+      });
+      authService.verifyChallenge.mockResolvedValue({
+        access_token: 'signed.jwt.token',
+        user,
+      });
+
+      const req = { ip: '198.51.100.20' } as unknown as Request;
+      await controller.verifyChallenge(dto, req);
+
+      expect(authService.verifyChallenge).toHaveBeenCalledWith(
+        dto.stellar_address,
+        dto.signed_challenge,
+        '198.51.100.20',
+      );
     });
 
     it('propagates UnauthorizedException from the service (invalid signature)', async () => {
@@ -160,6 +183,22 @@ describe('AuthController', () => {
       expect(result.expires_at).toBeDefined();
       expect(authService.rotateRefreshToken).toHaveBeenCalledWith(
         'raw-refresh-token',
+        null,
+      );
+    });
+
+    it('forwards the client IP from the request to the service', async () => {
+      authService.rotateRefreshToken.mockResolvedValue({
+        access_token: 'new.jwt.token',
+        refresh_token: 'new-refresh-token',
+      });
+
+      const req = { ip: '198.51.100.21' } as unknown as Request;
+      await controller.refreshToken(dto, req);
+
+      expect(authService.rotateRefreshToken).toHaveBeenCalledWith(
+        'raw-refresh-token',
+        '198.51.100.21',
       );
     });
 
@@ -223,6 +262,47 @@ describe('AuthController', () => {
       configService.get.mockReturnValue('3600s');
       const result3600s = await controller.refreshToken(dto);
       expect(result3600s.expires_at).toBeDefined();
+    });
+  });
+
+  describe('revoke', () => {
+    const user = Object.assign(new User(), { id: 'user-1' });
+    const dto = { refresh_token: 'raw-refresh-token' };
+
+    it('revokes the session for the current user and returns { revoked: true }', async () => {
+      authService.revokeSession.mockResolvedValue({ revoked: true });
+
+      const result = await controller.revoke(user, dto);
+
+      expect(result).toEqual({ revoked: true });
+      expect(authService.revokeSession).toHaveBeenCalledWith(
+        'user-1',
+        'raw-refresh-token',
+        null,
+      );
+    });
+
+    it('forwards the client IP from the request to the service', async () => {
+      authService.revokeSession.mockResolvedValue({ revoked: true });
+
+      const req = { ip: '198.51.100.22' } as unknown as Request;
+      await controller.revoke(user, dto, req);
+
+      expect(authService.revokeSession).toHaveBeenCalledWith(
+        'user-1',
+        'raw-refresh-token',
+        '198.51.100.22',
+      );
+    });
+
+    it('propagates UnauthorizedException from the service when the token is not found', async () => {
+      authService.revokeSession.mockRejectedValue(
+        new UnauthorizedException('Refresh token not found'),
+      );
+
+      await expect(controller.revoke(user, dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 });

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -5,7 +5,9 @@ import {
   HttpCode,
   HttpStatus,
   Post,
+  Req,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { AuthService } from './auth.service';
 import { RateLimitService } from './rate-limit.service';
 import { GenerateChallengeDto } from './dto/generate-challenge.dto';
@@ -16,6 +18,10 @@ import {
   RefreshTokenResponseDto,
   RotateRefreshTokenDto,
 } from './dto/refresh-token.dto';
+import {
+  RevokeSessionDto,
+  RevokeSessionResponseDto,
+} from './dto/revoke-session.dto';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -38,6 +44,19 @@ export class AuthController {
     private readonly configService: ConfigService,
   ) {}
 
+  /**
+   * Best-effort client IP extraction, matching the convention already used
+   * by TieredThrottlerGuard: prefer Express's parsed `req.ip` (respects
+   * `trust proxy`), fall back to the raw socket address.
+   */
+  private getClientIp(req?: Request): string | null {
+    return (
+      req?.ip ??
+      (req?.socket as { remoteAddress?: string })?.remoteAddress ??
+      null
+    );
+  }
+
   @Post('challenge')
   @HttpCode(HttpStatus.OK)
   generateChallenge(@Body() generateChallengeDto: GenerateChallengeDto) {
@@ -49,10 +68,14 @@ export class AuthController {
 
   @Post('verify')
   @HttpCode(HttpStatus.OK)
-  async verifyChallenge(@Body() verifyChallengeDto: VerifyChallengeDto) {
+  async verifyChallenge(
+    @Body() verifyChallengeDto: VerifyChallengeDto,
+    @Req() req?: Request,
+  ) {
     return this.authService.verifyChallenge(
       verifyChallengeDto.stellar_address,
       verifyChallengeDto.signed_challenge,
+      this.getClientIp(req),
     );
   }
 
@@ -105,9 +128,13 @@ export class AuthController {
   })
   async refreshToken(
     @Body() dto: RotateRefreshTokenDto,
+    @Req() req?: Request,
   ): Promise<RefreshTokenResponseDto> {
     const { access_token, refresh_token } =
-      await this.authService.rotateRefreshToken(dto.refresh_token);
+      await this.authService.rotateRefreshToken(
+        dto.refresh_token,
+        this.getClientIp(req),
+      );
 
     // Calculate expiry timestamp
     const expiresIn = this.configService.get<string>('JWT_EXPIRES_IN') || '7d';
@@ -115,6 +142,35 @@ export class AuthController {
     const expires_at = new Date(Date.now() + expiresMs).toISOString();
 
     return { access_token, refresh_token, expires_at };
+  }
+
+  @Post('revoke')
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Revoke a session (logout)',
+    description:
+      'Revokes the refresh token family for the presented refresh token, ending that session. The presented token — and any token already rotated from it — can no longer be used to obtain new access tokens. Requires authentication; a caller may only revoke their own sessions.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Session revoked',
+    type: RevokeSessionResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - not authenticated, or refresh token not found',
+  })
+  async revoke(
+    @CurrentUser() user: User,
+    @Body() dto: RevokeSessionDto,
+    @Req() req?: Request,
+  ): Promise<RevokeSessionResponseDto> {
+    return this.authService.revokeSession(
+      user.id,
+      dto.refresh_token,
+      this.getClientIp(req),
+    );
   }
 
   /**

--- a/backend/src/auth/auth.e2e.spec.ts
+++ b/backend/src/auth/auth.e2e.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ExecutionContext,
   INestApplication,
   UnauthorizedException,
   ValidationPipe,
@@ -24,8 +25,16 @@ import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 const sign = (kp: Keypair, text: string): string =>
   kp.sign(Buffer.from(text, 'utf-8')).toString('hex');
 
+// The real JwtAuthGuard is overridden for these tests; requests never carry
+// a real bearer token. Protected endpoints (e.g. /auth/revoke) still need a
+// `req.user` to resolve `@CurrentUser()`, so this stub attaches one matching
+// the default mocked user id used throughout this file ('e2e-uuid').
 const mockJwtAuthGuard = {
-  canActivate: jest.fn(() => true),
+  canActivate: jest.fn((context: ExecutionContext) => {
+    const req = context.switchToHttp().getRequest();
+    req.user = { id: 'e2e-uuid' };
+    return true;
+  }),
 };
 
 const mockJwtService = {
@@ -298,6 +307,15 @@ describe('Auth E2E — challenge → verify flow', () => {
     expect(mockUserPreferencesRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'e2e-uuid' }),
     );
+
+    // A login_success audit event is written for the successful login.
+    expect(mockAuthAuditEventRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'login_success',
+        user_id: 'e2e-uuid',
+        metadata: expect.objectContaining({ outcome: 'success' }),
+      }),
+    );
   });
 
   it('invalid signature → 401', async () => {
@@ -314,6 +332,15 @@ describe('Auth E2E — challenge → verify flow', () => {
       .expect(401);
 
     expect(mockUsersRepository.save).not.toHaveBeenCalled();
+
+    // A login_failure audit event is written, with no user_id resolved.
+    expect(mockAuthAuditEventRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'login_failure',
+        user_id: null,
+        metadata: expect.objectContaining({ outcome: 'failure' }),
+      }),
+    );
   });
 
   it('missing nonce → 401', async () => {
@@ -474,6 +501,15 @@ describe('Auth E2E — challenge → verify flow', () => {
       expect(body.refresh_token).not.toBe(refreshToken);
       expect(body.expires_at).toBeDefined();
 
+      // A refresh_success audit event is recorded for the rotation.
+      expect(mockAuthAuditEventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'refresh_success',
+          user_id: 'refresh-e2e-uuid',
+          metadata: expect.objectContaining({ outcome: 'success' }),
+        }),
+      );
+
       // The rotated-away token can no longer be used.
       await server
         .post('/auth/refresh')
@@ -521,6 +557,77 @@ describe('Auth E2E — challenge → verify flow', () => {
 
     it('missing refresh_token field → 400', async () => {
       await server.post('/auth/refresh').send({}).expect(400);
+    });
+  });
+
+  describe('revoke session (logout)', () => {
+    /**
+     * mockJwtAuthGuard always attaches `req.user = { id: 'e2e-uuid' }`
+     * (see the guard stub above), so a plain login through the default
+     * mocked user repos — which mints user id 'e2e-uuid' — lines up with
+     * the caller identity `/auth/revoke` will see via `@CurrentUser()`.
+     */
+    const loginAndGetRefreshToken = async (): Promise<string> => {
+      const kp = Keypair.random();
+      const address = kp.publicKey();
+
+      const challengeRes = await server
+        .post('/auth/challenge')
+        .send({ stellar_address: address })
+        .expect(200);
+      const challenge = (challengeRes.body as ChallengeResponse).challenge;
+      const sig = sign(kp, challenge);
+
+      const verifyRes = await server
+        .post('/auth/verify')
+        .send({ stellar_address: address, signed_challenge: sig })
+        .expect(200);
+
+      return (verifyRes.body as VerifyResponse).refresh_token;
+    };
+
+    it('revokes the session and records a revoke_success audit event', async () => {
+      const refreshToken = await loginAndGetRefreshToken();
+
+      const res = await server
+        .post('/auth/revoke')
+        .send({ refresh_token: refreshToken })
+        .expect(200);
+
+      expect(res.body).toEqual({ revoked: true });
+
+      expect(mockAuthAuditEventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'revoke_success',
+          user_id: 'e2e-uuid',
+          metadata: expect.objectContaining({ outcome: 'success' }),
+        }),
+      );
+
+      // The revoked refresh token can no longer be used to refresh.
+      await server
+        .post('/auth/refresh')
+        .send({ refresh_token: refreshToken })
+        .expect(401);
+    });
+
+    it('unknown refresh token → 401 with a revoke_failure audit event', async () => {
+      await server
+        .post('/auth/revoke')
+        .send({ refresh_token: 'not-a-real-token' })
+        .expect(401);
+
+      expect(mockAuthAuditEventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'revoke_failure',
+          user_id: 'e2e-uuid',
+          metadata: expect.objectContaining({ outcome: 'failure' }),
+        }),
+      );
+    });
+
+    it('missing refresh_token field → 400', async () => {
+      await server.post('/auth/revoke').send({}).expect(400);
     });
   });
 });

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -185,7 +185,11 @@ describe('AuthService', () => {
       userId: savedUser.id,
     } as UserPreferences);
 
-    const result = await service.verifyChallenge(address, 'signed-hex');
+    const result = await service.verifyChallenge(
+      address,
+      'signed-hex',
+      '203.0.113.5',
+    );
 
     expect(result.access_token).toBe('token.jwt.value');
     expect(result.user).toEqual(savedUser);
@@ -201,6 +205,56 @@ describe('AuthService', () => {
       expect.objectContaining({
         user_id: 'u-2',
         previous_token_id: null,
+      }),
+    );
+
+    // A login_success audit event is recorded with actor, ip and outcome.
+    expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'login_success',
+        user_id: 'u-2',
+        family_id: expect.any(String),
+        metadata: expect.objectContaining({
+          outcome: 'success',
+          ip: '203.0.113.5',
+        }),
+      }),
+    );
+  });
+
+  it('verifyChallenge() records a login_failure audit event (no user_id) on invalid signature', async () => {
+    service.generateChallenge(address);
+    jest.spyOn(service, 'verifyStellarSignature').mockReturnValue(false);
+
+    await expect(
+      service.verifyChallenge(address, 'bad-sig', '198.51.100.9'),
+    ).rejects.toThrow(UnauthorizedException);
+
+    expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'login_failure',
+        user_id: null,
+        metadata: expect.objectContaining({
+          outcome: 'failure',
+          ip: '198.51.100.9',
+        }),
+      }),
+    );
+
+    // No session should have been started.
+    expect(refreshTokensRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('verifyChallenge() records a login_failure audit event when no challenge exists', async () => {
+    await expect(
+      service.verifyChallenge('unknown-address', 'sig'),
+    ).rejects.toThrow(UnauthorizedException);
+
+    expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: 'login_failure',
+        user_id: null,
+        metadata: expect.objectContaining({ outcome: 'failure' }),
       }),
     );
   });
@@ -365,13 +419,13 @@ describe('AuthService', () => {
         ...overrides,
       }) as RefreshToken;
 
-    it('issues a new access + refresh token and revokes the old one on valid rotation', async () => {
+    it('issues a new access + refresh token, revokes the old one, and records a refresh_success audit event', async () => {
       const stored = buildStoredToken();
       refreshTokensRepository.findOneBy.mockResolvedValue(stored);
       usersRepository.findOneBy.mockResolvedValue(existingUser);
       jwtService.signAsync.mockResolvedValue('new.jwt.token');
 
-      const result = await service.rotateRefreshToken(rawToken);
+      const result = await service.rotateRefreshToken(rawToken, '203.0.113.7');
 
       expect(result.access_token).toBe('new.jwt.token');
       expect(typeof result.refresh_token).toBe('string');
@@ -396,22 +450,45 @@ describe('AuthService', () => {
         stellar_address: existingUser.stellar_address,
       });
 
-      // No reuse => no audit event.
-      expect(authAuditEventsRepository.save).not.toHaveBeenCalled();
+      // A refresh_success audit event is recorded with actor, ip and outcome.
+      expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'refresh_success',
+          user_id: existingUser.id,
+          family_id: 'family-1',
+          metadata: expect.objectContaining({
+            outcome: 'success',
+            ip: '203.0.113.7',
+            tokenId: 'rt-1',
+          }),
+        }),
+      );
     });
 
-    it('throws UnauthorizedException when the token does not exist', async () => {
+    it('throws UnauthorizedException and records a refresh_failure audit event when the token does not exist', async () => {
       refreshTokensRepository.findOneBy.mockResolvedValue(null);
 
-      await expect(service.rotateRefreshToken('unknown')).rejects.toThrow(
-        UnauthorizedException,
-      );
+      await expect(
+        service.rotateRefreshToken('unknown', '203.0.113.8'),
+      ).rejects.toThrow(UnauthorizedException);
       await expect(service.rotateRefreshToken('unknown')).rejects.toThrow(
         'Invalid refresh token',
       );
+
+      expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'refresh_failure',
+          user_id: null,
+          metadata: expect.objectContaining({
+            outcome: 'failure',
+            ip: '203.0.113.8',
+            reason: 'invalid_refresh_token',
+          }),
+        }),
+      );
     });
 
-    it('throws UnauthorizedException when the token has expired', async () => {
+    it('throws UnauthorizedException and records a refresh_failure audit event when the token has expired', async () => {
       const stored = buildStoredToken({
         expires_at: new Date(Date.now() - 1000),
       });
@@ -423,9 +500,21 @@ describe('AuthService', () => {
       await expect(service.rotateRefreshToken(rawToken)).rejects.toThrow(
         'Refresh token expired',
       );
+
+      expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'refresh_failure',
+          user_id: existingUser.id,
+          family_id: 'family-1',
+          metadata: expect.objectContaining({
+            outcome: 'failure',
+            reason: 'refresh_token_expired',
+          }),
+        }),
+      );
     });
 
-    it('throws UnauthorizedException when the user no longer exists', async () => {
+    it('throws UnauthorizedException and records a refresh_failure audit event when the user no longer exists', async () => {
       const stored = buildStoredToken();
       refreshTokensRepository.findOneBy.mockResolvedValue(stored);
       usersRepository.findOneBy.mockResolvedValue(null);
@@ -433,15 +522,27 @@ describe('AuthService', () => {
       await expect(service.rotateRefreshToken(rawToken)).rejects.toThrow(
         'User not found or has been deleted',
       );
+
+      expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'refresh_failure',
+          user_id: existingUser.id,
+          family_id: 'family-1',
+          metadata: expect.objectContaining({
+            outcome: 'failure',
+            reason: 'user_not_found',
+          }),
+        }),
+      );
     });
 
     it('detects reuse of an already-rotated token, revokes the whole family, and records an audit event', async () => {
       const stored = buildStoredToken({ revoked_at: new Date() });
       refreshTokensRepository.findOneBy.mockResolvedValue(stored);
 
-      await expect(service.rotateRefreshToken(rawToken)).rejects.toThrow(
-        UnauthorizedException,
-      );
+      await expect(
+        service.rotateRefreshToken(rawToken, '203.0.113.9'),
+      ).rejects.toThrow(UnauthorizedException);
       await expect(service.rotateRefreshToken(rawToken)).rejects.toThrow(
         'Refresh token reuse detected; session revoked',
       );
@@ -456,12 +557,108 @@ describe('AuthService', () => {
           event_type: 'refresh_token_reuse_detected',
           user_id: existingUser.id,
           family_id: 'family-1',
-          metadata: { tokenId: 'rt-1' },
+          metadata: expect.objectContaining({
+            outcome: 'failure',
+            ip: '203.0.113.9',
+            tokenId: 'rt-1',
+          }),
         }),
       );
 
       // Reuse must never mint new tokens or an access token.
       expect(jwtService.signAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revokeSession', () => {
+    const userId = 'user-revoke-1';
+    const rawToken = 'raw-refresh-token-to-revoke';
+
+    const buildStoredToken = (
+      overrides: Partial<RefreshToken> = {},
+    ): RefreshToken =>
+      ({
+        id: 'rt-revoke-1',
+        user_id: userId,
+        family_id: 'family-revoke-1',
+        token_hash: service['hashToken'](rawToken),
+        previous_token_id: null,
+        revoked_at: null,
+        expires_at: new Date(Date.now() + 60_000),
+        created_at: new Date(),
+        ...overrides,
+      }) as RefreshToken;
+
+    it('revokes the token family and records a revoke_success audit event', async () => {
+      const stored = buildStoredToken();
+      refreshTokensRepository.findOneBy.mockResolvedValue(stored);
+
+      const result = await service.revokeSession(
+        userId,
+        rawToken,
+        '203.0.113.10',
+      );
+
+      expect(result).toEqual({ revoked: true });
+
+      expect(refreshTokensRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ family_id: 'family-revoke-1' }),
+        expect.objectContaining({ revoked_at: expect.any(Date) }),
+      );
+
+      expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'revoke_success',
+          user_id: userId,
+          family_id: 'family-revoke-1',
+          metadata: expect.objectContaining({
+            outcome: 'success',
+            ip: '203.0.113.10',
+            tokenId: 'rt-revoke-1',
+          }),
+        }),
+      );
+    });
+
+    it('throws UnauthorizedException and records a revoke_failure audit event when the token is unknown', async () => {
+      refreshTokensRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(
+        service.revokeSession(userId, 'unknown-token', '203.0.113.11'),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(refreshTokensRepository.update).not.toHaveBeenCalled();
+
+      expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'revoke_failure',
+          user_id: userId,
+          metadata: expect.objectContaining({
+            outcome: 'failure',
+            ip: '203.0.113.11',
+            reason: 'refresh_token_not_found',
+          }),
+        }),
+      );
+    });
+
+    it('throws UnauthorizedException and records a revoke_failure audit event when the token belongs to another user', async () => {
+      const stored = buildStoredToken({ user_id: 'someone-else' });
+      refreshTokensRepository.findOneBy.mockResolvedValue(stored);
+
+      await expect(
+        service.revokeSession(userId, rawToken),
+      ).rejects.toThrow('Refresh token not found');
+
+      expect(refreshTokensRepository.update).not.toHaveBeenCalled();
+
+      expect(authAuditEventsRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_type: 'revoke_failure',
+          user_id: userId,
+          metadata: expect.objectContaining({ outcome: 'failure' }),
+        }),
+      );
     });
   });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -15,6 +15,10 @@ import { User } from '../users/entities/user.entity';
 import { UserPreferences } from '../users/entities/user-preferences.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { AuthAuditEvent } from './entities/auth-audit-event.entity';
+import {
+  AuthAuditEventType,
+  AuthAuditOutcome,
+} from './auth-audit-event-types';
 
 const DEFAULT_REFRESH_TOKEN_TTL_DAYS = 30;
 
@@ -42,6 +46,42 @@ export class AuthService implements OnModuleInit {
 
   onModuleInit() {
     this.logger.log('AuthService initialized - periodic cleanup enabled');
+  }
+
+  /**
+   * Writes one row to `auth_audit_events`. Used for every security-relevant
+   * auth action (login, refresh, revoke) — both successes and failures.
+   *
+   * `metadata` always carries `outcome` and `ip` so the audit trail is
+   * queryable without parsing `event_type` strings. A failure to write the
+   * audit row is logged but never allowed to break the underlying auth
+   * flow (e.g. throwing the real UnauthorizedException instead of a 500).
+   */
+  private async recordAuditEvent(params: {
+    eventType: string;
+    userId: string | null;
+    familyId?: string | null;
+    outcome: AuthAuditOutcome;
+    ip?: string | null;
+    metadata?: Record<string, unknown>;
+  }): Promise<void> {
+    try {
+      const auditEvent = this.authAuditEventsRepository.create({
+        event_type: params.eventType,
+        user_id: params.userId,
+        family_id: params.familyId ?? null,
+        metadata: {
+          outcome: params.outcome,
+          ip: params.ip ?? null,
+          ...params.metadata,
+        },
+      });
+      await this.authAuditEventsRepository.save(auditEvent);
+    } catch (error) {
+      this.logger.error(
+        `Failed to record auth audit event '${params.eventType}': ${error}`,
+      );
+    }
   }
 
   /**
@@ -102,8 +142,24 @@ export class AuthService implements OnModuleInit {
   async verifyChallenge(
     stellar_address: string,
     signed_challenge: string,
+    ip?: string | null,
   ): Promise<{ access_token: string; refresh_token: string; user: User }> {
-    const user = await this.verifySignature(stellar_address, signed_challenge);
+    let user: User;
+    try {
+      user = await this.verifySignature(stellar_address, signed_challenge);
+    } catch (error) {
+      await this.recordAuditEvent({
+        eventType: AuthAuditEventType.LOGIN_FAILURE,
+        userId: null,
+        outcome: 'failure',
+        ip,
+        metadata: {
+          stellar_address,
+          reason: error instanceof Error ? error.message : 'unknown_error',
+        },
+      });
+      throw error;
+    }
 
     // Sign JWT with sub: user.id
     const payload = { sub: user.id, stellar_address: user.stellar_address };
@@ -115,6 +171,15 @@ export class AuthService implements OnModuleInit {
       user.id,
       familyId,
     );
+
+    await this.recordAuditEvent({
+      eventType: AuthAuditEventType.LOGIN_SUCCESS,
+      userId: user.id,
+      familyId,
+      outcome: 'success',
+      ip,
+      metadata: { stellar_address: user.stellar_address },
+    });
 
     return { access_token, refresh_token, user };
   }
@@ -160,6 +225,7 @@ export class AuthService implements OnModuleInit {
    */
   async rotateRefreshToken(
     rawToken: string,
+    ip?: string | null,
   ): Promise<{ access_token: string; refresh_token: string }> {
     const tokenHash = this.hashToken(rawToken);
     const existing = await this.refreshTokensRepository.findOneBy({
@@ -167,12 +233,27 @@ export class AuthService implements OnModuleInit {
     });
 
     if (!existing) {
+      await this.recordAuditEvent({
+        eventType: AuthAuditEventType.REFRESH_FAILURE,
+        userId: null,
+        outcome: 'failure',
+        ip,
+        metadata: { reason: 'invalid_refresh_token' },
+      });
       throw new UnauthorizedException('Invalid refresh token');
     }
 
     const now = new Date();
 
     if (existing.expires_at < now) {
+      await this.recordAuditEvent({
+        eventType: AuthAuditEventType.REFRESH_FAILURE,
+        userId: existing.user_id,
+        familyId: existing.family_id,
+        outcome: 'failure',
+        ip,
+        metadata: { reason: 'refresh_token_expired', tokenId: existing.id },
+      });
       throw new UnauthorizedException('Refresh token expired');
     }
 
@@ -184,13 +265,14 @@ export class AuthService implements OnModuleInit {
         { revoked_at: now },
       );
 
-      const auditEvent = this.authAuditEventsRepository.create({
-        event_type: 'refresh_token_reuse_detected',
-        user_id: existing.user_id,
-        family_id: existing.family_id,
-        metadata: { tokenId: existing.id },
+      await this.recordAuditEvent({
+        eventType: AuthAuditEventType.REFRESH_TOKEN_REUSE_DETECTED,
+        userId: existing.user_id,
+        familyId: existing.family_id,
+        outcome: 'failure',
+        ip,
+        metadata: { tokenId: existing.id, reason: 'refresh_token_reuse' },
       });
-      await this.authAuditEventsRepository.save(auditEvent);
 
       this.logger.error(
         `Refresh token reuse detected for family ${existing.family_id}, user ${existing.user_id} — session revoked`,
@@ -205,6 +287,14 @@ export class AuthService implements OnModuleInit {
       id: existing.user_id,
     });
     if (!user) {
+      await this.recordAuditEvent({
+        eventType: AuthAuditEventType.REFRESH_FAILURE,
+        userId: existing.user_id,
+        familyId: existing.family_id,
+        outcome: 'failure',
+        ip,
+        metadata: { reason: 'user_not_found', tokenId: existing.id },
+      });
       throw new UnauthorizedException('User not found or has been deleted');
     }
 
@@ -224,7 +314,65 @@ export class AuthService implements OnModuleInit {
 
     this.logger.debug(`Refresh token rotated for user ${user.id}`);
 
+    await this.recordAuditEvent({
+      eventType: AuthAuditEventType.REFRESH_SUCCESS,
+      userId: user.id,
+      familyId: existing.family_id,
+      outcome: 'success',
+      ip,
+      metadata: { tokenId: existing.id },
+    });
+
     return { access_token, refresh_token };
+  }
+
+  /**
+   * Revokes the session (refresh token family) identified by `rawToken`,
+   * scoped to `userId` — a user may only revoke their own sessions. This is
+   * the "logout" action: it invalidates every non-revoked refresh token in
+   * the family so the presented token (and any token already rotated from
+   * it) can no longer mint new access tokens.
+   */
+  async revokeSession(
+    userId: string,
+    rawToken: string,
+    ip?: string | null,
+  ): Promise<{ revoked: boolean }> {
+    const tokenHash = this.hashToken(rawToken);
+    const existing = await this.refreshTokensRepository.findOneBy({
+      token_hash: tokenHash,
+    });
+
+    if (!existing || existing.user_id !== userId) {
+      await this.recordAuditEvent({
+        eventType: AuthAuditEventType.REVOKE_FAILURE,
+        userId,
+        outcome: 'failure',
+        ip,
+        metadata: { reason: 'refresh_token_not_found' },
+      });
+      throw new UnauthorizedException('Refresh token not found');
+    }
+
+    await this.refreshTokensRepository.update(
+      { family_id: existing.family_id, revoked_at: IsNull() },
+      { revoked_at: new Date() },
+    );
+
+    this.logger.debug(
+      `Session revoked for user ${userId}, family ${existing.family_id}`,
+    );
+
+    await this.recordAuditEvent({
+      eventType: AuthAuditEventType.REVOKE_SUCCESS,
+      userId,
+      familyId: existing.family_id,
+      outcome: 'success',
+      ip,
+      metadata: { tokenId: existing.id },
+    });
+
+    return { revoked: true };
   }
 
   async verifySignature(

--- a/backend/src/auth/dto/revoke-session.dto.ts
+++ b/backend/src/auth/dto/revoke-session.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RevokeSessionDto {
+  @ApiProperty({
+    description:
+      'The raw refresh token identifying the session (token family) to revoke',
+    example: 'a1b2c3d4e5f6...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  refresh_token: string;
+}
+
+export class RevokeSessionResponseDto {
+  @ApiProperty({
+    description: 'Whether the session was revoked',
+    example: true,
+  })
+  revoked: boolean;
+}

--- a/backend/src/auth/entities/auth-audit-event.entity.ts
+++ b/backend/src/auth/entities/auth-audit-event.entity.ts
@@ -10,8 +10,10 @@ import {
 import { User } from '../../users/entities/user.entity';
 
 /**
- * Security-relevant auth events, currently only emitted when a rotated
- * (already-used) refresh token is replayed — a strong signal of token theft.
+ * Security-relevant auth events: login, refresh token rotation, session
+ * revocation (logout), and refresh token reuse detection — both successes
+ * and failures. `metadata` always carries `outcome` ('success' | 'failure')
+ * and `ip` so the audit trail is queryable without parsing `event_type`.
  */
 @Entity('auth_audit_events')
 export class AuthAuditEvent {
@@ -31,7 +33,7 @@ export class AuthAuditEvent {
   @Column({ name: 'family_id', type: 'uuid', nullable: true })
   family_id: string | null;
 
-  /** e.g. 'refresh_token_reuse_detected' */
+  /** One of the `AuthAuditEventType` values, e.g. 'login_success'. */
   @Column({ name: 'event_type', type: 'varchar', length: 64 })
   event_type: string;
 


### PR DESCRIPTION
## Summary

Auth security-relevant actions weren't consistently written to `auth_audit_events` — only refresh-token reuse detection emitted a row, and no event carried a structured outcome/ip. This PR makes every auth-critical action emit an audit event, success or failure:

- **Login** (`POST /auth/verify`) — `login_success` / `login_failure`
- **Refresh token rotation** (`POST /auth/refresh`) — `refresh_success` / `refresh_failure` (invalid token, expired token, user deleted) / `refresh_token_reuse_detected` (stolen/replayed token)
- **Session revoke / logout** (new `POST /auth/revoke`) — `revoke_success` / `revoke_failure`

Every event carries:
- **actor** — `user_id` (nullable pre-authentication, e.g. an invalid login attempt against an address with no matching user)
- **ip** — best-effort client IP (`req.ip`, falling back to the raw socket address)
- **outcome** — `'success' | 'failure'` inside `metadata`, so the audit trail is queryable without parsing `event_type` strings

Audit writes are best-effort: a failure to persist the row is logged (`this.logger.error`) but never surfaces as a 500 in place of the real auth error (e.g. an invalid-signature attempt still gets its `401`).

A new `POST /auth/revoke` endpoint was added since "revoke" was named explicitly in the issue as an auth-critical action to audit, but no such user-facing action existed yet — it lets an authenticated caller log out by revoking their own refresh-token family (scoped so a user can't revoke someone else's session).

## Before / after

**Before:** only `refresh_token_reuse_detected` was ever written to `auth_audit_events`. Login attempts (success or failure) and ordinary refresh rotations left no trail, and there was no logout/revoke action at all.

**After:** every login, refresh, and revoke attempt — success or failure — writes one row with actor, ip, and outcome. New centralized event-type constants live in `backend/src/auth/auth-audit-event-types.ts` so dashboards/alerts can filter on stable strings.

## Changes

- `backend/src/auth/auth.service.ts` — added a shared `recordAuditEvent()` helper; wired it into `verifyChallenge`, `rotateRefreshToken`, and a new `revokeSession()` method; threads an optional `ip` parameter through each.
- `backend/src/auth/auth.controller.ts` — added `getClientIp()` (mirrors the IP-extraction convention already used by `TieredThrottlerGuard`), forwards it into the service calls, and adds the authenticated `POST /auth/revoke` endpoint.
- `backend/src/auth/auth-audit-event-types.ts` (new) — canonical `event_type` string constants and the `AuthAuditOutcome` type.
- `backend/src/auth/dto/revoke-session.dto.ts` (new) — `RevokeSessionDto` / `RevokeSessionResponseDto`, following the existing refresh-token DTO conventions.
- `backend/src/auth/entities/auth-audit-event.entity.ts` — updated stale doc comments (the entity previously documented itself as reuse-detection-only).
- No migration changes needed — the existing `auth_audit_events` table (`user_id`, `family_id`, `event_type`, `metadata` jsonb, `created_at`) already supports this; `outcome` and `ip` are recorded inside `metadata`.

## Testing notes

- `backend/src/auth/auth.service.spec.ts` — new/updated cases assert a specific audit row (`event_type`, `user_id`, `family_id`, `metadata.outcome`, `metadata.ip`) is written for: successful login, failed login (bad signature, no/expired challenge), successful refresh, each refresh failure branch (unknown/expired token, deleted user), refresh-token reuse, successful revoke, and each revoke failure branch (unknown token, token owned by another user).
- `backend/src/auth/auth.controller.spec.ts` — asserts the controller forwards the extracted client IP (or `null` when unavailable) into each service call, and covers the new `revoke` handler.
- `backend/src/auth/auth.e2e.spec.ts` — full HTTP-level coverage of the challenge → verify → refresh → revoke flow, including asserting the audit repository is called with the right event for happy-path and failure cases end-to-end.
- Could not run the test suite in this environment (`node_modules` isn't installed and installing dependencies was out of scope for this change) — changes were reviewed manually against the existing patterns and mocks in each spec file instead.

Closes #1638