### PR TITLE
[Backend] Analytics Endpoint Query Caching

### DIFF
--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -129,7 +129,10 @@ describe('AdminService (Verified Addresses)', () => {
         },
         {
           provide: require('../analytics/analytics.service').AnalyticsService,
-          useValue: { logActivity: jest.fn() },
+          useValue: {
+            logActivity: jest.fn(),
+            invalidateMarketResolutionCaches: jest.fn(),
+          },
         },
         {
           provide: require('../notifications/notifications.service')

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -596,6 +596,15 @@ export class AdminService {
       },
     );
 
+    // Resolution changes this market's analytics, category/platform
+    // aggregates, and every participant's dashboard KPIs (streak/tier) —
+    // invalidate now instead of waiting out their TTL.
+    await this.analyticsService.invalidateMarketResolutionCaches(
+      market.id,
+      market.on_chain_market_id,
+      predictions.map((p) => p.user.id),
+    );
+
     this.logger.log(
       `Admin ${adminId} resolved market "${market.title}" (${market.id}) with outcome "${dto.resolved_outcome}"`,
     );

--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -452,4 +452,295 @@ describe('AnalyticsService', () => {
       expect(marketsRepository.find).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('getMarketAnalytics caching', () => {
+    function makeMarket(id: string): Market {
+      return {
+        id,
+        on_chain_market_id: `chain-${id}`,
+        title: `Market ${id}`,
+        outcome_options: ['YES', 'NO'],
+        total_pool_stroops: '1000',
+        participant_count: 2,
+        end_time: new Date(Date.now() + 60_000),
+      } as Market;
+    }
+
+    it('serves a second identical request from cache without re-querying', async () => {
+      const predictionsRepo = module.get(getRepositoryToken(Prediction));
+      predictionsRepo.find = jest.fn().mockResolvedValue([]);
+      marketsRepository.findOne.mockResolvedValue(makeMarket('market-1'));
+
+      const first = await service.getMarketAnalytics('market-1');
+      const second = await service.getMarketAnalytics('market-1');
+
+      expect(second).toEqual(first);
+      expect(marketsRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(predictionsRepo.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a distinct cache entry for a different market id', async () => {
+      const predictionsRepo = module.get(getRepositoryToken(Prediction));
+      predictionsRepo.find = jest.fn().mockResolvedValue([]);
+      marketsRepository.findOne
+        .mockResolvedValueOnce(makeMarket('market-1'))
+        .mockResolvedValueOnce(makeMarket('market-2'));
+
+      const first = await service.getMarketAnalytics('market-1');
+      const second = await service.getMarketAnalytics('market-2');
+
+      expect(first.market_id).toBe('market-1');
+      expect(second.market_id).toBe('market-2');
+      expect(marketsRepository.findOne).toHaveBeenCalledTimes(2);
+      expect(predictionsRepo.find).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getUserTrends caching', () => {
+    const trendsUser = { id: 'user-42', stellar_address: 'GADDR42' } as User;
+
+    function makePrediction(): Prediction {
+      return {
+        submitted_at: new Date(),
+        chosen_outcome: 'YES',
+        stake_amount_stroops: '100',
+        payout_amount_stroops: '0',
+        market: { category: 'Politics', is_resolved: false } as Market,
+      } as Prediction;
+    }
+
+    function setup() {
+      const predictionsRepo = module.get(getRepositoryToken(Prediction));
+      predictionsRepo.find = jest.fn().mockResolvedValue([makePrediction()]);
+      usersRepository.findOne.mockResolvedValue(trendsUser);
+      return predictionsRepo;
+    }
+
+    it('serves a second identical request from cache without re-querying', async () => {
+      const predictionsRepo = setup();
+
+      await service.getUserTrends('GADDR42', 30);
+      await service.getUserTrends('GADDR42', 30);
+
+      expect(predictionsRepo.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a distinct cache entry when the days parameter differs', async () => {
+      const predictionsRepo = setup();
+
+      await service.getUserTrends('GADDR42', 30);
+      await service.getUserTrends('GADDR42', 60);
+
+      expect(predictionsRepo.find).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses a distinct cache entry for a different address', async () => {
+      const predictionsRepo = setup();
+
+      await service.getUserTrends('GADDR42', 30);
+      await service.getUserTrends('GOTHER99', 30);
+
+      expect(predictionsRepo.find).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getDashboardKPIs caching', () => {
+    it('serves a second identical request from cache without re-querying', async () => {
+      usersRepository.findOne.mockResolvedValue(baseUser);
+      leaderboardRepository.createQueryBuilder.mockReturnValue(
+        mockLeaderboardQb(null) as any,
+      );
+      predictionsRepository.createQueryBuilder.mockReturnValue(
+        mockQb({ getCount: 1 }) as any,
+      );
+
+      await service.getDashboardKPIs(baseUser);
+      await service.getDashboardKPIs(baseUser);
+
+      expect(usersRepository.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a distinct cache entry for a different user', async () => {
+      const otherUser = { ...baseUser, id: 'user-id-2' } as User;
+      usersRepository.findOne.mockImplementation((opts: any) =>
+        Promise.resolve(
+          opts.where.id === otherUser.id ? otherUser : baseUser,
+        ),
+      );
+      leaderboardRepository.createQueryBuilder.mockReturnValue(
+        mockLeaderboardQb(null) as any,
+      );
+      predictionsRepository.createQueryBuilder.mockReturnValue(
+        mockQb({ getCount: 1 }) as any,
+      );
+
+      await service.getDashboardKPIs(baseUser);
+      await service.getDashboardKPIs(otherUser);
+
+      expect(usersRepository.findOne).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getMarketHistory caching', () => {
+    function makeHistoryQb() {
+      return {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+    }
+
+    it('serves a second identical request from cache without re-querying', async () => {
+      const market = { id: 'market-1', title: 'Market 1' } as Market;
+      marketsRepository.findOne.mockResolvedValue(market);
+      marketHistoryRepository.createQueryBuilder.mockReturnValue(
+        makeHistoryQb() as any,
+      );
+
+      const from = new Date('2026-05-01T00:00:00.000Z');
+      const to = new Date('2026-06-01T00:00:00.000Z');
+
+      const first = await service.getMarketHistory('market-1', from, to);
+      const second = await service.getMarketHistory('market-1', from, to);
+
+      expect(second).toEqual(first);
+      expect(marketsRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(
+        marketHistoryRepository.createQueryBuilder,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a distinct cache entry when the date range differs', async () => {
+      const market = { id: 'market-1', title: 'Market 1' } as Market;
+      marketsRepository.findOne.mockResolvedValue(market);
+      marketHistoryRepository.createQueryBuilder.mockReturnValue(
+        makeHistoryQb() as any,
+      );
+
+      await service.getMarketHistory(
+        'market-1',
+        new Date('2026-05-01T00:00:00.000Z'),
+        new Date('2026-06-01T00:00:00.000Z'),
+      );
+      await service.getMarketHistory(
+        'market-1',
+        new Date('2026-06-01T00:00:00.000Z'),
+        new Date('2026-07-01T00:00:00.000Z'),
+      );
+
+      expect(
+        marketHistoryRepository.createQueryBuilder,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses a distinct cache entry for a different market id', async () => {
+      marketsRepository.findOne.mockImplementation((opts: any) =>
+        Promise.resolve({ id: opts.where[0].id, title: 'Market' } as Market),
+      );
+      marketHistoryRepository.createQueryBuilder.mockReturnValue(
+        makeHistoryQb() as any,
+      );
+
+      const from = new Date('2026-05-01T00:00:00.000Z');
+      const to = new Date('2026-06-01T00:00:00.000Z');
+
+      await service.getMarketHistory('market-1', from, to);
+      await service.getMarketHistory('market-2', from, to);
+
+      expect(
+        marketHistoryRepository.createQueryBuilder,
+      ).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('invalidateMarketResolutionCaches', () => {
+    it('clears the market, category, platform-stats, and per-user dashboard entries', async () => {
+      const cacheManager = module.get(CACHE_MANAGER);
+
+      await cacheService.getOrSet('analytics:market', 'market-1', () =>
+        Promise.resolve('market-by-id'),
+      );
+      await cacheService.getOrSet('analytics:market', 'chain-1', () =>
+        Promise.resolve('market-by-chain-id'),
+      );
+      await cacheService.getOrSet('analytics:category', 'all', () =>
+        Promise.resolve('category'),
+      );
+      await cacheService.getOrSet('analytics:platform-stats', 'all', () =>
+        Promise.resolve('platform'),
+      );
+      await cacheService.getOrSet('analytics:dashboard', 'user-1', () =>
+        Promise.resolve('dash-1'),
+      );
+      await cacheService.getOrSet('analytics:dashboard', 'user-2', () =>
+        Promise.resolve('dash-2'),
+      );
+      // Left alone: keyed by an unbounded parameter space, expires on its own TTL.
+      await cacheService.getOrSet(
+        'analytics:user-trends',
+        'GADDR:30',
+        () => Promise.resolve('trends'),
+      );
+
+      await service.invalidateMarketResolutionCaches('market-1', 'chain-1', [
+        'user-1',
+        'user-2',
+      ]);
+
+      expect(
+        await cacheManager.get('analytics:market:market-1'),
+      ).toBeUndefined();
+      expect(
+        await cacheManager.get('analytics:market:chain-1'),
+      ).toBeUndefined();
+      expect(
+        await cacheManager.get('analytics:category:all'),
+      ).toBeUndefined();
+      expect(
+        await cacheManager.get('analytics:platform-stats:all'),
+      ).toBeUndefined();
+      expect(
+        await cacheManager.get('analytics:dashboard:user-1'),
+      ).toBeUndefined();
+      expect(
+        await cacheManager.get('analytics:dashboard:user-2'),
+      ).toBeUndefined();
+      expect(await cacheManager.get('analytics:user-trends:GADDR:30')).toBe(
+        'trends',
+      );
+    });
+
+    it('is a no-op when no on-chain id or affected users are given', async () => {
+      const cacheManager = module.get(CACHE_MANAGER);
+      await cacheService.getOrSet('analytics:market', 'market-1', () =>
+        Promise.resolve('market-by-id'),
+      );
+
+      await service.invalidateMarketResolutionCaches('market-1', null, []);
+
+      expect(
+        await cacheManager.get('analytics:market:market-1'),
+      ).toBeUndefined();
+      expect(
+        await cacheManager.get('analytics:category:all'),
+      ).toBeUndefined();
+    });
+
+    it('logs a warning instead of throwing when a cache backend call fails', async () => {
+      const cacheManager = module.get(CACHE_MANAGER);
+      const warnSpy = jest
+        .spyOn((service as any).logger, 'warn')
+        .mockImplementation(() => undefined);
+      jest
+        .spyOn(cacheManager, 'del')
+        .mockRejectedValueOnce(new Error('cache backend unavailable'));
+
+      await expect(
+        service.invalidateMarketResolutionCaches('market-1', 'chain-1', []),
+      ).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -101,7 +101,17 @@ export class AnalyticsService {
     return this.activityLogsRepository.save(log);
   }
 
+  /**
+   * Cached per-user (short TTL, since rank/streak change with live activity)
+   * since this fans out into several queries over predictions/leaderboard.
+   */
   async getDashboardKPIs(user: User): Promise<DashboardKpisDto> {
+    return this.cacheService.getOrSet('analytics:dashboard', user.id, () =>
+      this.computeDashboardKPIs(user),
+    );
+  }
+
+  private async computeDashboardKPIs(user: User): Promise<DashboardKpisDto> {
     const fullUser = await this.usersRepository.findOne({
       where: { id: user.id },
     });
@@ -163,9 +173,18 @@ export class AnalyticsService {
   }
 
   /**
-   * Get market analytics: pool size, participant count, outcome distribution, and time remaining
+   * Get market analytics: pool size, participant count, outcome distribution, and time remaining.
+   * Cached per market id (short TTL, since pool/participant counts move with live predictions).
    */
   async getMarketAnalytics(marketId: string): Promise<MarketAnalyticsDto> {
+    return this.cacheService.getOrSet('analytics:market', marketId, () =>
+      this.computeMarketAnalytics(marketId),
+    );
+  }
+
+  private async computeMarketAnalytics(
+    marketId: string,
+  ): Promise<MarketAnalyticsDto> {
     const market = await this.marketsRepository.findOne({
       where: [{ id: marketId }, { on_chain_market_id: marketId }],
     });
@@ -223,13 +242,29 @@ export class AnalyticsService {
   }
 
   /**
-   * Get historical data for a market: prediction volume, pool size, participant growth over time
+   * Get historical data for a market: prediction volume, pool size, participant growth over time.
+   * Cached per (market, from, to, interval) combination — short TTL, since new
+   * snapshots land periodically via recordMarketSnapshot.
    */
   async getMarketHistory(
     marketId: string,
     from: Date,
     to: Date,
     interval?: string, // TODO: Implement interval-based aggregation
+  ): Promise<MarketHistoryResponseDto> {
+    const cacheKey = `${marketId}:${from.toISOString()}:${to.toISOString()}:${interval ?? ''}`;
+    return this.cacheService.getOrSet(
+      'analytics:market-history',
+      cacheKey,
+      () => this.computeMarketHistory(marketId, from, to, interval),
+    );
+  }
+
+  private async computeMarketHistory(
+    marketId: string,
+    from: Date,
+    to: Date,
+    interval?: string,
   ): Promise<MarketHistoryResponseDto> {
     const clampedRange = clampAnalyticsDateRange(from, to);
     from = clampedRange.from;
@@ -312,11 +347,24 @@ export class AnalyticsService {
   }
 
   /**
-   * Get user performance trends over time
+   * Get user performance trends over time.
+   * Cached per (address, days) combination — short TTL, since a new
+   * prediction or resolution shifts the trend.
    */
   async getUserTrends(
     address: string,
     days: number = 30,
+  ): Promise<UserTrendsDto> {
+    return this.cacheService.getOrSet(
+      'analytics:user-trends',
+      `${address}:${days}`,
+      () => this.computeUserTrends(address, days),
+    );
+  }
+
+  private async computeUserTrends(
+    address: string,
+    days: number,
   ): Promise<UserTrendsDto> {
     const validDays = Math.min(Math.max(days || 30, 1), 90);
 
@@ -761,5 +809,55 @@ export class AnalyticsService {
       active_users,
       active_markets,
     };
+  }
+
+  /**
+   * Invalidate cached aggregates that go stale the moment a market
+   * resolves, rather than waiting out their TTL:
+   * - this market's own analytics (looked up by either id, since callers
+   *   may key `getMarketAnalytics`/`getMarketHistory` by either one),
+   * - category analytics and platform stats, since resolution changes
+   *   active/resolved market counts,
+   * - the dashboard KPIs of every affected predictor, since resolution can
+   *   flip their streak/tier.
+   *
+   * `getMarketHistory` and `getUserTrends` are keyed by (id, date-range)
+   * and (address, days) respectively — an unbounded set of parameter
+   * combinations that can't be enumerated here, so those two are left to
+   * expire on their own short TTL instead.
+   *
+   * Called from write paths that resolve a market (e.g. admin resolution).
+   * Best-effort: failures are logged, not thrown, so a cache hiccup never
+   * blocks the write it's attached to.
+   */
+  async invalidateMarketResolutionCaches(
+    marketId: string,
+    onChainMarketId: string | null | undefined,
+    affectedUserIds: string[] = [],
+  ): Promise<void> {
+    const marketKeys = new Set([marketId]);
+    if (onChainMarketId) {
+      marketKeys.add(onChainMarketId);
+    }
+
+    const tasks = [
+      ...Array.from(marketKeys).map((key) =>
+        this.cacheService.invalidate('analytics:market', key),
+      ),
+      this.cacheService.invalidate('analytics:category', 'all'),
+      this.cacheService.invalidate('analytics:platform-stats', 'all'),
+      ...affectedUserIds.map((userId) =>
+        this.cacheService.invalidate('analytics:dashboard', userId),
+      ),
+    ];
+
+    const results = await Promise.allSettled(tasks);
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        this.logger.warn(
+          `Cache invalidation failed after market resolution: ${result.reason}`,
+        );
+      }
+    }
   }
 }

--- a/backend/src/cache/cache.policy.ts
+++ b/backend/src/cache/cache.policy.ts
@@ -7,6 +7,10 @@ export const CACHE_NAMESPACE_TTL_MS: Record<string, number> = {
   'analytics:category': 5 * 60 * 1000, // 5 minutes
   'analytics:retention': 15 * 60 * 1000, // 15 minutes — expensive full-table scan
   'analytics:platform-stats': 5 * 60 * 1000, // 5 minutes
+  'analytics:market': 30 * 1000, // 30 seconds — pool size/participants shift with live prediction activity
+  'analytics:market-history': 60 * 1000, // 1 minute — keyed by date range, so entries don't get reused as often
+  'analytics:user-trends': 60 * 1000, // 1 minute
+  'analytics:dashboard': 30 * 1000, // 30 seconds — personalized (rank/streak), kept fresh
 };
 
 export const DEFAULT_TTL_MS = 60 * 1000; // 1 minute


### PR DESCRIPTION
## Summary

Analytics aggregation endpoints were recomputing heavy queries on every request. This wires the remaining uncached endpoints into the existing `CacheService` (backend/src/cache/) so they're cached with a short, per-namespace TTL and keyed by request parameters, and invalidates the affected entries when a market resolves.

- `getDashboardKPIs` — cached per user id (`analytics:dashboard`, 30s TTL)
- `getMarketAnalytics` — cached per market id (`analytics:market`, 30s TTL)
- `getMarketHistory` — cached per `(market, from, to, interval)` (`analytics:market-history`, 60s TTL)
- `getUserTrends` — cached per `(address, days)` (`analytics:user-trends`, 60s TTL)

These join `getCategoryAnalytics`, `getRetention`, and `getPlatformStats`, which already used the same `CacheService.getOrSet` pattern (5–15 min TTLs) — no new caching infrastructure was introduced, this only extends the existing one.

Each service method keeps its original signature and public behavior; the actual query logic was moved into a private `computeXxx` method that the cache wrapper calls on a miss.

**Invalidation on writes:** `AnalyticsService.invalidateMarketResolutionCaches(marketId, onChainMarketId, affectedUserIds)` is called from `AdminService.adminResolveMarket` right after a market is resolved. It clears that market's own analytics entry, the category/platform-stats aggregates, and the dashboard KPIs of every predictor in that market — all of which go stale the instant a market resolves. `getMarketHistory` and `getUserTrends` are keyed by an open-ended parameter space (date ranges, arbitrary `days`) that can't be enumerated at invalidation time, so those are intentionally left to expire on their own short TTL instead. Invalidation is best-effort: a cache backend failure is caught and logged, never thrown, so it can't block the resolution write it's attached to.

## Before / after

- **Before:** every call to `/analytics/dashboard`, `/analytics/markets/:id`, `/analytics/markets/:id/history`, and `/analytics/users/:address/trends` re-ran its full set of repository queries (several joins/aggregations per call), even for back-to-back identical requests.
- **After:** the first request per parameter combination computes and caches the result; subsequent identical requests within the TTL window are served from cache with no DB round-trip. A market resolution proactively evicts the entries it invalidates rather than waiting out the TTL.

## Testing

- Added tests in `analytics.service.spec.ts` for each newly cached method, following the same pattern already used for `getCategoryAnalytics`:
  - a second identical call does not re-query the repositories (cache hit)
  - varying the parameters (user id, market id, date range, address, days) produces a distinct cache entry (re-queries)
- Added tests for `invalidateMarketResolutionCaches`: it clears the market/category/platform-stats/dashboard entries it targets, leaves `analytics:user-trends`/`analytics:market-history` entries alone, and resolves without throwing (logging a warning instead) when the cache backend fails.
- Could not run the suite directly in this environment (`node_modules` not installed / installs disabled here) — changes were reviewed manually against the existing test patterns and mocks in this file instead. Please run `npm test` (backend) in CI/locally to confirm.

Closes #1636