### PR TITLE
Feat/1767 season rollover leaderboard snapshot

### DIFF
--- a/backend/src/migrations/1788000000000-CreateSeasonLeaderboardSnapshots.ts
+++ b/backend/src/migrations/1788000000000-CreateSeasonLeaderboardSnapshots.ts
@@ -1,0 +1,70 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateSeasonLeaderboardSnapshots1788000000000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'season_leaderboard_snapshots',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            isGenerated: true,
+          },
+          { name: 'season_id', type: 'uuid' },
+          { name: 'user_id', type: 'uuid' },
+          { name: 'rank', type: 'int' },
+          { name: 'season_points', type: 'int' },
+          { name: 'captured_at', type: 'timestamptz', default: 'now()' },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'season_leaderboard_snapshots',
+      new TableForeignKey({
+        columnNames: ['season_id'],
+        referencedTableName: 'seasons',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'season_leaderboard_snapshots',
+      new TableForeignKey({
+        columnNames: ['user_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'season_leaderboard_snapshots',
+      new TableIndex({
+        columnNames: ['season_id', 'user_id'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'season_leaderboard_snapshots',
+      new TableIndex({
+        columnNames: ['season_id', 'rank'],
+      }),
+    );
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('season_leaderboard_snapshots');
+  }
+}

--- a/backend/src/seasons/entities/season-leaderboard-snapshot.entity.ts
+++ b/backend/src/seasons/entities/season-leaderboard-snapshot.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Season } from './season.entity';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Immutable per-user leaderboard row captured atomically at season rollover.
+ * Unique on (season, user) so a rollover retry can never duplicate rows for
+ * a season that already has a snapshot — see SeasonsService.processSeasonRollover.
+ */
+@Entity('season_leaderboard_snapshots')
+@Index(['season', 'user'], { unique: true })
+@Index(['season', 'rank'])
+export class SeasonLeaderboardSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Season, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'season_id' })
+  season: Season;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ type: 'int' })
+  rank: number;
+
+  @Column({ type: 'int' })
+  season_points: number;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  captured_at: Date;
+}

--- a/backend/src/seasons/seasons.module.ts
+++ b/backend/src/seasons/seasons.module.ts
@@ -6,13 +6,19 @@ import { UsersModule } from '../users/users.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { Season } from './entities/season.entity';
 import { SeasonDistributionLedgerEntry } from './entities/season-distribution-ledger.entity';
+import { SeasonLeaderboardSnapshot } from './entities/season-leaderboard-snapshot.entity';
 import { SeasonRolloverScheduler } from './season-rollover.scheduler';
 import { SeasonsController } from './seasons.controller';
 import { SeasonsService } from './seasons.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Season, User, SeasonDistributionLedgerEntry]),
+    TypeOrmModule.forFeature([
+      Season,
+      User,
+      SeasonDistributionLedgerEntry,
+      SeasonLeaderboardSnapshot,
+    ]),
     UsersModule,
     NotificationsModule,
     WebhooksModule,

--- a/backend/src/seasons/seasons.service.spec.ts
+++ b/backend/src/seasons/seasons.service.spec.ts
@@ -5,6 +5,7 @@ import { DataSource, Repository } from 'typeorm';
 import { NotificationsService } from '../notifications/notifications.service';
 import { SeasonsService } from './seasons.service';
 import { Season } from './entities/season.entity';
+import { User } from '../users/entities/user.entity';
 import {
   DistributionLedgerStatus,
   SeasonDistributionLedgerEntry,
@@ -657,6 +658,74 @@ describe('SeasonsService', () => {
       updated_at: new Date(),
     };
 
+    function buildTransactionalManager(overrides: {
+      season: Season;
+      winner: {
+        id: string;
+        stellar_address: string;
+        season_points: number;
+      } | null;
+      finalized: Season;
+      opened: Season | null;
+      standings: { u_id: string; season_points: number }[];
+      snapshotExists?: boolean;
+    }) {
+      const savedSnapshots: unknown[] = [];
+      const manager = {
+        findOne: jest
+          .fn()
+          .mockImplementation(
+            async (
+              entity: unknown,
+              opts: { where?: { id?: string; season_number?: number } },
+            ) => {
+              if (entity === Season) {
+                if (opts?.where?.id === overrides.season.id) {
+                  return { ...overrides.season };
+                }
+                if (
+                  opts?.where?.season_number ===
+                  overrides.season.season_number + 1
+                ) {
+                  return overrides.opened;
+                }
+                return null;
+              }
+              if (entity === User) {
+                return overrides.winner;
+              }
+              return null;
+            },
+          ),
+        save: jest
+          .fn()
+          .mockImplementation(async (entity: unknown, value: unknown) => {
+            if (entity === Season) {
+              const v = value as Season;
+              return v.id === overrides.season.id ? overrides.finalized : v;
+            }
+            if (Array.isArray(value)) {
+              savedSnapshots.push(...value);
+            }
+            return value;
+          }),
+        update: jest.fn().mockResolvedValue(undefined),
+        exists: jest.fn().mockResolvedValue(overrides.snapshotExists ?? false),
+        create: jest.fn().mockImplementation((_entity, value) => value),
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          addSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          addOrderBy: jest.fn().mockReturnThis(),
+          getRawMany: jest.fn().mockResolvedValue(overrides.standings),
+          getOne: jest.fn().mockResolvedValue(null),
+        }),
+      };
+      return { manager, savedSnapshots };
+    }
+
     it('closes ending season, opens next, and is idempotent on re-run', async () => {
       const now = new Date('2020-06-01T00:00:00.000Z');
       const winner = {
@@ -669,6 +738,7 @@ describe('SeasonsService', () => {
         ...ending,
         is_active: false,
         is_finalized: true,
+        rollover_processed_at: now,
         top_winner: winner as Season['top_winner'],
       };
 
@@ -679,14 +749,13 @@ describe('SeasonsService', () => {
         getOne: jest.fn().mockResolvedValue(ending),
       } as never);
 
-      const manager = {
-        findOne: jest
-          .fn()
-          .mockResolvedValueOnce(ending)
-          .mockResolvedValueOnce(winner),
-        save: jest.fn().mockResolvedValue(finalized),
-        update: jest.fn().mockResolvedValue(undefined),
-      };
+      const { manager, savedSnapshots } = buildTransactionalManager({
+        season: ending,
+        winner,
+        finalized,
+        opened: nextSeason,
+        standings: [{ u_id: 'u1', season_points: 10 }],
+      });
       const qr = {
         connect: jest.fn().mockResolvedValue(undefined),
         startTransaction: jest.fn().mockResolvedValue(undefined),
@@ -718,12 +787,15 @@ describe('SeasonsService', () => {
       expect(first.closedSeasonId).toBe('end-1');
       expect(first.openedSeasonId).toBe('next-1');
       expect(first.rewardsComputed).toBe(true);
-      expect(seasonsRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'end-1',
-          rollover_processed_at: now,
-        }),
-      );
+      expect(qr.commitTransaction).toHaveBeenCalledTimes(1);
+      expect(qr.rollbackTransaction).not.toHaveBeenCalled();
+      // Exactly one snapshot row written for the closed season's sole standing.
+      expect(savedSnapshots).toHaveLength(1);
+      expect(savedSnapshots[0]).toMatchObject({
+        rank: 1,
+        season_points: 10,
+        user: { id: 'u1' },
+      });
 
       // Second run with already-processed ending season filtered out.
       seasonsRepository.createQueryBuilder.mockReturnValue({
@@ -736,6 +808,121 @@ describe('SeasonsService', () => {
       const second = await service.processSeasonRollover(now);
       expect(second.skipped).toBe(true);
       expect(second.reason).toBe('nothing_to_rollover');
+    });
+
+    it('does not duplicate the snapshot when re-run inside the transaction finds one already exists', async () => {
+      const now = new Date('2020-06-01T00:00:00.000Z');
+      const winner = {
+        id: 'u1',
+        username: 'winner',
+        stellar_address: 'GWINNER',
+        season_points: 10,
+      };
+      const finalized: Season = {
+        ...ending,
+        is_active: false,
+        is_finalized: true,
+        rollover_processed_at: now,
+        top_winner: winner as Season['top_winner'],
+      };
+
+      seasonsRepository.createQueryBuilder.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(ending),
+      } as never);
+
+      const { manager, savedSnapshots } = buildTransactionalManager({
+        season: ending,
+        winner,
+        finalized,
+        opened: nextSeason,
+        standings: [{ u_id: 'u1', season_points: 10 }],
+        snapshotExists: true,
+      });
+      const qr = {
+        connect: jest.fn().mockResolvedValue(undefined),
+        startTransaction: jest.fn().mockResolvedValue(undefined),
+        manager,
+        commitTransaction: jest.fn().mockResolvedValue(undefined),
+        rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+        release: jest.fn().mockResolvedValue(undefined),
+      };
+      (
+        service as unknown as { dataSource: { createQueryRunner: jest.Mock } }
+      ).dataSource.createQueryRunner = jest.fn().mockReturnValue(qr);
+
+      seasonsRepository.findOne = jest.fn().mockResolvedValue(finalized);
+      seasonsRepository.save = jest
+        .fn()
+        .mockImplementation(async (s: Season) => s);
+
+      await service.processSeasonRollover(now);
+
+      expect(manager.exists).toHaveBeenCalledTimes(1);
+      expect(savedSnapshots).toHaveLength(0);
+    });
+
+    it('rolls back the whole transaction if the leaderboard snapshot write fails', async () => {
+      const now = new Date('2020-06-01T00:00:00.000Z');
+      const winner = {
+        id: 'u1',
+        username: 'winner',
+        stellar_address: 'GWINNER',
+        season_points: 10,
+      };
+      const finalized: Season = {
+        ...ending,
+        is_active: false,
+        is_finalized: true,
+        rollover_processed_at: now,
+        top_winner: winner as Season['top_winner'],
+      };
+
+      seasonsRepository.createQueryBuilder.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(ending),
+      } as never);
+
+      const { manager } = buildTransactionalManager({
+        season: ending,
+        winner,
+        finalized,
+        opened: nextSeason,
+        standings: [{ u_id: 'u1', season_points: 10 }],
+      });
+      manager.save = jest
+        .fn()
+        .mockImplementation(async (entity: unknown, value: unknown) => {
+          if (entity === Season) {
+            const v = value as Season;
+            return v.id === ending.id ? finalized : v;
+          }
+          throw new Error('snapshot write failed');
+        });
+      const qr = {
+        connect: jest.fn().mockResolvedValue(undefined),
+        startTransaction: jest.fn().mockResolvedValue(undefined),
+        manager,
+        commitTransaction: jest.fn().mockResolvedValue(undefined),
+        rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+        release: jest.fn().mockResolvedValue(undefined),
+      };
+      (
+        service as unknown as { dataSource: { createQueryRunner: jest.Mock } }
+      ).dataSource.createQueryRunner = jest.fn().mockReturnValue(qr);
+
+      await expect(service.processSeasonRollover(now)).rejects.toThrow(
+        'snapshot write failed',
+      );
+
+      expect(qr.commitTransaction).not.toHaveBeenCalled();
+      expect(qr.rollbackTransaction).toHaveBeenCalledTimes(1);
+      // Standings must not be reset if the snapshot never committed.
+      expect(manager.update).not.toHaveBeenCalled();
     });
 
     it('skips when rollover_processed_at is already set on ending season', async () => {

--- a/backend/src/seasons/seasons.service.ts
+++ b/backend/src/seasons/seasons.service.ts
@@ -6,11 +6,17 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository, SelectQueryBuilder } from 'typeorm';
+import {
+  DataSource,
+  EntityManager,
+  Repository,
+  SelectQueryBuilder,
+} from 'typeorm';
 import { NotificationType } from '../notifications/entities/notification.entity';
 import { NotificationsService } from '../notifications/notifications.service';
 import { User } from '../users/entities/user.entity';
 import { Season } from './entities/season.entity';
+import { SeasonLeaderboardSnapshot } from './entities/season-leaderboard-snapshot.entity';
 import {
   DistributionLedgerStatus,
   SeasonDistributionLedgerEntry,
@@ -337,7 +343,17 @@ export class SeasonsService {
 
   /**
    * Close an ending season and open the next one at the schedule boundary.
-   * Idempotent via `rollover_processed_at` — re-running does not double-finalize.
+   *
+   * Runs as a single DB transaction: freeze the ending season (finalize +
+   * mark rollover_processed_at), snapshot its final leaderboard into the
+   * immutable season_leaderboard_snapshots table, then activate the next
+   * season. A crash or overlapping tick mid-write can never leave standings
+   * finalized without a snapshot, or vice versa — both commit together or
+   * neither does.
+   *
+   * Idempotent via `rollover_processed_at`: re-running for an
+   * already-rolled season is a no-op (checked both before and again inside
+   * the transaction to close the race between two concurrent ticks).
    */
   async processSeasonRollover(now = new Date()): Promise<SeasonRolloverResult> {
     const ending = await this.seasonsRepository
@@ -380,46 +396,89 @@ export class SeasonsService {
       };
     }
 
-    if (!ending.is_finalized) {
-      try {
-        await this.finalizeSeason(ending.id);
-      } catch (err) {
-        // Concurrent rollover may have finalized already; continue if so.
-        if (!(err instanceof ConflictException)) {
-          throw err;
-        }
-      }
-    }
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-    const closed = await this.findById(ending.id);
-    if (closed.rollover_processed_at) {
-      return {
-        closedSeasonId: closed.id,
-        openedSeasonId: null,
-        rewardsComputed: false,
-        skipped: true,
-        reason: 'already_processed',
-      };
+    let closed: Season;
+    let opened: Season | null;
+    try {
+      const season = await queryRunner.manager.findOne(Season, {
+        where: { id: ending.id },
+      });
+      if (!season) {
+        throw new NotFoundException(`Season "${ending.id}" not found`);
+      }
+
+      // Re-check inside the transaction: another worker may have committed
+      // a rollover for this season between our lookup above and now.
+      if (season.rollover_processed_at) {
+        await queryRunner.rollbackTransaction();
+        return {
+          closedSeasonId: season.id,
+          openedSeasonId: null,
+          rewardsComputed: false,
+          skipped: true,
+          reason: 'already_processed',
+        };
+      }
+
+      const topWinner = await queryRunner.manager.findOne(User, {
+        where: {},
+        order: { season_points: 'DESC' },
+      });
+
+      season.is_active = false;
+      season.is_finalized = true;
+      season.top_winner = topWinner ?? null;
+      season.rollover_processed_at = now;
+      closed = await queryRunner.manager.save(Season, season);
+
+      await this.snapshotLeaderboard(queryRunner.manager, closed);
+
+      await queryRunner.manager.update(User, {}, { season_points: 0 });
+
+      opened =
+        (await queryRunner.manager.findOne(Season, {
+          where: { season_number: closed.season_number + 1 },
+        })) ?? null;
+
+      if (opened && !opened.is_finalized) {
+        opened.is_active = true;
+        if (opened.starts_at > now) {
+          opened.starts_at = now;
+        }
+        opened = await queryRunner.manager.save(Season, opened);
+      } else {
+        opened = await this.activateDueSeasonWithManager(
+          queryRunner.manager,
+          now,
+        );
+      }
+
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error(`Season rollover failed for "${ending.id}"`, err);
+      throw err;
+    } finally {
+      await queryRunner.release();
     }
 
     const rewardsComputed = await this.computeSeasonRewards(closed);
-    closed.rollover_processed_at = now;
-    closed.is_active = false;
-    await this.seasonsRepository.save(closed);
 
-    let opened =
-      (await this.seasonsRepository.findOne({
-        where: { season_number: closed.season_number + 1 },
-      })) ?? null;
-
-    if (opened && !opened.is_finalized) {
-      opened.is_active = true;
-      if (opened.starts_at > now) {
-        opened.starts_at = now;
-      }
-      opened = await this.seasonsRepository.save(opened);
-    } else {
-      opened = await this.activateDueSeason(now);
+    if (closed.top_winner?.stellar_address) {
+      await this.notificationsService.create(
+        closed.top_winner.stellar_address,
+        NotificationType.EventCreated,
+        '🎉 Season Winner!',
+        `Congratulations! You are the winner of the ${closed.name} season with the highest points!`,
+        {
+          season_id: closed.id,
+          season_name: closed.name,
+          winning_points: closed.top_winner.season_points,
+        },
+      );
     }
 
     await this.emitRolloverEvents(closed, opened);
@@ -434,6 +493,47 @@ export class SeasonsService {
       rewardsComputed,
       skipped: false,
     };
+  }
+
+  /**
+   * Snapshot the closed season's final standings into the immutable
+   * season_leaderboard_snapshots table, ordered by season_points desc.
+   * Skips if a snapshot for this season already exists (defends against a
+   * retry racing the unique (season, user) constraint mid-transaction).
+   */
+  private async snapshotLeaderboard(
+    manager: EntityManager,
+    season: Season,
+  ): Promise<void> {
+    const alreadySnapshotted = await manager.exists(SeasonLeaderboardSnapshot, {
+      where: { season: { id: season.id } },
+    });
+    if (alreadySnapshotted) {
+      return;
+    }
+
+    const standings = await manager
+      .createQueryBuilder(User, 'u')
+      .select(['u.id'])
+      .addSelect('u.season_points', 'season_points')
+      .orderBy('u.season_points', 'DESC')
+      .addOrderBy('u.id', 'ASC')
+      .getRawMany<{ u_id: string; season_points: number }>();
+
+    if (standings.length === 0) {
+      return;
+    }
+
+    const snapshots = standings.map((row, index) =>
+      manager.create(SeasonLeaderboardSnapshot, {
+        season,
+        user: { id: row.u_id } as User,
+        rank: index + 1,
+        season_points: Number(row.season_points),
+      }),
+    );
+
+    await manager.save(SeasonLeaderboardSnapshot, snapshots);
   }
 
   private async activateDueSeason(now: Date): Promise<Season | null> {
@@ -452,6 +552,27 @@ export class SeasonsService {
 
     due.is_active = true;
     return this.seasonsRepository.save(due);
+  }
+
+  private async activateDueSeasonWithManager(
+    manager: EntityManager,
+    now: Date,
+  ): Promise<Season | null> {
+    const due = await manager
+      .createQueryBuilder(Season, 's')
+      .where('s.is_active = :active', { active: false })
+      .andWhere('s.is_finalized = :fin', { fin: false })
+      .andWhere('s.starts_at <= :now', { now })
+      .andWhere('s.ends_at > :now', { now })
+      .orderBy('s.season_number', 'ASC')
+      .getOne();
+
+    if (!due) {
+      return null;
+    }
+
+    due.is_active = true;
+    return manager.save(Season, due);
   }
 
   /**


### PR DESCRIPTION
# Atomic season rollover with leaderboard snapshot

`season-rollover.scheduler.ts` finalized a season and saved
`rollover_processed_at` as separate steps, with no immutable record of the
closed season's final standings. A crash mid-write could leave standings
finalized without the idempotency marker, and there was nothing to pay
rewards or audit against.

## Changes
- Add `SeasonLeaderboardSnapshot` entity + migration for an immutable
  `season_leaderboard_snapshots` table (unique on `season, user`).
- `processSeasonRollover` now runs freeze → snapshot → reset points → open
  next season as **one** DB transaction — commits or rolls back together.
- Idempotent: `rollover_processed_at` is re-checked inside the transaction,
  and the snapshot step is skipped if one already exists for the season, so
  a retry can never duplicate rows.
- Unit tests for exactly-one-snapshot, no-duplicate-on-retry, and full
  rollback when the snapshot write fails.

## Testing
- `npm test` (backend) — 1490/1490 passing
- `npm run lint` (backend) — 0 errors
- `npm run build` (backend) — clean
- `npm run migration:check-timestamps` — passed

Closes #1767
